### PR TITLE
Add Text2Text custom SDK

### DIFF
--- a/src/rubrix/client/sdk/commons/models.py
+++ b/src/rubrix/client/sdk/commons/models.py
@@ -18,7 +18,7 @@ from enum import Enum
 from typing import Any, Dict, Generic, List, MutableMapping, Optional, TypeVar, Union
 from uuid import uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 from pydantic.generics import GenericModel
 
 MACHINE_NAME = socket.gethostname()
@@ -45,6 +45,13 @@ class BaseRecord(GenericModel, Generic[T]):
     status: Optional[TaskStatus] = None
     prediction: Optional[T] = None
     annotation: Optional[T] = None
+
+    # this is a small hack to get a json-compatible serialization on cls.dict(), which we use for the httpx calls.
+    # they want to build this feature into pydantic, see https://github.com/samuelcolvin/pydantic/issues/1409
+    @validator("event_timestamp")
+    def datetime_to_isoformat(cls, v: Optional[datetime]):
+        if v is not None:
+            return v.isoformat()
 
 
 class UpdateDatasetRequest(BaseModel):

--- a/src/rubrix/client/sdk/commons/models.py
+++ b/src/rubrix/client/sdk/commons/models.py
@@ -12,20 +12,16 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import socket
 from datetime import datetime
 from enum import Enum
-from typing import Any, MutableMapping, List
-from typing import Dict
-from typing import Generic
-from typing import Optional
-from typing import TypeVar
-from typing import Union
+from typing import Any, Dict, Generic, List, MutableMapping, Optional, TypeVar, Union
 from uuid import uuid4
 
-from pydantic import BaseModel
-from pydantic import Field
+from pydantic import BaseModel, Field
 from pydantic.generics import GenericModel
+
+MACHINE_NAME = socket.gethostname()
 
 
 class TaskStatus(str, Enum):

--- a/src/rubrix/client/sdk/text2text/__init__.py
+++ b/src/rubrix/client/sdk/text2text/__init__.py
@@ -1,0 +1,14 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/src/rubrix/client/sdk/text2text/api.py
+++ b/src/rubrix/client/sdk/text2text/api.py
@@ -43,7 +43,7 @@ def bulk(
         headers=client.get_headers(),
         cookies=client.get_cookies(),
         timeout=client.get_timeout(),
-        json=json_body.dict(exclude_unset=True),
+        json=json_body.dict(by_alias=True),
     )
 
     return build_bulk_response(response)

--- a/src/rubrix/client/sdk/text2text/api.py
+++ b/src/rubrix/client/sdk/text2text/api.py
@@ -1,0 +1,69 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from typing import List, Optional, Union
+
+import httpx
+
+from rubrix.client.sdk.client import AuthenticatedClient
+from rubrix.client.sdk.commons.api import build_bulk_response, build_data_response
+from rubrix.client.sdk.commons.models import (
+    BulkResponse,
+    ErrorMessage,
+    HTTPValidationError,
+    Response,
+)
+from rubrix.client.sdk.text2text.models import (
+    Text2TextBulkData,
+    Text2TextQuery,
+    Text2TextRecord,
+)
+
+
+def bulk(
+    client: AuthenticatedClient,
+    name: str,
+    json_body: Text2TextBulkData,
+) -> Response[Union[BulkResponse, ErrorMessage, HTTPValidationError]]:
+    url = "{}/api/datasets/{name}/Text2Text:bulk".format(client.base_url, name=name)
+
+    response = httpx.post(
+        url=url,
+        headers=client.get_headers(),
+        cookies=client.get_cookies(),
+        timeout=client.get_timeout(),
+        json=json_body.dict(exclude_unset=True),
+    )
+
+    return build_bulk_response(response)
+
+
+def data(
+    client: AuthenticatedClient,
+    name: str,
+    request: Optional[Text2TextQuery] = None,
+    limit: Optional[int] = None,
+) -> Response[Union[List[Text2TextRecord], HTTPValidationError, ErrorMessage]]:
+    url = "{}/api/datasets/{name}/Text2Text/data".format(client.base_url, name=name)
+
+    with httpx.stream(
+        method="POST",
+        url=url,
+        headers=client.get_headers(),
+        cookies=client.get_cookies(),
+        timeout=None,
+        params={"limit": limit},
+        json=request.dict() if request else {},
+    ) as response:
+        return build_data_response(response=response, data_type=Text2TextRecord)

