### PR TITLE
feat(task): new text2text task api and client

### DIFF
--- a/src/rubrix/__init__.py
+++ b/src/rubrix/__init__.py
@@ -28,6 +28,16 @@ _client: Optional[
 ] = None  # Client will be stored here to pass it through functions
 
 
+def _client_instance() -> RubrixClient:
+    """Checks module instance client and init if not initialized."""
+
+    global _client
+    # Calling a by-default-init if it was not called before
+    if _client is None:
+        init()
+    return _client
+
+
 def init(
     api_url: Optional[str] = None,
     api_key: Optional[str] = None,
@@ -135,16 +145,6 @@ def copy(dataset: str, name_of_copy: str):
         >>> df = rb.load("new_dataset")
     """
     _client_instance().copy(source=dataset, target=name_of_copy)
-
-
-def _client_instance() -> RubrixClient:
-    """Checks module instance client and init if not initialized."""
-
-    global _client
-    # Calling a by-default-init if it was not called before
-    if _client is None:
-        init()
-    return _client
 
 
 def load(

--- a/src/rubrix/sdk/api/security/login_for_access_token.py
+++ b/src/rubrix/sdk/api/security/login_for_access_token.py
@@ -1,0 +1,137 @@
+from typing import Any, Dict, Optional, Union
+
+import httpx
+from attr import asdict
+
+from ...client import Client
+from ...models.body_login_for_access_token_api_security_token_post import (
+    BodyLoginForAccessTokenApiSecurityTokenPost,
+)
+from ...models.http_validation_error import HTTPValidationError
+from ...models.token import Token
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    client: Client,
+    form_data: BodyLoginForAccessTokenApiSecurityTokenPost,
+) -> Dict[str, Any]:
+    url = "{}/api/security/token".format(client.base_url)
+
+    headers: Dict[str, Any] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    return {
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "data": asdict(form_data),
+    }
+
+
+def _parse_response(
+    *, response: httpx.Response
+) -> Optional[Union[Token, HTTPValidationError]]:
+    if response.status_code == 200:
+        response_200 = Token.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    return None
+
+
+def _build_response(
+    *, response: httpx.Response
+) -> Response[Union[Token, HTTPValidationError]]:
+    return Response(
+        status_code=response.status_code,
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Client,
+    form_data: BodyLoginForAccessTokenApiSecurityTokenPost,
+) -> Response[Union[Token, HTTPValidationError]]:
+    kwargs = _get_kwargs(
+        client=client,
+        form_data=form_data,
+    )
+
+    response = httpx.post(
+        **kwargs,
+    )
+
+    return _build_response(response=response)
+
+
+def sync(
+    *,
+    client: Client,
+    form_data: BodyLoginForAccessTokenApiSecurityTokenPost,
+) -> Optional[Union[Token, HTTPValidationError]]:
+    """Login access token api endpoint
+
+    Parameters
+    ----------
+    form_data:
+        The user/password form
+
+    Returns
+    -------
+        Logging token if user is properly authenticated.
+        Unauthorized exception otherwise"""
+
+    return sync_detailed(
+        client=client,
+        form_data=form_data,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Client,
+    form_data: BodyLoginForAccessTokenApiSecurityTokenPost,
+) -> Response[Union[Token, HTTPValidationError]]:
+    kwargs = _get_kwargs(
+        client=client,
+        form_data=form_data,
+    )
+
+    async with httpx.AsyncClient() as _client:
+        response = await _client.post(**kwargs)
+
+    return _build_response(response=response)
+
+
+async def asyncio(
+    *,
+    client: Client,
+    form_data: BodyLoginForAccessTokenApiSecurityTokenPost,
+) -> Optional[Union[Token, HTTPValidationError]]:
+    """Login access token api endpoint
+
+    Parameters
+    ----------
+    form_data:
+        The user/password form
+
+    Returns
+    -------
+        Logging token if user is properly authenticated.
+        Unauthorized exception otherwise"""
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            form_data=form_data,
+        )
+    ).parsed

--- a/src/rubrix/sdk/api/text_to_text/_get_dataset_data.py
+++ b/src/rubrix/sdk/api/text_to_text/_get_dataset_data.py
@@ -1,0 +1,50 @@
+from typing import Any, Dict, Optional, Union
+
+import httpx
+from rubrix.sdk.api._streaming_helpers import build_stream_response
+from rubrix.sdk.models.text2_text_query import Text2TextQuery
+
+from ...client import AuthenticatedClient
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    client: AuthenticatedClient,
+    name: str,
+    json_body: Optional[Text2TextQuery] = None,
+    limit: Optional[int] = None,
+) -> Dict[str, Any]:
+    url = "{}/api/datasets/{name}/Text2Text/data".format(
+        client.base_url, name=name
+    )
+
+    headers: Dict[str, Any] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    params = {"limit": limit}
+    params = {k: v for k, v in params.items() if v is not None}
+
+    json_json_body = json_body.to_dict() if json_body else {}
+    return {
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": None,
+        "params": params,
+        "json": json_json_body,
+    }
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    name: str,
+    request: Optional[Text2TextQuery] = None,
+    limit: Optional[int] = None,
+) -> Response[Union[None, HTTPValidationError]]:
+    kwargs = _get_kwargs(client=client, name=name, limit=limit, json_body=request)
+
+    with httpx.stream("POST", **kwargs) as response:
+        return build_stream_response(response=response)

--- a/src/rubrix/sdk/api/text_to_text/bulk_records.py
+++ b/src/rubrix/sdk/api/text_to_text/bulk_records.py
@@ -3,10 +3,10 @@ from typing import Any, Dict, Optional, Union
 import httpx
 
 from ...client import AuthenticatedClient
-from ...models.copy_dataset_request import CopyDatasetRequest
-from ...models.dataset import Dataset
+from ...models.bulk_response import BulkResponse
 from ...models.error_message import ErrorMessage
 from ...models.http_validation_error import HTTPValidationError
+from ...models.text2_text_bulk_data import Text2TextBulkData
 from ...types import Response
 
 
@@ -14,9 +14,9 @@ def _get_kwargs(
     *,
     client: AuthenticatedClient,
     name: str,
-    json_body: CopyDatasetRequest,
+    json_body: Text2TextBulkData,
 ) -> Dict[str, Any]:
-    url = "{}/api/datasets/{name}:copy".format(client.base_url, name=name)
+    url = "{}/api/datasets/{name}/TextToText:bulk".format(client.base_url, name=name)
 
     headers: Dict[str, Any] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()
@@ -34,9 +34,9 @@ def _get_kwargs(
 
 def _parse_response(
     *, response: httpx.Response
-) -> Optional[Union[Dataset, ErrorMessage, ErrorMessage, HTTPValidationError]]:
+) -> Optional[Union[BulkResponse, ErrorMessage, ErrorMessage, HTTPValidationError]]:
     if response.status_code == 200:
-        response_200 = Dataset.from_dict(response.json())
+        response_200 = BulkResponse.from_dict(response.json())
 
         return response_200
     if response.status_code == 404:
@@ -56,7 +56,7 @@ def _parse_response(
 
 def _build_response(
     *, response: httpx.Response
-) -> Response[Union[Dataset, ErrorMessage, ErrorMessage, HTTPValidationError]]:
+) -> Response[Union[BulkResponse, ErrorMessage, ErrorMessage, HTTPValidationError]]:
     return Response(
         status_code=response.status_code,
         content=response.content,
@@ -69,15 +69,15 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     name: str,
-    json_body: CopyDatasetRequest,
-) -> Response[Union[Dataset, ErrorMessage, ErrorMessage, HTTPValidationError]]:
+    json_body: Text2TextBulkData,
+) -> Response[Union[BulkResponse, ErrorMessage, ErrorMessage, HTTPValidationError]]:
     kwargs = _get_kwargs(
         client=client,
         name=name,
         json_body=json_body,
     )
 
-    response = httpx.put(
+    response = httpx.post(
         **kwargs,
     )
 
@@ -88,20 +88,26 @@ def sync(
     *,
     client: AuthenticatedClient,
     name: str,
-    json_body: CopyDatasetRequest,
-) -> Optional[Union[Dataset, ErrorMessage, ErrorMessage, HTTPValidationError]]:
-    """Creates a dataset copy and its tags/metadata info
+    json_body: Text2TextBulkData,
+) -> Optional[Union[BulkResponse, ErrorMessage, ErrorMessage, HTTPValidationError]]:
+    """Includes a chunk of record data with provided dataset bulk information
 
     Parameters
     ----------
     name:
         The dataset name
-    copy_request:
-        The copy request data
+    bulk:
+        The bulk data
     service:
-        The datasets service
+        the Service
+    datasets:
+        The dataset service
     current_user:
-        The current user"""
+        Current request user
+
+    Returns
+    -------
+        Bulk response data"""
 
     return sync_detailed(
         client=client,
@@ -114,8 +120,8 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     name: str,
-    json_body: CopyDatasetRequest,
-) -> Response[Union[Dataset, ErrorMessage, ErrorMessage, HTTPValidationError]]:
+    json_body: Text2TextBulkData,
+) -> Response[Union[BulkResponse, ErrorMessage, ErrorMessage, HTTPValidationError]]:
     kwargs = _get_kwargs(
         client=client,
         name=name,
@@ -123,7 +129,7 @@ async def asyncio_detailed(
     )
 
     async with httpx.AsyncClient() as _client:
-        response = await _client.put(**kwargs)
+        response = await _client.post(**kwargs)
 
     return _build_response(response=response)
 
@@ -132,20 +138,26 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     name: str,
-    json_body: CopyDatasetRequest,
-) -> Optional[Union[Dataset, ErrorMessage, ErrorMessage, HTTPValidationError]]:
-    """Creates a dataset copy and its tags/metadata info
+    json_body: Text2TextBulkData,
+) -> Optional[Union[BulkResponse, ErrorMessage, ErrorMessage, HTTPValidationError]]:
+    """Includes a chunk of record data with provided dataset bulk information
 
     Parameters
     ----------
     name:
         The dataset name
-    copy_request:
-        The copy request data
+    bulk:
+        The bulk data
     service:
-        The datasets service
+        the Service
+    datasets:
+        The dataset service
     current_user:
-        The current user"""
+        Current request user
+
+    Returns
+    -------
+        Bulk response data"""
 
     return (
         await asyncio_detailed(

--- a/src/rubrix/sdk/api/text_to_text/search_records.py
+++ b/src/rubrix/sdk/api/text_to_text/search_records.py
@@ -1,0 +1,209 @@
+from typing import Any, Dict, Optional, Union
+
+import httpx
+
+from ...client import AuthenticatedClient
+from ...models.error_message import ErrorMessage
+from ...models.http_validation_error import HTTPValidationError
+from ...models.text2_text_search_request import Text2TextSearchRequest
+from ...models.text2_text_search_results import Text2TextSearchResults
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    client: AuthenticatedClient,
+    name: str,
+    json_body: Text2TextSearchRequest,
+    limit: Union[Unset, int] = 50,
+    from_: Union[Unset, int] = 0,
+) -> Dict[str, Any]:
+    url = "{}/api/datasets/{name}/TextToText:search".format(client.base_url, name=name)
+
+    headers: Dict[str, Any] = client.get_headers()
+    cookies: Dict[str, Any] = client.get_cookies()
+
+    params: Dict[str, Any] = {
+        "limit": limit,
+        "from": from_,
+    }
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    json_json_body = json_body.to_dict()
+
+    return {
+        "url": url,
+        "headers": headers,
+        "cookies": cookies,
+        "timeout": client.get_timeout(),
+        "json": json_json_body,
+        "params": params,
+    }
+
+
+def _parse_response(
+    *, response: httpx.Response
+) -> Optional[
+    Union[Text2TextSearchResults, ErrorMessage, ErrorMessage, HTTPValidationError]
+]:
+    if response.status_code == 200:
+        response_200 = Text2TextSearchResults.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 404:
+        response_404 = ErrorMessage.from_dict(response.json())
+
+        return response_404
+    if response.status_code == 500:
+        response_500 = ErrorMessage.from_dict(response.json())
+
+        return response_500
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    return None
+
+
+def _build_response(
+    *, response: httpx.Response
+) -> Response[
+    Union[Text2TextSearchResults, ErrorMessage, ErrorMessage, HTTPValidationError]
+]:
+    return Response(
+        status_code=response.status_code,
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: AuthenticatedClient,
+    name: str,
+    json_body: Text2TextSearchRequest,
+    limit: Union[Unset, int] = 50,
+    from_: Union[Unset, int] = 0,
+) -> Response[
+    Union[Text2TextSearchResults, ErrorMessage, ErrorMessage, HTTPValidationError]
+]:
+    kwargs = _get_kwargs(
+        client=client,
+        name=name,
+        json_body=json_body,
+        limit=limit,
+        from_=from_,
+    )
+
+    response = httpx.post(
+        **kwargs,
+    )
+
+    return _build_response(response=response)
+
+
+def sync(
+    *,
+    client: AuthenticatedClient,
+    name: str,
+    json_body: Text2TextSearchRequest,
+    limit: Union[Unset, int] = 50,
+    from_: Union[Unset, int] = 0,
+) -> Optional[
+    Union[Text2TextSearchResults, ErrorMessage, ErrorMessage, HTTPValidationError]
+]:
+    """Searches data from dataset
+
+    Parameters
+    ----------
+    name:
+        The dataset name
+    search:
+        THe search query request
+    pagination:
+        The pagination params
+    service:
+        The dataset records service
+    datasets:
+        The dataset service
+    current_user:
+        The current request user
+
+    Returns
+    -------
+        The search results data"""
+
+    return sync_detailed(
+        client=client,
+        name=name,
+        json_body=json_body,
+        limit=limit,
+        from_=from_,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: AuthenticatedClient,
+    name: str,
+    json_body: Text2TextSearchRequest,
+    limit: Union[Unset, int] = 50,
+    from_: Union[Unset, int] = 0,
+) -> Response[
+    Union[Text2TextSearchResults, ErrorMessage, ErrorMessage, HTTPValidationError]
+]:
+    kwargs = _get_kwargs(
+        client=client,
+        name=name,
+        json_body=json_body,
+        limit=limit,
+        from_=from_,
+    )
+
+    async with httpx.AsyncClient() as _client:
+        response = await _client.post(**kwargs)
+
+    return _build_response(response=response)
+
+
+async def asyncio(
+    *,
+    client: AuthenticatedClient,
+    name: str,
+    json_body: Text2TextSearchRequest,
+    limit: Union[Unset, int] = 50,
+    from_: Union[Unset, int] = 0,
+) -> Optional[
+    Union[Text2TextSearchResults, ErrorMessage, ErrorMessage, HTTPValidationError]
+]:
+    """Searches data from dataset
+
+    Parameters
+    ----------
+    name:
+        The dataset name
+    search:
+        THe search query request
+    pagination:
+        The pagination params
+    service:
+        The dataset records service
+    datasets:
+        The dataset service
+    current_user:
+        The current request user
+
+    Returns
+    -------
+        The search results data"""
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            name=name,
+            json_body=json_body,
+            limit=limit,
+            from_=from_,
+        )
+    ).parsed

--- a/src/rubrix/sdk/models/body_login_for_access_token_api_security_token_post.py
+++ b/src/rubrix/sdk/models/body_login_for_access_token_api_security_token_post.py
@@ -1,0 +1,90 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="BodyLoginForAccessTokenApiSecurityTokenPost")
+
+
+@attr.s(auto_attribs=True)
+class BodyLoginForAccessTokenApiSecurityTokenPost:
+    """ """
+
+    username: str
+    password: str
+    grant_type: Union[Unset, str] = UNSET
+    scope: Union[Unset, str] = ""
+    client_id: Union[Unset, str] = UNSET
+    client_secret: Union[Unset, str] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        username = self.username
+        password = self.password
+        grant_type = self.grant_type
+        scope = self.scope
+        client_id = self.client_id
+        client_secret = self.client_secret
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "username": username,
+                "password": password,
+            }
+        )
+        if grant_type is not UNSET:
+            field_dict["grant_type"] = grant_type
+        if scope is not UNSET:
+            field_dict["scope"] = scope
+        if client_id is not UNSET:
+            field_dict["client_id"] = client_id
+        if client_secret is not UNSET:
+            field_dict["client_secret"] = client_secret
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        username = d.pop("username")
+
+        password = d.pop("password")
+
+        grant_type = d.pop("grant_type", UNSET)
+
+        scope = d.pop("scope", UNSET)
+
+        client_id = d.pop("client_id", UNSET)
+
+        client_secret = d.pop("client_secret", UNSET)
+
+        body_login_for_access_token_api_security_token_post = cls(
+            username=username,
+            password=password,
+            grant_type=grant_type,
+            scope=scope,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+
+        body_login_for_access_token_api_security_token_post.additional_properties = d
+        return body_login_for_access_token_api_security_token_post
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/creation_text2_text_record.py
+++ b/src/rubrix/sdk/models/creation_text2_text_record.py
@@ -1,0 +1,148 @@
+import datetime
+from typing import Any, Dict, List, Type, TypeVar, Union, cast
+
+import attr
+from dateutil.parser import isoparse
+
+from ..models.creation_text2_text_record_metadata import CreationText2TextRecordMetadata
+from ..models.task_status import TaskStatus
+from ..models.text2_text_annotation import Text2TextAnnotation
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="CreationText2TextRecord")
+
+
+@attr.s(auto_attribs=True)
+class CreationText2TextRecord:
+    """Text2Text record
+
+    Attributes:
+    -----------
+
+    text:
+        The input data text"""
+
+    text: str
+    id: Union[Unset, int, str] = UNSET
+    metadata: Union[CreationText2TextRecordMetadata, Unset] = UNSET
+    event_timestamp: Union[Unset, datetime.datetime] = UNSET
+    status: Union[Unset, TaskStatus] = UNSET
+    prediction: Union[Text2TextAnnotation, Unset] = UNSET
+    annotation: Union[Text2TextAnnotation, Unset] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        text = self.text
+        id: Union[Unset, int, str]
+        if isinstance(self.id, Unset):
+            id = UNSET
+        else:
+            id = self.id
+
+        metadata: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.metadata, Unset):
+            metadata = self.metadata.to_dict()
+
+        event_timestamp: Union[Unset, str] = UNSET
+        if not isinstance(self.event_timestamp, Unset):
+            event_timestamp = self.event_timestamp.isoformat()
+
+        status: Union[Unset, TaskStatus] = UNSET
+        if not isinstance(self.status, Unset):
+            status = self.status
+
+        prediction: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.prediction, Unset):
+            prediction = self.prediction.to_dict()
+
+        annotation: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.annotation, Unset):
+            annotation = self.annotation.to_dict()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "text": text,
+            }
+        )
+        if id is not UNSET:
+            field_dict["id"] = id
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+        if event_timestamp is not UNSET:
+            field_dict["event_timestamp"] = event_timestamp
+        if status is not UNSET:
+            field_dict["status"] = status
+        if prediction is not UNSET:
+            field_dict["prediction"] = prediction
+        if annotation is not UNSET:
+            field_dict["annotation"] = annotation
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        text = d.pop("text")
+
+        def _parse_id(data: Any) -> Union[Unset, int, str]:
+            data = None if isinstance(data, Unset) else data
+            id: Union[Unset, int, str]
+            return cast(Union[Unset, int, str], data)
+
+        id = _parse_id(d.pop("id", UNSET))
+
+        metadata: Union[CreationText2TextRecordMetadata, Unset] = UNSET
+        _metadata = d.pop("metadata", UNSET)
+        if not isinstance(_metadata, Unset):
+            metadata = CreationText2TextRecordMetadata.from_dict(_metadata)
+
+        event_timestamp: Union[Unset, datetime.datetime] = UNSET
+        _event_timestamp = d.pop("event_timestamp", UNSET)
+        if not isinstance(_event_timestamp, Unset):
+            event_timestamp = isoparse(_event_timestamp)
+
+        status: Union[Unset, TaskStatus] = UNSET
+        _status = d.pop("status", UNSET)
+        if not isinstance(_status, Unset):
+            status = TaskStatus(_status)
+
+        prediction: Union[Text2TextAnnotation, Unset] = UNSET
+        _prediction = d.pop("prediction", UNSET)
+        if not isinstance(_prediction, Unset):
+            prediction = Text2TextAnnotation.from_dict(_prediction)
+
+        annotation: Union[Text2TextAnnotation, Unset] = UNSET
+        _annotation = d.pop("annotation", UNSET)
+        if not isinstance(_annotation, Unset):
+            annotation = Text2TextAnnotation.from_dict(_annotation)
+
+        creation_text2_text_record = cls(
+            text=text,
+            id=id,
+            metadata=metadata,
+            event_timestamp=event_timestamp,
+            status=status,
+            prediction=prediction,
+            annotation=annotation,
+        )
+
+        creation_text2_text_record.additional_properties = d
+        return creation_text2_text_record
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/creation_text2_text_record_metadata.py
+++ b/src/rubrix/sdk/models/creation_text2_text_record_metadata.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="CreationText2TextRecordMetadata")
+
+
+@attr.s(auto_attribs=True)
+class CreationText2TextRecordMetadata:
+    """ """
+
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        creation_text2_text_record_metadata = cls()
+
+        creation_text2_text_record_metadata.additional_properties = d
+        return creation_text2_text_record_metadata
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_annotation.py
+++ b/src/rubrix/sdk/models/text2_text_annotation.py
@@ -1,0 +1,77 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+from ..models.text2_text_prediction import Text2TextPrediction
+
+T = TypeVar("T", bound="Text2TextAnnotation")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextAnnotation:
+    """Annotation class for text2text tasks
+
+    Attributes:
+    -----------
+
+    sentences: str
+        List of sentence predictions/annotations"""
+
+    agent: str
+    sentences: List[Text2TextPrediction]
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        agent = self.agent
+        sentences = []
+        for sentences_item_data in self.sentences:
+            sentences_item = sentences_item_data.to_dict()
+
+            sentences.append(sentences_item)
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "agent": agent,
+                "sentences": sentences,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        agent = d.pop("agent")
+
+        sentences = []
+        _sentences = d.pop("sentences")
+        for sentences_item_data in _sentences:
+            sentences_item = Text2TextPrediction.from_dict(sentences_item_data)
+
+            sentences.append(sentences_item)
+
+        text2_text_annotation = cls(
+            agent=agent,
+            sentences=sentences,
+        )
+
+        text2_text_annotation.additional_properties = d
+        return text2_text_annotation
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_bulk_data.py
+++ b/src/rubrix/sdk/models/text2_text_bulk_data.py
@@ -1,0 +1,100 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..models.creation_text2_text_record import CreationText2TextRecord
+from ..models.text2_text_bulk_data_metadata import Text2TextBulkDataMetadata
+from ..models.text2_text_bulk_data_tags import Text2TextBulkDataTags
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Text2TextBulkData")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextBulkData:
+    """API bulk data for text2text
+
+    Attributes:
+    -----------
+
+    records: List[CreationText2TextRecord]
+        The text2text record list"""
+
+    records: List[CreationText2TextRecord]
+    tags: Union[Text2TextBulkDataTags, Unset] = UNSET
+    metadata: Union[Text2TextBulkDataMetadata, Unset] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        records = []
+        for records_item_data in self.records:
+            records_item = records_item_data.to_dict()
+
+            records.append(records_item)
+
+        tags: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.tags, Unset):
+            tags = self.tags.to_dict()
+
+        metadata: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.metadata, Unset):
+            metadata = self.metadata.to_dict()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "records": records,
+            }
+        )
+        if tags is not UNSET:
+            field_dict["tags"] = tags
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        records = []
+        _records = d.pop("records")
+        for records_item_data in _records:
+            records_item = CreationText2TextRecord.from_dict(records_item_data)
+
+            records.append(records_item)
+
+        tags: Union[Text2TextBulkDataTags, Unset] = UNSET
+        _tags = d.pop("tags", UNSET)
+        if not isinstance(_tags, Unset):
+            tags = Text2TextBulkDataTags.from_dict(_tags)
+
+        metadata: Union[Text2TextBulkDataMetadata, Unset] = UNSET
+        _metadata = d.pop("metadata", UNSET)
+        if not isinstance(_metadata, Unset):
+            metadata = Text2TextBulkDataMetadata.from_dict(_metadata)
+
+        text2_text_bulk_data = cls(
+            records=records,
+            tags=tags,
+            metadata=metadata,
+        )
+
+        text2_text_bulk_data.additional_properties = d
+        return text2_text_bulk_data
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_bulk_data_metadata.py
+++ b/src/rubrix/sdk/models/text2_text_bulk_data_metadata.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="Text2TextBulkDataMetadata")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextBulkDataMetadata:
+    """ """
+
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        text2_text_bulk_data_metadata = cls()
+
+        text2_text_bulk_data_metadata.additional_properties = d
+        return text2_text_bulk_data_metadata
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_bulk_data_tags.py
+++ b/src/rubrix/sdk/models/text2_text_bulk_data_tags.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="Text2TextBulkDataTags")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextBulkDataTags:
+    """ """
+
+    additional_properties: Dict[str, str] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        text2_text_bulk_data_tags = cls()
+
+        text2_text_bulk_data_tags.additional_properties = d
+        return text2_text_bulk_data_tags
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> str:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_prediction.py
+++ b/src/rubrix/sdk/models/text2_text_prediction.py
@@ -1,0 +1,63 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Text2TextPrediction")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextPrediction:
+    """Represents a text prediction/annotation and its score"""
+
+    text: str
+    score: Union[Unset, float] = 1.0
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        text = self.text
+        score = self.score
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "text": text,
+            }
+        )
+        if score is not UNSET:
+            field_dict["score"] = score
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        text = d.pop("text")
+
+        score = d.pop("score", UNSET)
+
+        text2_text_prediction = cls(
+            text=text,
+            score=score,
+        )
+
+        text2_text_prediction.additional_properties = d
+        return text2_text_prediction
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_query.py
+++ b/src/rubrix/sdk/models/text2_text_query.py
@@ -1,0 +1,182 @@
+from typing import Any, Dict, List, Type, TypeVar, Union, cast
+
+import attr
+
+from ..models.prediction_status import PredictionStatus
+from ..models.score_range import ScoreRange
+from ..models.task_status import TaskStatus
+from ..models.text2_text_query_metadata import Text2TextQueryMetadata
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Text2TextQuery")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextQuery:
+    """API Filters for text2text
+
+    Attributes:
+    -----------
+    ids: Optional[List[Union[str, int]]]
+        Record ids list
+
+    query_text: str
+        Text query over input text
+
+    annotated_by: List[str]
+        List of annotation agents
+    predicted_by: List[str]
+        List of predicted agents
+
+    status: List[TaskStatus]
+        List of task status
+
+    metadata: Optional[Dict[str, Union[str, List[str]]]]
+        Text query over metadata fields. Default=None
+
+    predicted: Optional[PredictionStatus]
+        The task prediction status"""
+
+    ids: Union[Unset, List[Union[str, int]]] = UNSET
+    query_text: Union[Unset, str] = UNSET
+    annotated_by: Union[Unset, List[str]] = UNSET
+    predicted_by: Union[Unset, List[str]] = UNSET
+    score: Union[ScoreRange, Unset] = UNSET
+    status: Union[Unset, List[TaskStatus]] = UNSET
+    predicted: Union[Unset, PredictionStatus] = UNSET
+    metadata: Union[Text2TextQueryMetadata, Unset] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        ids: Union[Unset, List[Any]] = UNSET
+        if not isinstance(self.ids, Unset):
+            ids = []
+            for ids_item_data in self.ids:
+                ids_item = ids_item_data
+
+                ids.append(ids_item)
+
+        query_text = self.query_text
+        annotated_by: Union[Unset, List[Any]] = UNSET
+        if not isinstance(self.annotated_by, Unset):
+            annotated_by = self.annotated_by
+
+        predicted_by: Union[Unset, List[Any]] = UNSET
+        if not isinstance(self.predicted_by, Unset):
+            predicted_by = self.predicted_by
+
+        score: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.score, Unset):
+            score = self.score.to_dict()
+
+        status: Union[Unset, List[Any]] = UNSET
+        if not isinstance(self.status, Unset):
+            status = []
+            for status_item_data in self.status:
+                status_item = status_item_data.value
+
+                status.append(status_item)
+
+        predicted: Union[Unset, PredictionStatus] = UNSET
+        if not isinstance(self.predicted, Unset):
+            predicted = self.predicted
+
+        metadata: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.metadata, Unset):
+            metadata = self.metadata.to_dict()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if ids is not UNSET:
+            field_dict["ids"] = ids
+        if query_text is not UNSET:
+            field_dict["query_text"] = query_text
+        if annotated_by is not UNSET:
+            field_dict["annotated_by"] = annotated_by
+        if predicted_by is not UNSET:
+            field_dict["predicted_by"] = predicted_by
+        if score is not UNSET:
+            field_dict["score"] = score
+        if status is not UNSET:
+            field_dict["status"] = status
+        if predicted is not UNSET:
+            field_dict["predicted"] = predicted
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        ids = []
+        _ids = d.pop("ids", UNSET)
+        for ids_item_data in _ids or []:
+
+            def _parse_ids_item(data: Any) -> Union[str, int]:
+                data = None if isinstance(data, Unset) else data
+                ids_item: Union[str, int]
+                return cast(Union[str, int], data)
+
+            ids_item = _parse_ids_item(ids_item_data)
+
+            ids.append(ids_item)
+
+        query_text = d.pop("query_text", UNSET)
+
+        annotated_by = cast(List[str], d.pop("annotated_by", UNSET))
+
+        predicted_by = cast(List[str], d.pop("predicted_by", UNSET))
+
+        score: Union[ScoreRange, Unset] = UNSET
+        _score = d.pop("score", UNSET)
+        if not isinstance(_score, Unset):
+            score = ScoreRange.from_dict(_score)
+
+        status = []
+        _status = d.pop("status", UNSET)
+        for status_item_data in _status or []:
+            status_item = TaskStatus(status_item_data)
+
+            status.append(status_item)
+
+        predicted: Union[Unset, PredictionStatus] = UNSET
+        _predicted = d.pop("predicted", UNSET)
+        if not isinstance(_predicted, Unset):
+            predicted = PredictionStatus(_predicted)
+
+        metadata: Union[Text2TextQueryMetadata, Unset] = UNSET
+        _metadata = d.pop("metadata", UNSET)
+        if not isinstance(_metadata, Unset):
+            metadata = Text2TextQueryMetadata.from_dict(_metadata)
+
+        text2_text_query = cls(
+            ids=ids,
+            query_text=query_text,
+            annotated_by=annotated_by,
+            predicted_by=predicted_by,
+            score=score,
+            status=status,
+            predicted=predicted,
+            metadata=metadata,
+        )
+
+        text2_text_query.additional_properties = d
+        return text2_text_query
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_query_metadata.py
+++ b/src/rubrix/sdk/models/text2_text_query_metadata.py
@@ -1,0 +1,72 @@
+from typing import Any, Dict, List, Type, TypeVar, Union, cast
+
+import attr
+
+from ..types import Unset
+
+T = TypeVar("T", bound="Text2TextQueryMetadata")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextQueryMetadata:
+    """ """
+
+    additional_properties: Dict[str, Union[str, List[str]]] = attr.ib(
+        init=False, factory=dict
+    )
+
+    def to_dict(self) -> Dict[str, Any]:
+
+        field_dict: Dict[str, Any] = {}
+        for prop_name, prop in self.additional_properties.items():
+            if isinstance(prop, list):
+                field_dict[prop_name] = prop
+
+            else:
+                field_dict[prop_name] = prop
+
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        text2_text_query_metadata = cls()
+
+        additional_properties = {}
+        for prop_name, prop_dict in d.items():
+
+            def _parse_additional_property(data: Any) -> Union[str, List[str]]:
+                data = None if isinstance(data, Unset) else data
+                additional_property: Union[str, List[str]]
+                try:
+                    additional_property = cast(List[str], data)
+
+                    return additional_property
+                except:  # noqa: E722
+                    pass
+                return cast(Union[str, List[str]], data)
+
+            additional_property = _parse_additional_property(prop_dict)
+
+            additional_properties[prop_name] = additional_property
+
+        text2_text_query_metadata.additional_properties = additional_properties
+        return text2_text_query_metadata
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Union[str, List[str]]:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Union[str, List[str]]) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_record.py
+++ b/src/rubrix/sdk/models/text2_text_record.py
@@ -1,0 +1,155 @@
+import datetime
+from typing import Any, Dict, List, Type, TypeVar, Union, cast
+
+import attr
+from dateutil.parser import isoparse
+
+from ..models.task_status import TaskStatus
+from ..models.text2_text_annotation import Text2TextAnnotation
+from ..models.text2_text_record_metadata import Text2TextRecordMetadata
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Text2TextRecord")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextRecord:
+    """The output text2text task record"""
+
+    text: str
+    id: Union[Unset, int, str] = UNSET
+    metadata: Union[Text2TextRecordMetadata, Unset] = UNSET
+    event_timestamp: Union[Unset, datetime.datetime] = UNSET
+    status: Union[Unset, TaskStatus] = UNSET
+    prediction: Union[Text2TextAnnotation, Unset] = UNSET
+    annotation: Union[Text2TextAnnotation, Unset] = UNSET
+    last_updated: Union[Unset, datetime.datetime] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        text = self.text
+        id: Union[Unset, int, str]
+        if isinstance(self.id, Unset):
+            id = UNSET
+        else:
+            id = self.id
+
+        metadata: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.metadata, Unset):
+            metadata = self.metadata.to_dict()
+
+        event_timestamp: Union[Unset, str] = UNSET
+        if not isinstance(self.event_timestamp, Unset):
+            event_timestamp = self.event_timestamp.isoformat()
+
+        status: Union[Unset, TaskStatus] = UNSET
+        if not isinstance(self.status, Unset):
+            status = self.status
+
+        prediction: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.prediction, Unset):
+            prediction = self.prediction.to_dict()
+
+        annotation: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.annotation, Unset):
+            annotation = self.annotation.to_dict()
+
+        last_updated: Union[Unset, str] = UNSET
+        if not isinstance(self.last_updated, Unset):
+            last_updated = self.last_updated.isoformat()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "text": text,
+            }
+        )
+        if id is not UNSET:
+            field_dict["id"] = id
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+        if event_timestamp is not UNSET:
+            field_dict["event_timestamp"] = event_timestamp
+        if status is not UNSET:
+            field_dict["status"] = status
+        if prediction is not UNSET:
+            field_dict["prediction"] = prediction
+        if annotation is not UNSET:
+            field_dict["annotation"] = annotation
+        if last_updated is not UNSET:
+            field_dict["last_updated"] = last_updated
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        text = d.pop("text")
+
+        def _parse_id(data: Any) -> Union[Unset, int, str]:
+            data = None if isinstance(data, Unset) else data
+            id: Union[Unset, int, str]
+            return cast(Union[Unset, int, str], data)
+
+        id = _parse_id(d.pop("id", UNSET))
+
+        metadata: Union[Text2TextRecordMetadata, Unset] = UNSET
+        _metadata = d.pop("metadata", UNSET)
+        if not isinstance(_metadata, Unset):
+            metadata = Text2TextRecordMetadata.from_dict(_metadata)
+
+        event_timestamp: Union[Unset, datetime.datetime] = UNSET
+        _event_timestamp = d.pop("event_timestamp", UNSET)
+        if not isinstance(_event_timestamp, Unset):
+            event_timestamp = isoparse(_event_timestamp)
+
+        status: Union[Unset, TaskStatus] = UNSET
+        _status = d.pop("status", UNSET)
+        if not isinstance(_status, Unset):
+            status = TaskStatus(_status)
+
+        prediction: Union[Text2TextAnnotation, Unset] = UNSET
+        _prediction = d.pop("prediction", UNSET)
+        if not isinstance(_prediction, Unset):
+            prediction = Text2TextAnnotation.from_dict(_prediction)
+
+        annotation: Union[Text2TextAnnotation, Unset] = UNSET
+        _annotation = d.pop("annotation", UNSET)
+        if not isinstance(_annotation, Unset):
+            annotation = Text2TextAnnotation.from_dict(_annotation)
+
+        last_updated: Union[Unset, datetime.datetime] = UNSET
+        _last_updated = d.pop("last_updated", UNSET)
+        if not isinstance(_last_updated, Unset):
+            last_updated = isoparse(_last_updated)
+
+        text2_text_record = cls(
+            text=text,
+            id=id,
+            metadata=metadata,
+            event_timestamp=event_timestamp,
+            status=status,
+            prediction=prediction,
+            annotation=annotation,
+            last_updated=last_updated,
+        )
+
+        text2_text_record.additional_properties = d
+        return text2_text_record
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_record_metadata.py
+++ b/src/rubrix/sdk/models/text2_text_record_metadata.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="Text2TextRecordMetadata")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextRecordMetadata:
+    """ """
+
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        text2_text_record_metadata = cls()
+
+        text2_text_record_metadata.additional_properties = d
+        return text2_text_record_metadata
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_search_aggregations.py
+++ b/src/rubrix/sdk/models/text2_text_search_aggregations.py
@@ -1,0 +1,217 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..models.text2_text_search_aggregations_annotated_by import (
+    Text2TextSearchAggregationsAnnotatedBy,
+)
+from ..models.text2_text_search_aggregations_annotated_text import (
+    Text2TextSearchAggregationsAnnotatedText,
+)
+from ..models.text2_text_search_aggregations_metadata import (
+    Text2TextSearchAggregationsMetadata,
+)
+from ..models.text2_text_search_aggregations_predicted import (
+    Text2TextSearchAggregationsPredicted,
+)
+from ..models.text2_text_search_aggregations_predicted_by import (
+    Text2TextSearchAggregationsPredictedBy,
+)
+from ..models.text2_text_search_aggregations_predicted_text import (
+    Text2TextSearchAggregationsPredictedText,
+)
+from ..models.text2_text_search_aggregations_score import (
+    Text2TextSearchAggregationsScore,
+)
+from ..models.text2_text_search_aggregations_status import (
+    Text2TextSearchAggregationsStatus,
+)
+from ..models.text2_text_search_aggregations_words import (
+    Text2TextSearchAggregationsWords,
+)
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Text2TextSearchAggregations")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextSearchAggregations:
+    """API for result aggregations
+
+    Attributes:
+    -----------
+    words: Dict[str, int]
+        The word cloud aggregations for input text
+    predicted_text: Dict[str, int]
+        The word cloud aggregations for predicted text
+    annotated_text: Dict[str, int]
+        The word cloud aggregations for annotated text
+    annotated_by: Dict[str, int]
+        Occurrence info about more relevant annotation agent terms
+    predicted_by: Dict[str, int]
+        Occurrence info about more relevant prediction agent terms
+    status: Dict[str, int]
+        Occurrence info about task status
+    predicted: Dict[str, int]
+        Occurrence info about task prediction status
+    metadata: Dict[str, Dict[str, int]]
+        The metadata fields aggregations"""
+
+    words: Union[Text2TextSearchAggregationsWords, Unset] = UNSET
+    predicted_text: Union[Text2TextSearchAggregationsPredictedText, Unset] = UNSET
+    annotated_text: Union[Text2TextSearchAggregationsAnnotatedText, Unset] = UNSET
+    annotated_by: Union[Text2TextSearchAggregationsAnnotatedBy, Unset] = UNSET
+    predicted_by: Union[Text2TextSearchAggregationsPredictedBy, Unset] = UNSET
+    status: Union[Text2TextSearchAggregationsStatus, Unset] = UNSET
+    predicted: Union[Text2TextSearchAggregationsPredicted, Unset] = UNSET
+    score: Union[Text2TextSearchAggregationsScore, Unset] = UNSET
+    metadata: Union[Text2TextSearchAggregationsMetadata, Unset] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        words: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.words, Unset):
+            words = self.words.to_dict()
+
+        predicted_text: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.predicted_text, Unset):
+            predicted_text = self.predicted_text.to_dict()
+
+        annotated_text: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.annotated_text, Unset):
+            annotated_text = self.annotated_text.to_dict()
+
+        annotated_by: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.annotated_by, Unset):
+            annotated_by = self.annotated_by.to_dict()
+
+        predicted_by: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.predicted_by, Unset):
+            predicted_by = self.predicted_by.to_dict()
+
+        status: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.status, Unset):
+            status = self.status.to_dict()
+
+        predicted: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.predicted, Unset):
+            predicted = self.predicted.to_dict()
+
+        score: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.score, Unset):
+            score = self.score.to_dict()
+
+        metadata: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.metadata, Unset):
+            metadata = self.metadata.to_dict()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if words is not UNSET:
+            field_dict["words"] = words
+        if predicted_text is not UNSET:
+            field_dict["predicted_text"] = predicted_text
+        if annotated_text is not UNSET:
+            field_dict["annotated_text"] = annotated_text
+        if annotated_by is not UNSET:
+            field_dict["annotated_by"] = annotated_by
+        if predicted_by is not UNSET:
+            field_dict["predicted_by"] = predicted_by
+        if status is not UNSET:
+            field_dict["status"] = status
+        if predicted is not UNSET:
+            field_dict["predicted"] = predicted
+        if score is not UNSET:
+            field_dict["score"] = score
+        if metadata is not UNSET:
+            field_dict["metadata"] = metadata
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        words: Union[Text2TextSearchAggregationsWords, Unset] = UNSET
+        _words = d.pop("words", UNSET)
+        if not isinstance(_words, Unset):
+            words = Text2TextSearchAggregationsWords.from_dict(_words)
+
+        predicted_text: Union[Text2TextSearchAggregationsPredictedText, Unset] = UNSET
+        _predicted_text = d.pop("predicted_text", UNSET)
+        if not isinstance(_predicted_text, Unset):
+            predicted_text = Text2TextSearchAggregationsPredictedText.from_dict(
+                _predicted_text
+            )
+
+        annotated_text: Union[Text2TextSearchAggregationsAnnotatedText, Unset] = UNSET
+        _annotated_text = d.pop("annotated_text", UNSET)
+        if not isinstance(_annotated_text, Unset):
+            annotated_text = Text2TextSearchAggregationsAnnotatedText.from_dict(
+                _annotated_text
+            )
+
+        annotated_by: Union[Text2TextSearchAggregationsAnnotatedBy, Unset] = UNSET
+        _annotated_by = d.pop("annotated_by", UNSET)
+        if not isinstance(_annotated_by, Unset):
+            annotated_by = Text2TextSearchAggregationsAnnotatedBy.from_dict(
+                _annotated_by
+            )
+
+        predicted_by: Union[Text2TextSearchAggregationsPredictedBy, Unset] = UNSET
+        _predicted_by = d.pop("predicted_by", UNSET)
+        if not isinstance(_predicted_by, Unset):
+            predicted_by = Text2TextSearchAggregationsPredictedBy.from_dict(
+                _predicted_by
+            )
+
+        status: Union[Text2TextSearchAggregationsStatus, Unset] = UNSET
+        _status = d.pop("status", UNSET)
+        if not isinstance(_status, Unset):
+            status = Text2TextSearchAggregationsStatus.from_dict(_status)
+
+        predicted: Union[Text2TextSearchAggregationsPredicted, Unset] = UNSET
+        _predicted = d.pop("predicted", UNSET)
+        if not isinstance(_predicted, Unset):
+            predicted = Text2TextSearchAggregationsPredicted.from_dict(_predicted)
+
+        score: Union[Text2TextSearchAggregationsScore, Unset] = UNSET
+        _score = d.pop("score", UNSET)
+        if not isinstance(_score, Unset):
+            score = Text2TextSearchAggregationsScore.from_dict(_score)
+
+        metadata: Union[Text2TextSearchAggregationsMetadata, Unset] = UNSET
+        _metadata = d.pop("metadata", UNSET)
+        if not isinstance(_metadata, Unset):
+            metadata = Text2TextSearchAggregationsMetadata.from_dict(_metadata)
+
+        text2_text_search_aggregations = cls(
+            words=words,
+            predicted_text=predicted_text,
+            annotated_text=annotated_text,
+            annotated_by=annotated_by,
+            predicted_by=predicted_by,
+            status=status,
+            predicted=predicted,
+            score=score,
+            metadata=metadata,
+        )
+
+        text2_text_search_aggregations.additional_properties = d
+        return text2_text_search_aggregations
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_search_aggregations_annotated_by.py
+++ b/src/rubrix/sdk/models/text2_text_search_aggregations_annotated_by.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="Text2TextSearchAggregationsAnnotatedBy")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextSearchAggregationsAnnotatedBy:
+    """ """
+
+    additional_properties: Dict[str, int] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        text2_text_search_aggregations_annotated_by = cls()
+
+        text2_text_search_aggregations_annotated_by.additional_properties = d
+        return text2_text_search_aggregations_annotated_by
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> int:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: int) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_search_aggregations_annotated_text.py
+++ b/src/rubrix/sdk/models/text2_text_search_aggregations_annotated_text.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="Text2TextSearchAggregationsAnnotatedText")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextSearchAggregationsAnnotatedText:
+    """ """
+
+    additional_properties: Dict[str, int] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        text2_text_search_aggregations_annotated_text = cls()
+
+        text2_text_search_aggregations_annotated_text.additional_properties = d
+        return text2_text_search_aggregations_annotated_text
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> int:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: int) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_search_aggregations_metadata.py
+++ b/src/rubrix/sdk/models/text2_text_search_aggregations_metadata.py
@@ -1,0 +1,68 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+from ..models.text2_text_search_aggregations_metadata_additional_property import (
+    Text2TextSearchAggregationsMetadataAdditionalProperty,
+)
+
+T = TypeVar("T", bound="Text2TextSearchAggregationsMetadata")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextSearchAggregationsMetadata:
+    """ """
+
+    additional_properties: Dict[
+        str, Text2TextSearchAggregationsMetadataAdditionalProperty
+    ] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+
+        field_dict: Dict[str, Any] = {}
+        for prop_name, prop in self.additional_properties.items():
+            field_dict[prop_name] = prop.to_dict()
+
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        text2_text_search_aggregations_metadata = cls()
+
+        additional_properties = {}
+        for prop_name, prop_dict in d.items():
+            additional_property = (
+                Text2TextSearchAggregationsMetadataAdditionalProperty.from_dict(
+                    prop_dict
+                )
+            )
+
+            additional_properties[prop_name] = additional_property
+
+        text2_text_search_aggregations_metadata.additional_properties = (
+            additional_properties
+        )
+        return text2_text_search_aggregations_metadata
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(
+        self, key: str
+    ) -> Text2TextSearchAggregationsMetadataAdditionalProperty:
+        return self.additional_properties[key]
+
+    def __setitem__(
+        self, key: str, value: Text2TextSearchAggregationsMetadataAdditionalProperty
+    ) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_search_aggregations_metadata_additional_property.py
+++ b/src/rubrix/sdk/models/text2_text_search_aggregations_metadata_additional_property.py
@@ -1,0 +1,46 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="Text2TextSearchAggregationsMetadataAdditionalProperty")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextSearchAggregationsMetadataAdditionalProperty:
+    """ """
+
+    additional_properties: Dict[str, int] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        text2_text_search_aggregations_metadata_additional_property = cls()
+
+        text2_text_search_aggregations_metadata_additional_property.additional_properties = (
+            d
+        )
+        return text2_text_search_aggregations_metadata_additional_property
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> int:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: int) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_search_aggregations_predicted.py
+++ b/src/rubrix/sdk/models/text2_text_search_aggregations_predicted.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="Text2TextSearchAggregationsPredicted")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextSearchAggregationsPredicted:
+    """ """
+
+    additional_properties: Dict[str, int] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        text2_text_search_aggregations_predicted = cls()
+
+        text2_text_search_aggregations_predicted.additional_properties = d
+        return text2_text_search_aggregations_predicted
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> int:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: int) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_search_aggregations_predicted_by.py
+++ b/src/rubrix/sdk/models/text2_text_search_aggregations_predicted_by.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="Text2TextSearchAggregationsPredictedBy")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextSearchAggregationsPredictedBy:
+    """ """
+
+    additional_properties: Dict[str, int] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        text2_text_search_aggregations_predicted_by = cls()
+
+        text2_text_search_aggregations_predicted_by.additional_properties = d
+        return text2_text_search_aggregations_predicted_by
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> int:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: int) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_search_aggregations_predicted_text.py
+++ b/src/rubrix/sdk/models/text2_text_search_aggregations_predicted_text.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="Text2TextSearchAggregationsPredictedText")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextSearchAggregationsPredictedText:
+    """ """
+
+    additional_properties: Dict[str, int] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        text2_text_search_aggregations_predicted_text = cls()
+
+        text2_text_search_aggregations_predicted_text.additional_properties = d
+        return text2_text_search_aggregations_predicted_text
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> int:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: int) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_search_aggregations_score.py
+++ b/src/rubrix/sdk/models/text2_text_search_aggregations_score.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="Text2TextSearchAggregationsScore")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextSearchAggregationsScore:
+    """ """
+
+    additional_properties: Dict[str, int] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        text2_text_search_aggregations_score = cls()
+
+        text2_text_search_aggregations_score.additional_properties = d
+        return text2_text_search_aggregations_score
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> int:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: int) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_search_aggregations_status.py
+++ b/src/rubrix/sdk/models/text2_text_search_aggregations_status.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="Text2TextSearchAggregationsStatus")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextSearchAggregationsStatus:
+    """ """
+
+    additional_properties: Dict[str, int] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        text2_text_search_aggregations_status = cls()
+
+        text2_text_search_aggregations_status.additional_properties = d
+        return text2_text_search_aggregations_status
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> int:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: int) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_search_aggregations_words.py
+++ b/src/rubrix/sdk/models/text2_text_search_aggregations_words.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="Text2TextSearchAggregationsWords")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextSearchAggregationsWords:
+    """ """
+
+    additional_properties: Dict[str, int] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        text2_text_search_aggregations_words = cls()
+
+        text2_text_search_aggregations_words.additional_properties = d
+        return text2_text_search_aggregations_words
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> int:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: int) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_search_request.py
+++ b/src/rubrix/sdk/models/text2_text_search_request.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..models.text2_text_query import Text2TextQuery
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Text2TextSearchRequest")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextSearchRequest:
+    """API SearchRequest request
+
+    Attributes:
+    -----------
+
+    query: Text2TextQuery
+        The search query configuration"""
+
+    query: Union[Text2TextQuery, Unset] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        query: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.query, Unset):
+            query = self.query.to_dict()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if query is not UNSET:
+            field_dict["query"] = query
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        query: Union[Text2TextQuery, Unset] = UNSET
+        _query = d.pop("query", UNSET)
+        if not isinstance(_query, Unset):
+            query = Text2TextQuery.from_dict(_query)
+
+        text2_text_search_request = cls(
+            query=query,
+        )
+
+        text2_text_search_request.additional_properties = d
+        return text2_text_search_request
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/text2_text_search_results.py
+++ b/src/rubrix/sdk/models/text2_text_search_results.py
@@ -1,0 +1,97 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..models.text2_text_record import Text2TextRecord
+from ..models.text2_text_search_aggregations import Text2TextSearchAggregations
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Text2TextSearchResults")
+
+
+@attr.s(auto_attribs=True)
+class Text2TextSearchResults:
+    """API search results
+
+    Attributes:
+    -----------
+
+    total: int
+        The total number of records
+    records: List[Text2TextRecord]
+        The selected records to return
+    aggregations: Text2TextSearchAggregations
+        SearchRequest aggregations (if no pagination)"""
+
+    total: Union[Unset, int] = 0
+    records: Union[Unset, List[Text2TextRecord]] = UNSET
+    aggregations: Union[Text2TextSearchAggregations, Unset] = UNSET
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        total = self.total
+        records: Union[Unset, List[Any]] = UNSET
+        if not isinstance(self.records, Unset):
+            records = []
+            for records_item_data in self.records:
+                records_item = records_item_data.to_dict()
+
+                records.append(records_item)
+
+        aggregations: Union[Unset, Dict[str, Any]] = UNSET
+        if not isinstance(self.aggregations, Unset):
+            aggregations = self.aggregations.to_dict()
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if total is not UNSET:
+            field_dict["total"] = total
+        if records is not UNSET:
+            field_dict["records"] = records
+        if aggregations is not UNSET:
+            field_dict["aggregations"] = aggregations
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        total = d.pop("total", UNSET)
+
+        records = []
+        _records = d.pop("records", UNSET)
+        for records_item_data in _records or []:
+            records_item = Text2TextRecord.from_dict(records_item_data)
+
+            records.append(records_item)
+
+        aggregations: Union[Text2TextSearchAggregations, Unset] = UNSET
+        _aggregations = d.pop("aggregations", UNSET)
+        if not isinstance(_aggregations, Unset):
+            aggregations = Text2TextSearchAggregations.from_dict(_aggregations)
+
+        text2_text_search_results = cls(
+            total=total,
+            records=records,
+            aggregations=aggregations,
+        )
+
+        text2_text_search_results.additional_properties = d
+        return text2_text_search_results
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/sdk/models/token.py
+++ b/src/rubrix/sdk/models/token.py
@@ -1,0 +1,63 @@
+from typing import Any, Dict, List, Type, TypeVar, Union
+
+import attr
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Token")
+
+
+@attr.s(auto_attribs=True)
+class Token:
+    """Token response model"""
+
+    access_token: str
+    token_type: Union[Unset, str] = "bearer"
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        access_token = self.access_token
+        token_type = self.token_type
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "access_token": access_token,
+            }
+        )
+        if token_type is not UNSET:
+            field_dict["token_type"] = token_type
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        access_token = d.pop("access_token")
+
+        token_type = d.pop("token_type", UNSET)
+
+        token = cls(
+            access_token=access_token,
+            token_type=token_type,
+        )
+
+        token.additional_properties = d
+        return token
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/src/rubrix/server/routes.py
+++ b/src/rubrix/server/routes.py
@@ -7,8 +7,8 @@ from rubrix.server.commons.errors import ErrorMessage
 
 from .datasets import api as datasets
 from .info import api as info
-from .users import api as users
 from .tasks import api as tasks
+from .users import api as users
 
 api_router = APIRouter(
     responses={

--- a/src/rubrix/server/tasks/api.py
+++ b/src/rubrix/server/tasks/api.py
@@ -2,9 +2,10 @@ from fastapi import APIRouter
 
 from .text_classification import api as text_classification
 from .token_classification import api as token_classification
+from .text2text import api as text2text
 
 router = APIRouter()
 
 
-for task_api in [text_classification, token_classification]:
+for task_api in [text_classification, token_classification, text2text]:
     router.include_router(task_api.router)

--- a/src/rubrix/server/tasks/text2text/__init__.py
+++ b/src/rubrix/server/tasks/text2text/__init__.py
@@ -1,0 +1,1 @@
+from .api import *

--- a/src/rubrix/server/tasks/text2text/api/__init__.py
+++ b/src/rubrix/server/tasks/text2text/api/__init__.py
@@ -1,0 +1,2 @@
+from .api import *
+from .model import *

--- a/src/rubrix/server/tasks/text2text/api/api.py
+++ b/src/rubrix/server/tasks/text2text/api/api.py
@@ -1,0 +1,208 @@
+import itertools
+from rubrix.server.security.model import User
+from typing import Iterable, Optional
+
+from fastapi import APIRouter, Depends, Query, Security
+from fastapi.responses import StreamingResponse
+from rubrix.server.datasets.model import CreationDatasetRequest
+from rubrix.server.datasets.service import DatasetsService, create_dataset_service
+from rubrix.server.security import auth
+from rubrix.server.tasks.commons.api import BulkResponse, PaginationParams, TaskType
+from rubrix.server.tasks.commons.helpers import takeuntil
+from rubrix.server.tasks.text2text.api.model import (
+    Text2TextQuery,
+    Text2TextRecord,
+    Text2TextRecordDB,
+    Text2TextSearchResults,
+    Text2TextBulkData,
+    Text2TextSearchRequest,
+)
+from rubrix.server.tasks.text2text.service.service import (
+    Text2TextService,
+    text2text_service,
+)
+
+TASK_TYPE = TaskType.text_to_text
+BASE_ENDPOINT = "/{name}/" + TASK_TYPE
+
+router = APIRouter(tags=[TASK_TYPE], prefix="/datasets")
+
+
+@router.post(
+    BASE_ENDPOINT + ":bulk",
+    operation_id="bulk_records",
+    response_model=BulkResponse,
+    response_model_exclude_none=True,
+)
+def bulk_records(
+    name: str,
+    bulk: Text2TextBulkData,
+    service: Text2TextService = Depends(text2text_service),
+    datasets: DatasetsService = Depends(create_dataset_service),
+    current_user: User = Security(auth.get_user, scopes=[]),
+) -> BulkResponse:
+    """
+    Includes a chunk of record data with provided dataset bulk information
+
+    Parameters
+    ----------
+    name:
+        The dataset name
+    bulk:
+        The bulk data
+    service:
+        the Service
+    datasets:
+        The dataset service
+    current_user:
+        Current request user
+
+    Returns
+    -------
+        Bulk response data
+    """
+
+    task = TASK_TYPE
+
+    datasets.upsert(
+        CreationDatasetRequest(**{**bulk.dict(), "name": name}),
+        owner=current_user.current_group,
+        task=task,
+    )
+    result = service.add_records(
+        dataset=name,
+        owner=current_user.current_group,
+        records=bulk.records,
+    )
+    return BulkResponse(
+        dataset=name,
+        processed=result.processed,
+        failed=result.failed,
+    )
+
+
+@router.post(
+    BASE_ENDPOINT + ":search",
+    response_model=Text2TextSearchResults,
+    response_model_exclude_none=True,
+    operation_id="search_records",
+)
+def search_records(
+    name: str,
+    search: Text2TextSearchRequest = None,
+    pagination: PaginationParams = Depends(),
+    service: Text2TextService = Depends(text2text_service),
+    datasets: DatasetsService = Depends(create_dataset_service),
+    current_user: User = Security(auth.get_user, scopes=[]),
+) -> Text2TextSearchResults:
+    """
+    Searches data from dataset
+
+    Parameters
+    ----------
+    name:
+        The dataset name
+    search:
+        THe search query request
+    pagination:
+        The pagination params
+    service:
+        The dataset records service
+    datasets:
+        The dataset service
+    current_user:
+        The current request user
+
+    Returns
+    -------
+        The search results data
+
+    """
+
+    datasets.find_by_name(name, owner=current_user.current_group)
+    search = search or Text2TextSearchRequest()
+    query = search.query or Text2TextQuery()
+
+    result = service.search(
+        dataset=name,
+        owner=current_user.current_group,
+        search=query,
+        record_from=pagination.from_,
+        size=pagination.limit,
+    )
+
+    return result
+
+
+def scan_data_response(
+    data_stream: Iterable[Text2TextRecord],
+    chunk_size: int = 1000,
+    limit: Optional[int] = None,
+) -> StreamingResponse:
+    """Generate an textual stream data response for a dataset scan"""
+
+    async def stream_generator(stream):
+        """Converts dataset scan into a text stream"""
+
+        def grouper(n, iterable, fillvalue=None):
+            args = [iter(iterable)] * n
+            return itertools.zip_longest(fillvalue=fillvalue, *args)
+
+        if limit:
+            stream = takeuntil(stream, limit=limit)
+
+        for batch in grouper(
+            n=chunk_size,
+            iterable=stream,
+        ):
+            filtered_records = filter(lambda r: r is not None, batch)
+            yield "\n".join(
+                map(
+                    lambda r: r.json(by_alias=True, exclude_none=True), filtered_records
+                )
+            ) + "\n"
+
+    return StreamingResponse(
+        stream_generator(data_stream), media_type="application/json"
+    )
+
+
+@router.post(
+    BASE_ENDPOINT + "/data",
+    operation_id="stream_data",
+)
+async def stream_data(
+    name: str,
+    query: Optional[Text2TextQuery] = None,
+    limit: Optional[int] = Query(None, description="Limit loaded records", gt=0),
+    service: Text2TextService = Depends(text2text_service),
+    datasets: DatasetsService = Depends(create_dataset_service),
+    current_user: User = Security(auth.get_user, scopes=[]),
+) -> StreamingResponse:
+    """
+    Creates a data stream over dataset records
+
+    Parameters
+    ----------
+    name
+        The dataset name
+    query:
+        The stream data query
+    limit:
+        The load number of records limit. Optional
+    service:
+        The dataset records service
+    datasets:
+        The datasets service
+    current_user:
+        Request user
+
+    """
+    query = query or Text2TextQuery()
+    found = datasets.find_by_name(name, owner=current_user.current_group)
+    data_stream = service.read_dataset(found.name, owner=found.owner, query=query)
+
+    return scan_data_response(
+        data_stream=data_stream,
+        limit=limit,
+    )

--- a/src/rubrix/server/tasks/text2text/api/model.py
+++ b/src/rubrix/server/tasks/text2text/api/model.py
@@ -27,14 +27,14 @@ class Text2TextAnnotation(BaseAnnotation):
     -----------
 
     text: str
-        the generated text
+        the annotation text
 
     score: float
         the annotation score
     """
 
     text: str
