### PR TITLE
Feat: Enhance `rubrix.load`

### DIFF
--- a/src/rubrix/__init__.py
+++ b/src/rubrix/__init__.py
@@ -166,7 +166,8 @@ def load(
     name: str,
     ids: Optional[List[Union[str, int]]] = None,
     limit: Optional[int] = None,
-) -> pandas.DataFrame:
+    return_pandas: bool = True,
+) -> Union[pandas.DataFrame, List[Record]]:
     """Load dataset data to a pandas DataFrame.
 
     Args:
@@ -176,6 +177,8 @@ def load(
             If provided, load dataset records with given ids.
         limit:
             The number of records to retrieve.
+        return_pandas:
+            If True, return a pandas DataFrame. If False, return a list of records.
 
     Returns:
         The dataset as a pandas Dataframe.
@@ -184,7 +187,9 @@ def load(
         >>> import rubrix as rb
         >>> dataframe = rb.load(name="example-dataset")
     """
-    return _client_instance().load(name=name, limit=limit, ids=ids)
+    return _client_instance().load(
+        name=name, limit=limit, ids=ids, return_pandas=return_pandas
+    )
 
 
 def delete(name: str) -> None:

--- a/src/rubrix/__init__.py
+++ b/src/rubrix/__init__.py
@@ -166,7 +166,7 @@ def load(
     name: str,
     ids: Optional[List[Union[str, int]]] = None,
     limit: Optional[int] = None,
-    return_pandas: bool = True,
+    as_pandas: bool = True,
 ) -> Union[pandas.DataFrame, List[Record]]:
     """Load dataset data to a pandas DataFrame.
 
@@ -177,7 +177,7 @@ def load(
             If provided, load dataset records with given ids.
         limit:
             The number of records to retrieve.
-        return_pandas:
+        as_pandas:
             If True, return a pandas DataFrame. If False, return a list of records.
 
     Returns:
@@ -187,9 +187,7 @@ def load(
         >>> import rubrix as rb
         >>> dataframe = rb.load(name="example-dataset")
     """
-    return _client_instance().load(
-        name=name, limit=limit, ids=ids, return_pandas=return_pandas
-    )
+    return _client_instance().load(name=name, limit=limit, ids=ids, as_pandas=as_pandas)
 
 
 def delete(name: str) -> None:

