### PR TITLE
feat(server): per-tast predefined metrics

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,8 @@ server =
     elasticsearch >= 7.4.0,<8.0.0
     smart-open
     brotli-asgi ~= 1.1.0
+    # metrics
+    scikit-learn ~= 1.0.0
     # Words cloud
     stopwordsiso ~= 0.6.1
     # Statics server

--- a/src/rubrix/client/sdk/commons/models.py
+++ b/src/rubrix/client/sdk/commons/models.py
@@ -45,6 +45,7 @@ class BaseRecord(GenericModel, Generic[T]):
     status: Optional[TaskStatus] = None
     prediction: Optional[T] = None
     annotation: Optional[T] = None
+    metrics: Dict[str, Any] = Field(default_factory=dict)
 
     # this is a small hack to get a json-compatible serialization on cls.dict(), which we use for the httpx calls.
     # they want to build this feature into pydantic, see https://github.com/samuelcolvin/pydantic/issues/1409

--- a/src/rubrix/server/commons/es_helpers.py
+++ b/src/rubrix/server/commons/es_helpers.py
@@ -348,7 +348,7 @@ class aggregations:
             "meta": {"kind": "terms"},
             "terms": {
                 "field": field_name,
-                "size": size,
+                "size": size or aggregations.DEFAULT_AGGREGATION_SIZE,
                 "order": {"_count": "desc"},
             },
         }
@@ -361,7 +361,7 @@ class aggregations:
             },
             "histogram": {
                 "field": field_name,
-                "interval": interval,
+                "interval": interval or 0.1,
             },
         }
 

--- a/src/rubrix/server/datasets/model.py
+++ b/src/rubrix/server/datasets/model.py
@@ -18,7 +18,7 @@ Dataset models definition
 """
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel, Field
 

--- a/src/rubrix/server/tasks/api.py
+++ b/src/rubrix/server/tasks/api.py
@@ -19,30 +19,41 @@ from rubrix.server.tasks.token_classification.metrics import TokenClassification
 from .commons import TaskType
 from .commons.metrics.api import configure_metrics_endpoints
 from .commons.task_factory import TaskFactory
-from .text2text import Text2TextQuery, api as text2text
+from .text2text import Text2TextQuery, Text2TextRecord, api as text2text
 from .text2text.metrics import Text2TextMetrics
-from .text_classification import TextClassificationQuery, api as text_classification
+from .text_classification import (
+    TextClassificationQuery,
+    TextClassificationRecord,
+    api as text_classification,
+)
 from .text_classification.metrics import TextClassificationMetrics
-from .token_classification import TokenClassificationQuery, api as token_classification
+from .token_classification import (
+    TokenClassificationQuery,
+    TokenClassificationRecord,
+    api as token_classification,
+)
 
 router = APIRouter()
 
 TaskFactory.register_task(
     task_type=TaskType.token_classification,
     query_request=TokenClassificationQuery,
+    record_class=TokenClassificationRecord,
     metrics=TokenClassificationMetrics,
 )
 
 TaskFactory.register_task(
     task_type=TaskType.text_classification,
     query_request=TextClassificationQuery,
+    record_class=TextClassificationRecord,
     metrics=TextClassificationMetrics,
 )
 
 TaskFactory.register_task(
     task_type=TaskType.text2text,
     query_request=Text2TextQuery,
-    metrics=Text2TextMetrics
+    record_class=Text2TextRecord,
+    metrics=Text2TextMetrics,
 )
 
 

--- a/src/rubrix/server/tasks/api.py
+++ b/src/rubrix/server/tasks/api.py
@@ -15,25 +15,40 @@
 
 from fastapi import APIRouter
 
+from rubrix.server.tasks.token_classification.metrics import TokenClassificationMetrics
 from .commons import TaskType
+from .commons.metrics.api import configure_metrics_endpoints
 from .commons.task_factory import TaskFactory
 from .text2text import Text2TextQuery, api as text2text
+from .text2text.metrics import Text2TextMetrics
 from .text_classification import TextClassificationQuery, api as text_classification
+from .text_classification.metrics import TextClassificationMetrics
 from .token_classification import TokenClassificationQuery, api as token_classification
 
 router = APIRouter()
 
-
 TaskFactory.register_task(
-    task_type=TaskType.token_classification, query_request=TokenClassificationQuery
+    task_type=TaskType.token_classification,
+    query_request=TokenClassificationQuery,
+    metrics=TokenClassificationMetrics,
 )
 
 TaskFactory.register_task(
-    task_type=TaskType.text_classification, query_request=TextClassificationQuery
+    task_type=TaskType.text_classification,
+    query_request=TextClassificationQuery,
+    metrics=TextClassificationMetrics,
 )
 
-TaskFactory.register_task(task_type=TaskType.text2text, query_request=Text2TextQuery)
+TaskFactory.register_task(
+    task_type=TaskType.text2text,
+    query_request=Text2TextQuery,
+    metrics=Text2TextMetrics
+)
 
 
 for task_api in [text_classification, token_classification, text2text]:
+    cfg = TaskFactory.get_task_by_task_type(task_api.TASK_TYPE)
+    if cfg:
+        configure_metrics_endpoints(task_api.router, cfg)
+
     router.include_router(task_api.router)

--- a/src/rubrix/server/tasks/commons/api/model.py
+++ b/src/rubrix/server/tasks/commons/api/model.py
@@ -172,6 +172,7 @@ class BaseRecord(GenericModel, Generic[Annotation]):
     status: Optional[TaskStatus] = None
     prediction: Optional[Annotation] = None
     annotation: Optional[Annotation] = None
+    metrics: Dict[str, Any] = Field(default_factory=dict)
 
     @validator("id", always=True)
     def default_id_if_none_provided(cls, id: Optional[str]) -> str:
@@ -331,8 +332,6 @@ class BaseSearchResults(GenericModel, Generic[Record, Aggregations]):
         The selected records to return
     aggregations:
         Requested aggregations
-    metrics:
-        Requested metrics
     """
 
     total: int = 0

--- a/src/rubrix/server/tasks/commons/dao/model.py
+++ b/src/rubrix/server/tasks/commons/dao/model.py
@@ -36,6 +36,7 @@ class RecordSearch(BaseModel):
     query: Optional[Dict[str, Any]]
     sort: List[Dict[str, Any]] = Field(default_factory=list)
     aggregations: Optional[Dict[str, Any]]
+    include_default_aggregations: bool = True
 
 
 class RecordSearchResults(BaseModel):

