### PR TITLE
fix: enable nested fields in search dsl

### DIFF
--- a/src/rubrix/server/tasks/commons/dao/dao.py
+++ b/src/rubrix/server/tasks/commons/dao/dao.py
@@ -293,7 +293,10 @@ class DatasetRecordsDAO:
         for field, value in metadata_values.items():
             if detect_nested_type(value):
                 self._es.create_field_mapping(
-                    index, field_name=f"metadata.{field}", type="nested"
+                    index,
+                    field_name=f"metadata.{field}",
+                    type="nested",
+                    include_in_root=True,
                 )
 
 

--- a/src/rubrix/server/tasks/token_classification/metrics.py
+++ b/src/rubrix/server/tasks/token_classification/metrics.py
@@ -253,6 +253,7 @@ class TokenClassificationMetrics(BaseTaskMetrics):
         """Configure mentions as nested properties"""
         mentions_configuration = {
             "type": "nested",
+            "include_in_root": True,
             "properties": {
                 "mention": {"type": "keyword"},
                 "label": {"type": "keyword"},

--- a/tests/metrics/test_token_classification.py
+++ b/tests/metrics/test_token_classification.py
@@ -55,6 +55,16 @@ def log_some_data(dataset: str):
     )
 
 
+def test_search_by_nested_metric(monkeypatch):
+    mocking_client(monkeypatch)
+    dataset = "test_search_by_nested_metric"
+    rb.delete(dataset)
+    log_some_data(dataset)
+
+    df = rb.load(dataset, query="metrics.mentions.predicted.capitalness: LOWER")
+    assert len(df) > 0
+
+
 def test_tokens_length(monkeypatch):
     mocking_client(monkeypatch)
     dataset = "test_tokens_length"
@@ -126,7 +136,7 @@ def test_entity_consistency(monkeypatch):
                     {"count": 2, "label": "CARDINAL"},
                     {"count": 1, "label": "NUMBER"},
                     {"count": 1, "label": "PERSON"},
-                ]
+                ],
             }
         ]
     }


### PR DESCRIPTION
With this PR you can use single nested fields in query string dsl:

For example, for token classification datasets, you can query things like:
```python
"metrics.mentions.predicted.mention: first"
```

For now, combining nested fields for same group is not yet supported since specific nature of nested fields

Fixes #586  