### PR TITLE
feat(middleware): starlette middleware for rubrix logging

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ install_requires =
   # Client
   pandas >=1.0.0,<2.0.0 # For data loading
   pydantic ~= 1.8.1
+  starlette >=0.13.0,<1.0.0
 
 [options.packages.find]
 where = src

--- a/src/rubrix/client/asgi.py
+++ b/src/rubrix/client/asgi.py
@@ -1,0 +1,133 @@
+import datetime
+import json
+import logging
+import re
+import threading
+from queue import Queue
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import rubrix
+from rubrix import Record, TextClassificationRecord, TokenClassificationRecord
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+
+_logger = logging.getLogger(__name__)
+_spaces_regex = re.compile(r"\s+")
+
+
+def token_classification_mapper(inputs, outputs):
+    text = inputs.get("text", "")
+    tokens = outputs.get("tokens") if isinstance(outputs, dict) else None
+    return TokenClassificationRecord(
+        text=text,
+        tokens=tokens or _spaces_regex.split(text),
+        prediction=[
+            (entity["label"], entity["start"], entity["end"])
+            for entity in (
+                outputs.get("entities") if isinstance(outputs, dict) else outputs
+            )
+        ],
+        event_timestamp=datetime.datetime.now(),
+    )
+
+
+def text_classification_mapper(inputs, outputs):
+    return TextClassificationRecord(
+        inputs=inputs,
+        prediction=[
+            (label, score)
+            for label, score in zip(
+                outputs.get("labels", []), outputs.get("probabilities", [])
+            )
+        ],
+        event_timestamp=datetime.datetime.now(),
+    )
+
+
+class RubrixLogHTTPMiddleware(BaseHTTPMiddleware):
+    """An standard starlette middleware that enables rubrix logs for http prediction requests"""
+
+    def __init__(
+        self,
+        api_endpoint: str,
+        dataset: str,
+        records_mapper: Optional[Callable[[dict, dict], Record]] = None,
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self._endpoint = api_endpoint
+        self._dataset = dataset
+        self._records_mapper = records_mapper or text_classification_mapper
+        self._queue = Queue()
+        self._worker_task = threading.Thread(
+            target=self.__worker__, name=RubrixLogHTTPMiddleware.__name__, daemon=True
+        )
+        self._worker_task.start()
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        if self._endpoint != request.url.path:  # Filtering endpoint path
+            return await call_next(request)
+
+        response: Response = await call_next(request)
+        try:
+            if not isinstance(response, (JSONResponse, StreamingResponse)):
+                return response
+
+            inputs = await request.json()
+            new_response, outputs = await self._extract_response_content(response)
+            self._queue.put_nowait((inputs, outputs, str(request.url)))
+            return new_response
+        except Exception as ex:
+            _logger.error("Cannot log to rubrix", exc_info=ex)
+            return response
+
+    def __worker__(self):
+        while True:
+            try:
+                inputs, outputs, url = self._queue.get()
+                self._log_to_rubrix(inputs, outputs, url)
+            finally:
+                self._queue.task_done()
+
+    async def _extract_response_content(
+        self, response: Response
+    ) -> Tuple[Response, List[Dict[str, Any]]]:
+        """Extracts response body content from response and returns a new processable response"""
+        body = b""
+        new_response = response
+        if isinstance(response, StreamingResponse):
+            async for chunk in response.body_iterator:
+                body += chunk
+            new_response = StreamingResponse(
+                content=(chunk for chunk in [body]),
+                status_code=response.status_code,
+                headers={k: v for k, v in response.headers.items()},
+                media_type=response.media_type,
+                background=response.background,
+            )
+        else:
+            body = response.body
+        return new_response, json.loads(body)
+
+    def _log_to_rubrix(
+        self,
+        inputs: List[Dict[str, Any]],
+        outputs: List[Dict[str, Any]],
+        url: str,
+        **tags
+    ):
+        records = [
+            record
+            for _inputs, _outputs in zip(inputs, outputs)
+            for record in [self._records_mapper(_inputs, _outputs)]
+            if record
+        ]
+
+        if records:
+            for r in records:
+                r.prediction_agent = url
+            rubrix.log(records, name=self._dataset, tags=tags)

--- a/tests/client/test_asgi.py
+++ b/tests/client/test_asgi.py
@@ -1,0 +1,104 @@
+import rubrix
+from rubrix import TextClassificationRecord, TokenClassificationRecord
+from rubrix.client.asgi import RubrixLogHTTPMiddleware, token_classification_mapper
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse, PlainTextResponse
+from starlette.testclient import TestClient
+
+
+def test_rubrix_middleware_for_text_classification(monkeypatch):
+
+    expected_endpoint = "/predict"
+    expected_dataset_name = "mlmodel_v3_monitor_ds"
+
+    app = Starlette()
+    app.add_middleware(
+        RubrixLogHTTPMiddleware,
+        api_endpoint=expected_endpoint,
+        dataset=expected_dataset_name,
+    )
+
+    @app.route(expected_endpoint, methods=["POST"])
+    def mock_predict(request):
+        return JSONResponse(
+            content=[
+                {"labels": ["A", "B"], "probabilities": [0.9, 0.1]},
+                {"labels": ["A", "B"], "probabilities": [0.9, 0.1]},
+            ]
+        )
+
+    @app.route("/another/predict/route")
+    def another_mock(request):
+        return PlainTextResponse("Hello")
+
+    class MockLog:
+        def __init__(self):
+            self.was_called = False
+
+        def __call__(self, records, name: str, **kwargs):
+            self.was_called = True
+            assert name == expected_dataset_name
+            assert len(records) == 2
+            assert isinstance(records[0], TextClassificationRecord)
+
+    mock_log = MockLog()
+    monkeypatch.setattr(rubrix, "log", mock_log)
+    mock = TestClient(app)
+
+    mock.post(
+        expected_endpoint,
+        json=[
+            {"a": "The data input for A", "b": "The data input for B"},
+            {"a": "The data input for A", "b": "The data input for B"},
+        ],
+    )
+
+    mock.get("/another/predict/route")
+
+
+def test_rubrix_middleware_for_token_classification(monkeypatch):
+
+    expected_endpoint = "/predict"
+    expected_dataset_name = "mlmodel_v3_monitor_ds"
+
+    app = Starlette()
+    app.add_middleware(
+        RubrixLogHTTPMiddleware,
+        api_endpoint=expected_endpoint,
+        dataset=expected_dataset_name,
+        records_mapper=token_classification_mapper,
+    )
+
+    @app.route(expected_endpoint, methods=["POST"])
+    def mock_predict(request):
+        return JSONResponse(
+            content=[
+                [
+                    {"label": "fawn", "start": 1, "end": 10},
+                    {"label": "fobis", "start": 12, "end": 14},
+                ],
+                [],
+            ]
+        )
+
+    class MockLog:
+        def __init__(self):
+            self.was_called = False
+
+        def __call__(self, records, name: str, **kwargs):
+            self.was_called = True
+            assert name == expected_dataset_name
+            assert len(records) == 2
+            assert isinstance(records[0], TokenClassificationRecord)
+
+    mock_log = MockLog()
+    monkeypatch.setattr(rubrix, "log", mock_log)
+    mock = TestClient(app)
+
+    mock.post(
+        expected_endpoint,
+        json=[{"text": "The main text data"}, {"text": "The main text data"}],
+    )
+    assert mock_log.was_called
+
+    mock.get("/another/predict/route")


### PR DESCRIPTION
The rubrix log middleware tries to simplify workflow for http model inference with rubrix records logging.

Notes:

- The default inputs/outputs -> record mapping is for text classification with a fixed  `labels` - `probabilities` format
- Mappings are customizable, but a inputs/outputs norrmalization depending on model task should be a better option
- The rubrix log is a non-blocking process, so response latency should not be affected