### PR TITLE
Bugfix: Convert None to "None" for prediction/annotation agents

### DIFF
--- a/src/rubrix/client/__init__.py
+++ b/src/rubrix/client/__init__.py
@@ -19,6 +19,7 @@ Methods for using the Rubrix Client, called from the module init file.
 """
 
 import logging
+import socket
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 import httpx
@@ -72,6 +73,8 @@ class RubrixClient:
 
     # Larger sizes will trigger a warning
     MAX_CHUNK_SIZE = 5000
+
+    MACHINE_NAME = socket.gethostname()
 
     def __init__(
         self,
@@ -330,7 +333,7 @@ class RubrixClient:
                 for label, score in record.prediction
             ]
             model_dict["prediction"] = {
-                "agent": record.prediction_agent or "None",
+                "agent": record.prediction_agent or RubrixClient.MACHINE_NAME,
                 "labels": labels,
             }
         if record.annotation is not None:
@@ -341,7 +344,7 @@ class RubrixClient:
             )
             gold_labels = [{"class": label, "score": 1.0} for label in annotations]
             model_dict["annotation"] = {
-                "agent": record.annotation_agent or "None",
+                "agent": record.annotation_agent or RubrixClient.MACHINE_NAME,
                 "labels": gold_labels,
             }
             model_dict["status"] = record.status or "Validated"
@@ -410,7 +413,7 @@ class RubrixClient:
                 for pred in record.prediction
             ]
             model_dict["prediction"] = {
-                "agent": record.prediction_agent or "None",
+                "agent": record.prediction_agent or RubrixClient.MACHINE_NAME,
                 "entities": entities,
             }
         if record.annotation is not None:
@@ -419,7 +422,7 @@ class RubrixClient:
                 for ann in record.annotation
             ]
             model_dict["annotation"] = {
-                "agent": record.annotation_agent or "None",
+                "agent": record.annotation_agent or RubrixClient.MACHINE_NAME,
                 "entities": gold_entities,
             }
         if record.id is not None:
@@ -474,13 +477,13 @@ class RubrixClient:
                 {"text": text, "score": score} for text, score in record.prediction
             ]
             model_dict["prediction"] = {
-                "agent": record.prediction_agent or "None",
+                "agent": record.prediction_agent or RubrixClient.MACHINE_NAME,
                 "sentences": sentences,
             }
         if record.annotation is not None:
             sentence = {"text": record.annotation, "score": 1.0}
             model_dict["annotation"] = {
-                "agent": record.annotation_agent or "None",
+                "agent": record.annotation_agent or RubrixClient.MACHINE_NAME,
                 "sentences": [sentence],
             }
 

--- a/src/rubrix/client/__init__.py
+++ b/src/rubrix/client/__init__.py
@@ -410,7 +410,7 @@ class RubrixClient:
                 for pred in record.prediction
             ]
             model_dict["prediction"] = {
-                "agent": record.prediction_agent,
+                "agent": record.prediction_agent or "None",
                 "entities": entities,
             }
         if record.annotation is not None:
@@ -419,7 +419,7 @@ class RubrixClient:
                 for ann in record.annotation
             ]
             model_dict["annotation"] = {
-                "agent": record.annotation_agent,
+                "agent": record.annotation_agent or "None",
                 "entities": gold_entities,
             }
         if record.id is not None:

--- a/src/rubrix/client/models.py
+++ b/src/rubrix/client/models.py
@@ -71,9 +71,9 @@ class TextClassificationRecord(BaseModel):
         annotation:
             A string or a list of strings (multilabel) corresponding to the annotation (gold label) for the record.
         prediction_agent:
-            Name of the prediction agent.
+            Name of the prediction agent. By default, this is set to the hostname of your machine.
         annotation_agent:
-            Name of the annotation agent.
+            Name of the prediction agent. By default, this is set to the hostname of your machine.
         multi_label:
             Is the prediction/annotation for a multi label classification task? Defaults to `False`.
         explanation:
@@ -141,9 +141,9 @@ class TokenClassificationRecord(BaseModel):
             A list of tuples containing annotations (gold labels) for the record. The first entry of the tuple is the
             name of the entity, the second and third entry correspond to the start and stop char index of the entity.
         prediction_agent:
-            Name of the prediction agent.
+            Name of the prediction agent. By default, this is set to the hostname of your machine.
         annotation_agent:
-            Name of the annotation agent.
+            Name of the prediction agent. By default, this is set to the hostname of your machine.
         id:
             The id of the record. By default (None), we will generate a unique ID for you.
         metadata:
@@ -192,9 +192,9 @@ class Text2TextRecord(BaseModel):
         annotation:
             A string representing the expected output text for the given input text.
         prediction_agent:
-            Name of the prediction agent.
+            Name of the prediction agent. By default, this is set to the hostname of your machine.
         annotation_agent:
-            Name of the annotation agent.
+            Name of the prediction agent. By default, this is set to the hostname of your machine.
         id:
             The id of the record. By default (None), we will generate a unique ID for you.
         metadata:

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -196,14 +196,15 @@ def test_text_classification_client_to_sdk(annotation):
     assert sdk_record.event_timestamp == datetime.datetime(2000, 1, 1)
 
 
-def test_token_classification_client_to_sdk():
+@pytest.mark.parametrize("agent", ["test_agent", None])
+def test_token_classification_client_to_sdk(agent):
     record = TokenClassificationRecord(
         text="test text",
         tokens=["test", "text"],
         prediction=[("label", 0, 5)],
         annotation=[("label", 0, 5)],
-        prediction_agent="test_model",
-        annotation_agent="test_annotator",
+        prediction_agent=agent,
+        annotation_agent=agent,
         id=1,
         metadata={"metadata": "test"},
         status="Default",

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -14,6 +14,8 @@
 #  limitations under the License.
 
 import datetime
+import socket
+
 import httpx
 import pandas
 import pytest
@@ -211,6 +213,10 @@ def test_token_classification_client_to_sdk(agent):
         event_timestamp=datetime.datetime(2000, 1, 1),
     )
     sdk_record = RubrixClient._token_classification_client_to_sdk(record)
+
+    if agent is None:
+        assert sdk_record.prediction.agent == socket.gethostname()
+        assert sdk_record.annotation.agent == socket.gethostname()
 
     assert sdk_record.event_timestamp == datetime.datetime(2000, 1, 1)
 


### PR DESCRIPTION
This PR fixes a bug when one was providing a prediction/annotation without a prediction/annotation_agent in the `TokenClassificationRecord`:
```python
record = rb.TokenClassificationRecord(text="test", tokens=["test"], prediction=[("test", 0, 5)])
rb.log(record, "test")

Traceback (most recent call last):
  File "/home/david/miniconda3/envs/rubrix/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3441, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-5-3f76d744eda5>", line 1, in <module>
    rb.log(record, "test")
  File "/home/david/recognai/rubrix/src/rubrix/__init__.py", line 142, in log
    return _client_instance().log(
  File "/home/david/recognai/rubrix/src/rubrix/client/__init__.py", line 209, in log
    _check_response_errors(response)
  File "/home/david/recognai/rubrix/src/rubrix/client/__init__.py", line 542, in _check_response_errors
    raise Exception(
Exception: Unprocessable entity error: Something is wrong in your records. The API answered with a 422 code: HTTPValidationError(detail=[ValidationError(loc=['body', 'records', 0, 'prediction', 'agent'], msg='none is not an allowed value', type='type_error.none.not_allowed', additional_properties={})], additional_properties={})
```