-    score: float = Field(ge=0.0, le=1.0)
+    score: float = Field(default=1.0, ge=0.0, le=1.0)
 
 
 class CreationText2TextRecord(BaseRecord[Text2TextAnnotation]):

--- a/src/rubrix/server/tasks/text2text/api/model.py
+++ b/src/rubrix/server/tasks/text2text/api/model.py
@@ -1,0 +1,253 @@
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field, validator
+from rubrix.server.datasets.model import UpdateDatasetRequest
+from rubrix.server.tasks.commons.api.model import (
+    BaseAnnotation,
+    BaseRecord,
+    PredictionStatus,
+    ScoreRange,
+    TaskStatus,
+    TaskType,
+)
+
+
+class ExtendedEsRecordDataFieldNames(str, Enum):
+    text_predicted = "text_predicted"
+    text_annotated = "text_annotated"
+
+
+class Text2TextAnnotation(BaseAnnotation):
+    """
+    Annotation class for text2text tasks
+
+    Attributes:
+    -----------
+
+    text: str
+        the generated text
+
+    score: float
+        the annotation score
+    """
+
+    text: str
+    score: float = Field(ge=0.0, le=1.0)
+
+
+class CreationText2TextRecord(BaseRecord[Text2TextAnnotation]):
+    """
+    Text2Text record
+
+    Attributes:
+    -----------
+
+    text:
+        The input data text
+    """
+
+    text: str
+
+    @classmethod
+    def task(cls) -> TaskType:
+        """The task type"""
+        return TaskType.text_to_text
+
+    @property
+    def predicted(self) -> Optional[PredictionStatus]:
+        if self.predicted_as and self.annotated_as:
+            return (
+                PredictionStatus.OK
+                if set(self.predicted_as) == set(self.annotated_as)
+                else PredictionStatus.KO
+            )
+        return None
+
+    @property
+    def words(self) -> str:
+        return self.text
+
+    @property
+    def predicted_as(self) -> Optional[str]:
+        return self.prediction.text if self.prediction else None
+
+    @property
+    def annotated_as(self) -> Optional[str]:
+        return self.annotation.text if self.annotation else None
+
+    @property
+    def scores(self) -> List[float]:
+        """Values of prediction scores"""
+        if not self.prediction:
+            return []
+        return [self.prediction.score]
+
+    @validator("text")
+    def validate_text(cls, text: Dict[str, Any]):
+        """Applies validation over input text"""
+        assert len(text) > 0, "No text provided"
+        return text
+
+
+class Text2TextRecordDB(CreationText2TextRecord):
+    """
+    The db text2text task record
+
+    Attributes:
+    -----------
+
+    last_updated: datetime
+        Last record update (read only)
+    predicted: Optional[PredictionStatus]
+        The record prediction status. Optional
+    """
+
+    last_updated: datetime = None
+    _predicted: Optional[PredictionStatus] = Field(alias="predicted")
+
+    def extended_fields(self) -> Dict[str, Any]:
+        return {
+            ExtendedEsRecordDataFieldNames.text_predicted: self.predicted_as,
+            ExtendedEsRecordDataFieldNames.text_annotated: self.annotated_as,
+        }
+
+
+class Text2TextRecord(Text2TextRecordDB):
+    """
+    The output text2text task record
+    """
+
+    def extended_fields(self) -> Dict[str, Any]:
+        return {}
+
+
+class Text2TextBulkData(UpdateDatasetRequest):
+    """
+    API bulk data for text2text
+
+    Attributes:
+    -----------
+
+    records: List[CreationText2TextRecord]
+        The text2text record list
+
+    """
+
+    records: List[CreationText2TextRecord]
+
+
+class Text2TextQuery(BaseModel):
+    """
+    API Filters for text2text
+
+    Attributes:
+    -----------
+    ids: Optional[List[Union[str, int]]]
+        Record ids list
+
+    query_text: str
+        Text query over input text
+
+    annotated_by: List[str]
+        List of annotation agents
+    predicted_by: List[str]
+        List of predicted agents
+
+    status: List[TaskStatus]
+        List of task status
+
+    metadata: Optional[Dict[str, Union[str, List[str]]]]
+        Text query over metadata fields. Default=None
+
+    predicted: Optional[PredictionStatus]
+        The task prediction status
+
+    """
+
+    ids: Optional[List[Union[str, int]]]
+
+    query_text: str = Field(default=None)
+
+    annotated_by: List[str] = Field(default_factory=list)
+    predicted_by: List[str] = Field(default_factory=list)
+
+    score: Optional[ScoreRange] = Field(default=None)
+
+    status: List[TaskStatus] = Field(default_factory=list)
+
+    predicted: Optional[PredictionStatus] = Field(default=None, nullable=True)
+    metadata: Optional[Dict[str, Union[str, List[str]]]] = None
+
+
+class Text2TextSearchRequest(BaseModel):
+    """
+    API SearchRequest request
+
+    Attributes:
+    -----------
+
+    query: Text2TextQuery
+        The search query configuration
+    """
+
+    query: Text2TextQuery = Field(default_factory=Text2TextQuery)
+
+
+class Text2TextSearchAggregations(BaseModel):
+    """
+    API for result aggregations
+
+    Attributes:
+    -----------
+    words: Dict[str, int]
+        The word cloud aggregations for input text
+    predicted_text: Dict[str, int]
+        The word cloud aggregations for predicted text
+    annotated_text: Dict[str, int]
+        The word cloud aggregations for annotated text
+    annotated_by: Dict[str, int]
+        Occurrence info about more relevant annotation agent terms
+    predicted_by: Dict[str, int]
+        Occurrence info about more relevant prediction agent terms
+    status: Dict[str, int]
+        Occurrence info about task status
+    predicted: Dict[str, int]
+        Occurrence info about task prediction status
+    metadata: Dict[str, Dict[str, int]]
+        The metadata fields aggregations
+    """
+
+    words: Dict[str, int] = Field(default_factory=dict)
+    predicted_text: Dict[str, int] = Field(default_factory=dict)
+    annotated_text: Dict[str, int] = Field(default_factory=dict)
+
+    annotated_by: Dict[str, int] = Field(default_factory=dict)
+    predicted_by: Dict[str, int] = Field(default_factory=dict)
+
+    status: Dict[str, int] = Field(default_factory=dict)
+    predicted: Dict[str, int] = Field(default_factory=dict)
+    score: Dict[str, int] = Field(default_factory=dict)
+    metadata: Dict[str, Dict[str, int]] = Field(default_factory=dict)
+
+
+class Text2TextSearchResults(BaseModel):
+    """
+    API search results
+
+    Attributes:
+    -----------
+
+    total: int
+        The total number of records
+    records: List[Text2TextRecord]
+        The selected records to return
+    aggregations: Text2TextSearchAggregations
+        SearchRequest aggregations (if no pagination)
+
+    """
+
+    total: int = 0
+    records: List[Text2TextRecord] = Field(default_factory=list)
+    aggregations: Text2TextSearchAggregations = None

