### PR TITLE
Allow disabling ES index template creation by environment var

### DIFF
--- a/src/rubrix/server/commons/settings.py
+++ b/src/rubrix/server/commons/settings.py
@@ -46,6 +46,10 @@ class ApiSettings(BaseSettings):
 
     es_records_index_replicas:
         Configures the number of shard replicas for dataset records index creation. Default=0
+
+    disable_es_index_template_creation: (DISABLE_ES_INDEX_TEMPLATE_CREATION env var)
+         Allowing advanced users to create their own es index settings and mappings. Default=False
+
     """
 
     only_bulk_api: bool = False
@@ -56,6 +60,7 @@ class ApiSettings(BaseSettings):
 
     es_records_index_shards: int = 1
     es_records_index_replicas: int = 0
+    disable_es_index_template_creation: bool = False
 
 
 settings = ApiSettings()

--- a/src/rubrix/server/datasets/dao.py
+++ b/src/rubrix/server/datasets/dao.py
@@ -20,7 +20,7 @@ from fastapi import Depends
 
 from rubrix.server.commons.es_wrapper import ElasticsearchWrapper, create_es_wrapper
 from rubrix.server.tasks.commons import TaskType
-from .model import DatasetDB
+
 from ..commons import es_helpers
 from ..commons.errors import WrongInputParamError
 from ..commons.es_helpers import aggregations
@@ -29,7 +29,9 @@ from ..commons.es_settings import (
     DATASETS_INDEX_TEMPLATE,
     DATASETS_RECORDS_INDEX_NAME,
 )
+from ..commons.settings import settings
 from ..metrics.model import DatasetMetricDB
+from .model import DatasetDB
 
 
 def dataset_records_index(dataset_id: str) -> str:
@@ -67,7 +69,7 @@ class DatasetsDAO:
         self._es.create_index_template(
             name=DATASETS_INDEX_NAME,
             template=DATASETS_INDEX_TEMPLATE,
-            force_recreate=True,
+            force_recreate=not settings.disable_es_index_template_creation,
         )
         self._es.create_index(DATASETS_INDEX_NAME)
 


### PR DESCRIPTION
allowing advanced users to create their own es index settings and mappings.

See [#443](https://github.com/recognai/rubrix/issues/443) and [ #455](https://github.com/recognai/rubrix/issues/455)