### PR TITLE
feat(search): text query maps query string syntax

### DIFF
--- a/src/rubrix/server/tasks/commons/es_helpers.py
+++ b/src/rubrix/server/tasks/commons/es_helpers.py
@@ -207,7 +207,11 @@ class filters:
 
         if isinstance(text_query, str):
             return {
-                "query_string": {"fields": ["inputs.*", "tokens"], "query": text_query}
+                "query_string": {
+                    "default_field": "words",
+                    "default_operator": "AND",
+                    "query": text_query,
+                }
             }
 
         return {
@@ -216,6 +220,7 @@ class filters:
                     {
                         "query_string": {
                             "default_field": f"inputs.{key}",
+                            "default_operator": "AND",
                             "query": query_text,
                         }
                     }


### PR DESCRIPTION
This PR brings elasticsearch query string syntax to text search. You can use query-string syntax in text search box.

You can do cool things like:

Search : `predicted_as:(neutro AND transmisiones)` for finding records labeled as `neutro` AND `transmisiones` 

or

Search `inputs.subject:important message OR inputs.body:The confidential mail` for finding text classification records where `inputs.subject` field contains `important` and `message` tokens OR `inputs.body` field contains `The`, `confidential` and `mail` tokens.

You can visit [elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax) for a deeper query-string syntax understanding