### PR TITLE
fix(app): read all dataset labels for annotation

### DIFF
--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -11,6 +11,7 @@ dependencies:
 # tests
 - pytest
 - pytest-cov
+- pytest-asyncio
 # docs, pandoc needs conda ...
 - pandoc==2.12
 # we need this to ensure syntax highlighting in the notebook code cells for the docs

--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -523,7 +523,9 @@ const actions = {
     /**
      * Fetch all observation datasets from backend
      */
-    return await ObservationDataset.api().get("/datasets/", { persistBy: 'create' });
+    return await ObservationDataset.api().get("/datasets/", {
+      persistBy: "create",
+    });
   },
   async fetchByName(_, name) {
     /**
@@ -533,6 +535,7 @@ const actions = {
     const { allowAnnotation } = _configuredRouteParams();
     await _configureDatasetViewSettings(ds.name, allowAnnotation);
     const dataset = await _loadTaskDataset(ds);
+    await dataset.initialize();
     await _updateAnnotationProgress({
       id: name,
       total: dataset.globalResults.total,

--- a/frontend/models/Dataset.js
+++ b/frontend/models/Dataset.js
@@ -39,6 +39,23 @@ class ObservationDataset extends Model {
   getTaskDatasetClass() {
     return ObservationDataset.getClassDatasetForTask(this.task);
   }
+  async initialize() {}
+
+  async fetchMetricSummary(metricId) {
+    try {
+      const { response } = await ObservationDataset.api().post(
+        `/datasets/${this.task}/${this.name}/metrics/${metricId}:summary`,
+        {},
+        {
+          save: false,
+        }
+      );
+      return response.data;
+    } catch (error) {
+      console.log(error);
+      return { labels: [] };
+    }
+  }
 
   get visibleRecords() {
     return this.results.records.slice(0, this.viewSettings.pagination.size);

--- a/frontend/plugins/vuex-orm-axios.js
+++ b/frontend/plugins/vuex-orm-axios.js
@@ -58,7 +58,12 @@ export default ({ $axios, app }) => {
             type: "error",
           });
         });
-
+        break;
+      case 404:
+        Notification.dispatch("notify", {
+          message: "Warning: " + error.response.data.detail,
+          type: "warning",
+        });
         break;
       default:
         Notification.dispatch("notify", {

--- a/src/rubrix/server/commons/es_helpers.py
+++ b/src/rubrix/server/commons/es_helpers.py
@@ -344,10 +344,17 @@ class aggregations:
 
     @staticmethod
     def terms_aggregation(
-        field_name: str,
+        field_name: str = None,
+        script: Union[str, Dict[str, Any]] = None,
         missing: Optional[str] = None,
         size: int = DEFAULT_AGGREGATION_SIZE,
     ):
+        assert field_name or script, "Either field name or script must be provided"
+        if script:
+            query_part = {"script": script}
+        else:
+            query_part = {"field": field_name}
+
         dynamic_args = {}
         if missing is not None:
             dynamic_args["missing"] = missing
@@ -355,7 +362,7 @@ class aggregations:
         return {
             "meta": {"kind": "terms"},
             "terms": {
-                "field": field_name,
+                **query_part,
                 "size": size or aggregations.DEFAULT_AGGREGATION_SIZE,
                 "order": {"_count": "desc"},
                 **dynamic_args,
@@ -364,7 +371,9 @@ class aggregations:
 
     @staticmethod
     def histogram_aggregation(
-        field_name: str = None, script: str = None, interval: float = 0.1
+        field_name: str = None,
+        script: Union[str, Dict[str, Any]] = None,
+        interval: float = 0.1,
     ):
 
         assert field_name or script, "Either field name or script must be provided"

--- a/src/rubrix/server/tasks/commons/metrics/model/base.py
+++ b/src/rubrix/server/tasks/commons/metrics/model/base.py
@@ -1,4 +1,14 @@
-from typing import Any, ClassVar, Dict, Generic, Iterable, List, Optional, TypeVar
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    Generic,
+    Iterable,
+    List,
+    Optional,
+    TypeVar,
+    Union,
+)
 
 from pydantic import BaseModel
 from pydantic.generics import GenericModel
@@ -182,7 +192,7 @@ class HistogramAggregation(ElasticsearchMetric):
     """
 
     field: str
-    script: Optional[str] = None
+    script: Optional[Union[str, Dict[str, Any]]] = None
     fixed_interval: Optional[float] = None
 
     def aggregation_request(self, interval: float) -> Dict[str, Any]:
@@ -204,6 +214,9 @@ class TermsAggregation(ElasticsearchMetric):
 
     field:
         The term field
+    script:
+        If provided, it will be used as scripted field
+        for aggregation
     fixed_size:
         If provided, the size will use for terms aggregation
     missing:
@@ -211,15 +224,16 @@ class TermsAggregation(ElasticsearchMetric):
 
     """
 
-    field: str
+    field: str = None
+    script: Union[str, Dict[str, Any]] = None
     fixed_size: Optional[int] = None
     missing: Optional[str] = None
 
-    def aggregation_request(self, size: int) -> Dict[str, Any]:
+    def aggregation_request(self, size: int = None) -> Dict[str, Any]:
         if self.fixed_size:
             size = self.fixed_size
         return {
             self.id: aggregations.terms_aggregation(
-                self.field, size=size, missing=self.missing
+                self.field, script=self.script, size=size, missing=self.missing
             )
         }

--- a/tests/client/test_rubrix_client.py
+++ b/tests/client/test_rubrix_client.py
@@ -42,6 +42,8 @@ def test_log_something(monkeypatch):
     assert response.failed == 0
 
     response = client.post(f"/api/datasets/{dataset_name}/TextClassification:search")
+    assert response.status_code == 200, response.json()
+
     results = TextClassificationSearchResults.parse_obj(response.json())
     assert results.total == 1
     assert len(results.records) == 1

--- a/tests/server/metrics/test_api.py
+++ b/tests/server/metrics/test_api.py
@@ -156,7 +156,7 @@ def test_dataset_metrics():
 
     metrics = client.get(f"/api/datasets/TextClassification/{dataset}/metrics").json()
 
-    assert len(metrics) == COMMON_METRICS_LENGTH + 2
+    assert len(metrics) == COMMON_METRICS_LENGTH + 3
 
     response = client.post(
         f"/api/datasets/TextClassification/{dataset}/metrics/missing_metric:summary",


### PR DESCRIPTION
This PR affects to server and UI modules and resolve problems showing available annotation labels for text classification task.

Dataset labels are dynamically calculated using `dataset_labels` metrics and loaded when dataset if fetched in UI.

Also include minor improvement related to dev environment for testing

Fixes #685 