### PR TITLE
fix(metrix): empty metrics visualization

### DIFF
--- a/src/rubrix/metrics/helpers.py
+++ b/src/rubrix/metrics/helpers.py
@@ -1,8 +1,23 @@
 from typing import Dict
 
 
+def empty_visualization(message: str = "No data found"):
+    import plotly.graph_objects as go
+
+    fig = go.Figure()
+    fig.update_layout(
+        xaxis={"visible": False},
+        yaxis={"visible": False},
+        annotations=[{"text": message, "showarrow": False, "font": {"size": 30}}],
+    )
+    return fig
+
+
 def bar(data: dict, title: str = "Bar", x_legend: str = "", y_legend: str = ""):
     import plotly.graph_objects as go
+
+    if not data:
+        return empty_visualization()
 
     keys, values = zip(*data.items())
     fig = go.Figure(data=go.Bar(y=values, x=keys))
@@ -23,6 +38,9 @@ def stacked_bar(
 ):
     import plotly.graph_objects as go
 
+    if not x or not y_s:
+        return empty_visualization()
+
     data = [go.Bar(name=name, x=x, y=y_values) for name, y_values in y_s.items()]
 
     fig = go.Figure(data=data)
@@ -36,13 +54,19 @@ def stacked_bar(
     return fig
 
 
-def histogram(data, title: str = "Bar", x_legend: str = "", y_legend: str = ""):
+def histogram(data: dict, title: str = "Bar", x_legend: str = "", y_legend: str = ""):
+    if not data:
+        return empty_visualization()
+
     data = {float(k): v for k, v in data.items()}
     return bar(data, title, x_legend, y_legend)
 
 
 def tree_map(labels, parents, values, title: str = "Tree"):
     import plotly.graph_objects as go
+
+    if not values:  # TODO: review condition
+        return empty_visualization()
 
     fig = go.Figure(
         go.Treemap(

--- a/tests/metrics/test_text_classification.py
+++ b/tests/metrics/test_text_classification.py
@@ -56,7 +56,8 @@ def test_metrics_for_text_classification(monkeypatch):
     results.visualize()
 
 
-def test_f1_without_results():
+def test_f1_without_results(monkeypatch):
+    mocking_client(monkeypatch)
     dataset = "test_f1_without_results"
     import rubrix as rb
 

--- a/tests/metrics/test_text_classification.py
+++ b/tests/metrics/test_text_classification.py
@@ -54,3 +54,29 @@ def test_metrics_for_text_classification(monkeypatch):
         "per_label": {"spam": 1.0, "ham": 1.0},
     }
     results.visualize()
+
+
+def test_f1_without_results():
+    dataset = "test_f1_without_results"
+    import rubrix as rb
+
+    rb.log(
+        [
+            rb.TextClassificationRecord(
+                id=1,
+                inputs={"text": "my first rubrix example"},
+            ),
+            rb.TextClassificationRecord(
+                id=2,
+                inputs={"text": "my first rubrix example"},
+            ),
+        ],
+        name=dataset,
+    )
+
+    from rubrix.metrics.text_classification import f1
+
+    results = f1(dataset)
+    assert results
+    assert results.data == {}
+    results.visualize()

--- a/tests/metrics/test_token_classification.py
+++ b/tests/metrics/test_token_classification.py
@@ -1,4 +1,5 @@
 import httpx
+import pytest
 
 import rubrix
 import rubrix as rb
@@ -107,7 +108,7 @@ def test_mentions_length(monkeypatch):
     assert results.data == {"5.0": 4}
     results.visualize()
 
-    
+
 def test_entity_density(monkeypatch):
     mocking_client(monkeypatch)
     dataset = "test_entity_density"
@@ -194,4 +195,36 @@ def test_entity_consistency(monkeypatch):
             }
         ]
     }
+    results.visualize()
+
+
+@pytest.mark.parametrize(
+    ("metric", "expected_results"),
+    [
+        (entity_consistency, {"mentions": []}),
+        (mention_length, {}),
+        (entity_density, {}),
+        (entity_capitalness, {}),
+        (entity_labels, {}),
+    ],
+)
+def test_metrics_without_data(metric, expected_results, monkeypatch):
+    mocking_client(monkeypatch)
+    dataset = "test_metrics_without_data"
+    rb.delete(dataset)
+
+    text = "M"
+    tokens = text.split(" ")
+    rb.log(
+        rb.TokenClassificationRecord(
+            id=1,
+            text=text,
+            tokens=tokens,
+        ),
+        name=dataset,
+    )
+
+    results = metric(dataset)
+    assert results
+    assert results.data == expected_results
     results.visualize()


### PR DESCRIPTION
Metrics with empty results will visualizes something like:

![Screenshot 2021-11-16 at 13 48 06](https://user-images.githubusercontent.com/2518789/141987995-813316d9-fad9-4cfd-807a-353d038c3c4f.png)

Fixes #638 