### PR TITLE
fix(client): rb.load without limit fails

### DIFF
--- a/src/rubrix/client/__init__.py
+++ b/src/rubrix/client/__init__.py
@@ -261,6 +261,7 @@ class RubrixClient:
             limit=limit,
         )
 
+        _check_response_errors(response)
         return pandas.DataFrame(map(lambda r: r.to_client().dict(), response.parsed))
 
     def copy(self, source: str, target: str):

--- a/src/rubrix/client/sdk/text2text/api.py
+++ b/src/rubrix/client/sdk/text2text/api.py
@@ -63,7 +63,7 @@ def data(
         headers=client.get_headers(),
         cookies=client.get_cookies(),
         timeout=None,
-        params={"limit": limit},
+        params={"limit": limit} if limit else None,
         json=request.dict() if request else {},
     ) as response:
         return build_data_response(response=response, data_type=Text2TextRecord)

--- a/src/rubrix/client/sdk/text_classification/api.py
+++ b/src/rubrix/client/sdk/text_classification/api.py
@@ -67,7 +67,7 @@ def data(
         headers=client.get_headers(),
         cookies=client.get_cookies(),
         timeout=None,
-        params={"limit": limit},
+        params={"limit": limit} if limit else None,
         json=request.dict() if request else {},
     ) as response:
         return build_data_response(

--- a/src/rubrix/client/sdk/token_classification/api.py
+++ b/src/rubrix/client/sdk/token_classification/api.py
@@ -70,7 +70,7 @@ def data(
         headers=client.get_headers(),
         cookies=client.get_cookies(),
         timeout=None,
-        params={"limit": limit},
+        params={"limit": limit} if limit else None,
         json=request.dict() if request else {},
     ) as response:
         return build_data_response(

--- a/tests/client/sdk/text2text/test_api.py
+++ b/tests/client/sdk/text2text/test_api.py
@@ -63,7 +63,8 @@ def test_bulk(sdk_client, bulk_data, monkeypatch):
     assert isinstance(response.parsed, BulkResponse)
 
 
-def test_data(sdk_client, bulk_data, monkeypatch):
+@pytest.mark.parametrize("limit,expected", [(None, 3), (2, 2)])
+def test_data(limit, expected, sdk_client, bulk_data, monkeypatch):
     # TODO: Not sure how to test the streaming part of the response here
     monkeypatch.setattr(httpx, "stream", client.stream)
 
@@ -74,6 +75,6 @@ def test_data(sdk_client, bulk_data, monkeypatch):
         json=bulk_data.dict(by_alias=True),
     )
 
-    response = data(sdk_client, name=dataset_name, limit=2)
+    response = data(sdk_client, name=dataset_name, limit=limit)
     assert isinstance(response.parsed[0], Text2TextRecord)
-    assert len(response.parsed) == 2
+    assert len(response.parsed) == expected

--- a/tests/client/sdk/text_classification/test_api.py
+++ b/tests/client/sdk/text_classification/test_api.py
@@ -71,7 +71,8 @@ def test_bulk(sdk_client, bulk_data, monkeypatch):
     assert isinstance(response.parsed, BulkResponse)
 
 
-def test_data(bulk_data, sdk_client, monkeypatch):
+@pytest.mark.parametrize("limit,expected", [(None, 3), (2, 2)])
+def test_data(limit, expected, bulk_data, sdk_client, monkeypatch):
     # TODO: Not sure how to test the streaming part of the response here
     monkeypatch.setattr(httpx, "stream", client.stream)
 
@@ -82,6 +83,6 @@ def test_data(bulk_data, sdk_client, monkeypatch):
         json=bulk_data.dict(by_alias=True),
     )
 
-    response = data(sdk_client, name=dataset_name, limit=2)
+    response = data(sdk_client, name=dataset_name, limit=limit)
     assert isinstance(response.parsed[0], TextClassificationRecord)
-    assert len(response.parsed) == 2
+    assert len(response.parsed) == expected

--- a/tests/client/sdk/token_classification/test_api.py
+++ b/tests/client/sdk/token_classification/test_api.py
@@ -66,7 +66,8 @@ def test_bulk(sdk_client, bulk_data, monkeypatch):
     assert isinstance(response.parsed, BulkResponse)
 
 
-def test_data(sdk_client, bulk_data, monkeypatch):
+@pytest.mark.parametrize("limit,expected", [(None, 3), (2, 2)])
+def test_data(limit, expected, sdk_client, bulk_data, monkeypatch):
     # TODO: Not sure how to test the streaming part of the response here
     monkeypatch.setattr(httpx, "stream", client.stream)
 
@@ -77,6 +78,6 @@ def test_data(sdk_client, bulk_data, monkeypatch):
         json=bulk_data.dict(by_alias=True),
     )
 
-    response = data(sdk_client, name=dataset_name, limit=2)
+    response = data(sdk_client, name=dataset_name, limit=limit)
     assert isinstance(response.parsed[0], TokenClassificationRecord)
-    assert len(response.parsed) == 2
+    assert len(response.parsed) == expected


### PR DESCRIPTION
This is a hot hot hot fix. `rb.load` without specifying a limit in the current master fails, this fixes it. Plus it improves error handling and updates the tests.