### PR TITLE
Feat: similarity vector

### DIFF
--- a/src/rubrix/client/models.py
+++ b/src/rubrix/client/models.py
@@ -60,7 +60,9 @@ class TextClassificationRecord(BaseModel):
 
     Args:
         inputs:
-            The inputs of the record
+            The inputs of the record.
+        record_embedding:
+            A vector used for cosine-similarity searches.
         prediction:
             A list of tuples containing the predictions for the record.
             The first entry of the tuple is the predicted label, the second entry is its corresponding score.
@@ -87,6 +89,7 @@ class TextClassificationRecord(BaseModel):
     """
 
     inputs: Union[str, List[str], Dict[str, Union[str, List[str]]]]
+    record_embedding: Optional[List[float]]
 
     prediction: Optional[List[Tuple[str, float]]] = None
     annotation: Optional[Union[str, List[str]]] = None


### PR DESCRIPTION
This PR adds a `record_embedding` parameter to the `TextClassificationRecord` model, to be used in cosine-similarity searches.
It also adds a check to the `rb.log` method, but I feel like we should catch the error code of the API in this case, rather than checking this explicitly before.

This PR is a work in progress, the server side, as well as the UI component is still missing.