### PR TITLE
Add a codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "src/rubrix/sdk/**/*"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,5 @@
 ignore:
   - "src/rubrix/sdk/**/*"
+
+comment:
+  require_changes: true


### PR DESCRIPTION
This PR adds a `.codecov.yml` to ignore our sdk code, as well as limit the posting of coverage reports to PRs that actually change the coverage.