### PR TITLE
feat(weak supervision): client labeling rules from server

### DIFF
--- a/src/rubrix/client/_models.py
+++ b/src/rubrix/client/_models.py
@@ -12,10 +12,6 @@ class Rule(BaseModel):
     label: str
     name: Optional[str] = None
 
-    @classmethod
-    def from_sdk(cls, value: LabelingRule) -> "Rule":
-        return cls(query=value.query, label=value.label, name=value.description)
-
 
 class RuleMetrics(BaseModel):
 

--- a/src/rubrix/client/_models.py
+++ b/src/rubrix/client/_models.py
@@ -1,0 +1,25 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+from rubrix.client.sdk.text_classification.models import (
+    LabelingRule,
+)
+
+
+class Rule(BaseModel):
+    query: str
+    label: str
+    name: Optional[str] = None
+
+    @classmethod
+    def from_sdk(cls, value: LabelingRule) -> "Rule":
+        return cls(query=value.query, label=value.label, name=value.description)
+
+
+class RuleMetrics(BaseModel):
+
+    coverage: float
+    precision: float
+    correct: int
+    incorrect: int

--- a/src/rubrix/client/sdk/text_classification/api.py
+++ b/src/rubrix/client/sdk/text_classification/api.py
@@ -12,12 +12,17 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import httpx
 
 from rubrix.client.sdk.client import AuthenticatedClient
