### PR TITLE
Revise setup and installation guide

### DIFF
--- a/docs/community/developer_docs.rst
+++ b/docs/community/developer_docs.rst
@@ -1,0 +1,70 @@
+Developer documentation
+=======================
+
+Here we provide some guides for the development of *Rubrix*.
+
+Development setup
+-----------------
+
+To set up your system for *Rubrix* development, you first of all have to
+`fork <https://guides.github.com/activities/forking/>`_ our `repository <https://github.com/recognai/rubrix>`_
+and clone the fork to your computer:
+
+.. code-block:: bash
+
+    git clone https://github.com/[your-github-username]/rubrix.git
+    cd rubrix
+
+To keep your fork's master branch up to date with our repo you should add it as an
+`upstream remote branch <https://dev.to/louhayes3/git-add-an-upstream-to-a-forked-repo-1mik`_:
+
+.. code-block:: bash
+
+    git remote add upstream https://github.com/recognai/rubrix.git
+
+Now go ahead and create a new conda environment in which the development will take place and activate it:
+
+.. code-block:: bash
+
+    conda env create -f environment_dev.yml
+    conda activate rubrix
+
+Once you activated the environment, it is time to install *Rubrix* in editable mode with its server dependencies:
+
+.. code-block:: bash
+
+    pip install -e .[server]
+
+The last step is to build the static UI files in case you want to work on the UI:
+
+.. code-block:: bash
+
+    bash scripts/build_frontend.sh
+
+Now you are ready to take *Rubrix* to the next level 🚀
+
+
+Building the documentation
+--------------------------
+
+To build the documentation, make sure you set up your system for *Rubrix* development.
+Then go to the `docs` folder in your cloned repo and execute the ``make`` command:
+
+.. code-block:: bash
+
+    cd docs
+    make html
+
+This will create a ``_build/html`` folder in which you can find the ``index.html`` file of the documentation.
+
+
+Start the web app
+-----------------
+
+[TODO]
+
+
+Making a release
+----------------
+
+[TODO]

--- a/docs/getting_started/setup&installation.rst
+++ b/docs/getting_started/setup&installation.rst
@@ -58,7 +58,7 @@ This method may be preferred if you (1) want to avoid or cannot use ``Docker``,
 
    pip install rubrix[server]
 
-3. Launch a local instance of the Rubrix webapp
+3. Launch a local instance of the Rubrix web app
 
 .. code-block::
 

--- a/docs/getting_started/setup&installation.rst
+++ b/docs/getting_started/setup&installation.rst
@@ -8,7 +8,7 @@ In this guide, we will help you to get up and running with Rubrix. Basically, yo
 1. Install the Python client
 2. Launch the web app
 
-1. Install the Rubrix python client
+1. Install the Rubrix Python client
 ------------------------------------
 
 First, make sure you have Python 3.6 or above installed.

--- a/docs/getting_started/setup&installation.rst
+++ b/docs/getting_started/setup&installation.rst
@@ -30,22 +30,22 @@ There are two ways to launch the webapp:
 Using ``docker-compose`` (recommended)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This is the recommended way because it automatically includes an
-`Elasticsearch <https://www.elastic.co/elasticsearch/>`_ instance, Rubrix's main persistent layer.
-
-You first need to install the `Docker Engine <https://docs.docker.com/engine/install/>`_ for your platform.
+For this method you first need to install `Docker Compose <https://docs.docker.com/compose/install/>`_.
 Then you can launch the docker-contained webapp with the following command:
 
 .. code-block:: bash
 
    wget -O docker-compose.yml https://raw.githubusercontent.com/recognai/rubrix/master/docker-compose.yaml && docker-compose up
 
+This is the recommended way because it automatically includes an
+`Elasticsearch <https://www.elastic.co/elasticsearch/>`_ instance, Rubrix's main persistent layer.
+
 Executing the server code manually
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When executing the server coder manually you need to provide an
 `Elasticsearch <https://www.elastic.co/elasticsearch/>`_ instance yourself.
-This method may be preferred if you (1) want to avoid or cannot use ``Docker``\ ,
+This method may be preferred if you (1) want to avoid or cannot use ``Docker``,
 (2) have an existing Elasticsearch service, or
 (3) want to have full control over your Elasticsearch configuration.
 

