### PR TITLE
fix(server): delete dataset with refresh flag enabled

### DIFF
--- a/src/rubrix/server/commons/es_wrapper.py
+++ b/src/rubrix/server/commons/es_wrapper.py
@@ -227,7 +227,7 @@ class ElasticsearchWrapper(LoggingMixin):
         -------
 
         """
-        self.__client__.delete(index=index, id=doc_id)
+        self.__client__.delete(index=index, id=doc_id, refresh=True)
 
     def add_documents(
         self,

--- a/tests/server/datasets/test_api.py
+++ b/tests/server/datasets/test_api.py
@@ -12,10 +12,25 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
 from rubrix.server.tasks.text_classification import TextClassificationBulkData
 
 from tests.server.test_helpers import client
+
+
+def test_delete_dataset():
+    dataset = "test_delete_dataset"
+
+    client.post(
+        f"/api/datasets/{dataset}/TextClassification:bulk",
+        json=TextClassificationBulkData(
+            tags={"env": "test", "class": "text classification"},
+            metadata={"config": {"the": "config"}},
+            records=[],
+        ).dict(by_alias=True),
+    )
+
+    assert client.delete(f"/api/datasets/{dataset}").status_code == 200
+    assert client.get(f"/api/datasets/{dataset}").status_code == 404
 
 
 def test_dataset_naming_validation():


### PR DESCRIPTION
This PR enable refresh flag for dataset deletion to force drop deleted dataset form searches after deletion.

This change allow this flow:

```python
client.delete("/api/datasets/my-dataset")
assert client.get("api/datasets/my-dataset").status_code == 404
```