--- a/src/rubrix/server/tasks/commons/metrics/__init__.py
+++ b/src/rubrix/server/tasks/commons/metrics/__init__.py
@@ -1,0 +1,1 @@
+from .model import *

--- a/src/rubrix/server/tasks/commons/metrics/api.py
+++ b/src/rubrix/server/tasks/commons/metrics/api.py
@@ -97,7 +97,9 @@ def configure_metrics_endpoints(router: APIRouter, cfg: TaskConfig):
             A list of metric info availables for given dataset
 
         """
-        dataset = datasets.find_by_name(name, user=current_user, team=teams_query.team)
+        dataset = datasets.find_by_name(
+            name, task=cfg.task, user=current_user, team=teams_query.team
+        )
         metrics = metrics.get_dataset_metrics(dataset=dataset)
         return [MetricInfo.parse_obj(metric) for metric in metrics]
 
@@ -143,7 +145,9 @@ def configure_metrics_endpoints(router: APIRouter, cfg: TaskConfig):
             The metric summary for a given dataset
 
         """
-        dataset = datasets.find_by_name(name, user=current_user, team=teams_query.team)
+        dataset = datasets.find_by_name(
+            name, task=cfg.task, user=current_user, team=teams_query.team
+        )
         return metrics.summarize_metric(
             dataset=dataset,
             owner=current_user.check_team(teams_query.team),

--- a/src/rubrix/server/tasks/commons/metrics/api.py
+++ b/src/rubrix/server/tasks/commons/metrics/api.py
@@ -1,0 +1,153 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Query, Security
+from pydantic import BaseModel, Field
+
+from rubrix.server.commons.api import TeamsQueryParams
+from rubrix.server.datasets.service import DatasetsService
+from rubrix.server.security import auth
+from rubrix.server.security.model import User
+from rubrix.server.tasks.commons.metrics.service import MetricsService
+from rubrix.server.tasks.commons.task_factory import TaskConfig
+
+
+class MetricInfo(BaseModel):
+    """Metric info data model for retrieve dataset metrics information"""
+
+    id: str = Field(description="The metric id")
+    name: str = Field(description="The metric name")
+    description: Optional[str] = Field(
+        default=None, description="The metric description"
+    )
+
+
+@dataclass
+class MetricSummaryParams:
+    """
+    For metrics summary calculation, common summary parameters.
+
+    Attributes:
+    -----------
+
+    interval:
+        For histogram summaries, the bucket interval
+
+    size:
+        For terminological metrics, the number of terms to retrieve
+
+    """
+
+    interval: Optional[float] = Query(
+        default=None,
+        gt=0.0,
+        description="The histogram interval for histogram summaries",
+    )
+    size: Optional[int] = Query(
+        default=None,
+        ge=1,
+        description="The number of terms for terminological summaries",
+    )
+
+
+def configure_metrics_endpoints(router: APIRouter, cfg: TaskConfig):
+    """
+    Configures an api router with the dataset task metrics endpoints.
+
+    Parameters
+    ----------
+    router:
+        The api router
+    cfg:
+        The task configuration model
+
+    """
+    base_metrics_endpoint = f"/{cfg.task}/{{name}}/metrics"
+
+    @router.get(
+        base_metrics_endpoint,
+        operation_id=f"get_dataset_metrics",
+        name="get_dataset_metrics",
+    )
+    def get_dataset_metrics(
+        name: str,
+        teams_query: TeamsQueryParams = Depends(),
+        current_user: User = Security(auth.get_user, scopes=[]),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        metrics: MetricsService = Depends(MetricsService.get_instance),
+    ) -> List[MetricInfo]:
+        """
+        List available metrics info for a given dataset
+
+        Parameters
+        ----------
+        name:
+            The dataset name
+        teams_query:
+            Team query param where dataset belongs to. Optional
+        current_user:
+            The current user
+        datasets:
+            The datasets service
+        metrics:
+            The metrics service
+
+        Returns
+        -------
+            A list of metric info availables for given dataset
+
+        """
+        dataset = datasets.find_by_name(name, user=current_user, team=teams_query.team)
+        metrics = metrics.get_dataset_metrics(dataset=dataset)
+        return [MetricInfo.parse_obj(metric) for metric in metrics]
+
+    @router.post(
+        base_metrics_endpoint + "/{metric}:summary",
+        operation_id=f"metric_summary",
+        name="metric_summary",
+    )
+    def metric_summary(
+        name: str,
+        metric: str,
+        query: cfg.query,
+        metric_params: MetricSummaryParams = Depends(),
+        teams_query: TeamsQueryParams = Depends(),
+        current_user: User = Security(auth.get_user, scopes=[]),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        metrics: MetricsService = Depends(MetricsService.get_instance),
+    ):
+        """
+        Summarizes a given metric for a given dataset.
+
+        Parameters
+        ----------
+        name:
+            The dataset name
+        metric:
+            The metric id
+        query:
+            A query for records filtering. Optional
+        metric_params:
+            Metric parameters for result calculation
+        teams_query:
+            Team query param where dataset belongs to. Optional
+        current_user:
+            The current user
+        datasets:
+            The datasets service
+        metrics:
+            The metrics service
+
+        Returns
+        -------
+            The metric summary for a given dataset
+
+        """
+        dataset = datasets.find_by_name(name, user=current_user, team=teams_query.team)
+        return metrics.summarize_metric(
+            dataset=dataset,
+            owner=current_user.check_team(teams_query.team),
+            metric=metric,
+            query=query,
+            **vars(metric_params),
+        )

--- a/src/rubrix/server/tasks/commons/metrics/model/base.py
+++ b/src/rubrix/server/tasks/commons/metrics/model/base.py
@@ -1,11 +1,8 @@
-from abc import ABCMeta
-from typing import Any, ClassVar, Dict, Generic, List, Optional, TypeVar
+from typing import Any, ClassVar, Dict, Generic, Iterable, List, Optional, TypeVar
 
-import pandas as pd
 from pydantic import BaseModel
 from pydantic.generics import GenericModel
 
-from rubrix.server.commons import es_helpers
 from rubrix.server.commons.es_helpers import aggregations
 from rubrix.server.tasks.commons import BaseRecord
 
@@ -25,14 +22,14 @@ class PythonMetric(BaseMetric):
     A metric definition which will be calculated using raw queried data
     """
 
-    def apply(self, query_df: pd.DataFrame) -> Any:
+    def apply(self, records: Iterable[Dict[str, Any]]) -> Any:
         """
         Metric calculation method.
 
         Parameters
         ----------
-        query_df:
-            The filtered records data represented
+        records:
+            The matched records
 
         Returns
         -------

--- a/src/rubrix/server/tasks/commons/metrics/model/base.py
+++ b/src/rubrix/server/tasks/commons/metrics/model/base.py
@@ -1,0 +1,163 @@
+from abc import ABCMeta
+from typing import Any, ClassVar, Dict, Generic, List, Optional, TypeVar
+
+import pandas as pd
+from pydantic import BaseModel
+from pydantic.generics import GenericModel
+
+from rubrix.server.commons import es_helpers
+from rubrix.server.commons.es_helpers import aggregations
+from rubrix.server.tasks.commons import BaseRecord
+
+
+class BaseMetric(BaseModel):
+    """
+    Base model for rubrix dataset metrics summaries
+    """
+
+    id: str
+    name: str
+    description: str = None
+
+
+class PythonMetric(BaseMetric):
+    """
+    A metric definition which will be calculated using raw queried data
+    """
+
+    def apply(self, query_df: pd.DataFrame) -> Any:
+        """
+        Metric calculation method.
+
+        Parameters
+        ----------
+        query_df:
+            The filtered records data represented
+
+        Returns
+        -------
+            The metric result
+        """
+        raise NotImplementedError()
+
+
+class ElasticsearchMetric(BaseMetric):
+    """
+    A metric summarized by using one or several elasticsearch aggregations
+    """
+
+    def aggregation_request(self, *args, **kwargs) -> Dict[str, Any]:
+        """
+        Configures the summary es aggregation definition
+        """
+        raise NotImplementedError()
+
+    def aggregation_result(self, aggregation_result: Dict[str, Any]) -> Any:
+        """
+        Parse the es aggregation result. Override this method
+        for result customization
+
+        Parameters
+        ----------
+        aggregation_result:
+            Retrieved es aggregation result
+
+        """
+        return aggregation_result
+
+
+class NestedPathElasticsearchMetric(ElasticsearchMetric):
+    """
+    A ``ElasticsearchMetric`` which need nested fields for summary calculation.
+
+    Aggregations for nested fields need some extra configuration and this class
+    encapsulate these common logic.
+
+    Attributes:
+    -----------
+    nested_path:
+        The nested
+    """
+
+    nested_path: str
+
+    def inner_aggregation(self, *args, **kwargs):
+        """The specific aggregation definition"""
+        raise NotImplementedError()
+
+    def aggregation_request(self, *args, **kwargs) -> Dict[str, Any]:
+        """Implements the common mechanism to define aggregations with nested fields"""
+        return aggregations.nested_aggregation(
+            nested_path=self.nested_path,
+            inner_aggregation=self.inner_aggregation(*args, **kwargs),
+        )
+
+
+GenericRecord = TypeVar("GenericRecord", bound=BaseRecord)
+
+
+class BaseTaskMetrics(GenericModel, Generic[GenericRecord]):
+    """
+    Base class encapsulating related task metrics
+
+    Attributes:
+    -----------
+
+    metrics:
+        A list of configured metrics for task
+    """
+
+    metrics: ClassVar[List[BaseMetric]]
+
+    @classmethod
+    def configure_es_index(cls):
+        """
+        If some metrics require specific es field mapping definitions,
+        include them here.
+
+        """
+        pass
+
+    @classmethod
+    def find_metric(cls, id: str) -> Optional[BaseMetric]:
+        """
+        Finds a metric by id
+
+        Parameters
+        ----------
+        id:
+            The metric id
+
+        Returns
+        -------
+            Found metric if any, ``None`` otherwise
+
+        """
+        for metric in cls.metrics:
+            if metric.id == id:
+                return metric
+
+    @classmethod
+    def record_metrics(cls, record: GenericRecord) -> Dict[str, Any]:
+        """
+        Use this method is some configured metric requires additional
+        records fields.
+
+        Generated records will be persisted under ``metrics`` record path.
+        For example, if you define a field called ``sentence_length`` like
+
+        >>> def record_metrics(cls, record)-> Dict[str, Any]:
+        ...     return { "sentence_length" : len(record.text) }
+
+        The new field will be stored in elasticsearch in ``metrics.sentence_length``
+
+        Parameters
+        ----------
+        record:
+            The record used for calculate metrics fields
+
+        Returns
+        -------
+            A dict with calculated metrics fields
+        """
+        return {}

--- a/src/rubrix/server/tasks/commons/metrics/model/base.py
+++ b/src/rubrix/server/tasks/commons/metrics/model/base.py
@@ -7,6 +7,9 @@ from rubrix.server.commons.es_helpers import aggregations
 from rubrix.server.tasks.commons import BaseRecord
 
 
+GenericRecord = TypeVar("GenericRecord", bound=BaseRecord)
+
+
 class BaseMetric(BaseModel):
     """
     Base model for rubrix dataset metrics summaries
@@ -17,12 +20,12 @@ class BaseMetric(BaseModel):
     description: str = None
 
 
-class PythonMetric(BaseMetric):
+class PythonMetric(BaseMetric, Generic[GenericRecord]):
     """
     A metric definition which will be calculated using raw queried data
     """
 
-    def apply(self, records: Iterable[Dict[str, Any]]) -> Any:
+    def apply(self, records: Iterable[GenericRecord]) -> Dict[str, Any]:
         """
         Metric calculation method.
 
@@ -49,7 +52,7 @@ class ElasticsearchMetric(BaseMetric):
         """
         raise NotImplementedError()
 
-    def aggregation_result(self, aggregation_result: Dict[str, Any]) -> Any:
+    def aggregation_result(self, aggregation_result: Dict[str, Any]) -> Dict[str, Any]:
         """
         Parse the es aggregation result. Override this method
         for result customization
@@ -78,7 +81,7 @@ class NestedPathElasticsearchMetric(ElasticsearchMetric):
 
     nested_path: str
 
-    def inner_aggregation(self, *args, **kwargs):
+    def inner_aggregation(self, *args, **kwargs) -> Dict[str, Any]:
         """The specific aggregation definition"""
         raise NotImplementedError()
 
@@ -88,9 +91,6 @@ class NestedPathElasticsearchMetric(ElasticsearchMetric):
             nested_path=self.nested_path,
             inner_aggregation=self.inner_aggregation(*args, **kwargs),
         )
