### PR TITLE
fix(UI): encode redirect url

### DIFF
--- a/frontend/middleware/auth-guard.js
+++ b/frontend/middleware/auth-guard.js
@@ -4,7 +4,8 @@ export default ({ $auth, route, redirect }) => {
       break;
     default:
       if (!$auth.loggedIn) {
-        const REDIRECT_URL = "/login?redirect=" + route.fullPath;
+        const REDIRECT_URL =
+          "/login?redirect=" + encodeURIComponent(route.fullPath);
         redirect(REDIRECT_URL);
       }
   }


### PR DESCRIPTION
Non-encoded query parameters were lost on redirection. 

closes #213 