### PR TITLE
feat(server): detect nested metadata fields

### DIFF
--- a/src/rubrix/server/commons/es_wrapper.py
+++ b/src/rubrix/server/commons/es_wrapper.py
@@ -446,6 +446,14 @@ class ElasticsearchWrapper(LoggingMixin):
             index=index, body={"settings": {"index.blocks.write": read_only}}
         )
 
+    def create_field_mapping(
+        self, index: str, field_name: str, type: str, **extra_args
+    ):
+        self.__client__.indices.put_mapping(
+            index=index,
+            body={"properties": {field_name: {"type": type, **extra_args}}},
+        )
+
 
 _instance = None  # The singleton instance
 

--- a/src/rubrix/server/tasks/commons/dao/dao.py
+++ b/src/rubrix/server/tasks/commons/dao/dao.py
@@ -153,7 +153,7 @@ class DatasetRecordsDAO:
             now = datetime.datetime.utcnow()
 
         for r in records:
-            metadata_values.update(r.metadata)
+            metadata_values.update(r.metadata or {})
             db_record = record_class.parse_obj(r)
             if now:
                 db_record.last_updated = now

--- a/src/rubrix/server/tasks/commons/dao/dao.py
+++ b/src/rubrix/server/tasks/commons/dao/dao.py
@@ -14,8 +14,11 @@
 #  limitations under the License.
 
 import dataclasses
+import datetime
+from typing import Any, Dict, Iterable, List, Optional, Type, TypeVar
 
 from fastapi import Depends
+
 from rubrix.server.commons.es_wrapper import ElasticsearchWrapper, create_es_wrapper
 from rubrix.server.commons.helpers import unflatten_dict
 from rubrix.server.datasets.dao import (
@@ -23,13 +26,16 @@ from rubrix.server.datasets.dao import (
     dataset_records_index,
 )
 from rubrix.server.datasets.model import DatasetDB
+from rubrix.server.tasks.commons import BaseRecord
 from rubrix.server.tasks.commons.dao.model import RecordSearch, RecordSearchResults
 from rubrix.server.tasks.commons.es_helpers import (
     DATASETS_RECORDS_INDEX_TEMPLATE,
     aggregations,
     parse_aggregations,
 )
-from typing import Any, Dict, Iterable, List, Optional
+
+
+DBRecord = TypeVar("DBRecord", bound=BaseRecord)
 
 
 @dataclasses.dataclass
@@ -119,7 +125,8 @@ class DatasetRecordsDAO:
     def add_records(
         self,
         dataset: DatasetDB,
-        records: List[Dict[str, Any]],
+        records: List[BaseRecord],
+        record_class: Type[DBRecord],
     ) -> int:
         """
         Add records to dataset
@@ -130,16 +137,36 @@ class DatasetRecordsDAO:
             The dataset
         records:
             The list of records
-
+        record_class:
+            Record class used to convert records to
         Returns
         -------
             The number of failed records
 
         """
+
+        now = None
+        documents = []
+        metadata_values = {}
+
+        if "last_updated" in record_class.schema()["properties"]:
+            now = datetime.datetime.utcnow()
+
+        for r in records:
+            metadata_values.update(r.metadata)
+            db_record = record_class.parse_obj(r)
+            if now:
+                db_record.last_updated = now
+            documents.append(db_record.dict(exclude_none=True))
+
+        index_name = dataset_records_index(dataset.id)
+
+        self._es.create_index(index=index_name)
+        self._configure_metadata_fields(index_name, metadata_values)
         return self._es.add_documents(
-            index=dataset_records_index(dataset.id),
-            documents=records,
-            doc_id=lambda r: r.get("id"),
+            index=index_name,
+            documents=documents,
+            doc_id=lambda _record: _record.get("id"),
         )
 
     def search_records(
@@ -249,6 +276,17 @@ class DatasetRecordsDAO:
         )
         for doc in docs:
             yield doc["_source"]
+
+    def _configure_metadata_fields(self, index: str, metadata_values: Dict[str, Any]):
+        def detect_nested_type(v: Any) -> bool:
+            """Returns True if value match as nested value"""
+            return isinstance(v, list) and isinstance(v[0], dict)
+
+        for field, value in metadata_values.items():
+            if detect_nested_type(value):
+                self._es.create_field_mapping(
+                    index, field_name=f"metadata.{field}", type="nested"
+                )
 
 
 _instance: Optional[DatasetRecordsDAO] = None

--- a/src/rubrix/server/tasks/text2text/service/service.py
+++ b/src/rubrix/server/tasks/text2text/service/service.py
@@ -114,17 +114,10 @@ class Text2TextService:
         records: List[CreationText2TextRecord],
     ):
         dataset = self.__datasets__.find_by_name(dataset, owner=owner)
