### PR TITLE
Implement TokenClassification part of the custom SDK

### DIFF
--- a/src/rubrix/client/sdk/commons/models.py
+++ b/src/rubrix/client/sdk/commons/models.py
@@ -12,20 +12,16 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import socket
 from datetime import datetime
 from enum import Enum
-from typing import Any, MutableMapping, List
-from typing import Dict
-from typing import Generic
-from typing import Optional
-from typing import TypeVar
-from typing import Union
+from typing import Any, Dict, Generic, List, MutableMapping, Optional, TypeVar, Union
 from uuid import uuid4
 
-from pydantic import BaseModel
-from pydantic import Field
+from pydantic import BaseModel, Field, validator
 from pydantic.generics import GenericModel
+
+MACHINE_NAME = socket.gethostname()
 
 
 class TaskStatus(str, Enum):
@@ -49,6 +45,13 @@ class BaseRecord(GenericModel, Generic[T]):
     status: Optional[TaskStatus] = None
     prediction: Optional[T] = None
     annotation: Optional[T] = None
+
+    # this is a small hack to get a json-compatible serialization on cls.dict(), which we use for the httpx calls.
+    # they want to build this feature into pydantic, see https://github.com/samuelcolvin/pydantic/issues/1409
+    @validator("event_timestamp")
+    def datetime_to_isoformat(cls, v: Optional[datetime]):
+        if v is not None:
+            return v.isoformat()
 
 
 class UpdateDatasetRequest(BaseModel):

--- a/src/rubrix/client/sdk/text2text/__init__.py
+++ b/src/rubrix/client/sdk/text2text/__init__.py
@@ -1,0 +1,14 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/src/rubrix/client/sdk/text2text/api.py
+++ b/src/rubrix/client/sdk/text2text/api.py
@@ -12,7 +12,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
 from typing import List, Optional, Union
 
 import httpx
@@ -25,21 +24,19 @@ from rubrix.client.sdk.commons.models import (
     HTTPValidationError,
     Response,
 )