-
-
-GenericRecord = TypeVar("GenericRecord", bound=BaseRecord)
 
 
 class BaseTaskMetrics(GenericModel, Generic[GenericRecord]):

--- a/src/rubrix/server/tasks/commons/metrics/service.py
+++ b/src/rubrix/server/tasks/commons/metrics/service.py
@@ -135,7 +135,8 @@ class MetricsService:
                 dataset,
                 search=RecordSearch(query=query.as_elasticsearch() if query else None),
             )
-            return _metric.apply(records)
+            record_class = TaskFactory.get_task_record(dataset.task)
+            return _metric.apply(map(record_class.parse_obj, records))
 
         raise WrongInputParamError(f"Cannot process {metric} of type {type(_metric)}")
 

--- a/src/rubrix/server/tasks/commons/metrics/service.py
+++ b/src/rubrix/server/tasks/commons/metrics/service.py
@@ -1,0 +1,249 @@
+from typing import Any, Dict, List, Optional, TypeVar
+
+import pandas as pd
+from fastapi import Depends
+
+from rubrix.server.commons.errors import EntityNotFoundError, WrongInputParamError
+from rubrix.server.datasets.model import BaseDatasetDB
+from rubrix.server.tasks.commons import BaseRecord, TaskType
+from rubrix.server.tasks.commons.dao.dao import DatasetRecordsDAO, dataset_records_dao
+from rubrix.server.tasks.commons.dao.model import RecordSearch
+from rubrix.server.tasks.commons.metrics.model.base import (
+    BaseMetric,
+    ElasticsearchMetric,
+    NestedPathElasticsearchMetric,
+    PythonMetric,
+)
+from rubrix.server.tasks.commons.task_factory import TaskFactory
+
+GenericQuery = TypeVar("GenericQuery")
+
+
+class MetricsService:
+    """The dataset metrics service singleton"""
+
+    _INSTANCE = None
+
+    @classmethod
+    def get_instance(
+        cls,
+        dao: DatasetRecordsDAO = Depends(dataset_records_dao),
+    ) -> "MetricsService":
+        """
+        Creates the service instance.
+
+        Parameters
+        ----------
+        dao:
+            The dataset records dao
+
+        Returns
+        -------
+            The metrics service instance
+
+        """
+        if not cls._INSTANCE:
+            cls._INSTANCE = cls(dao)
+        return cls._INSTANCE
+
+    def __init__(self, dao: DatasetRecordsDAO):
+        """
+        Creates a service instance
+
+        Parameters
+        ----------
+        dao:
+            The dataset records dao
+        """
+        self.__dao__ = dao
+
+    @staticmethod
+    def find_metric_by_id(metric: str, task: TaskType) -> Optional[BaseMetric]:
+        """
+        Given a metric id, find corresponding task metric
+
+        Parameters
+        ----------
+        metric:
+            The metric id
+        task:
+            The nlp task
+
+        Returns
+        -------
+
+        The metric info if exists a metric with given id for given task. ``None`` otherwise
+
+        """
+        metrics = TaskFactory.get_task_metrics(task)
+        if metrics:
+            return metrics.find_metric(metric)
+
+    @staticmethod
+    def build_records_metrics(dataset: BaseDatasetDB, records: List[BaseRecord]):
+        """
+        Applies metrics calculation at record level for a given set of records
+
+        Parameters
+        ----------
+        dataset:
+            The records dataset
+        records:
+            A list of records
+
+        """
+        metrics = TaskFactory.get_task_metrics(dataset.task)
+        if metrics:
+            for record in records:
+                record.metrics = metrics.record_metrics(record)
+
+    def summarize_metric(
+        self,
+        dataset: BaseDatasetDB,
+        metric: str,
+        query: Optional[GenericQuery],
+        **metric_params,
+    ) -> Dict[str, Any]:
+        """
+        Applies a metric summarization.
+
+        Parameters
+        ----------
+        dataset:
+            The records dataset
+        metric:
+            The metric id
+        query:
+            An optional query passed for records filtering
+        metric_params:
+            Related metrics parameters
+
+        Returns
+        -------
+            The metric summarization info
+        """
+        _metric = self.find_metric_by_id(metric, task=dataset.task)
+        if not _metric:
+            raise EntityNotFoundError(name=metric, type=BaseMetric)
+
+        if isinstance(_metric, ElasticsearchMetric):
+            return self._handle_elasticsearch_metric(
+                _metric, metric_params, dataset=dataset, query=query
+            )
+        elif isinstance(_metric, PythonMetric):
+            df = self._load_data(dataset, query)
+            return _metric.apply(df)
+
+        raise WrongInputParamError(f"Cannot process {metric} of type {type(_metric)}")
+
+    def _load_data(
+        self, dataset: BaseDatasetDB, query: Optional[GenericQuery], limit: int = 10000
+    ) -> pd.DataFrame:
+        """
+        Load a set of records from dataset with filtered query.
+
+        For the sake of memory performance, the results will be limited to specified limit
+
+        Parameters
+        ----------
+        dataset:
+            The records dataset
+        query:
+            The filter to apply to dataset
+        limit:
+            A given limit for results
+
+        Returns
+        -------
+            A dataframe with filtered dataset records
+        """
+        data = [
+            record
+            for record in zip(
+                range(limit or 10000),
+                self.__dao__.scan_dataset(
+                    dataset,
+                    search=RecordSearch(
+                        query=query.as_elasticsearch() if query else None
+                    ),
+                ),
+            )
+        ]
+        # TODO: Use another lib than pandas for the sake of memory performance
+        return pd.DataFrame(data)
+
+    def _handle_elasticsearch_metric(
+        self,
+        metric: ElasticsearchMetric,
+        metric_params: Dict[str, Any],
+        dataset: BaseDatasetDB,
+        query: GenericQuery,
+    ) -> Dict[str, Any]:
+        """
+
+        Parameters
+        ----------
+        metric:
+            The elasticsearch metric summary
+        metric_params:
+            The summary params
+        dataset:
+            The records dataset
+        query:
+            The filter to apply to dataset
+
+        Returns
+        -------
+            The metric summary result
+
+        """
+        metric_params = self._filter_metric_params(metric, metric_params)
+        metric_aggregation = {metric.id: metric.aggregation_request(**metric_params)}
+        results = self.__dao__.search_records(
+            dataset,
+            size=0,  # No records at all
+            search=RecordSearch(
+                query=query.as_elasticsearch() if query else None,
+                aggregations=metric_aggregation,
+                include_default_aggregations=False,
+            ),
+        )
+        return metric.aggregation_result(results.aggregations[metric.id])
+
+    @staticmethod
+    def get_dataset_metrics(dataset: BaseDatasetDB) -> List[BaseMetric]:
+        """
+        Returns available metrics for dataset
+
+        Parameters
+        ----------
+        dataset:
+            The dataset
+        """
+        metrics = TaskFactory.get_task_metrics(dataset.task)
+        return metrics.metrics if metrics else []
+
+    @staticmethod
+    def _filter_metric_params(
+        _metric: ElasticsearchMetric, metric_params: Dict[str, Any]
+    ):
+        """
+        Select from provided metric parameter those who can be applied to given metric
+
+        Parameters
+        ----------
+        _metric:
+            The target metric
+        metric_params:
+            A dict of metric parameters
+
+        """
+        function = _metric.aggregation_request
+        if isinstance(_metric, NestedPathElasticsearchMetric):
+            function = _metric.inner_aggregation
+
+        return {
+            argument: metric_params[argument]
+            for argument in function.__code__.co_varnames
+            if argument in metric_params
+        }