--- a/src/rubrix/client/sdk/text2text/models.py
+++ b/src/rubrix/client/sdk/text2text/models.py
@@ -90,7 +90,7 @@ class Text2TextRecord(CreationText2TextRecord):
             annotation=self.annotation.sentences[0].text if self.annotation else None,
             annotation_agent=self.annotation.agent if self.annotation else None,
             status=self.status,
-            metadata=self.metadata,
+            metadata=self.metadata or {},
             id=self.id,
             event_timestamp=self.event_timestamp,
         )

--- a/src/rubrix/client/sdk/text2text/models.py
+++ b/src/rubrix/client/sdk/text2text/models.py
@@ -1,0 +1,66 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from datetime import datetime
+from typing import Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field
+
+from rubrix.client.sdk.commons.models import (
+    BaseAnnotation,
+    BaseRecord,
+    PredictionStatus,
+    ScoreRange,
+    TaskStatus,
+    UpdateDatasetRequest,
+)
+
+
+class Text2TextPrediction(BaseModel):
+    text: str
+    score: float = Field(default=1.0, ge=0.0, le=1.0)
+
+
+class Text2TextAnnotation(BaseAnnotation):
+    sentences: List[Text2TextPrediction]
+
+
+class CreationText2TextRecord(BaseRecord[Text2TextAnnotation]):
+    text: str
+
+
+class Text2TextRecord(CreationText2TextRecord):
+    last_updated: datetime = None
+    _predicted: Optional[PredictionStatus] = Field(alias="predicted")
+
+
+class Text2TextBulkData(UpdateDatasetRequest):
+    records: List[CreationText2TextRecord]
+
+
+class Text2TextQuery(BaseModel):
+    ids: Optional[List[Union[str, int]]]
+
+    query_text: str = Field(default=None)
+
+    annotated_by: List[str] = Field(default_factory=list)
+    predicted_by: List[str] = Field(default_factory=list)
+
+    score: Optional[ScoreRange] = Field(default=None)
+
+    status: List[TaskStatus] = Field(default_factory=list)
+
+    predicted: Optional[PredictionStatus] = Field(default=None, nullable=True)
+    metadata: Optional[Dict[str, Union[str, List[str]]]] = None

--- a/src/rubrix/client/sdk/text_classification/api.py
+++ b/src/rubrix/client/sdk/text_classification/api.py
@@ -45,7 +45,7 @@ def bulk(
         headers=client.get_headers(),
         cookies=client.get_cookies(),
         timeout=client.get_timeout(),
-        json=json_body.dict(exclude_unset=True),
+        json=json_body.dict(by_alias=True),
     )
 
     return build_bulk_response(response)

--- a/src/rubrix/client/sdk/text_classification/models.py
+++ b/src/rubrix/client/sdk/text_classification/models.py
@@ -12,27 +12,24 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import socket
 from datetime import datetime
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Union
+from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel
-from pydantic import Field
+from pydantic import BaseModel, Field
+
 from rubrix.client.models import (
     TextClassificationRecord as ClientTextClassificationRecord,
 )
 from rubrix.client.models import TokenAttributions as ClientTokenAttributions
-from rubrix.client.sdk.commons.models import BaseAnnotation
-from rubrix.client.sdk.commons.models import BaseRecord
-from rubrix.client.sdk.commons.models import PredictionStatus
-from rubrix.client.sdk.commons.models import ScoreRange
-from rubrix.client.sdk.commons.models import TaskStatus
-from rubrix.client.sdk.commons.models import UpdateDatasetRequest
-
-MACHINE_NAME = socket.gethostname()
+from rubrix.client.sdk.commons.models import (
+    MACHINE_NAME,
+    BaseAnnotation,
+    BaseRecord,
+    PredictionStatus,
+    ScoreRange,
+    TaskStatus,
+    UpdateDatasetRequest,
+)
 
 
 class ClassPrediction(BaseModel):
