### PR TITLE
feat(search): store text variant with special characters for search

### DIFF
--- a/tests/server/token_classification/test_api.py
+++ b/tests/server/token_classification/test_api.py
@@ -1,13 +1,51 @@
 from fastapi.testclient import TestClient
 from rubrix.server.server import app
 from rubrix.server.tasks.commons import BulkResponse
-from rubrix.server.tasks.token_classification import TokenClassificationSearchResults
+from rubrix.server.tasks.token_classification import (
+    TokenClassificationQuery,
+    TokenClassificationSearchRequest,
+    TokenClassificationSearchResults,
+)
 from rubrix.server.tasks.token_classification.api import (
     TokenClassificationBulkData,
     TokenClassificationRecord,
 )
 
 client = TestClient(app)
+
+
+def test_search_special_characters():
+    dataset = "test_search_special_characters"
+    assert client.delete(f"/api/datasets/{dataset}").status_code == 200
+    expected_text = "This is a text with !"
+    records = [
+        TokenClassificationRecord.parse_obj(data)
+        for data in [
+            {
+                "tokens": expected_text.split(" "),
+                "raw_text": expected_text,
+            }
+        ]
+    ]
+    client.post(
+        f"/api/datasets/{dataset}/TokenClassification:bulk",
+        json=TokenClassificationBulkData(
+            tags={"env": "test", "class": "text classification"},
+            metadata={"config": {"the": "config"}},
+            records=records,
+        ).dict(by_alias=True),
+    )
+
+    response = client.post(
+        f"/api/datasets/{dataset}/TokenClassification:search",
+        json=TokenClassificationSearchRequest(
+            query=TokenClassificationQuery(query_text="\!")
+        ).dict(),
+    )
+    assert response.status_code == 200, response.json()
+    results = TokenClassificationSearchResults.parse_obj(response.json())
+    assert results.total == 1
+
 
 
 def test_create_records_for_token_classification():


### PR DESCRIPTION
This PR include an input text variant in elasticsearch index that stores the special character. Then, api search combine this new field enabling queries with special characters (`!` or `?`)

Note: Old indices must be re-created for enable this feature. Non-stopped words are available, otherwise.