--- a/src/rubrix/__init__.py
+++ b/src/rubrix/__init__.py
@@ -164,6 +164,7 @@ def copy(dataset: str, name_of_copy: str):
 
 def load(
     name: str,
+    query: Optional[str] = None,
     ids: Optional[List[Union[str, int]]] = None,
     limit: Optional[int] = None,
     as_pandas: bool = True,
@@ -173,6 +174,8 @@ def load(
     Args:
         name:
             The dataset name.
+        query:
+            An ElasticSearch query with the [query string syntax](https://rubrix.readthedocs.io/en/stable/reference/rubrix_webapp_reference.html#search-input)
         ids:
             If provided, load dataset records with given ids.
         limit:
@@ -187,7 +190,9 @@ def load(
         >>> import rubrix as rb
         >>> dataframe = rb.load(name="example-dataset")
     """
-    return _client_instance().load(name=name, limit=limit, ids=ids, as_pandas=as_pandas)
+    return _client_instance().load(
+        name=name, query=query, limit=limit, ids=ids, as_pandas=as_pandas
+    )
 
 
 def delete(name: str) -> None:

--- a/src/rubrix/client/__init__.py
+++ b/src/rubrix/client/__init__.py
@@ -35,36 +35,30 @@ from rubrix.client.models import (
 )
 from rubrix.client.sdk.client import AuthenticatedClient
 from rubrix.client.sdk.commons.models import Response
-from rubrix.client.sdk.users.api import whoami
 from rubrix.client.sdk.datasets.api import copy_dataset, delete_dataset, get_dataset
 from rubrix.client.sdk.datasets.models import CopyDatasetRequest, TaskType
-from rubrix.client.sdk.text2text.api import (
-    bulk as text2text_bulk,
-    data as text2text_data,
-)
+from rubrix.client.sdk.text2text.api import bulk as text2text_bulk
+from rubrix.client.sdk.text2text.api import data as text2text_data
 from rubrix.client.sdk.text2text.models import (
     CreationText2TextRecord,
     Text2TextBulkData,
     Text2TextQuery,
 )
-from rubrix.client.sdk.text_classification.api import (
-    bulk as text_classification_bulk,
-    data as text_classification_data,
-)
+from rubrix.client.sdk.text_classification.api import bulk as text_classification_bulk
+from rubrix.client.sdk.text_classification.api import data as text_classification_data
 from rubrix.client.sdk.text_classification.models import (
     CreationTextClassificationRecord,
     TextClassificationBulkData,
     TextClassificationQuery,
 )
-from rubrix.client.sdk.token_classification.api import (
-    bulk as token_classification_bulk,
-    data as token_classification_data,
-)
+from rubrix.client.sdk.token_classification.api import bulk as token_classification_bulk
+from rubrix.client.sdk.token_classification.api import data as token_classification_data
 from rubrix.client.sdk.token_classification.models import (
     CreationTokenClassificationRecord,
     TokenClassificationBulkData,
     TokenClassificationQuery,
 )
+from rubrix.client.sdk.users.api import whoami
 
 
 class RubrixClient:
@@ -215,7 +209,8 @@ class RubrixClient:
         name: str,
         ids: Optional[List[Union[str, int]]] = None,
         limit: Optional[int] = None,
-    ) -> pandas.DataFrame:
+        return_pandas: bool = True,
+    ) -> Union[pandas.DataFrame, List[Record]]:
         """Load dataset data to a pandas DataFrame.
 
         Args:
@@ -225,6 +220,8 @@ class RubrixClient:
                 If provided, load dataset records with given ids.
             limit:
                 The number of records to retrieve.
+            return_pandas:
+                If True, return a pandas DataFrame. If False, return a list of records.
 
         Returns:
             The dataset as a pandas Dataframe.
@@ -266,7 +263,14 @@ class RubrixClient:
         )
 
         _check_response_errors(response)
-        return pandas.DataFrame(map(lambda r: r.to_client().dict(), response.parsed))
+
+        records_sorted_by_id = sorted(
+            [record.to_client() for record in response.parsed], key=lambda x: x.id
+        )
+
+        if return_pandas:
+            return pandas.DataFrame(map(lambda r: r.dict(), records_sorted_by_id))
+        return records_sorted_by_id
 
     def copy(self, source: str, target: str):
         """Makes a copy of the `source` dataset and saves it as `target`"""

--- a/src/rubrix/client/__init__.py
+++ b/src/rubrix/client/__init__.py
@@ -207,6 +207,7 @@ class RubrixClient:
     def load(
         self,
         name: str,
+        query: Optional[str] = None,
         ids: Optional[List[Union[str, int]]] = None,
         limit: Optional[int] = None,
         as_pandas: bool = True,
@@ -216,6 +217,8 @@ class RubrixClient:
         Args:
             name:
                 The dataset name.
+            query:
+                An ElasticSearch query with the [query string syntax](https://rubrix.readthedocs.io/en/stable/reference/rubrix_webapp_reference.html#search-input)
             ids:
                 If provided, load dataset records with given ids.
             limit:
@@ -258,7 +261,7 @@ class RubrixClient:
         response = get_dataset_data(
             client=self._client,
             name=name,
-            request=request_class(ids=ids or []),
+            request=request_class(ids=ids or [], query_text=query),
             limit=limit,
         )
 

--- a/src/rubrix/client/__init__.py
+++ b/src/rubrix/client/__init__.py
@@ -209,7 +209,7 @@ class RubrixClient:
         name: str,
         ids: Optional[List[Union[str, int]]] = None,
         limit: Optional[int] = None,
-        return_pandas: bool = True,
+        as_pandas: bool = True,
     ) -> Union[pandas.DataFrame, List[Record]]:
         """Load dataset data to a pandas DataFrame.
 
@@ -220,11 +220,11 @@ class RubrixClient:
                 If provided, load dataset records with given ids.
             limit:
                 The number of records to retrieve.
-            return_pandas:
+            as_pandas:
                 If True, return a pandas DataFrame. If False, return a list of records.
 
         Returns:
-            The dataset as a pandas Dataframe.
+            The dataset as a pandas Dataframe, or a list of records.
         """
         response = get_dataset(client=self._client, name=name)
         _check_response_errors(response)
@@ -268,7 +268,7 @@ class RubrixClient:
             [record.to_client() for record in response.parsed], key=lambda x: x.id
         )
 
-        if return_pandas:
+        if as_pandas:
             return pandas.DataFrame(map(lambda r: r.dict(), records_sorted_by_id))
         return records_sorted_by_id
 

--- a/src/rubrix/client/sdk/text_classification/models.py
+++ b/src/rubrix/client/sdk/text_classification/models.py
@@ -148,3 +148,6 @@ class TextClassificationQuery(BaseModel):
     score: Optional[ScoreRange] = Field(default=None)
     status: List[TaskStatus] = Field(default_factory=list)
     predicted: Optional[PredictionStatus] = Field(default=None, nullable=True)
+
+    class Config:
+        allow_population_by_field_name = True

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -312,6 +312,19 @@ def test_load_with_ids_list(monkeypatch):
     assert len(ds) == 2
 
 
+def test_load_with_query(monkeypatch):
+    mocking_client(monkeypatch)
+    dataset = "test_load_with_query"
+    client.delete(f"/api/datasets/{dataset}")
+    sleep(1)
+
+    expected_data = 4
+    create_some_data_for_text_classification(dataset, n=expected_data)
+    ds = rubrix.load(name=dataset, query="id:1")
+    assert len(ds) == 1
+    assert ds.id.iloc[0] == 1
+
+
 @pytest.mark.parametrize("as_pandas", [True, False])
 def test_load_as_pandas(monkeypatch, as_pandas):
     mocking_client(monkeypatch)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -312,8 +312,8 @@ def test_load_with_ids_list(monkeypatch):
     assert len(ds) == 2
 
 
-@pytest.mark.parametrize("return_pandas", [True, False])
-def test_load_return_pandas(monkeypatch, return_pandas):
+@pytest.mark.parametrize("as_pandas", [True, False])
+def test_load_as_pandas(monkeypatch, as_pandas):
     mocking_client(monkeypatch)
     dataset = "test_sorted_load"
     client.delete(f"/api/datasets/{dataset}")
@@ -322,12 +322,13 @@ def test_load_return_pandas(monkeypatch, return_pandas):
     expected_data = 3
     create_some_data_for_text_classification(dataset, n=expected_data)
 
-    if return_pandas:
+    # Check that the default value is True
+    if as_pandas:
         records = rubrix.load(name=dataset)
         assert isinstance(records, pandas.DataFrame)
         assert list(records.id) == [0, 1, 2, 3]
     else:
-        records = rubrix.load(name=dataset, return_pandas=False)
+        records = rubrix.load(name=dataset, as_pandas=False)
         assert isinstance(records[0], TextClassificationRecord)
         assert [record.id for record in records] == [0, 1, 2, 3]
 


### PR DESCRIPTION
This PR does 3 things to `rubrix.load()`:
- Sorts the records by id before returning them
- Adds an `as_pandas` parameter that controls the output type: or a pandas DataFrame, or simply a list of records (default: True)
- Adds a `query` parameter that allows one to filter the records with an ES DSL string (default: None)