### PR TITLE
feat(server): common task metrics

### DIFF
--- a/src/rubrix/server/commons/es_helpers.py
+++ b/src/rubrix/server/commons/es_helpers.py
@@ -343,24 +343,43 @@ class aggregations:
         }
 
     @staticmethod
-    def terms_aggregation(field_name: str, size: int = DEFAULT_AGGREGATION_SIZE):
+    def terms_aggregation(
+        field_name: str,
+        missing: Optional[str] = None,
+        size: int = DEFAULT_AGGREGATION_SIZE,
+    ):
+        dynamic_args = {}
+        if missing is not None:
+            dynamic_args["missing"] = missing
+
         return {
             "meta": {"kind": "terms"},
             "terms": {
                 "field": field_name,
                 "size": size or aggregations.DEFAULT_AGGREGATION_SIZE,
                 "order": {"_count": "desc"},
+                **dynamic_args,
             },
         }
 
     @staticmethod
-    def histogram_aggregation(field_name: str, interval: float = 0.1):
+    def histogram_aggregation(
+        field_name: str = None, script: str = None, interval: float = 0.1
+    ):
+
+        assert field_name or script, "Either field name or script must be provided"
+
+        if script:
+            query_part = {"script": script}
+        else:
+            query_part = {"field": field_name}
+
         return {
             "meta": {
                 "kind": "histogram",
             },
             "histogram": {
-                "field": field_name,
+                **query_part,
                 "interval": interval or 0.1,
             },
         }

--- a/src/rubrix/server/tasks/commons/metrics/__init__.py
+++ b/src/rubrix/server/tasks/commons/metrics/__init__.py
@@ -1,1 +1,2 @@
 from .model import *
+from .commons import *

--- a/src/rubrix/server/tasks/commons/metrics/commons.py
+++ b/src/rubrix/server/tasks/commons/metrics/commons.py
@@ -23,6 +23,7 @@ class CommonTasksMetrics:
             "with correct predictions vs records with incorrect prediction "
             "vs records with unknown prediction result",
             field=EsRecordDataFieldNames.predicted,
+            missing="unknown",
             fixed_size=3,
         ),
     ]

--- a/src/rubrix/server/tasks/commons/metrics/commons.py
+++ b/src/rubrix/server/tasks/commons/metrics/commons.py
@@ -1,0 +1,28 @@
+from rubrix.server.tasks.commons import EsRecordDataFieldNames
+from rubrix.server.tasks.commons.metrics.model.base import (
+    HistogramAggregation,
+    TermsAggregation,
+)
+
+
+class CommonTasksMetrics:
+
+    metrics = [
+        HistogramAggregation(
+            id="text_length",
+            name="Text length distribution",
+            description="Computes the input text length distribution",
+            field=EsRecordDataFieldNames.words,
+            script="doc['words'].size()",
+            fixed_interval=1,
+        ),
+        TermsAggregation(
+            id="error_distribution",
+            name="Error distribution",
+            description="Computes the dataset error distribution. It's mean, records "
+            "with correct predictions vs records with incorrect prediction "
+            "vs records with unknown prediction result",
+            field=EsRecordDataFieldNames.predicted,
+            fixed_size=3,
+        ),
+    ]

--- a/src/rubrix/server/tasks/commons/metrics/service.py
+++ b/src/rubrix/server/tasks/commons/metrics/service.py
@@ -165,7 +165,7 @@ class MetricsService:
 
         """
         metric_params = self._filter_metric_params(metric, metric_params)
-        metric_aggregation = {metric.id: metric.aggregation_request(**metric_params)}
+        metric_aggregation = metric.aggregation_request(**metric_params)
         results = self.__dao__.search_records(
             dataset,
             size=0,  # No records at all
@@ -175,7 +175,9 @@ class MetricsService:
                 include_default_aggregations=False,
             ),
         )
-        return metric.aggregation_result(results.aggregations[metric.id])
+        return metric.aggregation_result(
+            results.aggregations.get(metric.id, results.aggregations)
+        )
 
     @staticmethod
     def get_dataset_metrics(dataset: BaseDatasetDB) -> List[BaseMetric]:

--- a/src/rubrix/server/tasks/text2text/metrics.py
+++ b/src/rubrix/server/tasks/text2text/metrics.py
@@ -1,5 +1,6 @@
 from typing import ClassVar, List
 
+from rubrix.server.tasks.commons.metrics import CommonTasksMetrics
 from rubrix.server.tasks.commons.metrics.model.base import BaseMetric, BaseTaskMetrics
 from rubrix.server.tasks.text2text import Text2TextRecord
 
@@ -9,4 +10,4 @@ class Text2TextMetrics(BaseTaskMetrics[Text2TextRecord]):
     Configured metrics for text2text task
     """
 
