### PR TITLE
feature(search): aggregate float values

### DIFF
--- a/frontend/components/commons/header/filters/FiltersList.vue
+++ b/frontend/components/commons/header/filters/FiltersList.vue
@@ -20,7 +20,8 @@
           active: initialVisibleGroup === 'sort' || dataset.sort.length,
         }"
         @click="selectGroup('sort')"
-      ><svgicon name="sort" width="14" height="14" />
+      >
+        <svgicon name="sort" width="14" height="14" />
         Sort
         <span v-if="dataset.sort.length">({{ dataset.sort.length }})</span>
       </p>
@@ -160,6 +161,8 @@ export default {
       const metadataFilters =
         aggregations.metadata &&
         Object.keys(aggregations.metadata).map((key) => {
+          const filterContent = aggregations.metadata[key];
+
           return {
             key: key,
             name: key,
@@ -167,10 +170,8 @@ export default {
             group: "Metadata",
             placeholder: "Select options",
             id: key,
-            options: aggregations.metadata[key],
-            selected: this.dataset.query.metadata
-              ? this.dataset.query.metadata[key] || []
-              : [],
+            options: typeof filterContent === "object" ? [] : filterContent,
+            selected: (this.dataset.query.metadata || {})[key] || [],
           };
         });
       const sortedMetadataFilters =

--- a/src/rubrix/sdk/models/text2_text_search_aggregations_metadata_additional_property.py
+++ b/src/rubrix/sdk/models/text2_text_search_aggregations_metadata_additional_property.py
@@ -9,7 +9,7 @@ T = TypeVar("T", bound="Text2TextSearchAggregationsMetadataAdditionalProperty")
 class Text2TextSearchAggregationsMetadataAdditionalProperty:
     """ """
 
-    additional_properties: Dict[str, int] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
 
@@ -33,10 +33,10 @@ class Text2TextSearchAggregationsMetadataAdditionalProperty:
     def additional_keys(self) -> List[str]:
         return list(self.additional_properties.keys())
 
-    def __getitem__(self, key: str) -> int:
+    def __getitem__(self, key: str) -> Any:
         return self.additional_properties[key]
 
-    def __setitem__(self, key: str, value: int) -> None:
+    def __setitem__(self, key: str, value: Any) -> None:
         self.additional_properties[key] = value
 
     def __delitem__(self, key: str) -> None:

--- a/src/rubrix/sdk/models/text_classification_search_aggregations.py
+++ b/src/rubrix/sdk/models/text_classification_search_aggregations.py
@@ -54,7 +54,7 @@ class TextClassificationSearchAggregations:
         Occurrence info about task prediction status
     words: Dict[str, int]
         The word cloud aggregations
-    metadata: Dict[str, Dict[str, int]]
+    metadata: Dict[str, Dict[str, Any]]
         The metadata fields aggregations"""
 
     predicted_as: Union[TextClassificationSearchAggregationsPredictedAs, Unset] = UNSET

--- a/src/rubrix/sdk/models/text_classification_search_aggregations_metadata_additional_property.py
+++ b/src/rubrix/sdk/models/text_classification_search_aggregations_metadata_additional_property.py
@@ -9,7 +9,7 @@ T = TypeVar("T", bound="TextClassificationSearchAggregationsMetadataAdditionalPr
 class TextClassificationSearchAggregationsMetadataAdditionalProperty:
     """ """
 
-    additional_properties: Dict[str, int] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
 
@@ -33,10 +33,10 @@ class TextClassificationSearchAggregationsMetadataAdditionalProperty:
     def additional_keys(self) -> List[str]:
         return list(self.additional_properties.keys())
 
-    def __getitem__(self, key: str) -> int:
+    def __getitem__(self, key: str) -> Any:
         return self.additional_properties[key]
 
-    def __setitem__(self, key: str, value: int) -> None:
+    def __setitem__(self, key: str, value: Any) -> None:
         self.additional_properties[key] = value
 
     def __delitem__(self, key: str) -> None:

--- a/src/rubrix/sdk/models/token_classification_aggregations_metadata_additional_property.py
+++ b/src/rubrix/sdk/models/token_classification_aggregations_metadata_additional_property.py
@@ -9,7 +9,7 @@ T = TypeVar("T", bound="TokenClassificationAggregationsMetadataAdditionalPropert
 class TokenClassificationAggregationsMetadataAdditionalProperty:
     """ """
 
-    additional_properties: Dict[str, int] = attr.ib(init=False, factory=dict)
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
 
@@ -33,10 +33,10 @@ class TokenClassificationAggregationsMetadataAdditionalProperty:
     def additional_keys(self) -> List[str]:
         return list(self.additional_properties.keys())
 
-    def __getitem__(self, key: str) -> int:
+    def __getitem__(self, key: str) -> Any:
         return self.additional_properties[key]
 
-    def __setitem__(self, key: str, value: int) -> None:
+    def __setitem__(self, key: str, value: Any) -> None:
         self.additional_properties[key] = value
 
     def __delitem__(self, key: str) -> None:

--- a/src/rubrix/server/tasks/text2text/api/model.py
+++ b/src/rubrix/server/tasks/text2text/api/model.py
@@ -246,7 +246,7 @@ class Text2TextSearchAggregations(BaseModel):
     status: Dict[str, int] = Field(default_factory=dict)
     predicted: Dict[str, int] = Field(default_factory=dict)
     score: Dict[str, int] = Field(default_factory=dict)
-    metadata: Dict[str, Dict[str, int]] = Field(default_factory=dict)
+    metadata: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
 
 
 class Text2TextSearchResults(BaseModel):

--- a/src/rubrix/server/tasks/text_classification/api/model.py
+++ b/src/rubrix/server/tasks/text_classification/api/model.py
@@ -391,7 +391,7 @@ class TextClassificationSearchAggregations(BaseModel):
         Occurrence info about task prediction status
     words: Dict[str, int]
         The word cloud aggregations
-    metadata: Dict[str, Dict[str, int]]
+    metadata: Dict[str, Dict[str, Any]]
         The metadata fields aggregations
     """
 
@@ -403,7 +403,7 @@ class TextClassificationSearchAggregations(BaseModel):
     predicted: Dict[str, int] = Field(default_factory=dict)
     score: Dict[str, int] = Field(default_factory=dict)
     words: Dict[str, int] = Field(default_factory=dict)
-    metadata: Dict[str, Dict[str, int]] = Field(default_factory=dict)
+    metadata: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
 
     class Config:
         allow_population_by_field_name = True

--- a/src/rubrix/server/tasks/token_classification/api/model.py
+++ b/src/rubrix/server/tasks/token_classification/api/model.py
@@ -345,7 +345,7 @@ class TokenClassificationAggregations(BaseModel):
     predicted: Dict[str, int] = Field(default_factory=dict)
     score: Dict[str, int] = Field(default_factory=dict)
     words: Dict[str, int] = Field(default_factory=dict)
-    metadata: Dict[str, Dict[str, int]] = Field(default_factory=dict)
+    metadata: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
     predicted_mentions: Dict[str, Dict[str, int]] = Field(default_factory=dict)
     mentions: Dict[str, Dict[str, int]] = Field(default_factory=dict)
 


### PR DESCRIPTION
This PR includes in aggregations decimal metadata fields. The aggregation info contains a basic field statistics based on [Extended Stats Aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-extendedstats-aggregation.html#search-aggregations-metrics-extendedstats-aggregation)

@dvsrepo Including this kind of info in aggregations make possible sort by those kind of metadata fields.

The returned info is not processable as filter info. This PR includes logic discarding values that are not processable by defined filters. The filter is still shown, but without data. @dvsrepo Maybe disabling this kind of filter could help (for now).