-from rubrix.client.sdk.token_classification.models import (
-    TokenClassificationBulkData,
-    TokenClassificationQuery,
-    TokenClassificationRecord,
+from rubrix.client.sdk.text2text.models import (
+    Text2TextBulkData,
+    Text2TextQuery,
+    Text2TextRecord,
 )
 
 
 def bulk(
     client: AuthenticatedClient,
     name: str,
-    json_body: TokenClassificationBulkData,
+    json_body: Text2TextBulkData,
 ) -> Response[Union[BulkResponse, ErrorMessage, HTTPValidationError]]:
-    url = "{}/api/datasets/{name}/TokenClassification:bulk".format(
-        client.base_url, name=name
-    )
+    url = "{}/api/datasets/{name}/Text2Text:bulk".format(client.base_url, name=name)
 
     response = httpx.post(
         url=url,
@@ -55,14 +52,10 @@ def bulk(
 def data(
     client: AuthenticatedClient,
     name: str,
-    request: Optional[TokenClassificationQuery] = None,
+    request: Optional[Text2TextQuery] = None,
     limit: Optional[int] = None,
-) -> Response[
-    Union[List[TokenClassificationRecord], HTTPValidationError, ErrorMessage]
-]:
-    url = "{}/api/datasets/{name}/TokenClassification/data".format(
-        client.base_url, name=name
-    )
+) -> Response[Union[List[Text2TextRecord], HTTPValidationError, ErrorMessage]]:
+    url = "{}/api/datasets/{name}/Text2Text/data".format(client.base_url, name=name)
 
     with httpx.stream(
         method="POST",
@@ -73,6 +66,4 @@ def data(
         params={"limit": limit},
         json=request.dict() if request else {},
     ) as response:
-        return build_data_response(
-            response=response, data_type=TokenClassificationRecord
-        )
+        return build_data_response(response=response, data_type=Text2TextRecord)

--- a/src/rubrix/client/sdk/text_classification/api.py
+++ b/src/rubrix/client/sdk/text_classification/api.py
@@ -45,7 +45,7 @@ def bulk(
         headers=client.get_headers(),
         cookies=client.get_cookies(),
         timeout=client.get_timeout(),
-        json=json_body.dict(exclude_unset=True),
+        json=json_body.dict(by_alias=True),
     )
 
     return build_bulk_response(response)

--- a/src/rubrix/client/sdk/text_classification/models.py
+++ b/src/rubrix/client/sdk/text_classification/models.py
@@ -12,27 +12,24 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import socket
 from datetime import datetime
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Union
+from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel
-from pydantic import Field
+from pydantic import BaseModel, Field
+
 from rubrix.client.models import (
     TextClassificationRecord as ClientTextClassificationRecord,
 )
 from rubrix.client.models import TokenAttributions as ClientTokenAttributions
-from rubrix.client.sdk.commons.models import BaseAnnotation
-from rubrix.client.sdk.commons.models import BaseRecord
-from rubrix.client.sdk.commons.models import PredictionStatus
-from rubrix.client.sdk.commons.models import ScoreRange
-from rubrix.client.sdk.commons.models import TaskStatus
-from rubrix.client.sdk.commons.models import UpdateDatasetRequest
-
-MACHINE_NAME = socket.gethostname()
+from rubrix.client.sdk.commons.models import (
+    MACHINE_NAME,
+    BaseAnnotation,
+    BaseRecord,
+    PredictionStatus,
+    ScoreRange,
+    TaskStatus,
+    UpdateDatasetRequest,
+)
 
 
 class ClassPrediction(BaseModel):
@@ -74,7 +71,9 @@ class CreationTextClassificationRecord(BaseRecord[TextClassificationAnnotation])
                 else [record.annotation]
             )
             annotation = TextClassificationAnnotation(
-                labels=[ClassPrediction(**{"class": label}) for label in annotation_list],
+                labels=[
+                    ClassPrediction(**{"class": label}) for label in annotation_list
+                ],
                 agent=record.annotation_agent or MACHINE_NAME,
             )
 

--- a/src/rubrix/client/sdk/token_classification/__init__.py
+++ b/src/rubrix/client/sdk/token_classification/__init__.py
@@ -1,0 +1,14 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/src/rubrix/client/sdk/token_classification/api.py
+++ b/src/rubrix/client/sdk/token_classification/api.py
@@ -1,0 +1,78 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import List, Optional, Union
+
+import httpx
+
+from rubrix.client.sdk.client import AuthenticatedClient
+from rubrix.client.sdk.commons.api import build_bulk_response, build_data_response
+from rubrix.client.sdk.commons.models import (
+    BulkResponse,
+    ErrorMessage,
+    HTTPValidationError,
+    Response,
+)
+from rubrix.client.sdk.token_classification.models import (
+    TokenClassificationBulkData,
+    TokenClassificationQuery,
+    TokenClassificationRecord,
+)
+
+
+def bulk(
+    client: AuthenticatedClient,
+    name: str,
+    json_body: TokenClassificationBulkData,
+) -> Response[Union[BulkResponse, ErrorMessage, HTTPValidationError]]:
+    url = "{}/api/datasets/{name}/TokenClassification:bulk".format(
+        client.base_url, name=name
+    )
+
+    response = httpx.post(
+        url=url,
+        headers=client.get_headers(),
+        cookies=client.get_cookies(),
+        timeout=client.get_timeout(),
+        json=json_body.dict(exclude_unset=True),
+    )
+
+    return build_bulk_response(response)
+
+
+def data(
+    client: AuthenticatedClient,
+    name: str,
+    request: Optional[TokenClassificationQuery] = None,
+    limit: Optional[int] = None,
+) -> Response[
+    Union[List[TokenClassificationRecord], HTTPValidationError, ErrorMessage]
+]:
+    url = "{}/api/datasets/{name}/TokenClassification/data".format(
+        client.base_url, name=name
+    )
+
+    with httpx.stream(
+        method="POST",
+        url=url,
+        headers=client.get_headers(),
+        cookies=client.get_cookies(),
+        timeout=None,
+        params={"limit": limit},
+        json=request.dict() if request else {},
+    ) as response:
+        return build_data_response(
+            response=response, data_type=TokenClassificationRecord
+        )

--- a/src/rubrix/client/sdk/token_classification/models.py
+++ b/src/rubrix/client/sdk/token_classification/models.py
@@ -1,0 +1,14 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/src/rubrix/client/sdk/token_classification/models.py
+++ b/src/rubrix/client/sdk/token_classification/models.py
@@ -12,3 +12,124 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import socket
+from datetime import datetime
+from typing import Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field
+
+from rubrix._constants import MAX_KEYWORD_LENGTH
+from rubrix.client.models import (
+    TokenClassificationRecord as ClientTokenClassificationRecord,
+)
+from rubrix.client.sdk.commons.models import (
+    BaseAnnotation,
+    BaseRecord,
+    PredictionStatus,
+    ScoreRange,
+    TaskStatus,
+    UpdateDatasetRequest,
+)
+
+MACHINE_NAME = socket.gethostname()
+
+
+class EntitySpan(BaseModel):
+    start: int
+    end: int
+    label: str = Field(min_length=1, max_length=MAX_KEYWORD_LENGTH)
+    score: float = Field(default=1.0, ge=0.0, le=1.0)
+
+
+class TokenClassificationAnnotation(BaseAnnotation):
+    entities: List[EntitySpan] = Field(default_factory=list)
+    score: Optional[float] = None
+
+
+class CreationTokenClassificationRecord(BaseRecord[TokenClassificationAnnotation]):
+    tokens: List[str]
+    text: str = Field(alias="raw_text")
+
+    @classmethod
+    def from_client(cls, record: ClientTokenClassificationRecord):
+        prediction = None
+        if record.prediction is not None:
+            prediction = TokenClassificationAnnotation(
+                entities=[
+                    EntitySpan(label=ent[0], start=ent[1], end=ent[2])
+                    if len(ent) == 3
+                    else EntitySpan(
+                        label=ent[0], start=ent[1], end=ent[2], score=ent[3]
+                    )
+                    for ent in record.prediction
+                ],
+                agent=record.annotation_agent or MACHINE_NAME,
+            )
+
+        annotation = None
+        if record.annotation is not None:
+            annotation = TokenClassificationAnnotation(
+                entities=[
+                    EntitySpan(label=ent[0], start=ent[1], end=ent[2])
+                    for ent in record.annotation
+                ],
+                agent=record.annotation_agent or MACHINE_NAME,
+            )
+
+        return cls(
+            tokens=record.tokens,
+            raw_text=record.text,
+            prediction=prediction,
+            annotation=annotation,
+            status=record.status,
+            id=record.id,
+            metadata=record.metadata,
+            event_timestamp=record.event_timestamp,
+        )
+
+
+class TokenClassificationRecord(CreationTokenClassificationRecord):
+    last_updated: datetime = None
+    _predicted: Optional[PredictionStatus] = Field(alias="predicted")
+
+    def to_client(self) -> ClientTokenClassificationRecord:
+        return ClientTokenClassificationRecord(
+            text=self.text,
+            tokens=self.tokens,
+            prediction=[
+                (ent.label, ent.start, ent.end, ent.score)
+                for ent in self.prediction.entities
+            ]
+            if self.prediction
+            else None,
+            prediction_agent=self.prediction.agent if self.prediction else None,
+            annotation=[
+                (ent.label, ent.start, ent.end) for ent in self.annotation.entities
+            ]
+            if self.annotation
+            else None,
+            annotation_agent=self.annotation.agent if self.annotation else None,
+            id=self.id,
+            event_timestamp=self.event_timestamp,
+            status=self.status,
+            metadata=self.metadata or {},
+        )
+
+
+class TokenClassificationBulkData(UpdateDatasetRequest):
+    records: List[CreationTokenClassificationRecord]
+
+
+class TokenClassificationQuery(BaseModel):
+    ids: Optional[List[Union[str, int]]]
+
+    query_text: str = Field(default=None)
+    metadata: Optional[Dict[str, Union[str, List[str]]]] = None
+
+    predicted_as: List[str] = Field(default_factory=list)
+    annotated_as: List[str] = Field(default_factory=list)
+    annotated_by: List[str] = Field(default_factory=list)
+    predicted_by: List[str] = Field(default_factory=list)
+    score: Optional[ScoreRange] = Field(default=None)
+    status: List[TaskStatus] = Field(default_factory=list)
+    predicted: Optional[PredictionStatus] = Field(default=None, nullable=True)

--- a/tests/client/sdk/conftest.py
+++ b/tests/client/sdk/conftest.py
@@ -15,6 +15,9 @@
 
 import pytest
 
+from rubrix._constants import DEFAULT_API_KEY
+from rubrix.client.sdk.client import AuthenticatedClient
+
 
 class Helpers:
     def remove_description(self, schema: dict):
@@ -30,3 +33,8 @@ class Helpers:
 @pytest.fixture(scope="session")
 def helpers():
     return Helpers()
+
+
+@pytest.fixture(scope="session")
+def sdk_client():
+    return AuthenticatedClient(base_url="http://localhost:6900", token=DEFAULT_API_KEY)

--- a/tests/client/sdk/text2text/__init__.py
+++ b/tests/client/sdk/text2text/__init__.py
@@ -1,0 +1,14 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/client/sdk/text2text/test_api.py
+++ b/tests/client/sdk/text2text/test_api.py
@@ -17,15 +17,13 @@ from datetime import datetime
 import httpx
 import pytest
 
-from rubrix.client.models import (
-    TokenClassificationRecord as ClientTokenClassificationRecord,
-)
+from rubrix.client.models import Text2TextRecord as ClientText2TextRecord
 from rubrix.client.sdk.commons.models import BulkResponse
-from rubrix.client.sdk.token_classification.api import bulk, data
-from rubrix.client.sdk.token_classification.models import (
-    CreationTokenClassificationRecord,
-    TokenClassificationBulkData,
-    TokenClassificationRecord,
+from rubrix.client.sdk.text2text.api import bulk, data
+from rubrix.client.sdk.text2text.models import (
+    CreationText2TextRecord,
+    Text2TextBulkData,
+    Text2TextRecord,
 )
 from tests.server.test_helpers import client
 
@@ -33,12 +31,11 @@ from tests.server.test_helpers import client
 @pytest.fixture
 def bulk_data():
     records = [
-        ClientTokenClassificationRecord(
-            text="a raw text",
-            tokens=["a", "raw", "text"],
-            prediction=[("test", 2, 5, 0.9)],
+        ClientText2TextRecord(
+            text="test",
+            prediction=[("prueba", 0.5), ("intento", 0.5)],
             prediction_agent="agent",
-            annotation=[("test", 2, 5)],
+            annotation="prueba",
             annotation_agent="agent",
             id=i,
             metadata={"mymetadata": "str"},
@@ -48,8 +45,8 @@ def bulk_data():
         for i in range(3)
     ]
 
-    return TokenClassificationBulkData(
-        records=[CreationTokenClassificationRecord.from_client(rec) for rec in records],
+    return Text2TextBulkData(
+        records=[CreationText2TextRecord.from_client(rec) for rec in records],
         tags={"Mytag": "tag"},
         metadata={"MyMetadata": 5},
     )
@@ -73,10 +70,10 @@ def test_data(sdk_client, bulk_data, monkeypatch):
     dataset_name = "test_dataset"
     client.delete(f"/api/datasets/{dataset_name}")
     client.post(
-        f"/api/datasets/{dataset_name}/TokenClassification:bulk",
+        f"/api/datasets/{dataset_name}/Text2Text:bulk",
         json=bulk_data.dict(by_alias=True),
     )
 
     response = data(sdk_client, name=dataset_name, limit=2)
-    assert isinstance(response.parsed[0], TokenClassificationRecord)
+    assert isinstance(response.parsed[0], Text2TextRecord)
     assert len(response.parsed) == 2

--- a/tests/client/sdk/text2text/test_models.py
+++ b/tests/client/sdk/text2text/test_models.py
@@ -1,0 +1,115 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import socket
+from datetime import datetime
+
+import pytest
+
+from rubrix.client.models import Text2TextRecord
+from rubrix.client.sdk.text2text.models import (
+    CreationText2TextRecord,
+    Text2TextAnnotation,
+    Text2TextBulkData,
+    Text2TextPrediction,
+    Text2TextQuery,
+)
+from rubrix.client.sdk.text2text.models import Text2TextRecord as SdkText2TextRecord
+from rubrix.server.tasks.text2text.api.model import (
+    Text2TextBulkData as ServerText2TextBulkData,
+)
+from rubrix.server.tasks.text2text.api.model import (
+    Text2TextQuery as ServerText2TextQuery,
+)
+
+
+def test_bulk_data_schema(helpers):
+    client_schema = Text2TextBulkData.schema()
+    server_schema = ServerText2TextBulkData.schema()
+
+    assert helpers.remove_description(client_schema) == helpers.remove_description(
+        server_schema
+    )
+
+
+def test_query_schema(helpers):
+    client_schema = Text2TextQuery.schema()
+    server_schema = ServerText2TextQuery.schema()
+
+    assert helpers.remove_description(client_schema) == helpers.remove_description(
+        server_schema
+    )
+
+
+@pytest.mark.parametrize(
+    "prediction,expected",
+    [
+        (["texto de prueba para text2text", "texto de test para text2text"], 1.0),
+        ([("texto de prueba para text2text", 0.5)], 0.5),
+    ],
+)
+def test_from_client_prediction(prediction, expected):
+    record = Text2TextRecord(
+        text="Test text for text2text",
+        prediction=prediction,
+        annotation="texto de prueba para text2text",
+        id=1,
+    )
+    sdk_record = CreationText2TextRecord.from_client(record)
+
+    assert len(sdk_record.prediction.sentences) == len(prediction)
+    assert all(
+        [sentence.score == expected for sentence in sdk_record.prediction.sentences]
+    )
+
+
+@pytest.mark.parametrize(
+    "agent,expected", [(None, socket.gethostname()), ("agent", "agent")]
+)
+def test_from_client_agent(agent, expected):
+    record = Text2TextRecord(
+        text="test",
+        prediction=["prueba"],
+        annotation="prueba",
+        prediction_agent=agent,
+        annotation_agent=agent,
+    )
+    sdk_record = CreationText2TextRecord.from_client(record)
+
+    assert sdk_record.annotation.agent == expected
+    assert sdk_record.prediction.agent == expected
+
+
+def test_to_client():
+    prediction = Text2TextAnnotation(
+        sentences=[
+            Text2TextPrediction(text="prueba", score=0.5),
+            Text2TextPrediction(text="prueba2", score=0.5),
+        ],
+        agent="agent",
+    )
+
+    sdk_record = SdkText2TextRecord(
+        text="test",
+        prediction=prediction,
+        annotation=prediction,
+        event_timestamp=datetime(2000, 1, 1),
+    )
+
+    record = sdk_record.to_client()
+
+    assert record.prediction == [("prueba", 0.5), ("prueba2", 0.5)]
+    assert record.prediction_agent == "agent"
+    assert record.annotation == "prueba"
+    assert record.annotation_agent == "agent"

--- a/tests/client/sdk/text_classification/test_api.py
+++ b/tests/client/sdk/text_classification/test_api.py
@@ -15,21 +15,15 @@
 
 import httpx
 import pytest
-from rubrix._constants import DEFAULT_API_KEY
-from rubrix.client.sdk.client import AuthenticatedClient
+
 from rubrix.client.sdk.commons.models import BulkResponse
 from rubrix.client.sdk.text_classification.api import bulk, data
 from rubrix.client.sdk.text_classification.models import (
     CreationTextClassificationRecord,
+    TextClassificationBulkData,
     TextClassificationRecord,
 )
-from rubrix.client.sdk.text_classification.models import TextClassificationBulkData
 from tests.server.test_helpers import client
-
-
-@pytest.fixture
-def sdk_client():
-    return AuthenticatedClient(base_url="http://localhost:6900", token=DEFAULT_API_KEY)
 
 
 @pytest.fixture

--- a/tests/client/sdk/text_classification/test_models.py
+++ b/tests/client/sdk/text_classification/test_models.py
@@ -16,15 +16,15 @@ import socket
 from datetime import datetime
 
 import pytest
-from rubrix.client.models import TextClassificationRecord
-from rubrix.client.models import TokenAttributions
+
+from rubrix.client.models import TextClassificationRecord, TokenAttributions
 from rubrix.client.sdk.text_classification.models import (
+    ClassPrediction,
     CreationTextClassificationRecord,
     TextClassificationAnnotation,
-    ClassPrediction,
+    TextClassificationBulkData,
+    TextClassificationQuery,
 )
-from rubrix.client.sdk.text_classification.models import TextClassificationBulkData
-from rubrix.client.sdk.text_classification.models import TextClassificationQuery
 from rubrix.client.sdk.text_classification.models import (
     TextClassificationRecord as SdkTextClassificationRecord,
 )
@@ -99,6 +99,7 @@ def test_from_client_agent(agent, expected):
     sdk_record = CreationTextClassificationRecord.from_client(record)
 
     assert sdk_record.annotation.agent == expected
+    assert sdk_record.prediction.agent == expected
 
 
 @pytest.mark.parametrize(
@@ -121,6 +122,7 @@ def test_to_client(multi_label, expected):
         annotation=annotation,
         prediction=prediction,
         multi_label=multi_label,
+        event_timestamp=datetime(2000, 1, 1),
     )
 
     record = sdk_record.to_client()

--- a/tests/client/sdk/token_classification/__init__.py
+++ b/tests/client/sdk/token_classification/__init__.py
@@ -1,0 +1,14 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/client/sdk/token_classification/test_api.py
+++ b/tests/client/sdk/token_classification/test_api.py
@@ -1,0 +1,73 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import httpx
+import pytest
+
+from rubrix.client.sdk.commons.models import BulkResponse
+from rubrix.client.sdk.token_classification.api import bulk, data
+from rubrix.client.sdk.token_classification.models import (
+    CreationTokenClassificationRecord,
+    TokenClassificationBulkData,
+    TokenClassificationRecord,
+)
+from tests.server.test_helpers import client
+
+
+@pytest.fixture
+def bulk_data():
+    return TokenClassificationBulkData(
+        records=[
+            CreationTokenClassificationRecord(
+                raw_text="a raw text", tokens=["a", "raw", "text"]
+            )
+        ]
+    )
+
+
+def test_bulk(sdk_client, bulk_data, monkeypatch):
+    monkeypatch.setattr(httpx, "post", client.post)
+
+    dataset_name = "test_dataset"
+    client.delete(f"/api/datasets/{dataset_name}")
+    response = bulk(sdk_client, name=dataset_name, json_body=bulk_data)
+    print(response)
+
+    assert response.status_code == 200
+    assert isinstance(response.parsed, BulkResponse)
+
+
+def test_data(sdk_client, monkeypatch):
+    # TODO: Not sure how to test the streaming part of the response here
+    monkeypatch.setattr(httpx, "stream", client.stream)
+
+    # create test dataset
+    records = [
+        CreationTokenClassificationRecord(
+            raw_text="a raw text", tokens=["a", "raw", "text"]
+        )
+        for _ in range(3)
+    ]
+    bulk_data = TokenClassificationBulkData(records=records)
+    dataset_name = "test_dataset"
+    client.delete(f"/api/datasets/{dataset_name}")
+    client.post(
+        f"/api/datasets/{dataset_name}/TokenClassification:bulk",
+        json=bulk_data.dict(by_alias=True),
+    )
+
+    response = data(sdk_client, name=dataset_name, limit=2)
+    assert isinstance(response.parsed[0], TokenClassificationRecord)
+    assert len(response.parsed) == 2

--- a/tests/client/sdk/token_classification/test_models.py
+++ b/tests/client/sdk/token_classification/test_models.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import socket
+from datetime import datetime
 
 import pytest
 
@@ -81,6 +82,7 @@ def test_from_client_agent(agent, expected):
     )
     sdk_record = CreationTokenClassificationRecord.from_client(record)
 
+    assert sdk_record.prediction.agent == expected
     assert sdk_record.annotation.agent == expected
 
 
@@ -94,6 +96,7 @@ def test_to_client():
         tokens=["this", "is", "a", "test", "text"],
         annotation=prediction,
         prediction=prediction,
+        event_timestamp=datetime(2000, 1, 1),
     )
 
     record = sdk_record.to_client()

--- a/tests/client/sdk/token_classification/test_models.py
+++ b/tests/client/sdk/token_classification/test_models.py
@@ -1,0 +1,105 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import socket
+
+import pytest
+
+from rubrix.client.models import TokenClassificationRecord
+from rubrix.client.sdk.token_classification.models import (
+    CreationTokenClassificationRecord,
+    EntitySpan,
+    TokenClassificationAnnotation,
+    TokenClassificationBulkData,
+    TokenClassificationQuery,
+)
+from rubrix.client.sdk.token_classification.models import (
+    TokenClassificationRecord as SdkTokenClassificationRecord,
+)
+from rubrix.server.tasks.token_classification.api.model import (
+    TokenClassificationBulkData as ServerTokenClassificationBulkData,
+)
+from rubrix.server.tasks.token_classification.api.model import (
+    TokenClassificationQuery as ServerTokenClassificationQuery,
+)
+
+
+def test_bulk_data_schema(helpers):
+    client_schema = TokenClassificationBulkData.schema()
+    server_schema = ServerTokenClassificationBulkData.schema()
+
+    assert helpers.remove_description(client_schema) == helpers.remove_description(
+        server_schema
+    )
+
+
+def test_query_schema(helpers):
+    client_schema = TokenClassificationQuery.schema()
+    server_schema = ServerTokenClassificationQuery.schema()
+
+    assert helpers.remove_description(client_schema) == helpers.remove_description(
+        server_schema
+    )
+
+
+@pytest.mark.parametrize(
+    "prediction,expected", [([("label", 0, 4)], 1.0), ([("label", 0, 4, 0.5)], 0.5)]
+)
+def test_from_client_prediction(prediction, expected):
+    record = TokenClassificationRecord(
+        text="this is a test text",
+        tokens=["this", "is", "a", "test", "text"],
+        prediction=prediction,
+    )
+    sdk_record = CreationTokenClassificationRecord.from_client(record)
+
+    assert sdk_record.prediction.entities[0].score == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "agent,expected", [(None, socket.gethostname()), ("agent", "agent")]
+)
+def test_from_client_agent(agent, expected):
+    record = TokenClassificationRecord(
+        text="this is a test text",
+        tokens=["this", "is", "a", "test", "text"],
+        prediction=[("label", 0, 4)],
+        annotation=[("label", 0, 4)],
+        prediction_agent=agent,
+        annotation_agent=agent,
+    )
+    sdk_record = CreationTokenClassificationRecord.from_client(record)
+
+    assert sdk_record.annotation.agent == expected
+
+
+def test_to_client():
+    prediction = TokenClassificationAnnotation(
+        entities=[EntitySpan(label="label1", start=0, end=4)], agent="agent"
+    )
+
+    sdk_record = SdkTokenClassificationRecord(
+        raw_text="this is a test text",
+        tokens=["this", "is", "a", "test", "text"],
+        annotation=prediction,
+        prediction=prediction,
+    )
+
+    record = sdk_record.to_client()
+
+    assert isinstance(record, TokenClassificationRecord)
+    assert record.prediction == [("label1", 0, 4, 1.0)]
+    assert record.prediction_agent == "agent"
+    assert record.annotation == [("label1", 0, 4)]
+    assert record.annotation_agent == "agent"

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -165,31 +165,6 @@ def test_log_with_annotation(monkeypatch):
     assert records[0]["status"] == "Discarded"
 
 
-def test_text2text_client_to_sdk():
-    record = Text2TextRecord(
-        text="test text",
-        prediction=["test prediction"],
-        annotation="test annotation",
-        prediction_agent="test_model",
-        annotation_agent="test_annotator",
-        id=1,
-        metadata={"metadata": "test"},
-        status="Default",
-        event_timestamp=datetime.datetime(2000, 1, 1),
-    )
-
-    assert isinstance(record.prediction[0], tuple)
-    assert record.prediction[0][1] == pytest.approx(1.0)
-
-    sdk_record = RubrixClient._text2text_client_to_sdk(record)
-
-    assert sdk_record.event_timestamp == datetime.datetime(2000, 1, 1)
-
-    client_record = RubrixClient._text2text_sdk_to_client(sdk_record)
-
-    assert record == client_record
-
-
 def test_create_ds_with_wrong_name(monkeypatch):
     mocking_client(monkeypatch)
     dataset_name = "Test Create_ds_with_wrong_name"

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -15,21 +15,21 @@
 
 import datetime
 import socket
+from time import sleep
+from typing import Iterable
 
 import httpx
 import pandas
 import pytest
+
 import rubrix
 from rubrix import (
     RubrixClient,
+    Text2TextRecord,
     TextClassificationRecord,
     TokenClassificationRecord,
-    Text2TextRecord,
 )
 from rubrix.sdk.models import TextClassificationSearchResults
-from time import sleep
-from typing import Iterable
-
 from tests.server.test_api import create_some_data_for_text_classification
 from tests.server.test_helpers import client
 
@@ -163,29 +163,6 @@ def test_log_with_annotation(monkeypatch):
     records = df.to_dict(orient="records")
     assert len(records) == 1
     assert records[0]["status"] == "Discarded"
-
-
-@pytest.mark.parametrize("include_score, agent", [(False, "test_agent"), (True, None)])
-def test_token_classification_client_to_sdk(include_score, agent):
-    record = TokenClassificationRecord(
-        text="test text",
-        tokens=["test", "text"],
-        prediction=[("label", 0, 5, 0.9)] if include_score else [("label", 0, 5)],
-        annotation=[("label", 0, 5)],
-        prediction_agent=agent,
-        annotation_agent=agent,
-        id=1,
-        metadata={"metadata": "test"},
-        status="Default",
-        event_timestamp=datetime.datetime(2000, 1, 1),
-    )
-    sdk_record = RubrixClient._token_classification_client_to_sdk(record)
-
-    if agent is None:
-        assert sdk_record.prediction.agent == socket.gethostname()
-        assert sdk_record.annotation.agent == socket.gethostname()
-
-    assert sdk_record.event_timestamp == datetime.datetime(2000, 1, 1)
 
 
 def test_text2text_client_to_sdk():

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -34,9 +34,6 @@ from rubrix import (
     TokenClassificationRecord,
 )
 from rubrix.client.sdk.commons.models import Response
-from rubrix.sdk.models.text2_text_bulk_data import Text2TextBulkData
-from rubrix.sdk.models.text2_text_bulk_data_metadata import Text2TextBulkDataMetadata
-from rubrix.sdk.models.text2_text_bulk_data_tags import Text2TextBulkDataTags
 
 
 @pytest.fixture
@@ -111,9 +108,7 @@ def mock_response_text2text(monkeypatch):
 
     _response = BulkResponse(dataset="test", processed=500, failed=0)
 
-    def mock_get(*args, json_body: Text2TextBulkData, **kwargs):
-        assert isinstance(json_body.metadata, Text2TextBulkDataMetadata)
-        assert isinstance(json_body.tags, Text2TextBulkDataTags)
+    def mock_get(*args, **kwargs):
         return Response(
             status_code=200,
             content=b"Everything's fine",
@@ -127,7 +122,7 @@ def mock_response_text2text(monkeypatch):
         )
 
     monkeypatch.setattr(
-        "rubrix.client.text2text_bulk_records.sync_detailed",
+        "rubrix.client.text2text_bulk",
         mock_get,
     )  # apply the monkeypatch for requests.get to mock_get
 
@@ -195,17 +190,15 @@ def test_token_classification(mock_response_token):
     )
 
 
-def test_text2text(mock_response_200, mock_response_text2text):
+def test_text2text(mock_response_text2text):
     """Testing text2text with log function
 
     It checks a Response is generated.
 
     Parameters
     ----------
-    mock_response_200
-        Mocked correct http response, emulating API init
-    mock_response_token
-        Mocked response given by the sync method, emulating the log of data
+    mock_response_text2text
+        Mocked response for the text2text bulk API call
     """
     records = [
         Text2TextRecord(

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -20,32 +20,23 @@ Interaction with the client will be mocked, as this test are independent from th
 which could or could not be mounted.
 """
 
+import logging
 from typing import cast
 
 import httpx
 import pytest
-import rubrix
-import logging
 
+import rubrix
 from rubrix import (
     BulkResponse,
+    Text2TextRecord,
     TextClassificationRecord,
     TokenClassificationRecord,
-    Text2TextRecord,
 )
-import rubrix.sdk.api.text_classification.bulk_records
-from rubrix.sdk.models import (
-    TextClassificationBulkData,
-    TextClassificationBulkDataMetadata,
-    TextClassificationBulkDataTags,
-    TokenClassificationBulkData,
-    TokenClassificationBulkDataMetadata,
-    TokenClassificationBulkDataTags,
-)
+from rubrix.client.sdk.commons.models import Response
 from rubrix.sdk.models.text2_text_bulk_data import Text2TextBulkData
 from rubrix.sdk.models.text2_text_bulk_data_metadata import Text2TextBulkDataMetadata
 from rubrix.sdk.models.text2_text_bulk_data_tags import Text2TextBulkDataTags
-from rubrix.sdk.types import Response
 
 
 @pytest.fixture
@@ -74,9 +65,7 @@ def mock_response_200(monkeypatch):
 def mock_response_text(monkeypatch):
     """Mock log response for TextClassification records"""
 
-    _response = BulkResponse(dataset="test", processed=500, failed=0)
-
-    def mock_get(*args, json_body: TextClassificationBulkData, **kwargs):
+    def mock_get(*args, **kwargs):
         return Response(
             status_code=200,
             content=b"Everything's fine",
@@ -86,7 +75,7 @@ def mock_response_text(monkeypatch):
                 "content-length": "43",
                 "content-type": "application/json",
             },
-            parsed=_response,
+            parsed=BulkResponse(dataset="test", processed=500, failed=0),
         )
 
     monkeypatch.setattr(
@@ -98,11 +87,7 @@ def mock_response_text(monkeypatch):
 def mock_response_token(monkeypatch):
     """Mock log response for TokenClassification records"""
 
-    _response = BulkResponse(dataset="test", processed=500, failed=0)
-
-    def mock_get(*args, json_body: TokenClassificationBulkData, **kwargs):
-        assert isinstance(json_body.metadata, TokenClassificationBulkDataMetadata)
-        assert isinstance(json_body.tags, TokenClassificationBulkDataTags)
+    def mock_get(*args, **kwargs):
         return Response(
             status_code=200,
             content=b"Everything's fine",
@@ -112,11 +97,11 @@ def mock_response_token(monkeypatch):
                 "content-length": "43",
                 "content-type": "application/json",
             },
-            parsed=_response,
+            parsed=BulkResponse(dataset="test", processed=500, failed=0),
         )
 
     monkeypatch.setattr(
-        "rubrix.client.token_classification_bulk_records.sync_detailed", mock_get
+        "rubrix.client.token_classification_bulk", mock_get
     )  # apply the monkeypatch for requests.get to mock_get
 
 
@@ -147,17 +132,15 @@ def mock_response_text2text(monkeypatch):
     )  # apply the monkeypatch for requests.get to mock_get
 
 
-def test_text_classification(mock_response_200, mock_response_text):
+def test_text_classification(mock_response_text):
     """Testing text classification with log function
 
     It checks a Response is generated.
 
     Parameters
     ----------
-    mock_response_200
-        Mocked correct http response, emulating API init
     mock_response_text
-        Mocked response given by the sync method, emulating the log of data
+        Mocked response for the text_classification bulk API call
     """
     records = [
         TextClassificationRecord(
@@ -179,17 +162,15 @@ def test_text_classification(mock_response_200, mock_response_text):
     )
 
 
-def test_token_classification(mock_response_200, mock_response_token):
+def test_token_classification(mock_response_token):
     """Testing token classification with log function
 
     It checks a Response is generated.
 
     Parameters
     ----------
-    mock_response_200
-        Mocked correct http response, emulating API init
     mock_response_token
-        Mocked response given by the sync method, emulating the log of data
+        Mocked response for the token_classification bulk API call
     """
     records = [
         TokenClassificationRecord(


### PR DESCRIPTION
This PR implements the TokenClassification part of our custom SDK. It copies the same approach as for the TextClassification part.
**PR #453 should be first merged into this one, before merging both of them into master**.