-    metrics: ClassVar[List[BaseMetric]] = []
+    metrics: ClassVar[List[BaseMetric]] = CommonTasksMetrics.metrics

--- a/src/rubrix/server/tasks/text_classification/metrics.py
+++ b/src/rubrix/server/tasks/text_classification/metrics.py
@@ -3,6 +3,7 @@ from typing import Any, ClassVar, Iterable, List
 from sklearn.metrics import f1_score
 from sklearn.preprocessing import MultiLabelBinarizer
 
+from rubrix.server.tasks.commons.metrics import CommonTasksMetrics
 from rubrix.server.tasks.commons.metrics.model.base import (
     BaseMetric,
     BaseTaskMetrics,
@@ -76,7 +77,7 @@ class F1Metric(PythonMetric):
 class TextClassificationMetrics(BaseTaskMetrics[TextClassificationRecord]):
     """Configured metrics for text classification task"""
 
-    metrics: ClassVar[List[BaseMetric]] = [
+    metrics: ClassVar[List[BaseMetric]] = CommonTasksMetrics.metrics + [
         F1Metric(id="F1", name="F1 Metric for single-class", description=""),
         F1Metric(
             id="MultiLabelF1",

--- a/src/rubrix/server/tasks/token_classification/metrics.py
+++ b/src/rubrix/server/tasks/token_classification/metrics.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 
 from rubrix.server.commons.es_helpers import aggregations
 from rubrix.server.tasks.commons.dao import extends_index_properties
+from rubrix.server.tasks.commons.metrics import CommonTasksMetrics
 from rubrix.server.tasks.commons.metrics.model.base import (
     BaseMetric,
     BaseTaskMetrics,
@@ -30,9 +31,11 @@ class TokensLength(ElasticsearchMetric):
     length_field: str
 
     def aggregation_request(self, interval: int) -> Dict[str, Any]:
-        return aggregations.histogram_aggregation(
-            self.length_field, interval=interval or 1
-        )
+        return {
+            self.id: aggregations.histogram_aggregation(
+                self.length_field, interval=interval or 1
+            )
+        }
 
 
 _DEFAULT_MAX_ENTITY_BUCKET = 1000
@@ -501,11 +504,11 @@ class TokenClassificationMetrics(BaseTaskMetrics[TokenClassificationRecord]):
         ),
     ]
 
-    metrics: ClassVar[List[BaseMetric]] = [
+    metrics: ClassVar[List[BaseMetric]] = CommonTasksMetrics.metrics + [
         TokensLength(
             id="tokens_length",
             name="Tokens length",
-            description="Computes the text length measured in number of tokens",
+            description="Computes the text length distribution measured in number of tokens",
             length_field="metrics.tokens_length",
         ),
         *_PREDICTED_METRICS,

--- a/tests/server/metrics/test_api.py
+++ b/tests/server/metrics/test_api.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 import pytest
 
+from rubrix.server.tasks.commons.metrics import CommonTasksMetrics
 from rubrix.server.tasks.text2text import Text2TextBulkData, Text2TextRecord
 from rubrix.server.tasks.text_classification import (
     TextClassificationBulkData,
@@ -24,6 +25,9 @@ from rubrix.server.tasks.token_classification import (
     TokenClassificationRecord,
 )
 from tests.server.test_helpers import client
+
+
+COMMON_METRICS_LENGTH = len(CommonTasksMetrics.metrics)
 
 
 def test_wrong_dataset_metrics():
@@ -81,7 +85,7 @@ def test_dataset_for_text2text():
     )
 
     metrics = client.get(f"/api/datasets/Text2Text/{dataset}/metrics").json()
-    assert len(metrics) == 0
+    assert len(metrics) == COMMON_METRICS_LENGTH
 
 
 def test_dataset_for_token_classification():
@@ -152,7 +156,7 @@ def test_dataset_metrics():
 
     metrics = client.get(f"/api/datasets/TextClassification/{dataset}/metrics").json()
 
-    assert len(metrics) == 2
+    assert len(metrics) == COMMON_METRICS_LENGTH + 2
 
     response = client.post(
         f"/api/datasets/TextClassification/{dataset}/metrics/missing_metric:summary",


### PR DESCRIPTION
This PR include basic common metrics for all tasks. The basic metrics are the input text length (described in #652) and the dataset error distribution.

This metrics are define only at API level. Clients will be updated in a next PR when this one is merged.

Closes #652 

