### PR TITLE
[Requirements] Require python>=3.7

### DIFF
--- a/docs/getting_started/setup&installation.rst
+++ b/docs/getting_started/setup&installation.rst
@@ -12,7 +12,7 @@ In this guide, we will help you to get up and running with Rubrix. Basically, yo
 1. Install the Rubrix Python client
 ------------------------------------
 
-First, make sure you have Python 3.6 or above installed.
+First, make sure you have Python 3.7 or above installed.
 
 Then you can install Rubrix with ``pip``\ :
 
@@ -118,6 +118,3 @@ To continue learning we recommend you to:
 
 * Check our **Guides** and **Tutorials.**
 * Read about Rubrix's main :ref:`concepts`
-
-
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ maintainer_email = contact@recogn.ai
 package_dir =
   =src
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
   httpx ~= 0.15.0
   # Client


### PR DESCRIPTION
This PR updates the required python version to >= 3.7, and also updates the installation guide. Closes #768 