-
-        db_records = []
-        now = datetime.datetime.now()
-        for record in records:
-            db_record = Text2TextRecordDB.parse_obj(record)
-            db_record.last_updated = now
-            db_records.append(db_record.dict(exclude_none=True))
-
         failed = self.__dao__.add_records(
             dataset=dataset,
-            records=db_records,
+            records=records,
+            record_class=Text2TextRecordDB,
         )
         return BulkResponse(dataset=dataset.name, processed=len(records), failed=failed)
 

--- a/src/rubrix/server/tasks/text_classification/service/service.py
+++ b/src/rubrix/server/tasks/text_classification/service/service.py
@@ -96,17 +96,10 @@ class TextClassificationService:
         records: List[CreationTextClassificationRecord],
     ):
         dataset = self.__datasets__.find_by_name(dataset, owner=owner)
-
-        db_records = []
-        now = datetime.datetime.now()
-        for record in records:
-            db_record = TextClassificationRecord.parse_obj(record)
-            db_record.last_updated = now
-            db_records.append(db_record.dict(exclude_none=True))
-
         failed = self.__dao__.add_records(
             dataset=dataset,
-            records=db_records,
+            records=records,
+            record_class=TextClassificationRecord
         )
         return BulkResponse(dataset=dataset.name, processed=len(records), failed=failed)
 

--- a/src/rubrix/server/tasks/token_classification/service/service.py
+++ b/src/rubrix/server/tasks/token_classification/service/service.py
@@ -80,6 +80,7 @@ extends_index_properties(
     }
 )
 
+
 def as_elasticsearch(search: TokenClassificationQuery) -> Dict[str, Any]:
     """Build an elasticsearch query part from search query"""
 
@@ -137,17 +138,10 @@ class TokenClassificationService:
         records: List[CreationTokenClassificationRecord],
     ):
         dataset = self.__datasets__.find_by_name(dataset, owner=owner)
-
-        db_records = []
-        now = datetime.datetime.now()
-        for record in records:
-            db_record = TokenClassificationRecord.parse_obj(record)
-            db_record.last_updated = now
-            db_records.append(db_record.dict(exclude_none=True))
-
         failed = self.__dao__.add_records(
             dataset=dataset,
-            records=db_records,
+            records=records,
+            record_class=TokenClassificationRecord
         )
         return BulkResponse(dataset=dataset.name, processed=len(records), failed=failed)
 

--- a/tests/server/text_classification/test_api.py
+++ b/tests/server/text_classification/test_api.py
@@ -42,7 +42,11 @@ def test_create_records_for_text_classification_with_multi_label(monkeypatch):
                 "id": 0,
                 "inputs": {"data": "my data"},
                 "multi_label": True,
-                "metadata": {"field_one": "value one", "field_two": "value 2"},
+                "metadata": {
+                    "field_one": "value one",
+                    "field_two": "value 2",
+                    "one_more": [{"a": 1, "b": 2}],
+                },
                 "prediction": {
                     "agent": "test",
                     "labels": [
@@ -335,10 +339,18 @@ def test_some_sort_by():
 
     results = TextClassificationSearchResults.parse_obj(response.json())
     assert results.total == 100
-    assert (
-        list(map(lambda r: r.id, results.records))
-        == [14, 19, 24, 29, 34, 39, 4, 44, 49, 54]
-    )
+    assert list(map(lambda r: r.id, results.records)) == [
+        14,
+        19,
+        24,
+        29,
+        34,
+        39,
+        4,
+        44,
+        49,
+        54,
+    ]
 
 
 def test_disable_aggregations_when_scroll():

--- a/tests/server/text_classification/test_model.py
+++ b/tests/server/text_classification/test_model.py
@@ -36,11 +36,25 @@ def test_flatten_metadata():
     assert list(record.metadata.keys()) == ["mail.subject", "mail.body"]
 
 
+def test_metadata_with_object_list():
+    data = {
+        "inputs": {"text": "bogh"},
+        "metadata": {
+            "mails": [
+                {"subject": "Mail One", "body": "This is a large text body"},
+                {"subject": "Mail Two", "body": "This is a large text body"},
+            ]
+        },
+    }
+    record = TextClassificationRecord.parse_obj(data)
+    assert list(record.metadata.keys()) == ["mails"]
+
+
 def test_too_long_metadata():
     record = TextClassificationRecord.parse_obj(
         {
             "inputs": {"text": "bogh"},
-            "metadata": {"too_long": "a"*1000},
+            "metadata": {"too_long": "a" * 1000},
         }
     )
 
@@ -54,7 +68,7 @@ def test_too_long_label():
                 "inputs": {"text": "bogh"},
                 "prediction": {
                     "agent": "test",
-                    "labels": [{"class": "a"*1000}],
+                    "labels": [{"class": "a" * 1000}],
                 },
             }
         )


### PR DESCRIPTION
This PR detects nested objects (see [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html)) and automatically configures elasticsearch index mapping for enable nested queries over them