@@ -74,7 +71,9 @@ class CreationTextClassificationRecord(BaseRecord[TextClassificationAnnotation])
                 else [record.annotation]
             )
             annotation = TextClassificationAnnotation(
-                labels=[ClassPrediction(**{"class": label}) for label in annotation_list],
+                labels=[
+                    ClassPrediction(**{"class": label}) for label in annotation_list
+                ],
                 agent=record.annotation_agent or MACHINE_NAME,
             )
 

--- a/src/rubrix/client/sdk/token_classification/api.py
+++ b/src/rubrix/client/sdk/token_classification/api.py
@@ -46,7 +46,7 @@ def bulk(
         headers=client.get_headers(),
         cookies=client.get_cookies(),
         timeout=client.get_timeout(),
-        json=json_body.dict(exclude_unset=True),
+        json=json_body.dict(by_alias=True),
     )
 
     return build_bulk_response(response)

--- a/src/rubrix/client/sdk/token_classification/models.py
+++ b/src/rubrix/client/sdk/token_classification/models.py
@@ -12,7 +12,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import socket
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
@@ -23,6 +22,7 @@ from rubrix.client.models import (
     TokenClassificationRecord as ClientTokenClassificationRecord,
 )
 from rubrix.client.sdk.commons.models import (
+    MACHINE_NAME,
     BaseAnnotation,
     BaseRecord,
     PredictionStatus,
@@ -30,8 +30,6 @@ from rubrix.client.sdk.commons.models import (
     TaskStatus,
     UpdateDatasetRequest,
 )
-
-MACHINE_NAME = socket.gethostname()
 
 
 class EntitySpan(BaseModel):

--- a/tests/client/sdk/text2text/__init__.py
+++ b/tests/client/sdk/text2text/__init__.py
@@ -1,0 +1,14 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/client/sdk/text2text/test_api.py
+++ b/tests/client/sdk/text2text/test_api.py
@@ -1,0 +1,79 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+from datetime import datetime
+
+import httpx
+import pytest
+
+from rubrix.client.models import Text2TextRecord as ClientText2TextRecord
+from rubrix.client.sdk.commons.models import BulkResponse
+from rubrix.client.sdk.text2text.api import bulk, data
+from rubrix.client.sdk.text2text.models import (
+    CreationText2TextRecord,
+    Text2TextBulkData,
+    Text2TextRecord,
+)
+from tests.server.test_helpers import client
+
+
+@pytest.fixture
+def bulk_data():
+    records = [
+        ClientText2TextRecord(
+            text="test",
+            prediction=[("prueba", 0.5), ("intento", 0.5)],
+            prediction_agent="agent",
+            annotation="prueba",
+            annotation_agent="agent",
+            id=i,
+            metadata={"mymetadata": "str"},
+            event_timestamp=datetime(2020, 1, 1),
+            status="Validated",
+        )
+        for i in range(3)
+    ]
+
+    return Text2TextBulkData(
+        records=[CreationText2TextRecord.from_client(rec) for rec in records],
+        tags={"Mytag": "tag"},
+        metadata={"MyMetadata": 5},
+    )
+
+
+def test_bulk(sdk_client, bulk_data, monkeypatch):
+    monkeypatch.setattr(httpx, "post", client.post)
+
+    dataset_name = "test_dataset"
+    client.delete(f"/api/datasets/{dataset_name}")
+    response = bulk(sdk_client, name=dataset_name, json_body=bulk_data)
+
+    assert response.status_code == 200
+    assert isinstance(response.parsed, BulkResponse)
+
+
+def test_data(sdk_client, bulk_data, monkeypatch):
+    # TODO: Not sure how to test the streaming part of the response here
+    monkeypatch.setattr(httpx, "stream", client.stream)
+
+    dataset_name = "test_dataset"
+    client.delete(f"/api/datasets/{dataset_name}")
+    client.post(
+        f"/api/datasets/{dataset_name}/Text2Text:bulk",
+        json=bulk_data.dict(by_alias=True),
+    )
+
+    response = data(sdk_client, name=dataset_name, limit=2)
+    assert isinstance(response.parsed[0], Text2TextRecord)
+    assert len(response.parsed) == 2

--- a/tests/client/sdk/text2text/test_models.py
+++ b/tests/client/sdk/text2text/test_models.py
@@ -1,0 +1,113 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import socket
+
+import pytest
+
+from rubrix.client.models import Text2TextRecord
+from rubrix.client.sdk.text2text.models import (
+    CreationText2TextRecord,
+    Text2TextAnnotation,
+    Text2TextBulkData,
+    Text2TextPrediction,
+    Text2TextQuery,
+)
+from rubrix.client.sdk.text2text.models import Text2TextRecord as SdkText2TextRecord
+from rubrix.server.tasks.text2text.api.model import (
+    Text2TextBulkData as ServerText2TextBulkData,
+)
+from rubrix.server.tasks.text2text.api.model import (
+    Text2TextQuery as ServerText2TextQuery,
+)
+
+
+def test_bulk_data_schema(helpers):
+    client_schema = Text2TextBulkData.schema()
+    server_schema = ServerText2TextBulkData.schema()
+
+    assert helpers.remove_description(client_schema) == helpers.remove_description(
+        server_schema
+    )
+
+
+def test_query_schema(helpers):
+    client_schema = Text2TextQuery.schema()
+    server_schema = ServerText2TextQuery.schema()
+
+    assert helpers.remove_description(client_schema) == helpers.remove_description(
+        server_schema
+    )
+
+
+@pytest.mark.parametrize(
+    "prediction,expected",
+    [
+        (["texto de prueba para text2text", "texto de test para text2text"], 1.0),
+        ([("texto de prueba para text2text", 0.5)], 0.5),
+    ],
+)
+def test_from_client_prediction(prediction, expected):
+    record = Text2TextRecord(
+        text="Test text for text2text",
+        prediction=prediction,
+        annotation="texto de prueba para text2text",
+        id=1,
+    )
+    sdk_record = CreationText2TextRecord.from_client(record)
+
+    assert len(sdk_record.prediction.sentences) == len(prediction)
+    assert all(
+        [sentence.score == expected for sentence in sdk_record.prediction.sentences]
+    )
+
+
+@pytest.mark.parametrize(
+    "agent,expected", [(None, socket.gethostname()), ("agent", "agent")]
+)
+def test_from_client_agent(agent, expected):
+    record = Text2TextRecord(
+        text="test",
+        prediction=["prueba"],
+        annotation="prueba",
+        prediction_agent=agent,
+        annotation_agent=agent,
+    )
+    sdk_record = CreationText2TextRecord.from_client(record)
+
+    assert sdk_record.annotation.agent == expected
+    assert sdk_record.prediction.agent == expected
+
+
+def test_to_client():
+    prediction = Text2TextAnnotation(
+        sentences=[
+            Text2TextPrediction(text="prueba", score=0.5),
+            Text2TextPrediction(text="prueba2", score=0.5),
+        ],
+        agent="agent",
+    )
+
+    sdk_record = SdkText2TextRecord(
+        text="test",
+        prediction=prediction,
+        annotation=prediction,
+    )
+
+    record = sdk_record.to_client()
+
+    assert record.prediction == [("prueba", 0.5), ("prueba2", 0.5)]
+    assert record.prediction_agent == "agent"
+    assert record.annotation == "prueba"
+    assert record.annotation_agent == "agent"

--- a/tests/client/sdk/text2text/test_models.py
+++ b/tests/client/sdk/text2text/test_models.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import socket
+from datetime import datetime
 
 import pytest
 
@@ -103,6 +104,7 @@ def test_to_client():
         text="test",
         prediction=prediction,
         annotation=prediction,
+        event_timestamp=datetime(2000, 1, 1),
     )
 
     record = sdk_record.to_client()

