### PR TITLE
Fix: `rb.load` for ids with mixed types

### DIFF
--- a/src/rubrix/client/rubrix_client.py
+++ b/src/rubrix/client/rubrix_client.py
@@ -266,9 +266,12 @@ class RubrixClient:
 
         _check_response_errors(response)
 
-        records_sorted_by_id = sorted(
-            [record.to_client() for record in response.parsed], key=lambda x: str(x.id)
-        )
+        records = [sdk_record.to_client() for sdk_record in response.parsed]
+        try:
+            records_sorted_by_id = sorted(records, key=lambda x: x.id)
+        # record ids can be a mix of int/str -> sort all as str type
+        except TypeError:
+            records_sorted_by_id = sorted(records, key=lambda x: str(x.id))
 
         if as_pandas:
             return pandas.DataFrame(map(lambda r: r.dict(), records_sorted_by_id))

--- a/src/rubrix/client/rubrix_client.py
+++ b/src/rubrix/client/rubrix_client.py
@@ -267,7 +267,7 @@ class RubrixClient:
         _check_response_errors(response)
 
         records_sorted_by_id = sorted(
-            [record.to_client() for record in response.parsed], key=lambda x: x.id
+            [record.to_client() for record in response.parsed], key=lambda x: str(x.id)
         )
 
         if as_pandas:

--- a/tests/client/test_rubrix_client.py
+++ b/tests/client/test_rubrix_client.py
@@ -411,18 +411,40 @@ def test_load_text2text(monkeypatch):
             annotation="test annotation",
             prediction_agent="test_model",
             annotation_agent="test_annotator",
-            id=(str(i) + "str") if i < 2 else i,  # test mixture of str/int
+            id=i,
             metadata={"metadata": "test"},
             status="Default",
             event_timestamp=datetime.datetime(2000, 1, 1),
         )
-        for i in range(0, 5)
+        for i in range(0, 2)
     ]
 
     dataset = "test_load_text2text"
     rubrix.delete(dataset)
     rubrix.log(records, name=dataset)
+
     df = rubrix.load(name=dataset)
-    assert len(df) == 5
-    # check sorting policy
-    assert sorted(df.id, key=lambda x: str(x)) == list(df.id)
+    assert len(df) == 2
+
+
+def test_load_sort(monkeypatch):
+    mocking_client(monkeypatch, client)
+    records = [
+        TextClassificationRecord(
+            inputs="test text",
+            id=i,
+        )
+        for i in ["1str", 1, 2, 11, "2str", "11str"]
+    ]
+
+    dataset = "test_load_text2text"
+    rubrix.delete(dataset)
+    rubrix.log(records, name=dataset)
+
+    # check sorting policies
+    df = rubrix.load(name=dataset)
+    assert list(df.id) == [1, 11, "11str", "1str", 2, "2str"]
+    df = rubrix.load(name=dataset, ids=[1, 2, 11])
+    assert list(df.id) == [1, 2, 11]
+    df = rubrix.load(name=dataset, ids=["1str", "2str", "11str"])
+    assert list(df.id) == ["11str", "1str", "2str"]

--- a/tests/client/test_rubrix_client.py
+++ b/tests/client/test_rubrix_client.py
@@ -411,16 +411,18 @@ def test_load_text2text(monkeypatch):
             annotation="test annotation",
             prediction_agent="test_model",
             annotation_agent="test_annotator",
-            id=str(i),
+            id=(str(i) + "str") if i < 2 else i,  # test mixture of str/int
             metadata={"metadata": "test"},
             status="Default",
             event_timestamp=datetime.datetime(2000, 1, 1),
         )
-        for i in range(0, 100)
+        for i in range(0, 5)
     ]
 
     dataset = "test_load_text2text"
     rubrix.delete(dataset)
     rubrix.log(records, name=dataset)
     df = rubrix.load(name=dataset)
-    assert len(df) == 100
+    assert len(df) == 5
+    # check sorting policy
+    assert sorted(df.id, key=lambda x: str(x)) == list(df.id)

--- a/tests/client/test_rubrix_client.py
+++ b/tests/client/test_rubrix_client.py
@@ -437,7 +437,7 @@ def test_load_sort(monkeypatch):
         for i in ["1str", 1, 2, 11, "2str", "11str"]
     ]
 
-    dataset = "test_load_text2text"
+    dataset = "test_load_sort"
     rubrix.delete(dataset)
     rubrix.log(records, name=dataset)
 


### PR DESCRIPTION
Fixes #564 , by sorting always as str type.