### PR TITLE
refactor(user): bypass workspace for super users

### DIFF
--- a/src/rubrix/server/security/model.py
+++ b/src/rubrix/server/security/model.py
@@ -87,6 +87,8 @@ class User(BaseModel):
         """
         if not workspace:
             return self.default_workspace
+        if self.workspaces is None:
+            return workspace
         if workspace not in self.workspaces:
             raise ForbiddenOperationError(f"Missing or protected workspace {workspace}")
         return workspace

--- a/tests/server/security/test_model.py
+++ b/tests/server/security/test_model.py
@@ -63,6 +63,13 @@ def test_default_workspace():
     assert test_user.default_workspace == test_user.username
 
 
+def test_workspace_for_superuser():
+    user = User(username="admin")
+    assert user.default_workspace is None
+
+    assert user.check_workspace("some") == "some"
+    assert user.check_workspaces(["some"]) == ["some"]
+
 @pytest.mark.parametrize(
     "workspaces, expected",
     [


### PR DESCRIPTION
Since super users can access all datasets, requested workspaces should be bypassed for these kind of users. It's mean, no workspace restrictions should be applied.

This PR implements this logic. Without PR changes, super users requesting datasets for a single workspace will generate an access error.