### PR TITLE
Change naming from 'texttotext' to 'text2text'

### DIFF
--- a/src/rubrix/client/__init__.py
+++ b/src/rubrix/client/__init__.py
@@ -24,7 +24,7 @@ from rubrix.sdk.models.text2_text_bulk_data import Text2TextBulkData
 from rubrix.sdk.models.text2_text_bulk_data_metadata import Text2TextBulkDataMetadata
 from rubrix.sdk.models.text2_text_bulk_data_tags import Text2TextBulkDataTags
 from rubrix.sdk.models.text2_text_query import Text2TextQuery
-from rubrix.sdk.api.text_to_text import bulk_records as text_to_text_bulk_records
+from rubrix.sdk.api.text2_text import bulk_records as text2text_bulk_records
 from rubrix.sdk.api.datasets import copy_dataset, delete_dataset
 from rubrix.sdk.api.text_classification import (
     bulk_records as text_classification_bulk_records,
@@ -47,8 +47,8 @@ from rubrix.sdk.api.text_classification import (
 from rubrix.sdk.api.token_classification import (
     _get_dataset_data as token_classification_get_dataset_data,
 )
-from rubrix.sdk.api.text_to_text import (
-    _get_dataset_data as text_to_text_get_dataset_data,
+from rubrix.sdk.api.text2_text import (
+    _get_dataset_data as text2text_get_dataset_data,
 )
 
 
@@ -168,7 +168,7 @@ class RubrixClient:
 
         elif record_type is Text2TextRecord:
             bulk_class = Text2TextBulkData
-            bulk_records_function = text_to_text_bulk_records.sync_detailed
+            bulk_records_function = text2text_bulk_records.sync_detailed
             tags = Text2TextBulkDataTags.from_dict(tags)
             metadata = Text2TextBulkDataMetadata.from_dict(metadata)
             to_sdk_model = self._text2text_client_to_sdk
@@ -234,8 +234,8 @@ class RubrixClient:
                 self._token_classification_sdk_to_client,
                 TokenClassificationQuery,
             ),
-            TaskType.TEXTTOTEXT: (
-                text_to_text_get_dataset_data,
+            TaskType.TEXT2TEXT: (
+                text2text_get_dataset_data,
                 self._text2text_sdk_to_client,
                 Text2TextQuery,
             ),
@@ -246,7 +246,7 @@ class RubrixClient:
         except KeyError:
             raise ValueError(
                 f"Sorry, load method not supported for the '{task}' task. Supported tasks: "
-                f"{[TaskType.TEXTCLASSIFICATION, TaskType.TOKENCLASSIFICATION, TaskType.TEXTTOTEXT]}"
+                f"{[TaskType.TEXTCLASSIFICATION, TaskType.TOKENCLASSIFICATION, TaskType.TEXT2TEXT]}"
             )
         response = get_dataset_data.sync_detailed(
             client=self._client,

--- a/src/rubrix/sdk/api/text2_text/_get_dataset_data.py
+++ b/src/rubrix/sdk/api/text2_text/_get_dataset_data.py
@@ -16,7 +16,7 @@ def _get_kwargs(
     json_body: Optional[Text2TextQuery] = None,
     limit: Optional[int] = None,
 ) -> Dict[str, Any]:
-    url = "{}/api/datasets/{name}/TextToText/data".format(
+    url = "{}/api/datasets/{name}/Text2Text/data".format(
         client.base_url, name=name
     )
 

--- a/src/rubrix/sdk/api/text2_text/bulk_records.py
+++ b/src/rubrix/sdk/api/text2_text/bulk_records.py
@@ -3,31 +3,23 @@ from typing import Any, Dict, Optional, Union
 import httpx
 
 from ...client import AuthenticatedClient
+from ...models.bulk_response import BulkResponse
 from ...models.error_message import ErrorMessage
 from ...models.http_validation_error import HTTPValidationError
-from ...models.text2_text_search_request import Text2TextSearchRequest
-from ...models.text2_text_search_results import Text2TextSearchResults
-from ...types import UNSET, Response, Unset
+from ...models.text2_text_bulk_data import Text2TextBulkData
+from ...types import Response
 
 
 def _get_kwargs(
     *,
     client: AuthenticatedClient,
     name: str,
-    json_body: Text2TextSearchRequest,
-    limit: Union[Unset, int] = 50,
-    from_: Union[Unset, int] = 0,
+    json_body: Text2TextBulkData,
 ) -> Dict[str, Any]:
-    url = "{}/api/datasets/{name}/TextToText:search".format(client.base_url, name=name)
+    url = "{}/api/datasets/{name}/Text2Text:bulk".format(client.base_url, name=name)
 
     headers: Dict[str, Any] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()
-
-    params: Dict[str, Any] = {
-        "limit": limit,
-        "from": from_,
-    }
-    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     json_json_body = json_body.to_dict()
 
@@ -37,17 +29,14 @@ def _get_kwargs(
         "cookies": cookies,
         "timeout": client.get_timeout(),
         "json": json_json_body,
-        "params": params,
     }
 
 
 def _parse_response(
     *, response: httpx.Response
-) -> Optional[
-    Union[Text2TextSearchResults, ErrorMessage, ErrorMessage, HTTPValidationError]
-]:
+) -> Optional[Union[BulkResponse, ErrorMessage, ErrorMessage, HTTPValidationError]]:
     if response.status_code == 200:
-        response_200 = Text2TextSearchResults.from_dict(response.json())
+        response_200 = BulkResponse.from_dict(response.json())
 
         return response_200
     if response.status_code == 404:
@@ -67,9 +56,7 @@ def _parse_response(
 
 def _build_response(
     *, response: httpx.Response
-) -> Response[
-    Union[Text2TextSearchResults, ErrorMessage, ErrorMessage, HTTPValidationError]
-]:
+) -> Response[Union[BulkResponse, ErrorMessage, ErrorMessage, HTTPValidationError]]:
     return Response(
         status_code=response.status_code,
         content=response.content,
@@ -82,18 +69,12 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     name: str,
-    json_body: Text2TextSearchRequest,
-    limit: Union[Unset, int] = 50,
-    from_: Union[Unset, int] = 0,
-) -> Response[
-    Union[Text2TextSearchResults, ErrorMessage, ErrorMessage, HTTPValidationError]
-]:
+    json_body: Text2TextBulkData,
+) -> Response[Union[BulkResponse, ErrorMessage, ErrorMessage, HTTPValidationError]]:
     kwargs = _get_kwargs(
         client=client,
         name=name,
         json_body=json_body,
-        limit=limit,
-        from_=from_,
     )
 
     response = httpx.post(
@@ -107,39 +88,31 @@ def sync(
     *,
     client: AuthenticatedClient,
     name: str,
-    json_body: Text2TextSearchRequest,
-    limit: Union[Unset, int] = 50,
-    from_: Union[Unset, int] = 0,
-) -> Optional[
-    Union[Text2TextSearchResults, ErrorMessage, ErrorMessage, HTTPValidationError]
-]:
-    """Searches data from dataset
+    json_body: Text2TextBulkData,
+) -> Optional[Union[BulkResponse, ErrorMessage, ErrorMessage, HTTPValidationError]]:
+    """Includes a chunk of record data with provided dataset bulk information
 
     Parameters
     ----------
     name:
         The dataset name
-    search:
-        THe search query request
-    pagination:
-        The pagination params
+    bulk:
+        The bulk data
     service:
-        The dataset records service
+        the Service
     datasets:
         The dataset service
     current_user:
-        The current request user
+        Current request user
 
     Returns
     -------
-        The search results data"""
+        Bulk response data"""
 
     return sync_detailed(
         client=client,
         name=name,
         json_body=json_body,
-        limit=limit,
-        from_=from_,
     ).parsed
 
 
@@ -147,18 +120,12 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     name: str,
-    json_body: Text2TextSearchRequest,
-    limit: Union[Unset, int] = 50,
-    from_: Union[Unset, int] = 0,
-) -> Response[
-    Union[Text2TextSearchResults, ErrorMessage, ErrorMessage, HTTPValidationError]
-]:
+    json_body: Text2TextBulkData,
+) -> Response[Union[BulkResponse, ErrorMessage, ErrorMessage, HTTPValidationError]]:
     kwargs = _get_kwargs(
         client=client,
         name=name,
         json_body=json_body,
-        limit=limit,
-        from_=from_,
     )
 
     async with httpx.AsyncClient() as _client:
@@ -171,39 +138,31 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     name: str,
-    json_body: Text2TextSearchRequest,
-    limit: Union[Unset, int] = 50,
-    from_: Union[Unset, int] = 0,
-) -> Optional[
-    Union[Text2TextSearchResults, ErrorMessage, ErrorMessage, HTTPValidationError]
-]:
-    """Searches data from dataset
+    json_body: Text2TextBulkData,
+) -> Optional[Union[BulkResponse, ErrorMessage, ErrorMessage, HTTPValidationError]]:
+    """Includes a chunk of record data with provided dataset bulk information
 
     Parameters
     ----------
     name:
         The dataset name
-    search:
-        THe search query request
-    pagination:
-        The pagination params
+    bulk:
+        The bulk data
     service:
-        The dataset records service
+        the Service
     datasets:
         The dataset service
     current_user:
-        The current request user
+        Current request user
 
     Returns
     -------
-        The search results data"""
+        Bulk response data"""
 
     return (
         await asyncio_detailed(
             client=client,
             name=name,
             json_body=json_body,
-            limit=limit,
-            from_=from_,
         )
     ).parsed

--- a/src/rubrix/sdk/api/text2_text/search_records.py
+++ b/src/rubrix/sdk/api/text2_text/search_records.py
@@ -3,23 +3,31 @@ from typing import Any, Dict, Optional, Union
 import httpx
 
 from ...client import AuthenticatedClient
-from ...models.bulk_response import BulkResponse
 from ...models.error_message import ErrorMessage
 from ...models.http_validation_error import HTTPValidationError
-from ...models.text2_text_bulk_data import Text2TextBulkData
-from ...types import Response
+from ...models.text2_text_search_request import Text2TextSearchRequest
+from ...models.text2_text_search_results import Text2TextSearchResults
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     *,
     client: AuthenticatedClient,
     name: str,
-    json_body: Text2TextBulkData,
+    json_body: Text2TextSearchRequest,
+    limit: Union[Unset, int] = 50,
+    from_: Union[Unset, int] = 0,
 ) -> Dict[str, Any]:
