### PR TITLE
NoRecordsFoundError when rb.load results in empty list in WeakLabels

### DIFF
--- a/docs/reference/python/python_labeling.rst
+++ b/docs/reference/python/python_labeling.rst
@@ -18,7 +18,7 @@ Labeling tools for the text classification task.
 
 .. automodule:: rubrix.labeling.text_classification.weak_labels
    :members:
-   :exclude-members: WeakLabelsError, MultiLabelError, MissingLabelError
+   :exclude-members: WeakLabelsError, NoRecordsFoundError, MultiLabelError, MissingLabelError
 
 .. automodule:: rubrix.labeling.text_classification.label_models
    :members:

--- a/src/rubrix/labeling/text_classification/label_models.py
+++ b/src/rubrix/labeling/text_classification/label_models.py
@@ -256,9 +256,5 @@ class Snorkel(LabelModel):
         return metrics
 
 
-class LabelModelError(Exception):
-    pass
-
-
-class MissingAnnotationError(LabelModelError):
+class MissingAnnotationError(Exception):
     pass

--- a/src/rubrix/labeling/text_classification/label_models.py
+++ b/src/rubrix/labeling/text_classification/label_models.py
@@ -227,6 +227,9 @@ class Snorkel(LabelModel):
 
         Returns:
             A list of records that include the predictions of the label model.
+
+        Raises:
+            MissingAnnotationError: If the ``weak_labels`` do not contain annotated records.
         """
         if self._weak_labels.annotation().size == 0:
             raise MissingAnnotationError(

--- a/src/rubrix/labeling/text_classification/weak_labels.py
+++ b/src/rubrix/labeling/text_classification/weak_labels.py
@@ -37,6 +37,7 @@ class WeakLabels:
             abstention (e.g. ``{None: -1}``). By default, we will build a mapping on the fly when applying the rules.
 
     Raises:
+        NoRecordsFoundError: When the filtered dataset is empty.
         MultiLabelError: When trying to get weak labels for a multi-label text classification task.
         MissingLabelError: When provided with a ``label2int`` dict, and a
             weak label or annotation label is not present in its keys.
@@ -82,6 +83,14 @@ class WeakLabels:
         self._records: List[TextClassificationRecord] = load(
             dataset, query=query, ids=ids, as_pandas=False
         )
+        if not self._records:
+            raise NoRecordsFoundError(
+                f"No records found in dataset '{dataset}'"
+                + (f" with query '{query}'" if query else "")
+                + (" and" if query and ids else "")
+                + (f" with ids {ids}." if ids else ".")
+            )
+
         if self._records[0].multi_label:
             raise MultiLabelError(
                 "Multi-label text classification is not yet supported."
@@ -450,6 +459,10 @@ class WeakLabels:
 
 
 class WeakLabelsError(Exception):
+    pass
+
+
+class NoRecordsFoundError(WeakLabelsError):
     pass
 
 

--- a/tests/labeling/text_classification/test_label_models.py
+++ b/tests/labeling/text_classification/test_label_models.py
@@ -77,9 +77,8 @@ def uninstall_snorkel(monkeypatch):
 
 
 def test_snorkel_not_installed(uninstall_snorkel):
-    with pytest.raises(ModuleNotFoundError) as error:
+    with pytest.raises(ModuleNotFoundError, match="pip install snorkel"):
         Snorkel(None)
-        assert "pip install snorkel" in str(error)
 
 
 def test_snorkel_init(weak_labels):
@@ -143,9 +142,8 @@ def test_snorkel_fit(
 @pytest.mark.parametrize("kwargs", [{"L_train": None}, {"Y_dev": None}])
 def test_snorkel_fit_automatically_added_kwargs(weak_labels, kwargs):
     label_model = Snorkel(weak_labels)
-    with pytest.raises(ValueError) as error:
+    with pytest.raises(ValueError, match="provided automatically"):
         label_model.fit(**kwargs)
-        assert "provided automatically" in str(error)
 
 
 @pytest.mark.parametrize(
@@ -252,9 +250,10 @@ def test_snorkel_score_without_annotations(weak_labels):
     weak_labels._annotation_array = np.array([], dtype=np.short)
     label_model = Snorkel(weak_labels)
 
-    with pytest.raises(label_models.MissingAnnotationError) as error:
+    with pytest.raises(
+        label_models.MissingAnnotationError, match="need annotated records"
+    ):
         label_model.score()
-        assert "need annotated records" in str(error)
 
 
 @pytest.fixture


### PR DESCRIPTION
Closes #617 

This PR adds a `NoRecordsFoundError` that is raised if the `rb.load` call results in an empty list/DataFrame. 
I introduced a custom `RubrixClientError` type, maybe we can use it for the other Errors raised by the `RubrixClient` class. improved