### PR TITLE
[Stats] Keywords in stats re-sort when query is updated

### DIFF
--- a/frontend/components/text-classifier/sidebar/TextClassificationStats.vue
+++ b/frontend/components/text-classifier/sidebar/TextClassificationStats.vue
@@ -59,7 +59,10 @@ export default {
   },
   computed: {
     getKeywords() {
-      return this.dataset.results.aggregations.words;
+      const words = this.dataset.results.aggregations.words;
+      return Object.fromEntries(
+        Object.entries(words).sort((a, b) => b[1] - a[1])
+      );
     },
     options() {
       let options = [];

--- a/frontend/components/text2text/sidebar/Text2TextStats.vue
+++ b/frontend/components/text2text/sidebar/Text2TextStats.vue
@@ -59,7 +59,10 @@ export default {
   },
   computed: {
     getKeywords() {
-      return this.dataset.results.aggregations.words;
+      const words = this.dataset.results.aggregations.words;
+      return Object.fromEntries(
+        Object.entries(words).sort((a, b) => b[1] - a[1])
+      );
     },
     options() {
       let options = [];
@@ -89,6 +92,7 @@ export default {
     color: $font-secondary-dark;
     margin-top: 0.5em;
     @include font-size(20px);
+    font-weight: 700;
   }
 }
 label {

--- a/frontend/components/token-classifier/sidebar/TokenClassificationStats.vue
+++ b/frontend/components/token-classifier/sidebar/TokenClassificationStats.vue
@@ -90,7 +90,7 @@ export default {
     limit: 3,
     currentMentionsLength: 3,
     visible: false,
-    activeTab: "mentions",
+    activeTab: "predicted_mentions",
     filteredMentions: [],
     expandedMentionsGroup: undefined,
     selectedOption: {


### PR DESCRIPTION
- The PR also includes: Show predicted_as by default in Mentions

fix #627

fix #633