-from rubrix.client.sdk.commons.api import build_bulk_response, build_data_response
+from rubrix.client.sdk.commons.api import (
+    build_bulk_response,
+    build_data_response,
+    build_list_response,
+    build_raw_response,
+)
 from rubrix.client.sdk.commons.models import (
     BulkResponse,
     ErrorMessage,
@@ -25,6 +30,7 @@ from rubrix.client.sdk.commons.models import (
     Response,
 )
 from rubrix.client.sdk.text_classification.models import (
+    LabelingRule,
     TextClassificationBulkData,
     TextClassificationQuery,
     TextClassificationRecord,
@@ -73,3 +79,40 @@ def data(
         return build_data_response(
             response=response, data_type=TextClassificationRecord
         )
+
+
+def fetch_dataset_labeling_rules(
+    client: AuthenticatedClient,
+    name: str,
+) -> Response[Union[List[LabelingRule], HTTPValidationError, ErrorMessage]]:
+
+    url = "{}/api/datasets/TextClassification/{name}/labeling/rules".format(
+        client.base_url, name=name
+    )
+
+    response = httpx.get(
+        url=url,
+        headers=client.get_headers(),
+        cookies=client.get_cookies(),
+        timeout=client.get_timeout(),
+    )
+
+    return build_list_response(response, LabelingRule)
+
+
+def dataset_rule_metrics(
+    client: AuthenticatedClient, name: str, rule: LabelingRule
+) -> Response[Union[Dict[str, Any], HTTPValidationError, ErrorMessage]]:
+
+    url = "{}/api/datasets/TextClassification/{name}/labeling/rules/{query}/metrics?label={label}".format(
+        client.base_url, name=name, query=rule.query, label=rule.label
+    )
+
+    response = httpx.post(
+        url=url,
+        headers=client.get_headers(),
+        cookies=client.get_cookies(),
+        timeout=client.get_timeout(),
+    )
+
+    return build_raw_response(response)

--- a/src/rubrix/client/sdk/text_classification/models.py
+++ b/src/rubrix/client/sdk/text_classification/models.py
@@ -19,12 +19,12 @@ from pydantic import BaseModel, Field
 
 from rubrix.client.models import (
     TextClassificationRecord as ClientTextClassificationRecord,
+    TokenAttributions as ClientTokenAttributions,
 )
-from rubrix.client.models import TokenAttributions as ClientTokenAttributions
 from rubrix.client.sdk.commons.models import (
-    MACHINE_NAME,
     BaseAnnotation,
     BaseRecord,
+    MACHINE_NAME,
     PredictionStatus,
     ScoreRange,
     TaskStatus,
@@ -149,3 +149,34 @@ class TextClassificationQuery(BaseModel):
     score: Optional[ScoreRange] = Field(default=None)
     status: List[TaskStatus] = Field(default_factory=list)
     predicted: Optional[PredictionStatus] = Field(default=None, nullable=True)
+
+
+class LabelingRule(BaseModel):
+    """
+    Adds read-only attributes to the labeling rule
+
+    Attributes:
+    -----------
+
+    query:
+        The ES query of the rule
+
+    label: str
+        The label associated with the rule
+
+    description:
+        A brief description of the rule
+
+    author:
+        Who created the rule
+
+    created_at:
+        When was the rule created
+
+    """
+
+    query: str
+    label: str
+    description: Optional[str] = None
+    author: str = None
+    created_at: datetime = None

--- a/src/rubrix/server/commons/errors.py
+++ b/src/rubrix/server/commons/errors.py
@@ -70,18 +70,35 @@ class ForbiddenOperationError(HTTPException):
         )
 
 
-class WrongInputParamError(HTTPException):
+class BadRequestError(HTTPException):
+    """Generic bad request error"""
+
+    def __init__(self, detail: str):
+        super().__init__(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+
+
+class WrongInputParamError(BadRequestError):
     """Error related with input params in general"""
 
-    def __init__(self, detail: str):
-        super().__init__(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+    pass
 
 
-class InvalidTextSearchError(HTTPException):
+class InvalidTextSearchError(BadRequestError):
     """Error related with input params in search"""
 
-    def __init__(self, detail: str):
-        super().__init__(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+    pass
+
+
+class WrongTaskError(BadRequestError):
+    """Error raised when provided task cannot be processed with requested entity"""
+
+    pass
+
+
+class MissingInputParamError(BadRequestError):
+    """Error when some required parameter is missing for operation"""
+
+    pass
 
 
 class EntityAlreadyExistsError(HTTPException):
@@ -100,13 +117,6 @@ class EntityAlreadyExistsError(HTTPException):
             status_code=status.HTTP_409_CONFLICT,
             detail=msg,
         )
-
-
-class WrongTaskError(HTTPException):
-    """Error raised when provided task cannot be processed with requested entity"""
-
-    def __init__(self, detail: str):
-        super().__init__(detail=detail, status_code=status.HTTP_400_BAD_REQUEST)
 
 
 class EntityNotFoundError(HTTPException):

--- a/src/rubrix/server/commons/es_helpers.py
+++ b/src/rubrix/server/commons/es_helpers.py
@@ -307,28 +307,26 @@ class filters:
         """Filter records matching text query"""
         if text_query is None:
             return {"match_all": {}}
-        return {
-            "bool": {
-                "should": [
-                    {
-                        "query_string": {
-                            "default_field": EsRecordDataFieldNames.words,
-                            "default_operator": "AND",
-                            "query": text_query,
-                            "boost": "2.0",
-                        }
-                    },
-                    {
-                        "query_string": {
-                            "default_field": f"{EsRecordDataFieldNames.words}.extended",
-                            "default_operator": "AND",
-                            "query": text_query,
-                        }
-                    },
-                ],
-                "minimum_should_match": "50%",
-            }
-        }
+        return filters.boolean_filter(
+            should_filters=[
+                {
+                    "query_string": {
+                        "default_field": EsRecordDataFieldNames.words,
+                        "default_operator": "AND",
+                        "query": text_query,
+                        "boost": "2.0",
+                    }
+                },
+                {
+                    "query_string": {
+                        "default_field": f"{EsRecordDataFieldNames.words}.extended",
+                        "default_operator": "AND",
+                        "query": text_query,
+                    }
+                },
+            ],
+            minimum_should_match="50%",
+        )
 
     @staticmethod
     def score(

--- a/src/rubrix/server/commons/es_helpers.py
+++ b/src/rubrix/server/commons/es_helpers.py
@@ -172,7 +172,10 @@ def parse_aggregations(
     result = {}
     for key, values in es_aggregations.items() or {}:
         if "buckets" in values:
-            result[key] = parse_buckets(values["buckets"])
+            buckets = values["buckets"]
+            if isinstance(buckets, dict):
+                buckets = [{"key": k, **v} for k, v in buckets.items()]
+            result[key] = parse_buckets(buckets)
         elif is_extended_stats_aggregation(values):
             result[key] = {"rubrix:stats": values}  # statistical aggregations
         else:
@@ -186,6 +189,34 @@ def decode_field_name(field: EsRecordDataFieldNames) -> str:
 
 class filters:
     """Group of functions related to elasticsearch filters"""
+
+    @staticmethod
+    def boolean_filter(
+        filter_query: Optional[Dict[str, Any]] = None,
+        must_query: Optional[Dict[str, Any]] = None,
+        must_not_query: Optional[Dict[str, Any]] = None,
+        should_filters: Optional[List[Dict[str, Any]]] = None,
+        minimum_should_match: Union[int, str] = 1,
+    ):
+        es_query = {}
+
+        if filter_query:
+            es_query["filter"] = filter_query
+
+        if must_query:
+            es_query["must"] = must_query
+
+        if must_not_query:
+            es_query["must_not"] = must_not_query
+
+        if should_filters:
+            es_query["should"] = should_filters
+            es_query["minimum_should_match"] = minimum_should_match or 1
+
+        if not es_query:
+            raise ValueError("Must provide minimal data for boolean query")
+
+        return {"bool": es_query}
 
     @staticmethod
     def exists_field(field_name: str) -> Dict[str, Any]:

--- a/src/rubrix/server/tasks/commons/dao/dao.py
+++ b/src/rubrix/server/tasks/commons/dao/dao.py
@@ -17,6 +17,7 @@ import dataclasses
 import datetime
 from typing import Any, Dict, Iterable, List, Optional, Type, TypeVar
 
+import deprecated
 from fastapi import Depends
 
 from rubrix.server.commons.es_helpers import (
@@ -94,6 +95,26 @@ def extends_index_analyzers(analyzers: Dict[str, Any]):
 
 class DatasetRecordsDAO:
     """Datasets records DAO"""
+
+    _INSTANCE = None
+
+    @classmethod
+    def get_instance(
+        cls,
+        es: ElasticsearchWrapper = Depends(ElasticsearchWrapper.get_instance),
+    ) -> "DatasetRecordsDAO":
+        """
+        Creates a dataset records dao instance
+
+        Parameters
+        ----------
+        es:
+            The elasticserach wrapper dependency
+
+        """
+        if not cls._INSTANCE:
+            cls._INSTANCE = cls(es)
+        return cls._INSTANCE
 
     def __init__(self, es: ElasticsearchWrapper):
         self._es = es
@@ -303,6 +324,7 @@ class DatasetRecordsDAO:
 _instance: Optional[DatasetRecordsDAO] = None
 
 
+@deprecated.deprecated(reason="Use `DatasetRecordsDAO.get_instance` instead")
 def dataset_records_dao(
     es: ElasticsearchWrapper = Depends(create_es_wrapper),
 ) -> DatasetRecordsDAO:

--- a/src/rubrix/server/tasks/text_classification/api/model.py
+++ b/src/rubrix/server/tasks/text_classification/api/model.py
@@ -82,6 +82,17 @@ class LabelingRule(CreateLabelingRule):
     created_at: Optional[datetime] = Field(default_factory=datetime.utcnow)
 
 
+class LabelingRuleMetrics(BaseModel):
+    """Metrics generated for a labeling rule"""
+
+    coverage: float
+    correct: float
+    incorrect: float
+    precision: float
+
+    total_records: int
+
+
 class TextClassificationDatasetDB(DatasetDB):
     """
     A dataset class specialized for text classification task
@@ -217,8 +228,9 @@ class CreationTextClassificationRecord(BaseRecord[TextClassificationAnnotation])
             ), "Annotation must include some label for validated records"
 
         if not multi_label and annotation:
-            assert len(annotation.labels) == 1, "Single label record must include only one annotation label"
-
+            assert (
+                len(annotation.labels) == 1
+            ), "Single label record must include only one annotation label"
 
     @classmethod
     def _check_score_integrity(

--- a/src/rubrix/server/tasks/text_classification/service/labeling_service.py
+++ b/src/rubrix/server/tasks/text_classification/service/labeling_service.py
@@ -1,28 +1,100 @@
-from typing import List
+from typing import Any, Dict, List, Tuple
 
 from fastapi import Depends
+from pydantic import BaseModel, Field
 
-from rubrix.server.commons.errors import EntityAlreadyExistsError, EntityNotFoundError
-from rubrix.server.datasets.dao import DatasetsDAO, create_datasets_dao
+from rubrix.server.commons.errors import (
+    EntityAlreadyExistsError,
+    EntityNotFoundError,
+)
+from rubrix.server.commons.es_helpers import filters
+from rubrix.server.datasets.dao import DatasetsDAO
 from rubrix.server.datasets.model import BaseDatasetDB
 from ..api.model import (
     LabelingRule,
     TextClassificationDatasetDB,
 )
+from ...commons import EsRecordDataFieldNames
+from ...commons.dao.dao import DatasetRecordsDAO
+from ...commons.dao.model import RecordSearch
+from ...commons.metrics.model.base import ElasticsearchMetric
+
+
+class LabelingRulesMetrics(ElasticsearchMetric):
+    id: str = Field("labeling_rule", const=True)
+    name: str = Field("Computes metrics for a labeling rule", const=True)
+
+    def aggregation_request(
+        self,
+        rule_query: str,
+        label: str,
+    ) -> Dict[str, Any]:
+
+        rule_query_filter = filters.text_query(rule_query)
+        annotated_records_filter = filters.exists_field(
+            EsRecordDataFieldNames.annotated_as
+        )
+        rule_label_annotated_filter = filters.annotated_as([label])
+        return {
+            self.id: {
+                "filters": {
+                    "filters": {
+                        "covered_records": rule_query_filter,
+                        "correct_records": filters.boolean_filter(
+                            filter_query=annotated_records_filter,
+                            should_filters=[
+                                rule_query_filter,
+                                rule_label_annotated_filter,
+                            ],
+                            minimum_should_match=2,
+                        ),
+                        "incorrect_records": filters.boolean_filter(
+                            filter_query=annotated_records_filter,
+                            must_query=rule_query_filter,
+                            must_not_query=rule_label_annotated_filter,
+                        ),
+                    }
+                }
+            }
+        }
+
+    def aggregation_result(self, aggregation_result: Dict[str, Any]) -> Dict[str, Any]:
+        if self.id in aggregation_result:
+            aggregation_result = aggregation_result[self.id]
+
+        correct = aggregation_result["correct_records"]
+        incorrect = aggregation_result["incorrect_records"]
+
+        aggregation_result["precision"] = correct / (correct + incorrect)
+        return aggregation_result
+
+
+class LabelingRuleMetrics(BaseModel):
+    covered_records: int
+    correct_records: int
+    incorrect_records: int
+    precision: float
 
 
 class LabelingService:
 
     _INSTANCE = None
 
+    __rule_metrics__ = LabelingRulesMetrics()
+
     @classmethod
-    def get_instance(cls, dao: DatasetsDAO = Depends(create_datasets_dao)):
+    def get_instance(
+        cls,
+        dao: DatasetsDAO = Depends(DatasetsDAO.get_instance),
+        records: DatasetRecordsDAO = Depends(DatasetRecordsDAO.get_instance),
+    ):
         if cls._INSTANCE is None:
-            cls._INSTANCE = cls(dao)
+            cls._INSTANCE = cls(dao, records)
         return cls._INSTANCE
 
-    def __init__(self, dao: DatasetsDAO):
+    def __init__(self, dao: DatasetsDAO, records: DatasetRecordsDAO):
         self.__dao__ = dao
+        self.__records__ = records
 
     def _find_text_classification_dataset(
         self, dataset: BaseDatasetDB
@@ -56,3 +128,28 @@ class LabelingService:
         found_ds.rules.append(rule)
         self.__dao__.update_dataset(found_ds)
         return rule
+
+    def compute_rule_metrics(
+        self,
+        dataset: BaseDatasetDB,
+        rule_query: str,
+        label: str,
+    ) -> Tuple[int, LabelingRuleMetrics]:
+        """Computes metrics for given rule query and optional label against a set of rules"""
+
+        results = self.__records__.search_records(
+            dataset,
+            size=0,
+            search=RecordSearch(
+                include_default_aggregations=False,
+                aggregations=self.__rule_metrics__.aggregation_request(
+                    rule_query=rule_query, label=label
+                ),
+            ),
+        )
+
+        rule_metrics_summary = self.__rule_metrics__.aggregation_result(
+            results.aggregations
+        )
+
+        return results.total, LabelingRuleMetrics.parse_obj(rule_metrics_summary)

--- a/src/rubrix/server/tasks/text_classification/service/labeling_service.py
+++ b/src/rubrix/server/tasks/text_classification/service/labeling_service.py
@@ -64,8 +64,9 @@ class LabelingRulesMetrics(ElasticsearchMetric):
 
         correct = aggregation_result["correct_records"]
         incorrect = aggregation_result["incorrect_records"]
+        annotated = correct + incorrect
 
-        aggregation_result["precision"] = correct / (correct + incorrect)
+        aggregation_result["precision"] = (correct / annotated) if annotated > 0 else 0
         return aggregation_result
 
 

--- a/src/rubrix/server/tasks/text_classification/service/service.py
+++ b/src/rubrix/server/tasks/text_classification/service/service.py
@@ -31,6 +31,7 @@ from rubrix.server.tasks.commons.metrics.service import MetricsService
 from rubrix.server.tasks.text_classification.api.model import (
     CreationTextClassificationRecord,
     LabelingRule,
+    LabelingRuleMetrics,
     TextClassificationQuery,
     TextClassificationRecord,
     TextClassificationSearchAggregations,
@@ -252,3 +253,42 @@ class TextClassificationService:
         """
         if rule_query.strip():
             return self.__labeling__.delete_rule(dataset, rule_query)
+
+    def compute_rule_metrics(
+        self,
+        dataset: Dataset,
+        rule_query: str,
+        label: str,
+    ) -> LabelingRuleMetrics:
+        """
+        Compute metrics for a given rule. It's not necessary that query rule
+        is created in dataset. Basic computed rules are: coverage,
+        overlaps, conflicts[*], correct[*], incorrect[*], precision[*]
+
+        [*]: computed metrics only if label is provided or rule already created in dataset
+
+        Parameters
+        ----------
+        dataset:
+            The dataset
+        rule_query:
+            The provided rule query. If already created in dataset, the ``label``
+            param will be omitted
+        label:
+            Label used for rule metrics
+
+        Returns
+        -------
+
+        """
+        total, metrics = self.__labeling__.compute_rule_metrics(
+            dataset, rule_query=rule_query, label=label
+        )
+
+        return LabelingRuleMetrics(
+            coverage=metrics.covered_records / total,
+            correct=metrics.correct_records,
+            incorrect=metrics.incorrect_records,
+            precision=metrics.precision,
+            total_records=total,
+        )

--- a/tests/labeling/text_classification/test_rule.py
+++ b/tests/labeling/text_classification/test_rule.py
@@ -21,8 +21,14 @@ from rubrix.client.sdk.text_classification.models import (
     CreationTextClassificationRecord,
     TextClassificationBulkData,
 )
-from rubrix.labeling.text_classification.rule import Rule, RuleNotAppliedError
-from tests.server.test_helpers import client
+from rubrix.labeling.text_classification.rule import (
+    Rule,
+    RuleMetrics,
+    RuleNotAppliedError,
+    rule_metrics,
+    rules_from_dataset,
+)
+from tests.server.test_helpers import client, mocking_client
 
 
 @pytest.fixture(scope="module")
@@ -84,3 +90,42 @@ def test_call(monkeypatch, log_dataset):
     records = load(log_dataset, as_pandas=False)
     assert rule(records[0]) == "negative"
     assert rule(records[1]) is None
+
+
+def test_dataset_rules(monkeypatch, log_dataset):
+    mocking_client(monkeypatch, client)
+
+    client.post(
+        f"/api/datasets/TextClassification/{log_dataset}/labeling/rules",
+        json={"query": "a query", "label": "LALA"},
+    )
+
+    rules = rules_from_dataset(log_dataset)
+    assert len(rules) == 1
+    assert rules[0].query == "a query"
+    assert rules[0].label == "LALA"
+
+
+@pytest.mark.parametrize(
+    ["rule", "expected_metrics"],
+    [
+        (
+            Rule(query="neg*", label="LALA"),
+            RuleMetrics(correct=0, incorrect=1, coverage=0.5, precision=0),
+        ),
+        (
+            Rule(query="neg*", label="negative"),
+            RuleMetrics(correct=1, incorrect=0, coverage=0.5, precision=1),
+        ),
+    ],
+)
+def test_dataset_rule_metrics(monkeypatch, log_dataset, rule, expected_metrics):
+    mocking_client(monkeypatch, client)
+
+    client.post(
+        f"/api/datasets/TextClassification/{log_dataset}/labeling/rules",
+        json={"query": rule.query, "label": rule.label},
+    )
+
+    metrics = rule_metrics(log_dataset, rule=rule)
+    assert metrics == expected_metrics

--- a/tests/server/text_classification/test_api.py
+++ b/tests/server/text_classification/test_api.py
@@ -19,7 +19,6 @@ import pytest
 
 from rubrix.server.datasets.model import Dataset
 from rubrix.server.tasks.commons import BulkResponse, PredictionStatus
-from rubrix.server.tasks.text_classification import CreateLabelingRule, LabelingRule
 from rubrix.server.tasks.text_classification.api import (
     TextClassificationAnnotation,
     TextClassificationBulkData,
@@ -28,7 +27,6 @@ from rubrix.server.tasks.text_classification.api import (
     TextClassificationSearchRequest,
     TextClassificationSearchResults,
 )
-
 from tests.server.test_helpers import client
 
 
@@ -542,94 +540,3 @@ def test_wrong_text_query():
     assert response.json()["detail"] == "Failed to parse query [!]"
 
 
-def log_some_records(dataset: str):
-    assert client.delete(f"/api/datasets/{dataset}").status_code == 200
-    response = client.post(
-        f"/api/datasets/{dataset}/TextClassification:bulk",
-        data=TextClassificationBulkData(
-            records=[
-                TextClassificationRecord(
-                    **{
-                        "id": 0,
-                        "inputs": {"text": "Esto es un ejemplo de texto"},
-                        "metadata": {"field.one": 1, "field.two": 2},
-                    }
-                ),
-            ],
-        ).json(by_alias=True),
-    )
-    assert response.status_code == 200
-
-
-def test_dataset_without_rules():
-    dataset = "test_dataset_without_rules"
-    log_some_records(dataset)
-
-    response = client.get(f"/api/datasets/TextClassification/{dataset}/labeling/rules")
-    assert response.status_code == 200
-    assert len(response.json()) == 0
-
-
-def test_dataset_with_rules():
-    dataset = "test_dataset_with_rules"
-    log_some_records(dataset)
-
-    response = client.post(
-        f"/api/datasets/TextClassification/{dataset}/labeling/rules",
-        json=CreateLabelingRule(
-            query="a query", description="Description", label="LALA"
-        ).dict(),
-    )
-    assert response.status_code == 200
-
-    created_rule = LabelingRule.parse_obj(response.json())
-    assert created_rule.query == "a query"
-    assert created_rule.label == "LALA"
-    assert created_rule.description == "Description"
-    assert created_rule.author == "rubrix"
-
-    response = client.get(f"/api/datasets/TextClassification/{dataset}/labeling/rules")
-    assert response.status_code == 200
-    rules = list(map(LabelingRule.parse_obj, response.json()))
-    assert len(rules) == 1
-    assert rules[0] == created_rule
-
-
-def test_delete_dataset_rules():
-    dataset = "test_delete_dataset_rules"
-    log_some_records(dataset)
-
-    response = client.post(
-        f"/api/datasets/TextClassification/{dataset}/labeling/rules",
-        json=CreateLabelingRule(
-            query="a query", label="TEST", description="Description"
-        ).dict(),
-    )
-    assert response.status_code == 200
-
-    response = client.delete(
-        f"/api/datasets/TextClassification/{dataset}/labeling/rules/{'a query'}"
-    )
-    assert response.status_code == 200
-
-    response = client.get(f"/api/datasets/TextClassification/{dataset}/labeling/rules")
-    assert response.status_code == 200
-    assert len(response.json()) == 0
-
-
-def test_duplicated_dataset_rules():
-    dataset = "test_duplicated_dataset_rules"
-    log_some_records(dataset)
-
-    rule = CreateLabelingRule(query="a query", label="TEST")
-    response = client.post(
-        f"/api/datasets/TextClassification/{dataset}/labeling/rules",
-        json=rule.dict(),
-    )
-    assert response.status_code == 200
-
-    response = client.post(
-        f"/api/datasets/TextClassification/{dataset}/labeling/rules",
-        json=rule.dict(),
-    )
-    assert response.status_code == 409

--- a/tests/server/text_classification/test_api_rules.py
+++ b/tests/server/text_classification/test_api_rules.py
@@ -1,0 +1,164 @@
+from rubrix.server.tasks.text_classification import (
+    CreateLabelingRule,
+    LabelingRule,
+    LabelingRuleMetrics,
+    TextClassificationBulkData,
+    TextClassificationRecord,
+)
+from tests.server.test_helpers import client
+
+
+def log_some_records(dataset: str, annotation: str = None):
+    assert client.delete(f"/api/datasets/{dataset}").status_code == 200
+
+    record = {
+        "id": 0,
+        "inputs": {"text": "Esto es un ejemplo de texto"},
+        "metadata": {"field.one": 1, "field.two": 2},
+    }
+
+    if annotation:
+        record["annotation"] = {"agent": "test", "labels": [{"class": annotation}]}
+
+    response = client.post(
+        f"/api/datasets/{dataset}/TextClassification:bulk",
+        data=TextClassificationBulkData(
+            records=[
+                TextClassificationRecord(**record),
+            ],
+        ).json(by_alias=True),
+    )
+    assert response.status_code == 200
+
+
+def test_dataset_without_rules():
+    dataset = "test_dataset_without_rules"
+    log_some_records(dataset)
+
+    response = client.get(f"/api/datasets/TextClassification/{dataset}/labeling/rules")
+    assert response.status_code == 200
+    assert len(response.json()) == 0
+
+
+def test_dataset_with_rules():
+    dataset = "test_dataset_with_rules"
+    log_some_records(dataset)
+
+    response = client.post(
+        f"/api/datasets/TextClassification/{dataset}/labeling/rules",
+        json=CreateLabelingRule(
+            query="a query", description="Description", label="LALA"
+        ).dict(),
+    )
+    assert response.status_code == 200
+
+    created_rule = LabelingRule.parse_obj(response.json())
+    assert created_rule.query == "a query"
+    assert created_rule.label == "LALA"
+    assert created_rule.description == "Description"
+    assert created_rule.author == "rubrix"
+
+    response = client.get(f"/api/datasets/TextClassification/{dataset}/labeling/rules")
+    assert response.status_code == 200
+    rules = list(map(LabelingRule.parse_obj, response.json()))
+    assert len(rules) == 1
+    assert rules[0] == created_rule
+
+
+def test_delete_dataset_rules():
+    dataset = "test_delete_dataset_rules"
+    log_some_records(dataset)
+
+    response = client.post(
+        f"/api/datasets/TextClassification/{dataset}/labeling/rules",
+        json=CreateLabelingRule(
+            query="a query", label="TEST", description="Description"
+        ).dict(),
+    )
+    assert response.status_code == 200
+
+    response = client.delete(
+        f"/api/datasets/TextClassification/{dataset}/labeling/rules/{'a query'}"
+    )
+    assert response.status_code == 200
+
+    response = client.get(f"/api/datasets/TextClassification/{dataset}/labeling/rules")
+    assert response.status_code == 200
+    assert len(response.json()) == 0
+
+
+def test_duplicated_dataset_rules():
+    dataset = "test_duplicated_dataset_rules"
+    log_some_records(dataset)
+
+    rule = CreateLabelingRule(query="a query", label="TEST")
+    response = client.post(
+        f"/api/datasets/TextClassification/{dataset}/labeling/rules",
+        json=rule.dict(),
+    )
+    assert response.status_code == 200
+
+    response = client.post(
+        f"/api/datasets/TextClassification/{dataset}/labeling/rules",
+        json=rule.dict(),
+    )
+    assert response.status_code == 409
+
+
+def test_rule_metrics_with_missing_label():
+    dataset = "test_rule_metrics_with_missing_label"
+    log_some_records(dataset, annotation=True)
+
+    response = client.post(
+        f"/api/datasets/TextClassification/{dataset}/labeling/rules/a query/metrics"
+    )
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": [
+            {
+                "loc": ["query", "label"],
+                "msg": "field required",
+                "type": "value_error.missing",
+            }
+        ]
+    }
+
+
+def test_rule_metric():
+    dataset = "test_rule_metric"
+    log_some_records(dataset, annotation="OK")
+
+    response = client.post(
+        f"/api/datasets/TextClassification/{dataset}/labeling/rules/ejemplo/metrics?label=TEST"
+    )
+    assert response.status_code == 200
+
+    metrics = LabelingRuleMetrics.parse_obj(response.json())
+    assert metrics.total_records == 1
+    assert metrics.coverage == 1
+    assert metrics.correct == 0
+    assert metrics.incorrect == 1
+    assert metrics.precision == 0
+
+    response = client.post(
+        f"/api/datasets/TextClassification/{dataset}/labeling/rules/ejemplo/metrics?label=OK"
+    )
+    assert response.status_code == 200
+
+    metrics = LabelingRuleMetrics.parse_obj(response.json())
+    assert metrics.correct == 1
+    assert metrics.incorrect == 0
+    assert metrics.precision == 1
+
+    response = client.post(
+        f"/api/datasets/TextClassification/{dataset}/labeling/rules/badd/metrics?label=OK"
+    )
+    assert response.status_code == 200
+
+    metrics = LabelingRuleMetrics.parse_obj(response.json())
+    assert metrics.total_records == 1
+    assert metrics.coverage == 0
+    assert metrics.correct == 0
+    assert metrics.incorrect == 0
+    assert metrics.precision == 0
+


### PR DESCRIPTION
This PR includes functions to retrieve dataset labeling rules and compute rule metrics from python client. 

PR #790 must be approved and merged before merge this one

Fixes #798 

See #745 