### PR TITLE
feat(server): allow handle labeling rules for datasets from API

### DIFF
--- a/src/rubrix/server/datasets/dao.py
+++ b/src/rubrix/server/datasets/dao.py
@@ -65,12 +65,12 @@ class DatasetsDAO:
         cls, es: ElasticsearchWrapper = Depends(create_es_wrapper)
     ) -> "DatasetsDAO":
         """
-        Get or creates the dao instance
+        Gets or creates the dao instance
 
         Parameters
         ----------
         es:
-            The elasticsearch wrapper dependency>
+            The elasticsearch wrapper dependency
 
         Returns
         -------

--- a/src/rubrix/server/tasks/commons/dao/dao.py
+++ b/src/rubrix/server/tasks/commons/dao/dao.py
@@ -153,9 +153,7 @@ class DatasetRecordsDAO:
             now = datetime.datetime.utcnow()
 
         for r in records:
-            if hasattr(r, "metadata"):
-                metadata_values.update(r.metadata or {})
-
+            metadata_values.update(r.metadata or {})
             db_record = record_class.parse_obj(r)
             if now:
                 db_record.last_updated = now

--- a/src/rubrix/server/tasks/commons/dao/dao.py
+++ b/src/rubrix/server/tasks/commons/dao/dao.py
@@ -153,7 +153,9 @@ class DatasetRecordsDAO:
             now = datetime.datetime.utcnow()
 
         for r in records:
-            metadata_values.update(r.metadata or {})
+            if hasattr(r, "metadata"):
+                metadata_values.update(r.metadata or {})
+
             db_record = record_class.parse_obj(r)
             if now:
                 db_record.last_updated = now

--- a/src/rubrix/server/tasks/text_classification/api/api.py
+++ b/src/rubrix/server/tasks/text_classification/api/api.py
@@ -261,7 +261,7 @@ async def fetch_labeling_rules(
         workspace=common_params.workspace,
     )
 
-    return service.get_labeling_rules(Dataset.parse_obj(dataset))
+    return list(service.get_labeling_rules(Dataset.parse_obj(dataset)))
 
 
 @router.post(f"{NEW_BASE_ENDPOINT}/labeling/rules", operation_id="create_rule")
@@ -283,13 +283,16 @@ async def create_rule(
         workspace=common_params.workspace,
     )
 
-    return service.add_labeling_rule(
-        Dataset.parse_obj(dataset),
-        rule=LabelingRule(
-            **rule.dict(),
-            author=current_user.username,
-        ),
+    rule = LabelingRule(
+        **rule.dict(),
+        author=current_user.username,
     )
+    service.add_labeling_rule(
+        Dataset.parse_obj(dataset),
+        rule=rule,
+    )
+
+    return rule
 
 
 @router.delete(

--- a/src/rubrix/server/tasks/text_classification/api/model.py
+++ b/src/rubrix/server/tasks/text_classification/api/model.py
@@ -43,13 +43,13 @@ class CreateLabelingRule(BaseModel):
     -----------
 
     query:
-        The rule es query
+        The ES query of the rule
 
     label: str
-        The linked rule label
+        The label associated with the rule
 
     description:
-        Description related to rule
+        A brief description of the rule
 
     """
 
@@ -65,16 +65,16 @@ class CreateLabelingRule(BaseModel):
 
 class LabelingRule(CreateLabelingRule):
     """
-    Adds read-only attributes to labeling rule
+    Adds read-only attributes to the labeling rule
 
     Attributes:
     -----------
 
     author:
-        Who has created the rule
+        Who created the rule
 
     created_at:
-        When rule was created
+        When was the rule created
 
     """
 

--- a/src/rubrix/server/tasks/text_classification/api/model.py
+++ b/src/rubrix/server/tasks/text_classification/api/model.py
@@ -45,12 +45,16 @@ class CreateLabelingRule(BaseModel):
     query:
         The rule es query
 
