### PR TITLE
feat(server): remove partial update

### DIFF
--- a/src/rubrix/server/commons/es_wrapper.py
+++ b/src/rubrix/server/commons/es_wrapper.py
@@ -259,14 +259,18 @@ class ElasticsearchWrapper(LoggingMixin):
 
         def map_doc_2_action(doc: Dict[str, Any]) -> Dict[str, Any]:
             """Configures bulk action"""
-            return {
-                "_op_type": "update",
+            data = {
+                "_op_type": "index",
                 "_index": index,
-                "_id": doc_id(doc) if doc_id else doc["_id"],
                 "_routing": routing(doc) if routing else None,
-                "doc": doc,
-                "doc_as_upsert": True,
+                **doc,
             }
+
+            _id = doc_id(doc) if doc_id else None
+            if _id is not None:
+                data["_id"] = _id
+
+            return data
 
         success, failed = es_bulk(
             self.__client__,

--- a/src/rubrix/server/tasks/commons/api/model.py
+++ b/src/rubrix/server/tasks/commons/api/model.py
@@ -166,7 +166,7 @@ class BaseRecord(GenericModel, Generic[Annotation]):
 
     """
 
-    id: Optional[Union[int, str]] = Field(default_factory=lambda: str(uuid4()))
+    id: Optional[Union[int, str]] = Field(None)
     metadata: Dict[str, Any] = Field(default=None)
     event_timestamp: Optional[datetime] = None
     status: Optional[TaskStatus] = None


### PR DESCRIPTION
This PR includes changes discussed on #525 

Records could be updated by deleting some fields like annotations or predictions. 

With these changes, records must be totally sent when logging for updates