### PR TITLE
refactor: remove query_inputs alias for text-classification

### DIFF
--- a/src/rubrix/client/sdk/text_classification/models.py
+++ b/src/rubrix/client/sdk/text_classification/models.py
@@ -138,7 +138,7 @@ class TextClassificationBulkData(UpdateDatasetRequest):
 class TextClassificationQuery(BaseModel):
     ids: Optional[List[Union[str, int]]]
 
-    query_text: str = Field(default=None, alias="query_inputs")
+    query_text: str = Field(default=None)
     metadata: Optional[Dict[str, Union[str, List[str]]]] = None
 
     predicted_as: List[str] = Field(default_factory=list)
@@ -148,6 +148,3 @@ class TextClassificationQuery(BaseModel):
     score: Optional[ScoreRange] = Field(default=None)
     status: List[TaskStatus] = Field(default_factory=list)
     predicted: Optional[PredictionStatus] = Field(default=None, nullable=True)
-
-    class Config:
-        allow_population_by_field_name = True

--- a/src/rubrix/server/tasks/text_classification/api/model.py
+++ b/src/rubrix/server/tasks/text_classification/api/model.py
@@ -357,7 +357,7 @@ class TextClassificationQuery(BaseModel):
 
     ids: Optional[List[Union[str, int]]]
 
-    query_text: str = Field(default=None, alias="query_inputs")
+    query_text: str = Field(default=None)
     metadata: Optional[Dict[str, Union[str, List[str]]]] = None
 
     predicted_as: List[str] = Field(default_factory=list)
@@ -367,9 +367,6 @@ class TextClassificationQuery(BaseModel):
     score: Optional[ScoreRange] = Field(default=None)
     status: List[TaskStatus] = Field(default_factory=list)
     predicted: Optional[PredictionStatus] = Field(default=None, nullable=True)
-
-    class Config:
-        allow_population_by_field_name = True
 
     def as_elasticsearch(self) -> Dict[str, Any]:
         """Build an elasticsearch query part from search query"""

--- a/tests/server/text_classification/test_api.py
+++ b/tests/server/text_classification/test_api.py
@@ -31,7 +31,7 @@ from rubrix.server.tasks.text_classification.api import (
 from tests.server.test_helpers import client
 
 
-def test_create_records_for_text_classification_with_multi_label(monkeypatch):
+def test_create_records_for_text_classification_with_multi_label():
     dataset = "test_create_records_for_text_classification_with_multi_label"
     assert client.delete(f"/api/datasets/{dataset}").status_code == 200
 


### PR DESCRIPTION
closes #510 