### PR TITLE
Add tqdm to `rb.log`

### DIFF
--- a/src/rubrix/__init__.py
+++ b/src/rubrix/__init__.py
@@ -130,16 +130,6 @@ def log(
         ... )
         >>> response = rb.log(record, name="example-dataset")
     """
-
-    # Records can be a single object or a list. In case it is a single object, we create a single-element list
-    # This check filter dictionaries and string based objects (that are iterables too but we don't want to
-    # wrap in a list)
-    if not (
-        isinstance(records, Iterable)
-        and not isinstance(records, (dict, str, bytes, *Record.__args__))
-    ):
-        records = [records]
-
     # noinspection PyTypeChecker,PydanticTypeChecker
     return _client_instance().log(
         records=records, name=name, tags=tags, metadata=metadata, chunk_size=chunk_size

--- a/src/rubrix/client/rubrix_client.py
+++ b/src/rubrix/client/rubrix_client.py
@@ -111,7 +111,7 @@ class RubrixClient:
 
     def log(
         self,
-        records: Iterable[Record],
+        records: Union[Record, Iterable[Record]],
         name: str,
         tags: Optional[Dict[str, str]] = None,
         metadata: Optional[Dict[str, Any]] = None,
@@ -138,6 +138,9 @@ class RubrixClient:
 
         if not name:
             raise Exception("Empty project name has been passed as argument.")
+
+        if isinstance(records, Record.__args__):
+            records = [records]
 
         records = list(records)
         tags = tags or {}

--- a/src/rubrix/client/rubrix_client.py
+++ b/src/rubrix/client/rubrix_client.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, Iterable, List, Optional, Union
 
 import httpx
 import pandas
+from tqdm.auto import tqdm
 
 from rubrix.client.metrics.models import MetricResults
 from rubrix.client.models import (
@@ -186,6 +187,7 @@ class RubrixClient:
 
         processed = 0
         failed = 0
+        progress_bar = tqdm(total=len(records))
         for i in range(0, len(records), chunk_size):
             chunk = records[i : i + chunk_size]
 
@@ -202,6 +204,12 @@ class RubrixClient:
             _check_response_errors(response)
             processed += response.parsed.processed
             failed += response.parsed.failed
+
+            progress_bar.update(len(chunk))
+        progress_bar.close()
+
+        # TODO: improve logging policy in library
+        print(f"Records logged to {self._client.base_url + '/' + name}")
 
         # Creating a composite BulkResponse with the total processed and failed
         return BulkResponse(dataset=name, processed=processed, failed=failed)

--- a/src/rubrix/client/rubrix_client.py
+++ b/src/rubrix/client/rubrix_client.py
@@ -209,7 +209,7 @@ class RubrixClient:
         progress_bar.close()
 
         # TODO: improve logging policy in library
-        print(f"Records logged to {self._client.base_url + '/' + name}")
+        print(f"{processed} records logged to {self._client.base_url + '/' + name}")
 
         # Creating a composite BulkResponse with the total processed and failed
         return BulkResponse(dataset=name, processed=processed, failed=failed)


### PR DESCRIPTION
This PR adds a progress bar to the `rb.log` method, and also prints out the URL where the dataset can be found.
I left a todo to improve our logging policy in the library, for now, it is a simple `print` ...