### PR TITLE
refactor(UI): revise styles for Text2Text task

### DIFF
--- a/frontend/assets/icons/kebab-menu-h.js
+++ b/frontend/assets/icons/kebab-menu-h.js
@@ -19,9 +19,9 @@
 var icon = require('vue-svgicon')
 icon.register({
   'kebab-menu-h': {
-    width: 13,
-    height: 16,
-    viewBox: '0 0 13 16',
-    data: '<path pid="0" fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 100-3 1.5 1.5 0 000 3zm5 0a1.5 1.5 0 100-3 1.5 1.5 0 000 3zM13 7.5a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z"/>'
+    width: 12,
+    height: 4,
+    viewBox: '0 0 12 4',
+    data: '<text transform="translate(-1139 -222)" fill="#4C4EA3" fill-rule="evenodd" font-family="OpenSans-Bold, Open Sans" font-size="14" font-weight="bold"><tspan x="1139" y="225">…</tspan></text>'
   }
 })

--- a/frontend/components/text2text/results/RecordStringText2Text.vue
+++ b/frontend/components/text2text/results/RecordStringText2Text.vue
@@ -135,7 +135,7 @@ export default {
   }
   &__content {
     word-break: break-word;
-    margin-right: 140px;
+    margin-right: 200px;
     display: block;
     color: palette(grey, medium);
   }

--- a/frontend/components/text2text/results/RecordText2Text.vue
+++ b/frontend/components/text2text/results/RecordText2Text.vue
@@ -76,10 +76,18 @@ export default {
     }),
 
     initializeSentenceOrigin() {
-      if (this.annotationSentences.length) {
-        this.sentencesOrigin = "Annotation";
-      } else if (this.predictionSentences.length) {
-        this.sentencesOrigin = "Prediction";
+      if (this.annotationEnabled) {
+        if (this.annotationSentences.length) {
+          this.sentencesOrigin = "Annotation";
+        } else if (this.predictionSentences.length) {
+          this.sentencesOrigin = "Prediction";
+        }
+      } else {
+        if (this.predictionSentences.length) {
+          this.sentencesOrigin = "Prediction";
+        } else if (this.annotationSentences.length) {
+          this.sentencesOrigin = "Annotation";
+        }        
       }
     },
 

--- a/frontend/components/text2text/results/Text2TextList.vue
+++ b/frontend/components/text2text/results/Text2TextList.vue
@@ -34,6 +34,7 @@
       >
         <span v-for="(sentence, index) in sentences" :key="sentence.text">
           <div v-if="itemNumber === index" class="content__sentences">
+            <p class="content__sentences__title">{{sentencesOrigin}}</p>
             <div class="content__edition-area">
               <p
                 :key="refresh"
@@ -56,8 +57,8 @@
                 @click="changeVisibleSentences"
                 >{{
                   sentencesOrigin === "Annotation"
-                    ? `View predictions (${predictionsLength})`
-                    : "Back to annotation"
+                    ? editable ? `View predictions (${predictionsLength})` : `Back to predictions (${predictionsLength})`
+                    : editable ? "Back to annotation" : "View annotation"
                 }}</re-button
               >
             </div>
@@ -70,7 +71,7 @@
                   :decimals="2"
                 ></re-numeric>
               </div>
-              <div v-if="sentences.length > 1" class="content__nav-buttons">
+              <div v-if="sentences.length && sentencesOrigin === 'Prediction'" class="content__nav-buttons">
                 <a
                   :class="itemNumber <= 0 ? 'disabled' : null"
                   href="#"
@@ -130,11 +131,26 @@
 
         <div v-if="!sentences.length">
           <p
-            class="content__text"
+            class="content__text content__text--no-sentences"
             :contenteditable="editable"
             placeholder="Type your text"
             @input="input"
           ></p>
+            <div class="content__footer">
+              <div class="content__actions-buttons">
+                <re-button
+                  v-if="newSentence && editable"
+                  :class="[
+                    'button-primary',
+                    status === 'Validated' && sentencesOrigin === 'Annotation' && !editionMode ? 'active' : null,
+                  ]"
+                  @click="annotate"
+                  >{{
+                    status === "Validated" && sentencesOrigin === 'Annotation' && !editionMode ? "Validated" : "Validate"
+                  }}</re-button
+                >
+              </div>
+            </div>
         </div>
       </div>
     </div>
@@ -284,6 +300,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+$marginRight: 200px;
 [contenteditable="true"] {
   box-shadow: 0 1px 4px 1px rgba(222, 222, 222, 0.5);
   border-radius: 3px 3px 3px 3px;
@@ -336,16 +353,25 @@ export default {
     display: flex;
     flex-direction: column;
     min-height: 140px;
+    &__title {
+      color: palette(grey, verylight);
+      @include font-size(12px);
+      font-weight: 600;
+      margin: 0;
+    }
   }
   &__text {
     color: black;
     white-space: pre-wrap;
     display: inline-block;
     width: 100%;
+    &--no-sentences {
+      max-width: calc(100% - $marginRight);
+    }
   }
   &__edition-area {
     position: relative;
-    margin-right: 140px;
+    margin-right: $marginRight;
     span {
       position: absolute;
       top: 100%;
@@ -413,6 +439,7 @@ export default {
         border-color: $font-secondary;
         opacity: 0;
         transition: opacity 0.3s ease-in-out 0.2s;
+        min-width: auto;
       }
       &.button-primary:not(.active) {
         opacity: 0;
@@ -433,7 +460,7 @@ export default {
     a {
       height: 20px;
       width: 20px;
-      line-height: 20px;
+      line-height: 19px;
       text-align: center;
       border-radius: 3px;
       text-align: center;

--- a/frontend/components/text2text/results/Text2TextList.vue
+++ b/frontend/components/text2text/results/Text2TextList.vue
@@ -366,7 +366,7 @@ $marginRight: 200px;
     display: inline-block;
     width: 100%;
     &--no-sentences {
-      max-width: calc(100% - $marginRight);
+      max-width: calc(100% - #{$marginRight});
     }
   }
   &__edition-area {

--- a/frontend/static/icons/kebab-menu-h.svg
+++ b/frontend/static/icons/kebab-menu-h.svg
@@ -1,1 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="13" height="16" viewBox="0 0 13 16"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/></svg>
+
+<svg width="12px" height="4px" viewBox="0 0 12 4" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="Text2text" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" font-family="OpenSans-Bold, Open Sans" font-size="14" font-weight="bold">
+        <g id="annotation" transform="translate(-1139.000000, -222.000000)" fill="#4C4EA3">
+            <text id="…">
+                <tspan x="1139" y="225">…</tspan>
+            </text>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
see #377

 - Center the hover grey square on prediction slide number
 - Make "..." icon thiner
 - When I start typing in the text area cant see the CTAs to validate/back (empty predictions and annotation)
 - When there only 1 prediction, show "1 of 1 prediction"
 - Styles
 - In explore show first prediction, In annotation show first annotation
 - Add "Annotation" and "Prediction" as a title