### PR TITLE
Add verbose kwarg to rb.log

### DIFF
--- a/src/rubrix/__init__.py
+++ b/src/rubrix/__init__.py
@@ -111,7 +111,7 @@ def log(
         tags: A dictionary of tags related to the dataset.
         metadata: A dictionary of extra info for the dataset.
         chunk_size: The chunk size for a data bulk.
-        verbose: If True, shows a progress bar and prints out quick summary at the end.
+        verbose: If True, shows a progress bar and prints out a quick summary at the end.
 
     Returns:
         Summary of the response from the REST API

--- a/src/rubrix/__init__.py
+++ b/src/rubrix/__init__.py
@@ -65,14 +65,11 @@ def init(
     default values.
 
     Args:
-        api_url:
-            Address of the REST API. If `None` (default) and the env variable ``RUBRIX_API_URL`` is not set,
+        api_url: Address of the REST API. If `None` (default) and the env variable ``RUBRIX_API_URL`` is not set,
             it will default to `http://localhost:6900`.
-        api_key:
-            Authentification key for the REST API. If `None` (default) and the env variable ``RUBRIX_API_KEY``
+        api_key: Authentification key for the REST API. If `None` (default) and the env variable ``RUBRIX_API_KEY``
             is not set, it will default to `rubrix.apikey`.
-        timeout:
-            Wait `timeout` seconds for the connection to timeout. Default: 60.
+        timeout: Wait `timeout` seconds for the connection to timeout. Default: 60.
 
     Examples:
         >>> import rubrix as rb
@@ -104,20 +101,17 @@ def log(
     tags: Optional[Dict[str, str]] = None,
     metadata: Optional[Dict[str, Any]] = None,
     chunk_size: int = 500,
+    verbose: bool = True,
 ) -> BulkResponse:
     """Log Records to Rubrix.
 
     Args:
-        records:
-            The record or an iterable of records.
-        name:
-            The dataset name.
-        tags:
-            A dictionary of tags related to the dataset.
-        metadata:
-            A dictionary of extra info for the dataset.
-        chunk_size:
-            The chunk size for a data bulk.
+        records: The record or an iterable of records.
+        name: The dataset name.
+        tags: A dictionary of tags related to the dataset.
+        metadata: A dictionary of extra info for the dataset.
+        chunk_size: The chunk size for a data bulk.
+        verbose: If True, shows a progress bar and prints out quick summary at the end.
 
     Returns:
         Summary of the response from the REST API
@@ -132,7 +126,12 @@ def log(
     """
     # noinspection PyTypeChecker,PydanticTypeChecker
     return _client_instance().log(
-        records=records, name=name, tags=tags, metadata=metadata, chunk_size=chunk_size
+        records=records,
+        name=name,
+        tags=tags,
+        metadata=metadata,
+        chunk_size=chunk_size,
+        verbose=verbose,
     )
 
 
@@ -140,10 +139,8 @@ def copy(dataset: str, name_of_copy: str):
     """Creates a copy of a dataset including its tags and metadata
 
     Args:
-        dataset:
-            Name of the source dataset
-        name_of_copy:
-            Name of the copied dataset
+        dataset: Name of the source dataset
+        name_of_copy: Name of the copied dataset
 
     Examples:
         >>> import rubrix as rb
@@ -163,16 +160,12 @@ def load(
     """Load dataset data to a pandas DataFrame.
 
     Args:
-        name:
-            The dataset name.
-        query:
-            An ElasticSearch query with the [query string syntax](https://rubrix.readthedocs.io/en/stable/reference/rubrix_webapp_reference.html#search-input)
-        ids:
-            If provided, load dataset records with given ids.
-        limit:
-            The number of records to retrieve.
-        as_pandas:
-            If True, return a pandas DataFrame. If False, return a list of records.
+        name: The dataset name.
+        query: An ElasticSearch query with the
+            `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/rubrix_webapp_reference.html#search-input>`_
+        ids: If provided, load dataset records with given ids.
+        limit: The number of records to retrieve.
+        as_pandas: If True, return a pandas DataFrame. If False, return a list of records.
 
     Returns:
         The dataset as a pandas Dataframe.
@@ -190,8 +183,7 @@ def delete(name: str) -> None:
     """Delete a dataset.
 
     Args:
-        name:
-            The dataset name.
+        name: The dataset name.
 
     Examples:
         >>> import rubrix as rb

--- a/src/rubrix/client/rubrix_client.py
+++ b/src/rubrix/client/rubrix_client.py
@@ -124,7 +124,7 @@ class RubrixClient:
             tags: A set of tags related to the dataset.
             metadata: A set of extra info for the dataset.
             chunk_size: Records are logged in chunks to the Rubrix server, this defines their sizes.
-            verbose: If True, shows a progress bar and prints out quick summary at the end.
+            verbose: If True, shows a progress bar and prints out a quick summary at the end.
 
         Returns:
             A summary response from the API.

--- a/src/rubrix/client/rubrix_client.py
+++ b/src/rubrix/client/rubrix_client.py
@@ -80,12 +80,9 @@ class RubrixClient:
         """Client setup function.
 
         Args:
-            api_url:
-                Address from which the API is serving.
-            api_key:
-                Authentication token.
-            timeout:
-                Seconds to considered a connection timeout.
+            api_url: Address from which the API is serving.
+            api_key: Authentication token.
+            timeout: Seconds to considered a connection timeout.
         """
 
         self._client = None  # Variable to store the client after the init
@@ -117,24 +114,20 @@ class RubrixClient:
         tags: Optional[Dict[str, str]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         chunk_size: int = 500,
+        verbose: bool = True,
     ) -> BulkResponse:
         """Log records to Rubrix.
 
         Args:
-            records:
-                The records to be logged.
-            name:
-                The dataset name.
-            tags:
-                A set of tags related to the dataset.
-            metadata:
-                A set of extra info for the dataset.
-            chunk_size:
-                Records are logged in chunks to the Rubrix server, this defines their sizes.
+            records: The records to be logged.
+            name: The dataset name.
+            tags: A set of tags related to the dataset.
+            metadata: A set of extra info for the dataset.
+            chunk_size: Records are logged in chunks to the Rubrix server, this defines their sizes.
+            verbose: If True, shows a progress bar and prints out quick summary at the end.
 
         Returns:
             A summary response from the API.
-
         """
 
         if not name:
@@ -187,7 +180,7 @@ class RubrixClient:
 
         processed = 0
         failed = 0
-        progress_bar = tqdm(total=len(records))
+        progress_bar = tqdm(total=len(records), disable=not verbose)
         for i in range(0, len(records), chunk_size):
             chunk = records[i : i + chunk_size]
 
@@ -209,7 +202,8 @@ class RubrixClient:
         progress_bar.close()
 
         # TODO: improve logging policy in library
-        print(f"{processed} records logged to {self._client.base_url + '/' + name}")
+        if verbose:
+            print(f"{processed} records logged to {self._client.base_url + '/' + name}")
 
         # Creating a composite BulkResponse with the total processed and failed
         return BulkResponse(dataset=name, processed=processed, failed=failed)
@@ -225,16 +219,12 @@ class RubrixClient:
         """Load dataset data to a pandas DataFrame.
 
         Args:
-            name:
-                The dataset name.
-            query:
-                An ElasticSearch query with the [query string syntax](https://rubrix.readthedocs.io/en/stable/reference/rubrix_webapp_reference.html#search-input)
-            ids:
-                If provided, load dataset records with given ids.
-            limit:
-                The number of records to retrieve.
-            as_pandas:
-                If True, return a pandas DataFrame. If False, return a list of records.
+            name: The dataset name.
+            query: An ElasticSearch query with the
+                `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/rubrix_webapp_reference.html#search-input>`_
+            ids: If provided, load dataset records with given ids.
+            limit: The number of records to retrieve.
+            as_pandas: If True, return a pandas DataFrame. If False, return a list of records.
 
         Returns:
             The dataset as a pandas Dataframe, or a list of records.
@@ -300,8 +290,7 @@ class RubrixClient:
         """Delete a dataset with given name
 
         Args:
-            name:
-                The dataset name
+            name: The dataset name
         """
         response = delete_dataset(client=self._client, name=name)
         _check_response_errors(response)

--- a/src/rubrix/monitoring/_spacy.py
+++ b/src/rubrix/monitoring/_spacy.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Optional
 
 import rubrix as rb
 from rubrix import TokenClassificationRecord
-
 from rubrix.monitoring.base import BaseMonitor
 from rubrix.monitoring.types import MissingType
 
@@ -43,7 +42,7 @@ class SpacyNERMonitor(BaseMonitor):
             metadata=metadata or {},
             prediction_agent=agent,
             prediction=entities,
-            event_timestamp=datetime.utcnow()
+            event_timestamp=datetime.utcnow(),
         )
 
     def _log2rubrix(self, doc: Doc, metadata: Optional[Dict[str, Any]] = None):
@@ -55,6 +54,7 @@ class SpacyNERMonitor(BaseMonitor):
             name=self.dataset,
             tags={k: v for k, v in self.__wrapped__.meta.items() if isinstance(v, str)},
             metadata=self.__model__.meta,
+            verbose=False,
         )
 
     def pipe(self, *args, **kwargs):

--- a/src/rubrix/monitoring/_transformers.py
+++ b/src/rubrix/monitoring/_transformers.py
@@ -14,8 +14,8 @@ try:
         Pipeline,
         TextClassificationPipeline,
         ZeroShotClassificationPipeline,
-        __version__ as _transformers_version,
     )
+    from transformers import __version__ as _transformers_version
 except ModuleNotFoundError:
     TextClassificationPipeline = MissingType
     Pipeline = MissingType
@@ -71,6 +71,7 @@ class HuggingFaceMonitor(BaseMonitor):
                 "task": self.__model__.task,
             },
             metadata=config.to_dict(),
+            verbose=False,
         )
         pass
 

--- a/src/rubrix/monitoring/base.py
+++ b/src/rubrix/monitoring/base.py
@@ -3,7 +3,6 @@ import random
 
 import wrapt
 
-import rubrix
 from rubrix.monitoring.helpers import start_loop_in_thread
 
 _LOGGING_LOOP = None

--- a/src/rubrix/monitoring/model_monitor.py
+++ b/src/rubrix/monitoring/model_monitor.py
@@ -4,7 +4,6 @@ from typing import Any
 
 from ._spacy import Language, ner_monitor
 from ._transformers import Pipeline, huggingface_monitor
-from .base import ModelNotSupportedError
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Closes #629: I added a `verbose` kwarg to the `rb.log` method, which by default is True. When monitoring stuff this is set to False.

It also does some minor cleanups + puts the docstrings in the right google style format