-    url = "{}/api/datasets/{name}/TextToText:bulk".format(client.base_url, name=name)
+    url = "{}/api/datasets/{name}/Text2Text:search".format(client.base_url, name=name)
 
     headers: Dict[str, Any] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()
+
+    params: Dict[str, Any] = {
+        "limit": limit,
+        "from": from_,
+    }
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
 
     json_json_body = json_body.to_dict()
 
@@ -29,14 +37,17 @@ def _get_kwargs(
         "cookies": cookies,
         "timeout": client.get_timeout(),
         "json": json_json_body,
+        "params": params,
     }
 
 
 def _parse_response(
     *, response: httpx.Response
-) -> Optional[Union[BulkResponse, ErrorMessage, ErrorMessage, HTTPValidationError]]:
+) -> Optional[
+    Union[Text2TextSearchResults, ErrorMessage, ErrorMessage, HTTPValidationError]
+]:
     if response.status_code == 200:
-        response_200 = BulkResponse.from_dict(response.json())
+        response_200 = Text2TextSearchResults.from_dict(response.json())
 
         return response_200
     if response.status_code == 404:
@@ -56,7 +67,9 @@ def _parse_response(
 
 def _build_response(
     *, response: httpx.Response
-) -> Response[Union[BulkResponse, ErrorMessage, ErrorMessage, HTTPValidationError]]:
+) -> Response[
+    Union[Text2TextSearchResults, ErrorMessage, ErrorMessage, HTTPValidationError]
+]:
     return Response(
         status_code=response.status_code,
         content=response.content,
@@ -69,12 +82,18 @@ def sync_detailed(
     *,
     client: AuthenticatedClient,
     name: str,
-    json_body: Text2TextBulkData,
-) -> Response[Union[BulkResponse, ErrorMessage, ErrorMessage, HTTPValidationError]]:
+    json_body: Text2TextSearchRequest,
+    limit: Union[Unset, int] = 50,
+    from_: Union[Unset, int] = 0,
+) -> Response[
+    Union[Text2TextSearchResults, ErrorMessage, ErrorMessage, HTTPValidationError]
+]:
     kwargs = _get_kwargs(
         client=client,
         name=name,
         json_body=json_body,
+        limit=limit,
+        from_=from_,
     )
 
     response = httpx.post(
@@ -88,31 +107,39 @@ def sync(
     *,
     client: AuthenticatedClient,
     name: str,
-    json_body: Text2TextBulkData,
-) -> Optional[Union[BulkResponse, ErrorMessage, ErrorMessage, HTTPValidationError]]:
-    """Includes a chunk of record data with provided dataset bulk information
+    json_body: Text2TextSearchRequest,
+    limit: Union[Unset, int] = 50,
+    from_: Union[Unset, int] = 0,
+) -> Optional[
+    Union[Text2TextSearchResults, ErrorMessage, ErrorMessage, HTTPValidationError]
+]:
+    """Searches data from dataset
 
     Parameters
     ----------
     name:
         The dataset name
-    bulk:
-        The bulk data
+    search:
+        THe search query request
+    pagination:
+        The pagination params
     service:
-        the Service
+        The dataset records service
     datasets:
         The dataset service
     current_user:
-        Current request user
+        The current request user
 
     Returns
     -------
-        Bulk response data"""
+        The search results data"""
 
     return sync_detailed(
         client=client,
         name=name,
         json_body=json_body,
+        limit=limit,
+        from_=from_,
     ).parsed
 
 
@@ -120,12 +147,18 @@ async def asyncio_detailed(
     *,
     client: AuthenticatedClient,
     name: str,
-    json_body: Text2TextBulkData,
-) -> Response[Union[BulkResponse, ErrorMessage, ErrorMessage, HTTPValidationError]]:
+    json_body: Text2TextSearchRequest,
+    limit: Union[Unset, int] = 50,
+    from_: Union[Unset, int] = 0,
+) -> Response[
+    Union[Text2TextSearchResults, ErrorMessage, ErrorMessage, HTTPValidationError]
+]:
     kwargs = _get_kwargs(
         client=client,
         name=name,
         json_body=json_body,
+        limit=limit,
+        from_=from_,
     )
 
     async with httpx.AsyncClient() as _client:
