### PR TITLE
refactor: improve index task extension

### DIFF
--- a/src/rubrix/server/tasks/commons/api/model.py
+++ b/src/rubrix/server/tasks/commons/api/model.py
@@ -25,6 +25,7 @@ class EsRecordDataFieldNames(str, Enum):
     predicted = "predicted"
     score = "score"
     words = "words"
+    event_timestamp = "event_timestamp"
 
 
 class BulkResponse(BaseModel):

--- a/src/rubrix/server/tasks/commons/dao/__init__.py
+++ b/src/rubrix/server/tasks/commons/dao/__init__.py
@@ -1,0 +1,5 @@
+from .dao import (
+    extends_index_properties,
+    extends_index_dynamic_templates,
+    extends_index_analyzers,
+)

--- a/src/rubrix/server/tasks/commons/es_helpers.py
+++ b/src/rubrix/server/tasks/commons/es_helpers.py
@@ -37,7 +37,7 @@ DATASETS_RECORDS_INDEX_TEMPLATE = {
     "index_patterns": [DATASETS_RECORDS_INDEX_NAME.format("*")],
     "mappings": {
         "properties": {
-            "event_timestamp": {"type": "date"},
+            EsRecordDataFieldNames.event_timestamp: {"type": "date"},
             # TODO(in new index version): Data based on text field with multiple fields:
             #   - keywords: for words aggregations
             #   - extended: including stop words and special characters in search
@@ -49,45 +49,38 @@ DATASETS_RECORDS_INDEX_TEMPLATE = {
                     "extended": {"type": "text", "analyzer": "extended_analyzer"}
                 },
             },
-            # TODO: Not here since is task dependant
-            "tokens": {"type": "text"},
-            "predicted_mentions": {"type": "nested"},
-            "mentions": {"type": "nested"},
+            EsRecordDataFieldNames.predicted_as: {
+                "type": "keyword",
+                "ignore_above": MAX_KEYWORD_LENGTH,
+            },
+            EsRecordDataFieldNames.predicted_by: {
+                "type": "keyword",
+                "ignore_above": MAX_KEYWORD_LENGTH,
+            },
+            EsRecordDataFieldNames.annotated_as: {
+                "type": "keyword",
+                "ignore_above": MAX_KEYWORD_LENGTH,
+            },
+            EsRecordDataFieldNames.annotated_by: {
+                "type": "keyword",
+                "ignore_above": MAX_KEYWORD_LENGTH,
+            },
+            EsRecordDataFieldNames.status: {
+                "type": "keyword",
+            },
+            EsRecordDataFieldNames.predicted: {
+                "type": "keyword",
+            },
+
         },
         "dynamic_templates": [
-            # TODO: Not here since is task dependant
-            {"inputs": {"path_match": "inputs.*", "mapping": {"type": "text"}}},
             {
-                "status": {
-                    "path_match": "*.status",
-                    "mapping": {
-                        "type": "keyword",
-                    },
-                }
-            },
-            {
-                "predicted": {
-                    "path_match": "*.predicted",
-                    "mapping": {
-                        "type": "keyword",
-                    },
-                }
-            },
-            {
-                "strings": {
-                    # TODO: Limit metadata.* mapping expansion
+                "metadata_strings": {
+                    "path_match": "metadata.*",
                     "match_mapping_type": "string",
                     "mapping": {
                         "type": "keyword",
-                        "ignore_above": MAX_KEYWORD_LENGTH,  # Avoid bulk errors with too long keywords
-                        # Some elasticsearch versions includes automatically raw fields, so
-                        # we must limit those fields too
-                        "fields": {
-                            "raw": {
-                                "type": "keyword",
-                                "ignore_above": MAX_KEYWORD_LENGTH,
-                            }
-                        },
+                        "ignore_above": MAX_KEYWORD_LENGTH,
                     },
                 }
             },

--- a/src/rubrix/server/tasks/text_classification/service/service.py
+++ b/src/rubrix/server/tasks/text_classification/service/service.py
@@ -1,9 +1,8 @@
 import datetime
-from typing import Any, Dict, Iterable, List, Optional
-
 from fastapi import Depends
 from rubrix.server.datasets.service import DatasetsService, create_dataset_service
 from rubrix.server.tasks.commons import BulkResponse
+from rubrix.server.tasks.commons.dao import extends_index_dynamic_templates
 from rubrix.server.tasks.commons.dao.dao import DatasetRecordsDAO, dataset_records_dao
 from rubrix.server.tasks.commons.dao.model import RecordSearch
 from rubrix.server.tasks.commons.es_helpers import filters
@@ -14,7 +13,11 @@ from rubrix.server.tasks.text_classification.api.model import (
     TextClassificationSearchAggregations,
     TextClassificationSearchResults,
 )
+from typing import Any, Dict, Iterable, List, Optional
 
+extends_index_dynamic_templates(
+    {"inputs": {"path_match": "inputs.*", "mapping": {"type": "text"}}}
+)
 
 def as_elasticsearch(search: TextClassificationQuery) -> Dict[str, Any]:
     """Build an elasticsearch query part from search query"""

--- a/src/rubrix/server/tasks/token_classification/service/service.py
+++ b/src/rubrix/server/tasks/token_classification/service/service.py
@@ -1,9 +1,12 @@
 import datetime
-from typing import Any, Dict, Iterable, List, Optional
-
 from fastapi import Depends
+from rubrix import MAX_KEYWORD_LENGTH
 from rubrix.server.datasets.service import DatasetsService, create_dataset_service
-from rubrix.server.tasks.commons import BulkResponse, EsRecordDataFieldNames
+from rubrix.server.tasks.commons import BulkResponse
+from rubrix.server.tasks.commons.dao import (
+    extends_index_dynamic_templates,
+    extends_index_properties,
+)
 from rubrix.server.tasks.commons.dao.dao import DatasetRecordsDAO, dataset_records_dao
 from rubrix.server.tasks.commons.dao.model import RecordSearch
 from rubrix.server.tasks.commons.es_helpers import aggregations, filters
@@ -15,6 +18,27 @@ from rubrix.server.tasks.token_classification.api.model import (
     TokenClassificationQuery,
     TokenClassificationRecord,
     TokenClassificationSearchResults,
+)
+from typing import Any, Dict, Iterable, List, Optional
+
+extends_index_properties(
+    {
+        "tokens": {"type": "text"},
+        "predicted_mentions": {"type": "nested"},
+        "mentions": {"type": "nested"},
+    }
+)
+
+extends_index_dynamic_templates(
+    {
+        "mentions": {
+            "path_match": "*mentions.*",
+            "mapping": {
+                "type": "keyword",
+                "ignore_above": MAX_KEYWORD_LENGTH,
+            },
+        }
+    },
 )
 
 


### PR DESCRIPTION
Instead of setting specific task index settings (properties, analyzers,...) this PR include code refactoring to allow task include its own es configuration.

See [here](https://github.com/recognai/rubrix/pull/273/files#diff-4e658dba045835ec32c8251b1f51f608b56971dfc55d40d368e559f595e76f5eR18) or [here](https://github.com/recognai/rubrix/pull/273/files#diff-318638962be6ea85b3db60587a924c7ba8decfaa97740e370fff39358fddc36dR22) for details