### PR TITLE
Docs: Hide input/output prompts (cell counts) in the tutorial notebooks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,18 @@ extensions = [
 # Do not execute the notebooks when building the docs
 nbsphinx_execute = "never"
 
+# Hide input/output prompts (cell counts)
+nbsphinx_prolog = """
+.. raw:: html
+
+    <style>
+        .nbinput .prompt,
+        .nboutput .prompt {
+            display: none;
+        }
+    </style>
+"""
+
 # TODO: Change this to "both" once Sphinx 4.1 is out
 autodoc_typehints = "description"
 


### PR DESCRIPTION
Closes #249 