@@ -138,31 +171,39 @@ async def asyncio(
     *,
     client: AuthenticatedClient,
     name: str,
-    json_body: Text2TextBulkData,
-) -> Optional[Union[BulkResponse, ErrorMessage, ErrorMessage, HTTPValidationError]]:
-    """Includes a chunk of record data with provided dataset bulk information
+    json_body: Text2TextSearchRequest,
+    limit: Union[Unset, int] = 50,
+    from_: Union[Unset, int] = 0,
+) -> Optional[
+    Union[Text2TextSearchResults, ErrorMessage, ErrorMessage, HTTPValidationError]
+]:
+    """Searches data from dataset
 
     Parameters
     ----------
     name:
         The dataset name
-    bulk:
-        The bulk data
+    search:
+        THe search query request
+    pagination:
+        The pagination params
     service:
-        the Service
+        The dataset records service
     datasets:
         The dataset service
     current_user:
-        Current request user
+        The current request user
 
     Returns
     -------
-        Bulk response data"""
+        The search results data"""
 
     return (
         await asyncio_detailed(
             client=client,
             name=name,
             json_body=json_body,
+            limit=limit,
+            from_=from_,
         )
     ).parsed

--- a/src/rubrix/sdk/models/task_type.py
+++ b/src/rubrix/sdk/models/task_type.py
@@ -4,7 +4,7 @@ from enum import Enum
 class TaskType(str, Enum):
     TEXTCLASSIFICATION = "TextClassification"
     TOKENCLASSIFICATION = "TokenClassification"