--- a/docs/getting_started/setup&installation.rst
+++ b/docs/getting_started/setup&installation.rst
@@ -43,7 +43,7 @@ This is the recommended way because it automatically includes an
 Executing the server code manually
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When executing the server coder manually you need to provide an
+When executing the server code manually you need to provide an
 `Elasticsearch <https://www.elastic.co/elasticsearch/>`_ instance yourself.
 This method may be preferred if you (1) want to avoid or cannot use ``Docker``,
 (2) have an existing Elasticsearch service, or

--- a/docs/getting_started/setup&installation.rst
+++ b/docs/getting_started/setup&installation.rst
@@ -52,6 +52,9 @@ This method may be preferred if you (1) want to avoid or cannot use ``Docker``,
 1. First you need to install
    `Elasticsearch <https://www.elastic.co/guide/en/elasticsearch/reference/7.10/install-elasticsearch.html>`_
    (we recommend version 7.10) and launch an Elasticsearch instance.
+   For MacOS and Windows there are
+   `Homebrew formulae <https://www.elastic.co/guide/en/elasticsearch/reference/7.13/brew.html>`_ and a
+   `msi package <https://www.elastic.co/guide/en/elasticsearch/reference/current/windows.html>`_, respectively.
 2. Install the Rubrix Python library together with its server dependencies:
 
 .. code-block:: bash

--- a/docs/getting_started/setup&installation.rst
+++ b/docs/getting_started/setup&installation.rst
@@ -5,49 +5,13 @@ Setup and installation
 
 In this guide, we will help you to get up and running with Rubrix. Basically, you need to:
 
+1. Install the Python client
+2. Launch the webapp
 
-#. Setup and launch the webapp, whose main external dependency is `Elasticsearch <https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html#install-elasticsearch>`_\ , Rubrix's main persistence layer.
-#. Install the Python library.
-
-1. Setup and launch the webapp
-------------------------------
-
-There are two ways of launching the webapp:
-
-
-#. Using **Docker** and a ``docker-compose`` file we provide with all you need for the *webapp* (recommended).
-#. Setting up your own Elasticsearch installation and launching the Rubrix server. This method is useful if you (1) want to avoid or cannot use ``Docker``\ , (2)  have an existing Elasticsearch service, or (3) want to have full control over your Elasticsearch configuration.
-
-Using Docker and ``docker-compose`` (recommended)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-You first need to install the `Docker Engine <https://docs.docker.com/engine/install/>`_ for your platform.
-
-You can launch your docker-contained environment with the following command:
-
-.. code-block:: bash
-
-   wget -O docker-compose.yml https://raw.githubusercontent.com/recognai/rubrix/master/docker-compose.yaml && docker-compose up
-
-Using an Elasticsearch installation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-
-#. If you do not have an existing Elasticsearch installation,  install `Elasticsearch <https://www.elastic.co/guide/en/elasticsearch/reference/7.12/install-elasticsearch.html>`_ and launch your Elasticsearch instance.
-#. Install the Rubrix Python library following the `guide <>`_ below.
-#. Launch a local instance of the Rubrix webapp ``python -m rubrix.server``. By default, the Rubrix server will look for your ES endpoint URL at ``http://localhost:9200`` if you want to customize this, you can setup the ``ELASTICSEARCH`` env variable with your ES endpoint URL.
-
-Checking your webapp and REST API
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-You should be able to access Rubrix via `http://localhost:6900/ <http://localhost:6900/>`_\ , and you can also check the API docs at `http://localhost:6900/api/docs <http://localhost:6900/api/docs>`_.
-
-2. Install the Rubrix Python library
+1. Install the Rubrix python client
 ------------------------------------
 
-First, make sure you have Python 3.6-3.8 and ``pip`` installed. 
-
-Before installing the library  recommend you to create a fresh `Conda virtual environment <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_\ ,  `venv <https://docs.python.org/3/library/venv.html>`_ or a similar virtual environment manager.
+First, make sure you have Python 3.6 or above installed.
 
 Then you can install Rubrix with ``pip``\ :
 
@@ -55,10 +19,64 @@ Then you can install Rubrix with ``pip``\ :
 
    pip install rubrix
 
