### PR TITLE
feat(server): rubrix namespaces for elasticsearch indices

### DIFF
--- a/src/rubrix/server/commons/es_settings.py
+++ b/src/rubrix/server/commons/es_settings.py
@@ -1,5 +1,7 @@
-DATASETS_INDEX_NAME = f".rubrix.datasets-v0"
-DATASETS_RECORDS_INDEX_NAME = ".rubrix.dataset.{}.records-v0"
+from rubrix.server.commons.settings import settings
+
+DATASETS_INDEX_NAME = settings.dataset_index_name
+DATASETS_RECORDS_INDEX_NAME = settings.dataset_records_index_name
 
 
 DATASETS_INDEX_TEMPLATE = {
@@ -24,4 +26,3 @@ DATASETS_INDEX_TEMPLATE = {
         }
     },
 }
-

--- a/src/rubrix/server/commons/settings.py
+++ b/src/rubrix/server/commons/settings.py
@@ -19,7 +19,7 @@ Common environment vars / settings
 
 from typing import List
 
-from pydantic import BaseSettings
+from pydantic import BaseSettings, Field
 
 
 class ApiSettings(BaseSettings):
@@ -52,6 +52,9 @@ class ApiSettings(BaseSettings):
 
     """
 
+    __DATASETS_INDEX_NAME__ = ".rubrix<NAMESPACE>.datasets-v0"
+    __DATASETS_RECORDS_INDEX_NAME__ = ".rubrix<NAMESPACE>.dataset.{}.records-v0"
+
     only_bulk_api: bool = False
     elasticsearch: str = "http://localhost:9200"
     cors_origins: List[str] = ["*"]
@@ -61,6 +64,29 @@ class ApiSettings(BaseSettings):
     es_records_index_shards: int = 1
     es_records_index_replicas: int = 0
     disable_es_index_template_creation: bool = False
+
+    namespace: str = Field(default=None, regex=r"^[a-z]+$")
+
+    @property
+    def dataset_index_name(self) -> str:
+        ns = self.namespace
+        if ns is None:
+            return self.__DATASETS_INDEX_NAME__.replace("<NAMESPACE>", "")
+        return self.__DATASETS_INDEX_NAME__.replace("<NAMESPACE>", f".{ns}")
+
+    @property
+    def dataset_records_index_name(self) -> str:
+        ns = self.namespace
+        if ns is None:
+            return self.__DATASETS_RECORDS_INDEX_NAME__.replace("<NAMESPACE>", "")
+        return self.__DATASETS_RECORDS_INDEX_NAME__.replace("<NAMESPACE>", f".{ns}")
+
+    class Config:
+        fields = {
+            "namespace": {
+                "env": "RUBRIX_NAMESPACE",
+            }
+        }
 
 
 settings = ApiSettings()

--- a/tests/server/commons/test_settings.py
+++ b/tests/server/commons/test_settings.py
@@ -1,0 +1,24 @@
+import os
+
+import pytest
+from pydantic import ValidationError
+
+from rubrix.server.commons.settings import ApiSettings
+
+
+@pytest.mark.parametrize("bad_namespace", ["Badns", "bad-ns", "12-bad-ns", "@bad"])
+def test_wrong_settings_namespace(bad_namespace):
+    os.environ["RUBRIX_NAMESPACE"] = bad_namespace
+    with pytest.raises(ValidationError):
+        ApiSettings()
+
+
+def test_settings_namespace():
+    os.environ["RUBRIX_NAMESPACE"] = "namespace"
+    settings = ApiSettings()
+
+    assert settings.namespace == "namespace"
+    assert settings.dataset_index_name == ".rubrix.namespace.datasets-v0"
+    assert (
+        settings.dataset_records_index_name == ".rubrix.namespace.dataset.{}.records-v0"
+    )


### PR DESCRIPTION
This PR includes an environment variable to create `namespaced`  indices in elastic search. This allow to run multiples rubrix servers totally independent using the same elasticsearch  cluster. 