### PR TITLE
fix(ui): refresh aggregations to paginated dataset

### DIFF
--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -590,8 +590,12 @@ const actions = {
 
   async refresh(_, { dataset }) {
     const pagination = Pagination.find(dataset.name);
-    await _paginate({ dataset, size: pagination.size, page: pagination.page });
-    await _refreshDatasetAggregations({ dataset });
+    const paginatedDataset = await _paginate({
+      dataset,
+      size: pagination.size,
+      page: pagination.page,
+    });
+    await _refreshDatasetAggregations({ dataset: paginatedDataset });
   },
 };
 


### PR DESCRIPTION
Refresh button action doesn't use the last updated dataset. This PR fixes that