+2. Setup and launch the webapp
+------------------------------
+
+There are two ways to launch the webapp:
+
+#. Using `docker-compose <https://docs.docker.com/compose/>`_ (**recommended**).
+#. Executing the server code manually
+
+Using ``docker-compose`` (recommended)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This is the recommended way because it automatically includes an
+`Elasticsearch <https://www.elastic.co/elasticsearch/>`_ instance, Rubrix's main persistent layer.
+
+You first need to install the `Docker Engine <https://docs.docker.com/engine/install/>`_ for your platform.
+Then you can launch the docker-contained webapp with the following command:
+
+.. code-block:: bash
+
+   wget -O docker-compose.yml https://raw.githubusercontent.com/recognai/rubrix/master/docker-compose.yaml && docker-compose up
+
+Executing the server code manually
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When executing the server coder manually you need to provide an
+`Elasticsearch <https://www.elastic.co/elasticsearch/>`_ instance yourself.
+This method may be preferred if you (1) want to avoid or cannot use ``Docker``\ ,
+(2) have an existing Elasticsearch service, or
+(3) want to have full control over your Elasticsearch configuration.
+
+1. First you need to install
+   `Elasticsearch <https://www.elastic.co/guide/en/elasticsearch/reference/7.12/install-elasticsearch.html>`_
+   and launch an Elasticsearch instance.
+2. Install the Rubrix Python library together with its server dependencies:
+
+.. code-block:: bash
+
+   pip install rubrix[server]
+
+3. Launch a local instance of the Rubrix webapp
+
+.. code-block::
+
+   python -m rubrix.server
+
+By default, the Rubrix server will look for your Elasticsearch endpoint at ``http://localhost:9200``.
+If you want to customize this, you can set the ``ELASTICSEARCH`` environment variable pointing to your endpoint.
+
+Checking your webapp and REST API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Now you should be able to access Rubrix via `http://localhost:6900/ <http://localhost:6900/>`_\ ,
+and you can also check the API docs at `http://localhost:6900/api/docs <http://localhost:6900/api/docs>`_.
+
 3. Testing the installation by logging some data
 ------------------------------------------------
 
-The following code will log one record into the ``example-dataset`` :
+The following code will log one record into a data set called ``example-dataset`` :
 
 .. code-block:: python
 
@@ -69,17 +87,17 @@ The following code will log one record into the ``example-dataset`` :
        name='example-dataset'
    )
 
-You should receive this response in your terminal or your Jupyter Notebook:
+You should receive this response in your terminal or Jupyter Notebook:
 
 .. code-block:: bash
 
    BulkResponse(dataset='example-dataset', processed=1, failed=0)
 
-Which means that the data has been logged correctly. 
+This means that the data has been logged correctly.
 
-If you go to your Rubrix app at `http://localhost:6900/ <http://localhost:6900/>`_\ , you will find your first dataset.
+If you now go to your Rubrix app at `http://localhost:6900/ <http://localhost:6900/>`_ , you will find your first data set.
 
-Congratulations! You are ready to start working with Rubrix with your own data. 
+Congratulations! You are ready to start working with Rubrix.
 
 Next steps
 ----------

--- a/docs/getting_started/setup&installation.rst
+++ b/docs/getting_started/setup&installation.rst
@@ -50,8 +50,8 @@ This method may be preferred if you (1) want to avoid or cannot use ``Docker``,
 (3) want to have full control over your Elasticsearch configuration.
 
 1. First you need to install
-   `Elasticsearch <https://www.elastic.co/guide/en/elasticsearch/reference/7.12/install-elasticsearch.html>`_
-   and launch an Elasticsearch instance.
+   `Elasticsearch <https://www.elastic.co/guide/en/elasticsearch/reference/7.10/install-elasticsearch.html>`_
+   (we recommend version 7.10) and launch an Elasticsearch instance.
 2. Install the Rubrix Python library together with its server dependencies:
 
 .. code-block:: bash

--- a/docs/getting_started/setup&installation.rst
+++ b/docs/getting_started/setup&installation.rst
@@ -6,7 +6,7 @@ Setup and installation
 In this guide, we will help you to get up and running with Rubrix. Basically, you need to:
 
 1. Install the Python client
-2. Launch the webapp
+2. Launch the web app
 
 1. Install the Rubrix python client
 ------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -164,6 +164,7 @@ You can join the conversation on our Github page and our Github forum.
    :caption: Community
    :hidden:
 
+   community/developer_docs
    Github page <https://github.com/recognai/rubrix>
    Discussion forum <https://github.com/recognai/rubrix/discussions>
 


### PR DESCRIPTION
A quick revision of our Setup&Installation guide in the docs. If you are ok with the changes, i would copy some of them over to the repo's readme:
- switched order, first install client, than launch webapp
- moved the descriptions to the sections rather than putting them in the enumerations
- changed some wordings