### PR TITLE
chore(CI): codecov config only for CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: pip install .[server]
       - name: Run tests 📈
         run: 
-          pytest
+          pytest --cov=rubrix --cov-report=xml
       - name: Upload Coverage to Codecov 📦
         uses: codecov/codecov-action@v1
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "setuptools.build_meta"
 log_format = "%(asctime)s %(name)s %(levelname)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"
 log_cli = "True"
-addopts = "--cov=rubrix --cov-report=xml"
 testpaths = [
     "tests"
 ]


### PR DESCRIPTION
This PR configures code coverage generation for codecov only in CI builds.

This changes allow to debug tests internally without comment `addons` parameter in `pyproject.toml` file and running tests with code coverage from PyCharm (https://www.jetbrains.com/help/pycharm/running-test-with-coverage.html)