--- a/tests/client/sdk/text_classification/test_models.py
+++ b/tests/client/sdk/text_classification/test_models.py
@@ -122,6 +122,7 @@ def test_to_client(multi_label, expected):
         annotation=annotation,
         prediction=prediction,
         multi_label=multi_label,
+        event_timestamp=datetime(2000, 1, 1),
     )
 
     record = sdk_record.to_client()

--- a/tests/client/sdk/text_classification/test_models.py
+++ b/tests/client/sdk/text_classification/test_models.py
@@ -16,15 +16,15 @@ import socket
 from datetime import datetime
 
 import pytest
-from rubrix.client.models import TextClassificationRecord
-from rubrix.client.models import TokenAttributions
+
+from rubrix.client.models import TextClassificationRecord, TokenAttributions
 from rubrix.client.sdk.text_classification.models import (
+    ClassPrediction,
     CreationTextClassificationRecord,
     TextClassificationAnnotation,
-    ClassPrediction,
+    TextClassificationBulkData,
+    TextClassificationQuery,
 )
-from rubrix.client.sdk.text_classification.models import TextClassificationBulkData
-from rubrix.client.sdk.text_classification.models import TextClassificationQuery
 from rubrix.client.sdk.text_classification.models import (
     TextClassificationRecord as SdkTextClassificationRecord,
 )