+    label: str
+        The linked rule label
+
     description:
         Description related to rule
 
     """
 
     query: str
+    label: str
     description: Optional[str] = None
 
     @validator("query")

--- a/src/rubrix/server/tasks/text_classification/api/model.py
+++ b/src/rubrix/server/tasks/text_classification/api/model.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel, Field, root_validator, validator
 from rubrix._constants import MAX_KEYWORD_LENGTH
 from rubrix.server.commons.es_helpers import filters
 from rubrix.server.commons.helpers import flatten_dict
-from rubrix.server.datasets.model import UpdateDatasetRequest
+from rubrix.server.datasets.model import DatasetDB, UpdateDatasetRequest
 from rubrix.server.tasks.commons.api.model import (
     BaseAnnotation,
     BaseRecord,
@@ -33,6 +33,63 @@ from rubrix.server.tasks.commons.api.model import (
     TaskStatus,
     TaskType,
 )
+
+
+class CreateLabelingRule(BaseModel):
+    """
+    Data model for labeling rules creation
+
+    Attributes:
+    -----------
+
+    query:
+        The rule es query
+
+    description:
+        Description related to rule
+
+    """
+
+    query: str
+    description: Optional[str] = None
+
+    @validator("query")
+    def strip_query(cls, query: str) -> str:
+        """Remove blank spaces for query"""
+        return query.strip()
+
+
+class LabelingRule(CreateLabelingRule):
+    """
+    Adds read-only attributes to labeling rule
+
+    Attributes:
+    -----------
+
+    author:
+        Who has created the rule
+
+    created_at:
+        When rule was created
+
+    """
+
+    author: str
+    created_at: Optional[datetime] = Field(default_factory=datetime.utcnow)
+
+
+class TextClassificationDatasetDB(DatasetDB):
+    """
+    A dataset class specialized for text classification task
+
+    Attributes:
+    -----------
+
+        rules:
+            A list of dataset labeling rules
+    """
+
+    rules: List[LabelingRule] = Field(default_factory=list)
 
 
 class ClassPrediction(BaseModel):

--- a/src/rubrix/server/tasks/text_classification/service/labeling_service.py
+++ b/src/rubrix/server/tasks/text_classification/service/labeling_service.py
@@ -1,0 +1,58 @@
+from typing import List
+
+from fastapi import Depends
+
+from rubrix.server.commons.errors import EntityAlreadyExistsError, EntityNotFoundError
+from rubrix.server.datasets.dao import DatasetsDAO, create_datasets_dao
+from rubrix.server.datasets.model import BaseDatasetDB
+from ..api.model import (
+    LabelingRule,
+    TextClassificationDatasetDB,
+)
+
+
+class LabelingService:
+
+    _INSTANCE = None
+
+    @classmethod
+    def get_instance(cls, dao: DatasetsDAO = Depends(create_datasets_dao)):
+        if cls._INSTANCE is None:
+            cls._INSTANCE = cls(dao)
+        return cls._INSTANCE
+
+    def __init__(self, dao: DatasetsDAO):
+        self.__dao__ = dao
+
+    def _find_text_classification_dataset(
+        self, dataset: BaseDatasetDB
+    ) -> TextClassificationDatasetDB:
+        found_ds = self.__dao__.find_by_id(
+            dataset.id, ds_class=TextClassificationDatasetDB
+        )
+        if found_ds is None:
+            raise EntityNotFoundError(dataset.name, dataset.__class__)
+        return found_ds
+
+    def list_rules(self, dataset: BaseDatasetDB) -> List[LabelingRule]:
+        """List a set of rules for a given dataset"""
+        found_ds = self._find_text_classification_dataset(dataset)
+        return found_ds.rules
+
+    def delete_rule(self, dataset: BaseDatasetDB, rule_query: str):
+        """Delete a rule from a dataset by its defined query string"""
+        found_ds = self._find_text_classification_dataset(dataset)
+        new_rules_set = [r for r in found_ds.rules if r.query != rule_query]
+        if len(found_ds.rules) != new_rules_set:
+            found_ds.rules = new_rules_set
+            self.__dao__.update_dataset(found_ds)
+
+    def add_rule(self, dataset: BaseDatasetDB, rule: LabelingRule) -> LabelingRule:
+        """Adds a rule to a dataset"""
+        found_ds = self._find_text_classification_dataset(dataset)
+        for r in found_ds.rules:
+            if r.query == rule.query:
+                raise EntityAlreadyExistsError(rule.query, type=LabelingRule)
+        found_ds.rules.append(rule)
+        self.__dao__.update_dataset(found_ds)
+        return rule

--- a/src/rubrix/server/tasks/text_classification/service/service.py
+++ b/src/rubrix/server/tasks/text_classification/service/service.py
@@ -214,7 +214,7 @@ class TextClassificationService:
 
         Returns
         -------
-            A list of labeling rules create for a given dataset
+            A list of labeling rules for a given dataset
 
         """
         return self.__labeling__.list_rules(dataset)
@@ -238,7 +238,7 @@ class TextClassificationService:
         """
         Deletes a rule from a dataset.
 
-        Nothing happens if rule does exists in dataset.
+        Nothing happens if the rule does not exist in dataset.
 
         Parameters
         ----------

--- a/src/rubrix/server/tasks/text_classification/service/service.py
+++ b/src/rubrix/server/tasks/text_classification/service/service.py
@@ -30,10 +30,14 @@ from rubrix.server.tasks.commons.dao.model import RecordSearch
 from rubrix.server.tasks.commons.metrics.service import MetricsService
 from rubrix.server.tasks.text_classification.api.model import (
     CreationTextClassificationRecord,
+    LabelingRule,
     TextClassificationQuery,
     TextClassificationRecord,
     TextClassificationSearchAggregations,
     TextClassificationSearchResults,
+)
+from rubrix.server.tasks.text_classification.service.labeling_service import (
+    LabelingService,
 )
 
 extends_index_dynamic_templates(
@@ -47,13 +51,44 @@ class TextClassificationService:
 
     """
 