--- a/src/rubrix/server/tasks/commons/service.py
+++ b/src/rubrix/server/tasks/commons/service.py
@@ -8,11 +8,7 @@ class TaskService:
 
     _INSTANCE = None
 
-    def __init__(
-        self,
-        datasets: DatasetsService,
-        dao: DatasetRecordsDAO,
-    ):
+    def __init__(self, datasets: DatasetsService, dao: DatasetRecordsDAO):
         self.__datasets__ = datasets
         self.__dao__ = dao
 

--- a/src/rubrix/server/tasks/commons/task_factory.py
+++ b/src/rubrix/server/tasks/commons/task_factory.py
@@ -1,13 +1,15 @@
-from typing import Any, Optional, Type
+from typing import Any, List, Optional, Type
 
 from pydantic import BaseModel
 
 from rubrix.server.tasks.commons import TaskType
+from rubrix.server.tasks.commons.metrics.model.base import BaseTaskMetrics
 
 
-class _TaskConfig(BaseModel):
-
+class TaskConfig(BaseModel):
+    task: TaskType
     query: Any
+    metrics: Optional[Type[BaseTaskMetrics]]
 
 
 class TaskFactory:
@@ -19,9 +21,25 @@ class TaskFactory:
         cls,
         task_type: TaskType,
         query_request: Type[Any],
