### PR TITLE
remove requests calls

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ install_requires =
   httpx ~= 0.15.0
   attrs ~= 20.1
   python-dateutil >= 2.8.1
-  requests ~= 2.25.0 # TODO We should use httpx instead to avoid a new dependency
   # Client
   pandas >=1.0.0,<2.0.0 # For data loading
   pydantic ~= 1.8.1

--- a/src/rubrix/client/__init__.py
+++ b/src/rubrix/client/__init__.py
@@ -8,8 +8,8 @@ Methods for using the Rubrix Client, called from the module init file.
 import logging
 from typing import Any, Dict, Iterable, List, Optional, Union
 
+import httpx
 import pandas
-import requests
 from rubrix.client.models import (
     BulkResponse,
     DatasetSnapshot,
@@ -25,6 +25,7 @@ from rubrix.sdk.api.text_classification import bulk_records as text_classificati
 from rubrix.sdk.api.token_classification import (
     bulk_records as token_classification_bulk,
 )
+from rubrix.sdk.api.users import whoami
 from rubrix.sdk.models import (
     TaskType,
     TextClassificationQuery,
@@ -61,7 +62,7 @@ class RubrixClient:
         self._client = None  # Variable to store the client after the init
 
         try:
-            response = requests.get(url=f"{api_url}/api/docs/spec.json").status_code
+            response = httpx.get(url=f"{api_url}/api/docs/spec.json").status_code
         except ConnectionRefusedError:
             raise Exception("Connection Refused: cannot connect to the API.")
 
@@ -79,11 +80,8 @@ class RubrixClient:
                 base_url=api_url, token=api_key, timeout=timeout
             )
 
-            response_token = requests.get(
-                url=api_url + "/api/me", headers=self._client.get_headers()
-            ).status_code
-
-            if response_token == 401:
+            whoami_response_status = whoami.sync_detailed(client=self._client).status_code
+            if whoami_response_status == 401:
                 raise Exception("Authentification error: invalid credentials.")
 
     def log(

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -8,8 +8,8 @@ which could or could not be mounted.
 """
 from typing import cast
 
+import httpx
 import pytest
-import requests
 import rubrix
 import logging
 
@@ -46,12 +46,10 @@ def mock_response_200(monkeypatch):
     """
 
     def mock_get(*args, **kwargs):
-        response = requests.models.Response()
-        response.status_code = 200
-        return response
+        return httpx.Response(200)
 
     monkeypatch.setattr(
-        requests, "get", mock_get
+        httpx, "get", mock_get
     )  # apply the monkeypatch for requests.get to mock_get
 
 


### PR DESCRIPTION
Since rubrix.sdk module uses `httpx`, this PR migrates all `requests` calls by `httpx` ones.