### PR TITLE
Add F1 metrics to token classification task

### DIFF
--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -30,5 +30,6 @@ dependencies:
     - transformers[torch]
     - https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.1.0/en_core_web_sm-3.1.0.tar.gz
     - snorkel>=0.9.7
+    - plotly>=4.1.0
     # install Rubrix in editable mode
     - -e .[server]

--- a/src/rubrix/metrics/helpers.py
+++ b/src/rubrix/metrics/helpers.py
@@ -93,3 +93,33 @@ def multilevel_pie(labels, parents, values, title: str = "Pie"):
     fig.update_layout(title=title, margin=dict(t=50, l=0, r=0, b=0))
 
     return fig
+
+
+def token_classification_f1(data: Dict[str, float], title: str):
+    from plotly.subplots import make_subplots
+
+    fig = make_subplots(
+        rows=1, cols=3, subplot_titles=["macro average", "micro average", "per label"]
+    )
+
+    fig.add_bar(
+        x=[k.split("_")[0] for k, v in data.items() if "macro" in k],
+        y=[v for k, v in data.items() if "macro" in k],
+        row=1,
+        col=1,
+    )
+    fig.add_bar(
+        x=[k.split("_")[0] for k, v in data.items() if "micro" in k],
+        y=[v for k, v in data.items() if "micro" in k],
+        row=1,
+        col=2,
+    )
+    fig.add_bar(
+        x=[k for k, v in data.items() if "macro" not in k and "micro" not in k],
+        y=[v for k, v in data.items() if "macro" not in k and "micro" not in k],
+        row=1,
+        col=3,
+    )
+    fig.update_layout(showlegend=False, title_text=title)
+
+    return fig

--- a/src/rubrix/metrics/token_classification/__init__.py
+++ b/src/rubrix/metrics/token_classification/__init__.py
@@ -1,8 +1,9 @@
 from .metrics import (
-    tokens_length,
-    mention_length,
-    entity_density,
-    entity_labels,
     entity_capitalness,
     entity_consistency,
+    entity_density,
+    entity_labels,
+    f1,
+    mention_length,
+    tokens_length,
 )

--- a/src/rubrix/metrics/token_classification/metrics.py
+++ b/src/rubrix/metrics/token_classification/metrics.py
@@ -314,3 +314,32 @@ def entity_consistency(
             x=mentions, y_s=entities, title=metric.description
         ),
     )
+
+
+def f1(name: str, query: Optional[str] = None) -> MetricSummary:
+    """Computes F1 metrics for a dataset based on entity-level.
+
+    Args:
+        name: The dataset name.
+        query: An ElasticSearch query with the
+            `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/rubrix_webapp_reference.html#search-input>`_
+
+    Returns:
+        The F1 metric summary containing precision, recall and the F1 score (averaged and per label).
+
+    Examples:
+        >>> from rubrix.metrics.token_classification import f1
+        >>> summary = f1(name="example-dataset")
+        >>> summary.visualize() # will plot a bar chart with results
+        >>> summary.data # returns the raw result data
+    """
+    current_client = client()
+    metric = current_client.compute_metric(name, metric="F1", query=query)
+
+    return MetricSummary.new_summary(
+        data=metric.results,
+        visualization=lambda: helpers.bar(
+            metric.results,
+            title=metric.description,
+        ),
+    )

--- a/src/rubrix/metrics/token_classification/metrics.py
+++ b/src/rubrix/metrics/token_classification/metrics.py
@@ -330,16 +330,20 @@ def f1(name: str, query: Optional[str] = None) -> MetricSummary:
     Examples:
         >>> from rubrix.metrics.token_classification import f1
         >>> summary = f1(name="example-dataset")
-        >>> summary.visualize() # will plot a bar chart with results
+        >>> summary.visualize() # will plot three bar charts with the results
         >>> summary.data # returns the raw result data
+
+        To display the results as a table:
+
+        >>> import pandas as pd
+        >>> pd.DataFrame(summary.data.values(), index=summary.data.keys())
     """
     current_client = client()
     metric = current_client.compute_metric(name, metric="F1", query=query)
 
     return MetricSummary.new_summary(
         data=metric.results,
-        visualization=lambda: helpers.bar(
-            metric.results,
-            title=metric.description,
+        visualization=lambda: helpers.token_classification_f1(
+            metric.results, metric.description
         ),
     )

--- a/src/rubrix/server/tasks/commons/metrics/service.py
+++ b/src/rubrix/server/tasks/commons/metrics/service.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, List, Optional, TypeVar
 
-import pandas as pd
 from fastapi import Depends
 
 from rubrix.server.commons.errors import EntityNotFoundError, WrongInputParamError


### PR DESCRIPTION
Closes #620

Adds the F1 metric (including precision and recall, averaged and per label) to the Token Classification task. When you have a lot of labels, this results in a lot of metrics, and the visualization could potentially become a bit messy. But with plotly you can always zoom in, so I am not sure if this is really an issue.
![Screenshot from 2021-11-16 10-59-10](https://user-images.githubusercontent.com/15979778/141964468-55596206-34f8-4304-9597-66e392b9debf.png)


