### PR TITLE
[Labeling] Throw error when encountering duplicated rule names

### DIFF
--- a/src/rubrix/labeling/text_classification/weak_labels.py
+++ b/src/rubrix/labeling/text_classification/weak_labels.py
@@ -74,9 +74,16 @@ class WeakLabels:
         self._rules = rules
         self._rules_index2name = {
             # covers our Rule class, snorkel's LabelingFunction class and arbitrary methods
-            index: getattr(rule, "name", None)
-            or getattr(rule, "__name__", None)
-            or f"rule_{index}"
+            index: (
+                getattr(rule, "name", None)
+                or (
+                    getattr(rule, "__name__", None)
+                    # allow multiple lambda functions
+                    if getattr(rule, "__name__", None) != "<lambda>"
+                    else None
+                )
+                or f"rule_{index}"
+            )
             for index, rule in enumerate(rules)
         }
         # raise error if there are duplicates

--- a/tests/labeling/text_classification/test_weak_labels.py
+++ b/tests/labeling/text_classification/test_weak_labels.py
@@ -26,6 +26,7 @@ from rubrix.client.sdk.text_classification.models import (
 )
 from rubrix.labeling.text_classification.rule import Rule
 from rubrix.labeling.text_classification.weak_labels import (
+    DuplicatedRuleNameError,
     MissingLabelError,
     MultiLabelError,
     NoRecordsFoundError,
@@ -87,6 +88,12 @@ def rules(monkeypatch) -> List[Callable]:
     rubrix_rule = Rule(query="mock", label="positive", name="rubrix_rule")
 
     return [first_rule, rule2, rubrix_rule]
+
+
+def test_duplicated_rule_name_error():
+    rules = [Rule(query="mock", label="mock"), Rule(query="mock", label="not mock")]
+    with pytest.raises(DuplicatedRuleNameError, match="'mock': 2"):
+        WeakLabels(rules=rules, dataset="mock")
 
 
 def test_multi_label_error(monkeypatch):

--- a/tests/labeling/text_classification/test_weak_labels.py
+++ b/tests/labeling/text_classification/test_weak_labels.py
@@ -226,6 +226,7 @@ def test_rules_matrix_records_annotation(monkeypatch):
 
     # rules property
     assert len(weak_labels.rules) == 2
+    assert weak_labels._rules_name2index == {"rule_0": 0, "rule_1": 1}
     assert weak_labels.rules[0](None) == "mock"
 
     assert (


### PR DESCRIPTION
Closes #669 

In the end, I decided that it would be better to throw an error when encountering duplicated rule names as described in the linked issue. Most of the time when this happens, it's actually a mistake that you want to correct. I could not come up with a use case where you actually prefer a warning and which is not easily fixable in the user's code.

So now, if duplicated rule names are encountered, `WeakLabels` will throw a `DuplicatedRuleNameError` on init, mentioning the duplicated rule names.