### PR TITLE
[UI] Fix: set record height in Text Classifier explore view

### DIFF
--- a/frontend/components/text-classifier/results/RecordTextClassification.vue
+++ b/frontend/components/text-classifier/results/RecordTextClassification.vue
@@ -155,7 +155,6 @@ export default {
     position: relative;
     margin-left: 2em;
     width: 200px;
-    margin-bottom: -3em;
     display: block;
     height: 100%;
     overflow: auto;


### PR DESCRIPTION
prevent labels tags from being cut off

fix #553