@@ -99,6 +99,7 @@ def test_from_client_agent(agent, expected):
     sdk_record = CreationTextClassificationRecord.from_client(record)
 
     assert sdk_record.annotation.agent == expected
+    assert sdk_record.prediction.agent == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/client/sdk/token_classification/test_api.py
+++ b/tests/client/sdk/token_classification/test_api.py
@@ -12,10 +12,14 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from datetime import datetime
 
 import httpx
 import pytest
 
+from rubrix.client.models import (
+    TokenClassificationRecord as ClientTokenClassificationRecord,
+)
 from rubrix.client.sdk.commons.models import BulkResponse
 from rubrix.client.sdk.token_classification.api import bulk, data
 from rubrix.client.sdk.token_classification.models import (
@@ -28,12 +32,26 @@ from tests.server.test_helpers import client
 
 @pytest.fixture
 def bulk_data():
+    records = [
+        ClientTokenClassificationRecord(
+            text="a raw text",
+            tokens=["a", "raw", "text"],
+            prediction=[("test", 2, 5, 0.9)],
+            prediction_agent="agent",
+            annotation=[("test", 2, 5)],
+            annotation_agent="agent",
+            id=i,
+            metadata={"mymetadata": "str"},
+            event_timestamp=datetime(2020, 1, 1),
+            status="Validated",
+        )
+        for i in range(3)
+    ]
+
     return TokenClassificationBulkData(
-        records=[
-            CreationTokenClassificationRecord(
-                raw_text="a raw text", tokens=["a", "raw", "text"]
-            )
-        ]
+        records=[CreationTokenClassificationRecord.from_client(rec) for rec in records],
+        tags={"Mytag": "tag"},
+        metadata={"MyMetadata": 5},
     )
 
 
@@ -43,24 +61,15 @@ def test_bulk(sdk_client, bulk_data, monkeypatch):
     dataset_name = "test_dataset"
     client.delete(f"/api/datasets/{dataset_name}")
     response = bulk(sdk_client, name=dataset_name, json_body=bulk_data)
-    print(response)
 
     assert response.status_code == 200
     assert isinstance(response.parsed, BulkResponse)
 
 
-def test_data(sdk_client, monkeypatch):
+def test_data(sdk_client, bulk_data, monkeypatch):
     # TODO: Not sure how to test the streaming part of the response here
     monkeypatch.setattr(httpx, "stream", client.stream)
 
-    # create test dataset
-    records = [
-        CreationTokenClassificationRecord(
-            raw_text="a raw text", tokens=["a", "raw", "text"]
-        )
-        for _ in range(3)
-    ]
-    bulk_data = TokenClassificationBulkData(records=records)
     dataset_name = "test_dataset"
     client.delete(f"/api/datasets/{dataset_name}")
     client.post(

--- a/tests/client/sdk/token_classification/test_models.py
+++ b/tests/client/sdk/token_classification/test_models.py
@@ -81,6 +81,7 @@ def test_from_client_agent(agent, expected):
     )
     sdk_record = CreationTokenClassificationRecord.from_client(record)
 
+    assert sdk_record.prediction.agent == expected
     assert sdk_record.annotation.agent == expected
 
 

--- a/tests/client/sdk/token_classification/test_models.py
+++ b/tests/client/sdk/token_classification/test_models.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import socket
+from datetime import datetime
 
 import pytest
 
@@ -95,6 +96,7 @@ def test_to_client():
         tokens=["this", "is", "a", "test", "text"],
         annotation=prediction,
         prediction=prediction,
+        event_timestamp=datetime(2000, 1, 1),
     )
 
     record = sdk_record.to_client()

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -165,31 +165,6 @@ def test_log_with_annotation(monkeypatch):
     assert records[0]["status"] == "Discarded"
 
 