-    TEXTTOTEXT = "TextToText"
+    TEXT2TEXT = "Text2Text"
     MULTITASKTEXTTOKENCLASSIFICATION = "MultitaskTextTokenClassification"
 
     def __str__(self) -> str:

--- a/src/rubrix/server/tasks/commons/api/model.py
+++ b/src/rubrix/server/tasks/commons/api/model.py
@@ -95,7 +95,7 @@ class TaskType(str, Enum):
 
     text_classification = "TextClassification"
     token_classification = "TokenClassification"
-    text_to_text = "TextToText"
+    text2text = "Text2Text"
     multi_task_text_token_classification = "MultitaskTextTokenClassification"
 
 

--- a/src/rubrix/server/tasks/text2text/api/api.py
+++ b/src/rubrix/server/tasks/text2text/api/api.py
@@ -22,7 +22,7 @@ from rubrix.server.tasks.text2text.service.service import (
     text2text_service,
 )
 
-TASK_TYPE = TaskType.text_to_text
+TASK_TYPE = TaskType.text2text
 BASE_ENDPOINT = "/{name}/" + TASK_TYPE
 
 router = APIRouter(tags=[TASK_TYPE], prefix="/datasets")

--- a/src/rubrix/server/tasks/text2text/api/model.py
+++ b/src/rubrix/server/tasks/text2text/api/model.py
@@ -57,7 +57,7 @@ class CreationText2TextRecord(BaseRecord[Text2TextAnnotation]):
     @classmethod
     def task(cls) -> TaskType:
         """The task type"""
-        return TaskType.text_to_text
+        return TaskType.text2text
 
     @property
     def predicted(self) -> Optional[PredictionStatus]:

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -130,7 +130,7 @@ def mock_response_text2text(monkeypatch):
         )
 
     monkeypatch.setattr(
-        "rubrix.client.text_to_text_bulk_records.sync_detailed",
+        "rubrix.client.text2text_bulk_records.sync_detailed",
         mock_get,
     )  # apply the monkeypatch for requests.get to mock_get
 


### PR DESCRIPTION
This PR changes all namings from 'texttotext' (or 'text_to_text') to 'text2text'. I am not sure if this automatically solves the naming in the UI, maye @frascuchon or @leiyre can answer this. Closes #321 