### PR TITLE
fix(token-class): validate predicted entities when no record edition

### DIFF
--- a/frontend/components/commons/GlobalActions.vue
+++ b/frontend/components/commons/GlobalActions.vue
@@ -156,7 +156,6 @@ export default {
         return {
           ...record,
           annotation: {
-            agent: this.$auth.user,
             labels: this.isMultiLabelRecord
               ? [...appliedLabels, ...newLabels]
               : newLabels,
@@ -167,6 +166,7 @@ export default {
       await this.validate({
         dataset: this.dataset,
         records: records,
+        agent: this.$auth.user,
       });
     },
     closeNewLabelVisible() {
@@ -180,9 +180,19 @@ export default {
       });
     },
     async onValidate() {
+      let records = this.selectedRecords;
+      if (this.isTokenClassification) {
+        records = records.map((record) => ({
+          ...record,
+          annotation: record.annotation
+            ? record.annotation
+            : { entities: record.prediction.entities },
+        }));
+      }
       await this.validate({
         dataset: this.dataset,
-        records: this.selectedRecords,
+        records: records,
+        agent: this.$auth.user,
       });
     },
     async addNewLabel(newLabel) {

--- a/frontend/components/text-classifier/RecordTextClassification.vue
+++ b/frontend/components/text-classifier/RecordTextClassification.vue
@@ -135,6 +135,7 @@ export default {
     async onAnnotate({ labels }) {
       await this.validate({
         dataset: this.dataset,
+        agent: this.$auth.user,
         records: [
           {
             ...this.record,
@@ -142,7 +143,6 @@ export default {
               ? "Edited"
               : this.record.status,
             annotation: {
-              agent: this.$auth.user,
               labels: labels.map((label) => ({
                 class: label,
                 confidence: 1.0,

--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -98,9 +98,13 @@ const actions = {
       persistBackend: true,
     });
   },
-  async validateAnnotations({ dispatch }, { dataset, records }) {
+  async validateAnnotations({ dispatch }, { dataset, records, agent }) {
     const newRecords = records.map((record) => ({
       ...record,
+      annotation: {
+        agent,
+        ...record.annotation,
+      },
       selected: false,
       status: "Validated",
     }));


### PR DESCRIPTION
This PR fills annotation info for token classification from predicted data to validate non modified records 