### PR TITLE
rubrix container waits for elasticsearch up and running

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -23,7 +23,9 @@ RUN git log --oneline \
 
 WORKDIR /app
 
-RUN rm -rf /build
+RUN rm -rf /build \
+ && wget -O /wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh \
+ && chmod +x /wait-for-it.sh
 
 # See <https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker#module_name>
 ENV MODULE_NAME="rubrix.server.server"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3.9"
+version: "3"
 
 services:
   rubrix:
@@ -7,6 +7,8 @@ services:
       - "6900:80"
     environment:
       ELASTICSEARCH: http://elasticsearch:9200
+
+    command: /wait-for-it.sh elasticsearch:9200 -- /start.sh
 
     networks:
       - rubrix


### PR DESCRIPTION
This PR makes rubrix container wait for elasticsearch before start. This will avoid connection errors messages showed in #14

Closes #14