--- a/src/rubrix/server/tasks/text2text/service/service.py
+++ b/src/rubrix/server/tasks/text2text/service/service.py
@@ -1,0 +1,217 @@
+import datetime
+from typing import Any, Dict, Iterable, List, Optional
+
+from fastapi import Depends
+from rubrix.server.datasets.service import DatasetsService, create_dataset_service
+from rubrix.server.tasks.commons import BulkResponse
+from rubrix.server.tasks.commons.dao import extends_index_properties
+from rubrix.server.tasks.commons.dao.dao import DatasetRecordsDAO, dataset_records_dao
+from rubrix.server.tasks.commons.dao.model import RecordSearch
+from rubrix.server.tasks.commons.es_helpers import aggregations, filters
+from rubrix.server.tasks.text2text.api.model import (
+    CreationText2TextRecord,
+    ExtendedEsRecordDataFieldNames,
+    Text2TextQuery,
+    Text2TextRecord, Text2TextRecordDB,
+    Text2TextSearchAggregations,
+    Text2TextSearchResults,
+)
+
+extends_index_properties(
+    {
+        ExtendedEsRecordDataFieldNames.text_predicted: {
+            "type": "text",
+            "fielddata": True,
+            "analyzer": "multilingual_stop_analyzer",
+            "fields": {"extended": {"type": "text", "analyzer": "extended_analyzer"}},
+        },
+        ExtendedEsRecordDataFieldNames.text_annotated: {
+            "type": "text",
+            "fielddata": True,
+            "analyzer": "multilingual_stop_analyzer",
+            "fields": {"extended": {"type": "text", "analyzer": "extended_analyzer"}},
+        },
+    }
+)
+
+
+def as_elasticsearch(search: Text2TextQuery) -> Dict[str, Any]:
+    """Build an elasticsearch query part from search query"""
+
+    if search.ids:
+        return {"ids": {"values": search.ids}}
+
+    all_filters = filters.metadata(search.metadata)
+    query_filters = [
+        query_filter
+        for query_filter in [
+            filters.predicted_by(search.predicted_by),
+            filters.annotated_by(search.annotated_by),
+            filters.status(search.status),
+            filters.predicted(search.predicted),
+            filters.score(search.score),
+        ]
+        if query_filter
+    ]
+    query_text = filters.text_query(search.query_text)
+    all_filters.extend(query_filters)
+
+    return {
+        "bool": {
+            "must": query_text or {"match_all": {}},
+            "filter": {
+                "bool": {
+                    "should": all_filters,
+                    "minimum_should_match": len(all_filters),
+                }
+            },
+        }
+    }
+
+
+class Text2TextService:
+    """
+    Text2text service
+
+    """
+
+    def __init__(
+        self,
+        datasets: DatasetsService,
+        dao: DatasetRecordsDAO,
+    ):
+        self.__datasets__ = datasets
+        self.__dao__ = dao
+
+    def add_records(
+        self,
+        dataset: str,
+        owner: Optional[str],
+        records: List[CreationText2TextRecord],
+    ):
+        dataset = self.__datasets__.find_by_name(dataset, owner=owner)
+
+        db_records = []
+        now = datetime.datetime.now()
+        for record in records:
+            db_record = Text2TextRecordDB.parse_obj(record)
+            db_record.last_updated = now
+            db_records.append(db_record.dict(exclude_none=True))
+
+        failed = self.__dao__.add_records(
+            dataset=dataset,
+            records=db_records,
+        )
+        return BulkResponse(dataset=dataset.name, processed=len(records), failed=failed)
+
+    def search(
+        self,
+        dataset: str,
+        owner: Optional[str],
+        search: Text2TextQuery,
+        record_from: int = 0,
+        size: int = 100,
+    ) -> Text2TextSearchResults:
+        """
+        Run a search in a dataset
+
+        Parameters
+        ----------
+        dataset:
+            The dataset name
+        owner:
+            The dataset owner
+        search:
+            The search parameters
+        record_from:
+            The record from return results
+        size:
+            The max number of records to return
+
+        Returns
+        -------
+            The matched records with aggregation info for specified task_meta.py
+
+        """
+        dataset = self.__datasets__.find_by_name(dataset, owner=owner)
+
+        results = self.__dao__.search_records(
+            dataset,
+            search=RecordSearch(
+                query=as_elasticsearch(search),
+                aggregations={
+                    **aggregations.terms_aggregation(
+                        ExtendedEsRecordDataFieldNames.text_predicted
+                    ),
+                    **aggregations.terms_aggregation(
+                        ExtendedEsRecordDataFieldNames.text_predicted
+                    ),
+                },
+            ),
+            size=size,
+            record_from=record_from,
+        )
+        return Text2TextSearchResults(
+            total=results.total,
+            records=[Text2TextRecord.parse_obj(r) for r in results.records],
+            aggregations=Text2TextSearchAggregations(
+                **results.aggregations,
+                words=results.words,
+                metadata=results.metadata or {},
+            )
+            if results.aggregations
+            else None,
+        )
+
+    def read_dataset(
+        self,
+        dataset: str,
+        owner: Optional[str],
+        query: Optional[Text2TextQuery] = None,
+    ) -> Iterable[Text2TextRecord]:
+        """
+        Scan a dataset records
+
+        Parameters
+        ----------
+        dataset:
+            The dataset name
+        owner:
+            The dataset owner. Optional
+        query:
+            If provided, scan will retrieve only records matching
+            the provided query filters. Optional
+
+        """
+        dataset = self.__datasets__.find_by_name(dataset, owner=owner)
+        for db_record in self.__dao__.scan_dataset(
+            dataset, search=RecordSearch(query=as_elasticsearch(query))
+        ):
+            yield Text2TextRecord.parse_obj(db_record)
+
+
+_instance = None
+
+
+def text2text_service(
+    datasets: DatasetsService = Depends(create_dataset_service),
+    dao: DatasetRecordsDAO = Depends(dataset_records_dao),
+) -> Text2TextService:
+    """
+    Creates a dataset record service instance
+
+    Parameters
+    ----------
+    datasets:
+        The datasets service dependency
+    dao:
+        The dataset records dao dependency
+
+    Returns
+    -------
+        A dataset records service instance
+    """
+    global _instance
+    if not _instance:
+        _instance = Text2TextService(datasets=datasets, dao=dao)
+    return _instance

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -131,7 +131,7 @@ def test_init_incorrect(mock_response_500):
     rubrix._client = None  # assert empty client
     with pytest.raises(
         Exception,
-        match="Connection error: Indetermined error connecting to Rubrix Server. The API answered with a 500 code: b",
+        match="Connection error: Undetermined error connecting to the Rubrix Server. The API answered with a 500 code: b",
     ):
         rubrix.init()
 