+        metrics: Optional[Type[BaseTaskMetrics]] = None,
     ):
-        cls._REGISTERED_TASKS[task_type] = _TaskConfig(query=query_request)
+        if metrics:
+            metrics.configure_es_index()
+
+        cls._REGISTERED_TASKS[task_type] = TaskConfig(
+            task=task_type, query=query_request, metrics=metrics
+        )
 
     @classmethod
-    def get_task_by_task_type(cls, task_type: TaskType) -> Optional[_TaskConfig]:
+    def get_all(cls) -> List[TaskConfig]:
+        return [cfg for cfg in cls._REGISTERED_TASKS.values()]
+
+    @classmethod
+    def get_task_by_task_type(cls, task_type: TaskType) -> Optional[TaskConfig]:
         return cls._REGISTERED_TASKS.get(task_type)
+
+    @classmethod
+    def get_task_metrics(cls, task: TaskType) -> Optional[Type[BaseTaskMetrics]]:
+        config = cls.get_task_by_task_type(task)
+        if config:
+            return config.metrics

--- a/src/rubrix/server/tasks/text2text/metrics.py
+++ b/src/rubrix/server/tasks/text2text/metrics.py
@@ -1,0 +1,12 @@
+from typing import ClassVar, List
+
+from rubrix.server.tasks.commons.metrics.model.base import BaseMetric, BaseTaskMetrics
+from rubrix.server.tasks.text2text import Text2TextRecord
+
+
+class Text2TextMetrics(BaseTaskMetrics[Text2TextRecord]):
+    """
+    Configured metrics for text2text task
+    """
+
+    metrics: ClassVar[List[BaseMetric]] = []

