### PR TITLE
Remove dynamic metadata, move it to `setup.cfg`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,8 @@
 requires = ["setuptools", "wheel", "setuptools_scm[toml]"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools_scm]
+
 [tool.pytest.ini_options]
 log_format = "%(asctime)s %(name)s %(levelname)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,8 @@
 [metadata]
 name = rubrix
 description = Open-source tool for exploring, labeling, and monitoring data for NLP projects.
-long_description = Rubrix is a tool for tracking and iterating on data for artificial intelligence projects. Rubrix focuses on enabling novel, human in the loop workflows involving data scientists, subject matter experts and ML/data engineers.
+long_description = file: README.md
+long_description_content_type = text/markdown
 keywords = data-science natural-language-processing text-labeling data-annotation artificial-intelligence knowledged-graph developers-tools human-in-the-loop mlops
 license = Apache-2.0
 url = https://recogn.ai

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,3 @@
 from setuptools import setup
 
-# read the contents of your README file
-from os import path
-
-this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
-    long_description = f.read()
-
-setup(
-    name="rubrix",
-    # other arguments omitted
-    description="Open-source tool for tracking, exploring and labelling data for AI projects.",
-    long_description=long_description,
-    author="recognai",
-    author_email="contact@recogn.ai",
-    maintainer="recognai",
-    maintainer_email="contact@recogn.ai",
-    url="https://recogn.ai",
-    license="Apache-2.0",
-    keywords="data-science natural-language-processing artificial-intelligence knowledged-graph developers-tools human-in-the-loop mlops",
-    long_description_content_type="text/markdown",
-    use_scm_version=True,
-)
+setup(use_scm_version=True)


### PR DESCRIPTION
No need to have our package metadata duplicated, moved everything to the static `setup.cfg`.

Also, set the flag of using scm in the `pyproject.toml`. pip 21.3 now supports editable installs with `pyproject.toml`, so at some point, we might want to get rid of the `setup.py` file.