### PR TITLE
feat(metrics): improve common dataset metrics

### DIFF
--- a/src/rubrix/metrics/commons.py
+++ b/src/rubrix/metrics/commons.py
@@ -1,0 +1,65 @@
+from typing import Optional
+
+from rubrix import _client_instance as client
+from rubrix.metrics import helpers
+from rubrix.metrics.models import MetricSummary
+
+
+def text_length(name: str, query: Optional[str] = None) -> MetricSummary:
+    """Computes the input text length metrics for a dataset
+
+    Args:
+        name:
+            The dataset name.
+        query:
+            An ElasticSearch query with the [query string syntax](https://rubrix.readthedocs.io/en/stable/reference/rubrix_webapp_reference.html#search-input)
+
+    Returns:
+        The text length metric summary
+
+    Examples:
+        >>> from rubrix.metrics.commons import text_length
+        >>> summary = text_length(name="example-dataset")
+        >>> summary.visualize() # will plot an histogram with results
+        >>> summary.data # returns the raw result data
+    """
+    current_client = client()
+    metric = current_client.compute_metric(name, metric="text_length", query=query)
+
+    return MetricSummary.new_summary(
+        data=metric.results,
+        visualization=lambda: helpers.histogram(
+            data=metric.results, title=metric.description
+        ),
+    )
+
+
+def records_status(name: str, query: Optional[str] = None) -> MetricSummary:
+    """Computes the records status distribution for a dataset
+
+    Args:
+        name:
+            The dataset name.
+        query:
+            An ElasticSearch query with the [query string syntax](https://rubrix.readthedocs.io/en/stable/reference/rubrix_webapp_reference.html#search-input)
+
+    Returns:
+        The status distribution  metric summary
+
+    Examples:
+        >>> from rubrix.metrics.commons import records_status
+        >>> summary = records_status(name="example-dataset")
+        >>> summary.visualize() # will plot an histogram with results
+        >>> summary.data # returns the raw result data
+    """
+    current_client = client()
+    metric = current_client.compute_metric(
+        name, metric="status_distribution", query=query
+    )
+
+    return MetricSummary.new_summary(
+        data=metric.results,
+        visualization=lambda: helpers.bar(
+            data=metric.results, title=metric.description
+        ),
+    )

--- a/src/rubrix/server/tasks/commons/metrics/commons.py
+++ b/src/rubrix/server/tasks/commons/metrics/commons.py
@@ -1,4 +1,4 @@
-from rubrix.server.tasks.commons import EsRecordDataFieldNames
+from rubrix.server.tasks.commons import EsRecordDataFieldNames, TaskStatus
 from rubrix.server.tasks.commons.metrics.model.base import (
     HistogramAggregation,
     TermsAggregation,
@@ -13,7 +13,7 @@ class CommonTasksMetrics:
             name="Text length distribution",
             description="Computes the input text length distribution",
             field=EsRecordDataFieldNames.words,
-            script="doc['words'].size()",
+            script="params._source.words.length()",
             fixed_interval=1,
         ),
         TermsAggregation(
@@ -25,5 +25,12 @@ class CommonTasksMetrics:
             field=EsRecordDataFieldNames.predicted,
             missing="unknown",
             fixed_size=3,
+        ),
+        TermsAggregation(
+            id="status_distribution",
+            name="Record status distribution",
+            description="The dataset record status distribution",
+            field=EsRecordDataFieldNames.status,
+            fixed_size=len(TaskStatus),
         ),
     ]

--- a/tests/client/test_models.py
+++ b/tests/client/test_models.py
@@ -12,12 +12,14 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import json
 
+import numpy
 import pytest
 from pydantic import ValidationError
 from rubrix._constants import MAX_KEYWORD_LENGTH
 
-from rubrix.client.models import TextClassificationRecord
+from rubrix.client.models import Text2TextRecord, TextClassificationRecord
 from rubrix.client.models import TokenClassificationRecord
 
 
@@ -82,3 +84,11 @@ def test_metadata_values_length():
         text=text, tokens=text.split(), metadata=metadata
     )
     assert len(record.metadata["too_long"]) == MAX_KEYWORD_LENGTH
+
+
+def test_model_serialization_with_numpy_nan():
+    record = Text2TextRecord(
+        text="My name is Sarah and I love my dog.", metadata={"nan": numpy.nan}
+    )
+
+    json_record = json.loads(record.json())

--- a/tests/metrics/test_common_metrics.py
+++ b/tests/metrics/test_common_metrics.py
@@ -1,0 +1,102 @@
+import httpx
+
+from tests.server.test_helpers import client
+
+
+def mocking_client(monkeypatch):
+    monkeypatch.setattr(httpx, "post", client.post)
+    monkeypatch.setattr(httpx, "get", client.get)
+    monkeypatch.setattr(httpx, "delete", client.delete)
+    monkeypatch.setattr(httpx, "put", client.put)
+    monkeypatch.setattr(httpx, "stream", client.stream)
+
+
+def test_status_distribution(monkeypatch):
+    mocking_client(monkeypatch)
+    dataset = "test_status_distribution"
+
+    import rubrix as rb
+
+    rb.delete(dataset)
+
+    rb.log(
+        [
+            rb.TextClassificationRecord(
+                id=1,
+                inputs={"text": "my first rubrix example"},
+                prediction=[("spam", 0.8), ("ham", 0.2)],
+                annotation=["spam"],
+            ),
+            rb.TextClassificationRecord(
+                id=2,
+                inputs={"text": "my second rubrix example"},
+                prediction=[("ham", 0.8), ("spam", 0.2)],
+                annotation=["ham"],
+                status="Default",
+            ),
+        ],
+        name=dataset,
+    )
+
+    from rubrix.metrics.commons import records_status
+
+    results = records_status(dataset)
+    assert results
+    assert results.data == {"Default": 1, "Validated": 1}
+    results.visualize()
+
+
+def test_text_length(monkeypatch):
+    mocking_client(monkeypatch)
+    dataset = "test_text_length"
+
+    import rubrix as rb
+
+    rb.delete(dataset)
+
+    rb.log(
+        [
+            rb.TextClassificationRecord(
+                id=1,
+                inputs={"text": "my first rubrix example"},
+                prediction=[("spam", 0.8), ("ham", 0.2)],
+                annotation=["spam"],
+            ),
+            rb.TextClassificationRecord(
+                id=2,
+                inputs={"text": "my second rubrix example"},
+                prediction=[("ham", 0.8), ("spam", 0.2)],
+                annotation=["ham"],
+                status="Default",
+            ),
+            rb.TextClassificationRecord(
+                id=3,
+                inputs={"text": "simple text"},
+                prediction=[("ham", 0.8), ("spam", 0.2)],
+                annotation=["ham"],
+            ),
+        ],
+        name=dataset,
+    )
+
+    from rubrix.metrics.commons import text_length
+
+    results = text_length(dataset)
+    assert results
+    assert results.data == {
+        "11.0": 1,
+        "12.0": 0,
+        "13.0": 0,
+        "14.0": 0,
+        "15.0": 0,
+        "16.0": 0,
+        "17.0": 0,
+        "18.0": 0,
+        "19.0": 0,
+        "20.0": 0,
+        "21.0": 0,
+        "22.0": 0,
+        "23.0": 1,
+        "24.0": 1,
+    }
+    results.visualize()


### PR DESCRIPTION
This PR makes accesible basic common metrics `text_length` and `records_status` through python client.

- The `text_length` metric computes the input text distribution for the rubrix tasks.
- The `record_status` metric computes the record status distribution: `Default`, `Validated` and `Discarded` are the available status keys.