### PR TITLE
fix(UI): allow records with empty annotations for text classification

### DIFF
--- a/frontend/components/text-classifier/results/RecordTextClassification.vue
+++ b/frontend/components/text-classifier/results/RecordTextClassification.vue
@@ -35,7 +35,7 @@
       />
       <ClassifierExplorationArea v-else :record="record" />
     </div>
-    <div v-if="!annotationEnabled" class="record__labels">
+    <div v-if="!annotationEnabled && record.annotation" class="record__labels">
       <svgicon
         v-if="record.predicted"
         :class="['icon__predicted', record.predicted]"


### PR DESCRIPTION
Records with empty annotations breaks re-tag component