-def test_text2text_client_to_sdk():
-    record = Text2TextRecord(
-        text="test text",
-        prediction=["test prediction"],
-        annotation="test annotation",
-        prediction_agent="test_model",
-        annotation_agent="test_annotator",
-        id=1,
-        metadata={"metadata": "test"},
-        status="Default",
-        event_timestamp=datetime.datetime(2000, 1, 1),
-    )
-
-    assert isinstance(record.prediction[0], tuple)
-    assert record.prediction[0][1] == pytest.approx(1.0)
-
-    sdk_record = RubrixClient._text2text_client_to_sdk(record)
-
-    assert sdk_record.event_timestamp == datetime.datetime(2000, 1, 1)
-
-    client_record = RubrixClient._text2text_sdk_to_client(sdk_record)
-
-    assert record == client_record
-
-
 def test_create_ds_with_wrong_name(monkeypatch):
     mocking_client(monkeypatch)
     dataset_name = "Test Create_ds_with_wrong_name"

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -34,9 +34,6 @@ from rubrix import (
     TokenClassificationRecord,
 )
 from rubrix.client.sdk.commons.models import Response
-from rubrix.sdk.models.text2_text_bulk_data import Text2TextBulkData
-from rubrix.sdk.models.text2_text_bulk_data_metadata import Text2TextBulkDataMetadata
-from rubrix.sdk.models.text2_text_bulk_data_tags import Text2TextBulkDataTags
 
 
 @pytest.fixture
@@ -111,9 +108,7 @@ def mock_response_text2text(monkeypatch):
 
     _response = BulkResponse(dataset="test", processed=500, failed=0)
 
-    def mock_get(*args, json_body: Text2TextBulkData, **kwargs):
-        assert isinstance(json_body.metadata, Text2TextBulkDataMetadata)
-        assert isinstance(json_body.tags, Text2TextBulkDataTags)
+    def mock_get(*args, **kwargs):
         return Response(
             status_code=200,
             content=b"Everything's fine",
@@ -127,7 +122,7 @@ def mock_response_text2text(monkeypatch):
         )
 
     monkeypatch.setattr(
-        "rubrix.client.text2text_bulk_records.sync_detailed",
+        "rubrix.client.text2text_bulk",
         mock_get,
     )  # apply the monkeypatch for requests.get to mock_get
 
@@ -195,17 +190,15 @@ def test_token_classification(mock_response_token):
     )
 
 
-def test_text2text(mock_response_200, mock_response_text2text):
+def test_text2text(mock_response_text2text):
     """Testing text2text with log function
 
     It checks a Response is generated.
 
     Parameters
     ----------
-    mock_response_200
-        Mocked correct http response, emulating API init
-    mock_response_token
-        Mocked response given by the sync method, emulating the log of data
+    mock_response_text2text
+        Mocked response for the text2text bulk API call
     """
     records = [
         Text2TextRecord(


### PR DESCRIPTION
This PR adds the Text2Text part to our custom SDK. It also includes an important bug fix that prevents logging records with an `event_timestamp`. **Keep in mind that this PR merges into #452.** Closes #454 