### PR TITLE
Docs/improve python client api

### DIFF
--- a/docs/getting_started/concepts.rst
+++ b/docs/getting_started/concepts.rst
@@ -134,59 +134,30 @@ Metada will hold extra information that you want your record to have: if it belo
 Methods
 -------
 
-To find more information about these methods, please visit our :ref:`api`
-
-rb.log
-^^^^^^
-
-Register a set of logs into Rubrix. 
-
-.. code-block:: python
-
-   rb.log(
-       rb.TextClassificationRecord(
-           inputs={"text": "my first rubrix example"},
-           prediction=[('spam', 0.8), ('ham', 0.2)]
-       ),
-       name='example-dataset'
-   )
-
-
-rb.load
-^^^^^^^
-
-Load a dataset or a snapshot as a Huggingface dataset.
-
-.. code-block:: python
-
-   rb.load(name='example-dataset')
-
-
-rb.snapshots
-^^^^^^^^^^^^
-
-Retrieve a dataset snapshot.
-
-.. code-block:: python
-
-   rb.snapshots(name='example-dataset')
-
-
-rb.delete
-^^^^^^^^^
-
-Delete a dataset with a given name.
-
-.. code-block:: python
-
-   rb.delete(name='example-dataset')
-
+To find more information about these methods, please check out the :ref:`api`.
 
 rb.init
 ^^^^^^^
 
-Client setup function. You can pass  the api url and api key via environment variables ``RUBRIX_API_URL`` and ``RUBRIX_API_KEY``\ , or via arguments of these functions. We recommend to use the environment variables, if you set them calling this function won't be necessary, magic will happen in the background.
+Setup the python client: :meth:`rubrix.init`
 
-.. code-block:: python
+rb.log
+^^^^^^
 
-   rb.init(api_url='http://localhost:9090', api_key='4AkeAPIk3Y')
+Register a set of logs into Rubrix: :meth:`rubrix.log`
+
+rb.load
+^^^^^^^
+
+Load a dataset or a snapshot as a pandas DataFrame: :meth:`rubrix.load`
+
+rb.snapshots
+^^^^^^^^^^^^
+
+Retrieve a list of dataset snapshots: :meth:`rubrix.snapshots`
+
+rb.delete
+^^^^^^^^^
+
+Delete a dataset with a given name: :meth:`rubrix.delete`
+

--- a/docs/reference/python_client_api.rst
+++ b/docs/reference/python_client_api.rst
@@ -3,6 +3,13 @@
 Python client API
 =================
 
+Here we describe the python client API of Rubrix that we divide into two basic modules:
+
+- Methods: These methods make up the interface to interact with Rubrix's REST API.
+- Models: You need to wrap your data in these data models for Rubrix to understand it.
+
+.. _test:
+
 Methods
 -------
 

--- a/src/rubrix/__init__.py
+++ b/src/rubrix/__init__.py
@@ -46,6 +46,9 @@ def init(
             is not set, it will default to a not authenticated connection.
         timeout:
             Wait `timeout` seconds for the connection to timeout. Default: 60.
+
+    Examples:
+        >>> rb.init(api_url="http://localhost:9090", api_key="4AkeAPIk3Y")
     """
 
     global _client
@@ -90,6 +93,13 @@ def log(
 
     Returns:
         Summary of the response from the REST API
+
+    Examples:
+        >>> record = rb.TextClassificationRecord(
+        ...     inputs={"text": "my first rubrix example"},
+        ...     prediction=[('spam', 0.8), ('ham', 0.2)]
+        ... )
+        >>> response = rb.log(record, name="example-dataset")
     """
 
     # Records can be a single object or a list. In case it is a single object, we create a single-element list
@@ -124,6 +134,9 @@ def snapshots(name: str) -> List[DatasetSnapshot]:
 
     Returns:
         A list of snapshots.
+
+    Examples:
+        >>> snapshot_list = rb.snapshots(name="example-dataset")
     """
     return _client_instance().snapshots(name)
 
@@ -148,6 +161,9 @@ def load(
 
     Returns:
         The dataset as a pandas Dataframe.
+
+    Examples:
+        >>> dataframe = rb.load(name="example-dataset")
     """
     return _client_instance().load(name=name, snapshot=snapshot, limit=limit, ids=ids)
 
@@ -159,5 +175,7 @@ def delete(name: str) -> None:
         name:
             The dataset name.
 
+    Examples:
+        >>> rb.delete(name="example-dataset")
     """
     _client_instance().delete(name=name)


### PR DESCRIPTION
Completes @dvsrepo suggestions in #48:
- Add small introduction to the Python client API
- Add examples to the doc strings
- Remove examples and leave links in the concepts sections