@@ -165,7 +165,7 @@ def test_init_token_incorrect(mock_response_500):
     rubrix._client = None  # assert empty client
     with pytest.raises(
         Exception,
-        match="Connection error: Indetermined error connecting to Rubrix Server. The API answered with a 500 code: b",
+        match="Connection error: Undetermined error connecting to the Rubrix Server. The API answered with a 500 code: b",
     ):
         rubrix.init(api_key="422")
 
@@ -181,7 +181,7 @@ def test_init_token_auth_fail(mock_response_token_401):
         Mocked correct http response
     """
     rubrix._client = None  # assert empty client
-    with pytest.raises(Exception, match="Authentification error: invalid credentials."):
+    with pytest.raises(Exception, match="Authentication error: invalid credentials."):
         rubrix.init(api_url="fake_url", api_key="422")
 
 


### PR DESCRIPTION
This is a WIP PR providing a task (just in API) for text2text tasks (machine translation, sumarization,...). Once this PR is discussed and approved, we can make efforts to bring the integration with client and UI.

The api record data model proposed is (common record properties are omitted):
```yaml
---
title: Text2TextAnnotation
description: |-
  Annotation class for text2text tasks
required:
- agent
- text
- score
type: object
properties:
  agent:
    title: Agent
    type: string
  text:
    title: Text
    type: string
  score:
    title: Score
    maximum: 1
    minimum: 0
    type: number
---
title: Text2TextRecord
description: The output text2text task record
required:
- text
type: object
properties:
  text:
    title: Text
    type: string
  prediction:
    "$ref": "#/components/schemas/Text2TextAnnotation"
  annotation:
    "$ref": "#/components/schemas/Text2TextAnnotation"
```

For search queries, `predicted_as` and `annotated_as` fields are removed and 2 new fields are available for text search on those fields `text_predicted` and `text_annotated` .



 