### PR TITLE
fix(UI): validate the model prediction when no annotation

### DIFF
--- a/frontend/components/text-classifier/header/TextClassificationHeader.vue
+++ b/frontend/components/text-classifier/header/TextClassificationHeader.vue
@@ -112,9 +112,20 @@ export default {
       });
     },
     async onValidate(records) {
+
       await this.validate({
         dataset: this.dataset,
-        records: records,
+        records: records.map((record) => {
+          let modelPrediction = {};
+          modelPrediction.labels = record.predicted_as.map((pred) => ({class: pred, score: 1}));
+          return {
+            ...record,
+            annotation: {
+              ...(record.annotation || modelPrediction),
+              agent: this.$auth.user,
+            },
+          }
+        }),
       });
     },
     async onNewLabel(newLabel) {


### PR DESCRIPTION
In Text Classification task,  when validating globally annotate the model prediction in case no annotations exist