### PR TITLE
Add tutorials to docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.cfg') }}
       - name: Install rubrix 🧊
-        run: pip install .[server,tests]
+        run: pip install .[server]
       - name: Run tests 📈
         run: pytest tests
       - name: Build Package 🍟

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ release = '0.0.1'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'nbsphinx',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -53,3 +54,5 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+nbsphinx_execute = 'never'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,11 +6,7 @@
 Welcome to rubrix's documentation!
 ==================================
 
-.. toctree::
-   :maxdepth: 2
-   :caption: Contents:
-
-
+Coming soon!
 
 Indices and tables
 ==================
@@ -18,3 +14,13 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
+
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Tutorials
+   :hidden:
+
+   tutorials/01-huggingface
+   tutorials/02.spacy
+   tutorials/03-kglab_pytorch_geometric

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -6,7 +6,14 @@ channels:
 dependencies:
 - python~=3.8.0
 - pip>=20.3.0
-# for building the frontend and the docs
+# tests
+- pytest
+# docs
+- sphinx==3.5.4
+- sphinx_rtd_theme
+- nbsphinx
+- pandoc
+# for building the frontend
 - nodejs~=14.15.0
 - pip:
     # build python sdk

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,3 @@ server =
     # Info status
     hurry.filesize
     psutil ~= 5.8.0
-tests =
-  pytest
-


### PR DESCRIPTION
This PR adds a tutorials section to the docs. It introduces the `nbsphinx` extension and adds a 'Tutorials' section to the TOC.

It also moves the tests&docs dependencies to the `environment_dev.yml` file. I think i prefer the option to keep all the "development" dependencies there and use `options.extras_require` only for "usage cases" of rubrix.

BTW: We already have the docs public at https://rubrix.readthedocs.io