### PR TITLE
Bugfixes/mentions calculation

### DIFF
--- a/src/rubrix/server/commons/helpers.py
+++ b/src/rubrix/server/commons/helpers.py
@@ -57,15 +57,16 @@ def unflatten_dict(
     resultDict = {}
 
     for key, value in data.items():
-        parts = key.split(sep)
-        if parts[0] in stop_keys:
-            parts = [parts[0], sep.join(parts[1:])]
-        d = resultDict
-        for part in parts[:-1]:
-            if part not in d:
-                d[part] = {}
-            d = d[part]
-        d[parts[-1]] = value
+        if key is not None:
+            parts = key.split(sep)
+            if parts[0] in stop_keys:
+                parts = [parts[0], sep.join(parts[1:])]
+            d = resultDict
+            for part in parts[:-1]:
+                if part not in d:
+                    d[part] = {}
+                d = d[part]
+            d[parts[-1]] = value
     return resultDict
 
 

--- a/src/rubrix/server/tasks/commons/es_helpers.py
+++ b/src/rubrix/server/tasks/commons/es_helpers.py
@@ -93,8 +93,6 @@ def parse_aggregations(
         return None
 
     def parse_buckets(buckets: List[Dict[str, Any]]) -> Dict[str, Any]:
-        # TODO(me): process custom kind of aggregations (mentions & predicted mentions)
-        # raise NotImplementedError()
         parsed = {}
         for bucket in buckets:
             key, doc_count = bucket.pop("key", None), bucket.pop("doc_count")

--- a/src/rubrix/server/tasks/commons/es_helpers.py
+++ b/src/rubrix/server/tasks/commons/es_helpers.py
@@ -40,6 +40,8 @@ DATASETS_RECORDS_INDEX_TEMPLATE = {
             },
             # TODO: Not here since is task dependant
             "tokens": {"type": "text"},
+            "predicted_mentions": {"type": "nested"},
+            "mentions": {"type": "nested"},
         },
         "dynamic_templates": [
             # TODO: Not here since is task dependant
@@ -91,21 +93,26 @@ def parse_aggregations(
         return None
 
     def parse_buckets(buckets: List[Dict[str, Any]]) -> Dict[str, Any]:
+        # TODO(me): process custom kind of aggregations (mentions & predicted mentions)
+        # raise NotImplementedError()
         parsed = {}
         for bucket in buckets:
-            key, doc_count = bucket.pop("key"), bucket.pop("doc_count")
+            key, doc_count = bucket.pop("key", None), bucket.pop("doc_count")
             if len(bucket) == 1 and not ("from" in bucket or "to" in bucket):
                 k = [k for k in bucket if k not in ["key", "doc_count"]][0]
-                parsed.update({key: parse_buckets(bucket[k].get("buckets", []))})
+                parsed.update({key or k: parse_buckets(bucket[k].get("buckets", []))})
             else:
                 parsed.update({key: doc_count})
 
         return parsed
 
-    return {
-        key: parse_buckets(values.get("buckets", []))
-        for key, values in es_aggregations.items() or {}
-    }
+    result = {}
+    for key, values in es_aggregations.items() or {}:
+        if "buckets" in values:
+            result[key] = parse_buckets(values["buckets"])
+        else:
+            result.update(parse_buckets([values]))
+    return result
 
 
 def decode_field_name(field: EsRecordDataFieldNames) -> str:
@@ -250,6 +257,12 @@ class aggregations:
     """Group of functions related to elasticsearch aggregations requests"""
 
     DEFAULT_AGGREGATION_SIZE = 100
+
+    @staticmethod
+    def nested_aggregation(
+        name: str, nested_path: str, inner_aggregation: Dict[str, Any]
+    ):
+        return {name: {"nested": {"path": nested_path}, "aggs": inner_aggregation}}
 
     @staticmethod
     def bidimentional_terms_aggregations(

--- a/src/rubrix/server/tasks/token_classification/service/service.py
+++ b/src/rubrix/server/tasks/token_classification/service/service.py
@@ -125,15 +125,23 @@ class TokenClassificationService:
             search=RecordSearch(
                 query=as_elasticsearch(search),
                 aggregations={
-                    **aggregations.bidimentional_terms_aggregations(
+                    **aggregations.nested_aggregation(
                         name=PREDICTED_MENTIONS_ES_FIELD_NAME,
-                        field_name_x=EsRecordDataFieldNames.predicted_as,
-                        field_name_y=PREDICTED_MENTIONS_ES_FIELD_NAME,
+                        nested_path=PREDICTED_MENTIONS_ES_FIELD_NAME,
+                        inner_aggregation=aggregations.bidimentional_terms_aggregations(
+                            name=PREDICTED_MENTIONS_ES_FIELD_NAME,
+                            field_name_x=PREDICTED_MENTIONS_ES_FIELD_NAME + ".entity",
+                            field_name_y=PREDICTED_MENTIONS_ES_FIELD_NAME + ".mention",
+                        ),
                     ),
-                    **aggregations.bidimentional_terms_aggregations(
+                    **aggregations.nested_aggregation(
                         name=MENTIONS_ES_FIELD_NAME,
-                        field_name_x=EsRecordDataFieldNames.annotated_as,
-                        field_name_y=MENTIONS_ES_FIELD_NAME,
+                        nested_path=MENTIONS_ES_FIELD_NAME,
+                        inner_aggregation=aggregations.bidimentional_terms_aggregations(
+                            name=MENTIONS_ES_FIELD_NAME,
+                            field_name_x=MENTIONS_ES_FIELD_NAME + ".entity",
+                            field_name_y=MENTIONS_ES_FIELD_NAME + ".mention",
+                        ),
                     ),
                 },
             ),

--- a/tests/server/token_classification/test_api.py
+++ b/tests/server/token_classification/test_api.py
@@ -58,3 +58,67 @@ def test_create_records_for_token_classification():
     results = TokenClassificationSearchResults.parse_obj(response.json())
     assert "This" in results.aggregations.predicted_mentions[entity_label]
     assert "This" in results.aggregations.mentions[entity_label]
+
+
+def test_multiple_mentions_in_same_record():
+    dataset = "test_multiple_mentions_in_same_record"
+    assert client.delete(f"/api/datasets/{dataset}").status_code == 200
+    entity_a, entity_b = ("TESTA", "TESTB")
+
+    records = [
+        TokenClassificationRecord.parse_obj(data)
+        for data in [
+            {
+                "tokens": "This is a text".split(" "),
+                "raw_text": "This is a text",
+                "metadata": {"field_one": "value one", "field_two": "value 2"},
+                "prediction": {
+                    "agent": "test",
+                    "entities": [
+                        {"start": 0, "end": 4, "label": entity_a},
+                        {"start": 5, "end": 7, "label": entity_b},
+                    ],
+                },
+            },
+            {
+                "tokens": "This is a text".split(" "),
+                "raw_text": "This is a text",
+                "metadata": {"field_one": "value one", "field_two": "value 2"},
+                "prediction": {
+                    "agent": "test",
+                    "entities": [{"start": 0, "end": 4, "label": entity_a}],
+                },
+            },
+            {
+                "tokens": "This is a text".split(" "),
+                "raw_text": "This is a text",
+                "metadata": {"field_one": "value one", "field_two": "value 2"},
+                "annotation": {
+                    "agent": "test",
+                    "entities": [{"start": 0, "end": 4, "label": entity_a}],
+                },
+            },
+        ]
+    ]
+    response = client.post(
+        f"/api/datasets/{dataset}/TokenClassification:bulk",
+        json=TokenClassificationBulkData(
+            tags={"env": "test", "class": "text classification"},
+            metadata={"config": {"the": "config"}},
+            records=records,
+        ).dict(by_alias=True),
+    )
+
+    assert response.status_code == 200, response.json()
+    bulk_response = BulkResponse.parse_obj(response.json())
+    assert bulk_response.dataset == dataset
+    assert bulk_response.failed == 0
+    assert bulk_response.processed == 3
+
+    response = client.post(f"/api/datasets/{dataset}/TokenClassification:search")
+    assert response.status_code == 200, response.json()
+    results = TokenClassificationSearchResults.parse_obj(response.json())
+    assert "This" in results.aggregations.predicted_mentions[entity_a]
+    assert results.aggregations.predicted_mentions[entity_a]["This"] == 2
+    assert "is" in results.aggregations.predicted_mentions[entity_b]
+    assert results.aggregations.predicted_mentions[entity_b]["is"] == 1


### PR DESCRIPTION
This PR store token classification mentions (predicted and annotated) as `[key,value]` pair list, in order of calculate related metrics (mentions per entity) properly.

The main change is defined by the setting as `nested` type the mentions related fields.