--- a/src/rubrix/server/tasks/text2text/service/service.py
+++ b/src/rubrix/server/tasks/text2text/service/service.py
@@ -30,6 +30,7 @@ from rubrix.server.tasks.commons import (
 from rubrix.server.tasks.commons.dao import extends_index_properties
 from rubrix.server.tasks.commons.dao.dao import DatasetRecordsDAO, dataset_records_dao
 from rubrix.server.tasks.commons.dao.model import RecordSearch
+from rubrix.server.tasks.commons.metrics.service import MetricsService
 from rubrix.server.tasks.text2text.api.model import (
     CreationText2TextRecord,
     ExtendedEsRecordDataFieldNames,
@@ -67,14 +68,17 @@ class Text2TextService:
     def __init__(
         self,
         dao: DatasetRecordsDAO,
+        metrics: MetricsService,
     ):
         self.__dao__ = dao
+        self.__metrics__ = metrics
 
     def add_records(
         self,
         dataset: Dataset,
         records: List[CreationText2TextRecord],
     ):
+        self.__metrics__.build_records_metrics(dataset, records)
         failed = self.__dao__.add_records(
             dataset=dataset,
             records=records,
@@ -178,6 +182,7 @@ _instance = None
 
 def text2text_service(
     dao: DatasetRecordsDAO = Depends(dataset_records_dao),
+    metrics: MetricsService = Depends(MetricsService.get_instance),
 ) -> Text2TextService:
     """
     Creates a dataset record service instance
@@ -186,6 +191,8 @@ def text2text_service(
     ----------
     dao:
         The dataset records dao dependency
+    metrics:
+        The metrics service
 
     Returns
     -------
@@ -193,5 +200,5 @@ def text2text_service(
     """
     global _instance
     if not _instance:
-        _instance = Text2TextService(dao=dao)
+        _instance = Text2TextService(dao=dao, metrics=metrics)
     return _instance

--- a/src/rubrix/server/tasks/text_classification/metrics.py
+++ b/src/rubrix/server/tasks/text_classification/metrics.py
@@ -1,0 +1,91 @@
+from typing import Any, ClassVar, List
+
+import pandas as pd
+
+from rubrix.server.tasks.commons.metrics.model.base import (
+    BaseMetric,
+    BaseTaskMetrics,
+    PythonMetric,
+)
+from rubrix.server.tasks.text_classification import TextClassificationRecord
+
+
+class F1Metric(PythonMetric):
+    """
+    A basic f1 calculation for text classification
+
+    Attributes:
+    -----------
+        multi_label:
+            If True, F1 will be calculated assuming multi class task. Default False
+    """
+
+    multi_label: bool = False
+
+    def apply(self, query_df: pd.DataFrame) -> Any:
+        from sklearn.metrics import f1_score
+        from sklearn.preprocessing import MultiLabelBinarizer
+
+        df = query_df[["predicted_as", "annotated_as"]].dropna()
+        df = df[
+            df.apply(
+                lambda d: len(d["predicted_as"]) > 0 and len(d["annotated_as"]) > 0,
+                axis=1,
+            )
+        ]
+
+        ds_labels = set()
+        df.predicted_as.map(lambda labels: [ds_labels.add(l) for l in labels])
+        df.annotated_as.map(lambda labels: [ds_labels.add(l) for l in labels])
+
+        labels_mapping = {label: i for i, label in enumerate(ds_labels)}
+        if not labels_mapping:
+            return {}
+
+        y_true, y_pred = ([], [])
+        for array, column in [(y_true, "annotated_as"), (y_pred, "predicted_as")]:
+            array.extend(
+                df[column]
+                .map(
+                    lambda x: labels_mapping[x[0]]
+                    if not self.multi_label
+                    else [labels_mapping[l] for l in x]
+                )
+                .values
+            )
+        if self.multi_label:
+            mlb = MultiLabelBinarizer(list(labels_mapping.values()))
+            y_true = mlb.fit_transform(y_true)
+            y_pred = mlb.fit_transform(y_pred)
+
+        micro = f1_score(y_true=y_true, y_pred=y_pred, average="micro")
+        macro = f1_score(y_true=y_true, y_pred=y_pred, average="macro")
+
+        reverse_labels_mapping = {v: k for k, v in labels_mapping.items()}
+        per_label = {
+            reverse_labels_mapping[i]: f1score
+            for i, f1score in enumerate(
+                f1_score(
+                    y_true=y_true,
+                    y_pred=y_pred,
+                    labels=list(labels_mapping.values()),
+                    average=None,
+                )
+            )
+        }
+
+        return {"micro": micro, "macro": macro, **per_label}
+
+
+class TextClassificationMetrics(BaseTaskMetrics[TextClassificationRecord]):
+    """Configured metrics for text classification task"""
+
+    metrics: ClassVar[List[BaseMetric]] = [
+        F1Metric(id="F1", name="F1 Metric for single class", description=""),
+        F1Metric(
+            id="MultiLabelF1",
+            name="F1 Metric for multi-class task",
+            description="",
+            multi_label=True,
+        ),
+    ]

--- a/src/rubrix/server/tasks/text_classification/metrics.py
+++ b/src/rubrix/server/tasks/text_classification/metrics.py
@@ -26,6 +26,11 @@ class F1Metric(PythonMetric):
         from sklearn.metrics import f1_score
         from sklearn.preprocessing import MultiLabelBinarizer
 
+        if not (
+            "predicted_as" in query_df.columns and "annotated_as" in query_df.columns
+        ):
+            return {}
+
         df = query_df[["predicted_as", "annotated_as"]].dropna()
         df = df[
             df.apply(

--- a/src/rubrix/server/tasks/token_classification/metrics.py
+++ b/src/rubrix/server/tasks/token_classification/metrics.py
@@ -1,0 +1,315 @@
+from typing import Any, ClassVar, Dict, List, Tuple
+
+from pydantic import BaseModel, Field
+
+from rubrix.server.commons.es_helpers import aggregations
+from rubrix.server.tasks.commons.dao import extends_index_properties
+from rubrix.server.tasks.commons.metrics.model.base import (
+    BaseMetric,
+    BaseTaskMetrics,
+    ElasticsearchMetric,
+    NestedPathElasticsearchMetric,
+)
+from rubrix.server.tasks.token_classification import (
+    EntitySpan,
+    TokenClassificationRecord,
+)
+
+
+class SentenceLength(ElasticsearchMetric):
+    """
+    Summarizes the sentence length metric into an histogram
+
+    Attributes:
+    -----------
+    length_field:
+        The elasticsearch field where sentence length is stored
+    """
+
+    length_field: str
+
+    def aggregation_request(self, interval: int) -> Dict[str, Any]:
+        return aggregations.histogram_aggregation(self.length_field, interval=interval)
+
+
+class EntityTags(NestedPathElasticsearchMetric):
+    """
+    Calculates the entity tags distribution
+
+    Attributes:
+    -----------
+    tags_field:
+        The elasticsearch field where tags are stored
+    """
+
+    tags_field: str
+
+    def inner_aggregation(self, size: int = 10) -> Dict[str, Any]:
+        return {"tags": aggregations.terms_aggregation(self.tags_field, size=size)}
+
+
+class EntityDensity(NestedPathElasticsearchMetric):
+    """Summarizes the entity density metric into an histogram"""
+
+    density_field: str
+
+    def inner_aggregation(self, interval: float = 0.1) -> Dict[str, Any]:
+        return {
+            "density": aggregations.histogram_aggregation(
+                field_name=self.density_field, interval=interval
+            )
+        }
+
+
+class MentionLength(NestedPathElasticsearchMetric):
+    """Summarizes the mention length into an histogram"""
+
+    length_field: str
+
+    def inner_aggregation(self, interval: int = 1) -> Dict[str, Any]:
+        return {
+            "mention_length": aggregations.histogram_aggregation(
+                self.length_field, interval=interval
+            )
+        }
+
+
+class EntityCapitalness(NestedPathElasticsearchMetric):
+    """Calculates the mention capitalness distribution"""
+
+    capitalness_field: str
+
+    def inner_aggregation(self) -> Dict[str, Any]:
+        return {
+            "capitalness": aggregations.terms_aggregation(
+                self.capitalness_field, size=4  # The number of capitalness choices
+            )
+        }
+
+
+class MentionConsistency(NestedPathElasticsearchMetric):
+    """Calculates the mention consistence distribution"""
+
+    mention_field: str
+    entity_field: str
+
+    def inner_aggregation(
+        self,
+        size: int = 20,
+        entity_size: int = 10,
+    ) -> Dict[str, Any]:
+        return {
+            "consistency": {
+                **aggregations.terms_aggregation(self.mention_field, size=size),
+                "aggs": {
+                    "entities": aggregations.terms_aggregation(
+                        self.entity_field, size=entity_size
+                    ),
+                    "count": {"cardinality": {"field": self.entity_field}},
+                    "sortby_entities_count": {
+                        "bucket_sort": {
+                            "sort": [{"count": {"order": "desc"}}],
+                            "size": entity_size,
+                        }
+                    },
+                },
+            }
+        }
+
+    def aggregation_result(self, aggregation_result: Dict[str, Any]) -> Any:
+        """Simplifies the aggregation result sorting by worst mention consistency"""
+        result = [
+            {
+                "mention": mention,
+                "entities": [
+                    {"entity": entity, "count": count}
+                    for entity, count in mention_aggs["entities"].items()
+                ],
+            }
+            for mention, mention_aggs in aggregation_result.items()
+        ]
+        result.sort(key=lambda m: len(m["entities"]), reverse=True)
+        return result
+
+
+class TokenClassificationMetrics(BaseTaskMetrics):
+    """Configured metrics for token classification"""
+
+    class MentionMetrics(BaseModel):
+        """Mention metrics model"""
+
+        mention: str
+        entity: str
+        score: float = Field(ge=0.0)
+        capitalness: str = Field(...)
+        density: float = Field(ge=0.0)
+        length: int = Field(g=0)
+
+    @staticmethod
+    def mentions_metrics(
+        mentions: List[Tuple[str, EntitySpan]],
+        tokens: List[str],
+        chars2tokens: Dict[int, int],
+    ) -> List[MentionMetrics]:
+        """Given a list of mentions with its entity spans, calculate all required metrics"""
+
+        def mention_capitalness(mention: str) -> str:
+            """Calculate mention capitalness"""
+            mention = mention.strip()
+            if mention.upper() == mention:
+                return "UPPER"
+            if mention.lower() == mention:
+                return "LOWER"
+            if mention[0].isupper():
+                return "FIRST"
+            return "MIDDLE"
+
+        def mention_length(entity: EntitySpan, chars2token_map: Dict[int, int]) -> int:
+            """Calculate mention tokens length"""
+            return len(
+                set(
+                    [
+                        token_idx
+                        for i in range(entity.start, entity.end)
+                        for token_idx in [chars2token_map.get(i)]
+                        if token_idx is not None
+                    ]
+                )
+            )
+
+        def mention_density(mention_length: int, sentence_length: int) -> float:
+            """Calculate mention density"""
+            return (1.0 * mention_length) / sentence_length
+
+        return [
+            TokenClassificationMetrics.MentionMetrics(
+                mention=mention,
+                entity=entity.label,
+                score=entity.score,
+                capitalness=mention_capitalness(mention),
+                density=mention_density(_mention_length, sentence_length=len(tokens)),
+                length=_mention_length,
+            )
+            for mention, entity in mentions
+            for _mention_length in [
+                mention_length(entity, chars2tokens),
+            ]
+        ]
+
+    @staticmethod
+    def build_chars2tokens_map(record: TokenClassificationRecord) -> Dict[int, int]:
+        """
+        Build the mapping between text characters and where belongs to.
+
+        For example, ``chars2tokens_map.get(i)`` value is the
+        token id where char i is contained (if any).
+
+        Out-of-token characters won't be included in this map,
+        so access should be using ``chars2tokens_map.get(i)``
+        instead of ``chars2tokens_map[i]``.
+
+        """
+
+        chars_map = {}
+        current_token = 0
+        current_token_char_start = 0
+        for idx, char in enumerate(record.text):
+            relative_idx = idx - current_token_char_start
+            if (
+                relative_idx < len(record.tokens[current_token])
+                and char == record.tokens[current_token][relative_idx]
+            ):
+                chars_map[idx] = current_token
+            elif (
+                relative_idx >= len(record.tokens[current_token])
+                and char == record.tokens[current_token + 1][0]
+            ):
+                current_token += 1
+                current_token_char_start += relative_idx
+                chars_map[idx] = current_token
+        return chars_map
+
+    @classmethod
+    def configure_es_index(cls):
+        """Configure mentions as nested properties"""
+        mentions_configuration = {
+            "type": "nested",
+            "properties": {
+                "mention": {"type": "keyword"},
+                "entity": {"type": "keyword"},
+                "score": {"type": "float"},
+                "capitalness": {"type": "keyword"},
+                "density": {"type": "float"},
+                "length": {"type": "integer"},
+            },
+        }
+        extends_index_properties(
+            {
+                "metrics.mentions.predicted": mentions_configuration,
+                "metrics.mentions.annotated": mentions_configuration,
+            }
+        )
+
+    @classmethod
+    def record_metrics(cls, record: TokenClassificationRecord) -> Dict[str, Any]:
+        """Calculate metrics at record level"""
+        chars2tokens = cls.build_chars2tokens_map(record)
+
+        return {
+            "sentence_length": len(record.tokens),
+            "mentions.predicted": cls.mentions_metrics(
+                mentions=record.predicted_mentions(),
+                tokens=record.tokens,
+                chars2tokens=chars2tokens,
+            ),
+            "mentions.annotated": cls.mentions_metrics(
+                mentions=record.annotated_mentions(),
+                tokens=record.tokens,
+                chars2tokens=chars2tokens,
+            ),
+        }
+
+    metrics: ClassVar[List[BaseMetric]] = [
+        SentenceLength(
+            id="sentence_length",
+            name="Sentence tokens length",
+            description="Calculates tokens length",
+            length_field="metrics.sentence_length",
+        ),
+        EntityDensity(
+            id="entity_density",
+            name="Mention entity density",
+            description="Calculates relation between mention tokens and sentence tokens",
+            nested_path="metrics.mentions.predicted",
+            density_field="metrics.mentions.predicted.density",
+        ),
+        EntityTags(
+            id="entity_tags",
+            name="Entity tags",
+            description="The entity tags distribution",
+            nested_path="metrics.mentions.predicted",
+            tags_field="metrics.mentions.predicted.entity",
+        ),
+        EntityCapitalness(
+            id="entity_capitalness",
+            name="Mention entity capitalness",
+            description="Calculate capitalized information for mentions",
+            nested_path="metrics.mentions.predicted",
+            capitalness_field="metrics.mentions.predicted.capitalness",
+        ),
+        MentionLength(
+            id="mention_length",
+            name="Mention length",
+            description="The token level mention length",
+            nested_path="metrics.mentions.predicted",
+            length_field="metrics.mentions.predicted.length",
+        ),
+        MentionConsistency(
+            id="mention_consistency",
+            name="Mention entity consistency",
+            description="Calculates top k-mentions with more entity variability",
+            nested_path="metrics.mentions.predicted",
+            mention_field="metrics.mentions.predicted.mention",
+            entity_field="metrics.mentions.predicted.entity",
+        ),
+    ]

--- a/src/rubrix/server/tasks/token_classification/metrics.py
+++ b/src/rubrix/server/tasks/token_classification/metrics.py
@@ -116,7 +116,7 @@ class MentionConsistency(NestedPathElasticsearchMetric):
             }
         }
 
-    def aggregation_result(self, aggregation_result: Dict[str, Any]) -> Any:
+    def aggregation_result(self, aggregation_result: Dict[str, Any]) -> Dict[str, Any]:
         """Simplifies the aggregation result sorting by worst mention consistency"""
         result = [
             {
@@ -129,7 +129,7 @@ class MentionConsistency(NestedPathElasticsearchMetric):
             for mention, mention_aggs in aggregation_result.items()
         ]
         result.sort(key=lambda m: len(m["entities"]), reverse=True)
-        return result
+        return { "metions": result }
 
 
 class TokenClassificationMetrics(BaseTaskMetrics):

--- a/tests/server/metrics/test_api.py
+++ b/tests/server/metrics/test_api.py
@@ -26,6 +26,37 @@ from rubrix.server.tasks.token_classification import (
 from tests.server.test_helpers import client
 
 
+def test_wrong_dataset_metrics():
+    text = "This is a text"
+    records = [
+        Text2TextRecord.parse_obj(data)
+        for data in [
+            {"text": text},
+            {"text": text},
+            {"text": text},
+            {"text": text},
+        ]
+    ]
+    request = Text2TextBulkData(records=records)
+    dataset = "test_wrong_dataset_metrics"
+
+    assert client.delete(f"/api/datasets/{dataset}").status_code == 200
+    assert (
+        client.post(
+            f"/api/datasets/{dataset}/Text2Text:bulk",
+            json=request.dict(by_alias=True),
+        ).status_code
+        == 200
+    )
+
+    response = client.get(f"/api/datasets/TokenClassification/{dataset}/metrics")
+    assert response.status_code == 400
+    response = client.post(
+        f"/api/datasets/TokenClassification/{dataset}/metrics/a-metric:summary", json={}
+    )
+    assert response.status_code == 400
+
+
 def test_dataset_for_text2text():
     text = "This is a text"
     records = [

--- a/tests/server/metrics/test_api.py
+++ b/tests/server/metrics/test_api.py
@@ -1,0 +1,138 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import pytest
+
+from rubrix.server.tasks.text2text import Text2TextBulkData, Text2TextRecord
+from rubrix.server.tasks.text_classification import (
+    TextClassificationBulkData,
+    TextClassificationRecord,
+)
+from rubrix.server.tasks.token_classification import (
+    TokenClassificationBulkData,
+    TokenClassificationRecord,
+)
+from tests.server.test_helpers import client
+
+
+def test_dataset_for_text2text():
+    text = "This is a text"
+    records = [
+        Text2TextRecord.parse_obj(data)
+        for data in [
+            {"text": text},
+            {"text": text},
+            {"text": text},
+            {"text": text},
+        ]
+    ]
+    request = Text2TextBulkData(records=records)
+    dataset = "test_dataset_for_text2text"
+
+    assert client.delete(f"/api/datasets/{dataset}").status_code == 200
+    assert (
+        client.post(
+            f"/api/datasets/{dataset}/Text2Text:bulk",
+            json=request.dict(by_alias=True),
+        ).status_code
+        == 200
+    )
+
+    metrics = client.get(f"/api/datasets/Text2Text/{dataset}/metrics").json()
+    assert len(metrics) == 0
+
+
+def test_dataset_for_token_classification():
+    text = "This is a text"
+    records = [
+        TokenClassificationRecord.parse_obj(data)
+        for data in [
+            {"text": text, "tokens": text.split(" ")},
+            {"text": text, "tokens": text.split(" ")},
+            {"text": text, "tokens": text.split(" ")},
+            {"text": text, "tokens": text.split(" ")},
+        ]
+    ]
+
+    request = TokenClassificationBulkData(records=records)
+    dataset = "test_dataset_for_token_classification"
+
+    assert client.delete(f"/api/datasets/{dataset}").status_code == 200
+
+    assert (
+        client.post(
+            f"/api/datasets/{dataset}/TokenClassification:bulk",
+            json=request.dict(by_alias=True),
+        ).status_code
+        == 200
+    )
+    metrics = client.get(f"/api/datasets/TokenClassification/{dataset}/metrics").json()
+    assert len(metrics) > 0
+
+    for metric in metrics:
+        response = client.post(
+            f"/api/datasets/TokenClassification/{dataset}/metrics/{metric['id']}:summary",
+            json={},
+        )
+        assert response.status_code == 200
+
+
+def test_dataset_metrics():
+    records = [
+        TextClassificationRecord.parse_obj(data)
+        for data in [
+            {
+                "id": 0,
+                "inputs": {"text": "Some test data"},
+                "multi_label": False,
+                "metadata": {"textLength": len("Some test data")},
+            },
+            {
+                "id": 1,
+                "inputs": {"text": "Another data with different length"},
+                "multi_label": False,
+                "metadata": {"textLength": len("Another data with different length")},
+            },
+        ]
+    ]
+    request = TextClassificationBulkData(records=records)
+    dataset = "test_get_dataset_metrics"
+
+    assert client.delete(f"/api/datasets/{dataset}").status_code == 200
+
+    assert (
+        client.post(
+            f"/api/datasets/{dataset}/TextClassification:bulk",
+            json=request.dict(by_alias=True),
+        ).status_code
+        == 200
+    )
+
+    metrics = client.get(f"/api/datasets/TextClassification/{dataset}/metrics").json()
+
+    assert len(metrics) == 2
+
+    response = client.post(
+        f"/api/datasets/TextClassification/{dataset}/metrics/missing_metric:summary",
+        json={},
+    )
+
+    assert response.status_code == 404
+
+    for metric in metrics:
+        response = client.post(
+            f"/api/datasets/TextClassification/{dataset}/metrics/{metric['id']}:summary",
+            json={},
+        )
+        assert response.status_code == 200


### PR DESCRIPTION
See [here](https://github.com/recognai/rubrix/blob/af38b91514477d63484d738a6e930f993673a7db/src/rubrix/server/tasks/text_classification/metrics.py#L16) and [here](https://github.com/recognai/rubrix/blob/af38b91514477d63484d738a6e930f993673a7db/src/rubrix/server/tasks/token_classification/metrics.py#L19
) for several examples of metric implementation and [here](https://github.com/recognai/rubrix/blob/af38b91514477d63484d738a6e930f993673a7db/src/rubrix/server/tasks/text_classification/metrics.py#L88
) or [here](https://github.com/recognai/rubrix/blob/af38b91514477d63484d738a6e930f993673a7db/src/rubrix/server/tasks/token_classification/metrics.py#L135) to see how to configure a set of task metrics.