+    _INSTANCE = None
+
+    @classmethod
+    def get_instance(
+        cls,
+        dao: DatasetRecordsDAO = Depends(dataset_records_dao),
+        labeling: LabelingService = Depends(LabelingService.get_instance),
+        metrics: MetricsService = Depends(MetricsService.get_instance),
+    ) -> "TextClassificationService":
+        """
+        Creates a service instance for text classification operations
+
+        Parameters
+        ----------
+        dao:
+            The dataset records dao dependency
+        labeling:
+            The labeling service dependency
+        metrics:
+            The metrics service dependency
+
+        Returns
+        -------
+            A dataset records service instance
+        """
+        if not cls._INSTANCE:
+            cls._INSTANCE = cls(dao, metrics, labeling=labeling)
+        return cls._INSTANCE
+
     def __init__(
         self,
         dao: DatasetRecordsDAO,
         metrics: MetricsService,
+        labeling: LabelingService,
     ):
         self.__dao__ = dao
         self.__metrics__ = metrics
+        self.__labeling__ = labeling
 
     def add_records(
         self,
@@ -168,29 +203,52 @@ class TextClassificationService:
                 )
             )
 
+    def get_labeling_rules(self, dataset: Dataset) -> Iterable[LabelingRule]:
+        """
+        Gets rules for a given dataset
 
-_instance = None
+        Parameters
+        ----------
+        dataset:
+            The dataset
 
+        Returns
+        -------
+            A list of labeling rules create for a given dataset
 
-def text_classification_service(
-    dao: DatasetRecordsDAO = Depends(dataset_records_dao),
-    metrics: MetricsService = Depends(MetricsService.get_instance),
-) -> TextClassificationService:
-    """
-    Creates a dataset record service instance
+        """
+        return self.__labeling__.list_rules(dataset)
 
-    Parameters
-    ----------
-    dao:
-        The dataset records dao dependency
-    metrics:
-        The metrics service
+    def add_labeling_rule(self, dataset: Dataset, rule: LabelingRule) -> None:
+        """
+        Adds a labeling rule
 
-    Returns
-    -------
-        A dataset records service instance
-    """
-    global _instance
-    if not _instance:
-        _instance = TextClassificationService(dao=dao, metrics=metrics)
-    return _instance
+        Parameters
+        ----------
+        dataset:
+            The dataset
+
+        rule:
+            The rule
+
+        """
+        self.__labeling__.add_rule(dataset, rule)
+
+    def delete_labeling_rule(self, dataset: Dataset, rule_query: str):
+        """
+        Deletes a rule from a dataset.
+
+        Nothing happens if rule does exists in dataset.
+
+        Parameters
+        ----------
+
+        dataset:
+            The dataset
+
+        rule_query:
+            The rule query
+
+        """
+        if rule_query.strip():
+            return self.__labeling__.delete_rule(dataset, rule_query)

--- a/tests/server/text_classification/test_api.py
+++ b/tests/server/text_classification/test_api.py
@@ -576,12 +576,15 @@ def test_dataset_with_rules():
 
     response = client.post(
         f"/api/datasets/TextClassification/{dataset}/labeling/rules",
-        json=CreateLabelingRule(query="a query", description="Description").dict(),
+        json=CreateLabelingRule(
+            query="a query", description="Description", label="LALA"
+        ).dict(),
     )
     assert response.status_code == 200
 
     created_rule = LabelingRule.parse_obj(response.json())
     assert created_rule.query == "a query"
+    assert created_rule.label == "LALA"
     assert created_rule.description == "Description"
     assert created_rule.author == "rubrix"
 
@@ -598,7 +601,9 @@ def test_delete_dataset_rules():
 
     response = client.post(
         f"/api/datasets/TextClassification/{dataset}/labeling/rules",
-        json=CreateLabelingRule(query="a query", description="Description").dict(),
+        json=CreateLabelingRule(
+            query="a query", label="TEST", description="Description"
+        ).dict(),
     )
     assert response.status_code == 200
 
@@ -616,7 +621,7 @@ def test_duplicated_dataset_rules():
     dataset = "test_duplicated_dataset_rules"
     log_some_records(dataset)
 
-    rule = CreateLabelingRule(query="a query")
+    rule = CreateLabelingRule(query="a query", label="TEST")
     response = client.post(
         f"/api/datasets/TextClassification/{dataset}/labeling/rules",
         json=rule.dict(),


### PR DESCRIPTION
This PR includes dataset labeling rules management for API.

- Following the API rule data model:

LabelingRule | Data model for labeling rules creation
-- | --
query* | The rule es query
label* | The linked rule label
description | Description related to rule

- Rules are keyed by query, we cannot include rules with same query

@dcfidalgo @dvsrepo  Feedback welcome


See #745