### PR TITLE
feat(labeling rules): add coverage for annotated records

### DIFF
--- a/src/rubrix/client/_models.py
+++ b/src/rubrix/client/_models.py
@@ -16,6 +16,7 @@ class Rule(BaseModel):
 class RuleMetrics(BaseModel):
 
     coverage: float
+    coverage_annotated: float
     precision: float
     correct: int
     incorrect: int

--- a/src/rubrix/client/rubrix_client.py
+++ b/src/rubrix/client/rubrix_client.py
@@ -391,7 +391,7 @@ class RubrixClient:
 
     def rule_metrics_for_dataset(self, dataset: str, rule: Rule) -> RuleMetrics:
         response = dataset_rule_metrics(
-            self._client, name=dataset, rule=LabelingRule.parse_obj(rule)
+            self._client, name=dataset, query=rule.query, label=rule.label
         )
         _check_response_errors(response)
 

--- a/src/rubrix/client/sdk/text_classification/api.py
+++ b/src/rubrix/client/sdk/text_classification/api.py
@@ -12,7 +12,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Any, Dict, List, Optional, Union
+from typing import List, Optional, Union
 
 import httpx
 
@@ -21,7 +21,7 @@ from rubrix.client.sdk.commons.api import (
     build_bulk_response,
     build_data_response,
     build_list_response,
-    build_raw_response,
+    build_typed_response,
 )
 from rubrix.client.sdk.commons.models import (
     BulkResponse,
@@ -31,6 +31,7 @@ from rubrix.client.sdk.commons.models import (
 )
 from rubrix.client.sdk.text_classification.models import (
     LabelingRule,
+    LabelingRuleMetrics,
     TextClassificationBulkData,
     TextClassificationQuery,
     TextClassificationRecord,
@@ -101,11 +102,14 @@ def fetch_dataset_labeling_rules(
 
 
 def dataset_rule_metrics(
-    client: AuthenticatedClient, name: str, rule: LabelingRule
-) -> Response[Union[Dict[str, Any], HTTPValidationError, ErrorMessage]]:
+    client: AuthenticatedClient,
+    name: str,
+    query: str,
+    label: str,
+) -> Response[Union[LabelingRuleMetrics, HTTPValidationError, ErrorMessage]]:
 
     url = "{}/api/datasets/TextClassification/{name}/labeling/rules/{query}/metrics?label={label}".format(
-        client.base_url, name=name, query=rule.query, label=rule.label
+        client.base_url, name=name, query=query, label=label
     )
 
     response = httpx.post(
@@ -115,4 +119,4 @@ def dataset_rule_metrics(
         timeout=client.get_timeout(),
     )
 
-    return build_raw_response(response)
+    return build_typed_response(response, response_type_class=LabelingRuleMetrics)

--- a/src/rubrix/client/sdk/text_classification/models.py
+++ b/src/rubrix/client/sdk/text_classification/models.py
@@ -178,5 +178,17 @@ class LabelingRule(BaseModel):
     query: str
     label: str
     description: Optional[str] = None
-    author: str = None
+    author: str
     created_at: datetime = None
+
+
+class LabelingRuleMetrics(BaseModel):
+    """Metrics generated for a labeling rule"""
+
+    coverage: float
+    coverage_annotated: float
+    correct: float
+    incorrect: float
+    precision: float
+
+    total_records: int

--- a/src/rubrix/labeling/text_classification/rule.py
+++ b/src/rubrix/labeling/text_classification/rule.py
@@ -105,6 +105,7 @@ class RuleMetrics(BaseModel):
     """The rule metrics results dataclass"""
 
     coverage: float
+    coverage_annotated: float
     precision: float
     correct: int
     incorrect: int

--- a/src/rubrix/server/tasks/text_classification/api/model.py
+++ b/src/rubrix/server/tasks/text_classification/api/model.py
@@ -86,6 +86,7 @@ class LabelingRuleMetrics(BaseModel):
     """Metrics generated for a labeling rule"""
 
     coverage: float
+    coverage_annotated: float
     correct: float
     incorrect: float
     precision: float

--- a/src/rubrix/server/tasks/text_classification/service/labeling_service.py
+++ b/src/rubrix/server/tasks/text_classification/service/labeling_service.py
@@ -135,8 +135,19 @@ class LabelingService:
         dataset: BaseDatasetDB,
         rule_query: str,
         label: str,
-    ) -> Tuple[int, LabelingRuleMetrics]:
+    ) -> Tuple[int, int, LabelingRuleMetrics]:
         """Computes metrics for given rule query and optional label against a set of rules"""
+
+        results  = self.__records__.search_records(
+            dataset,
+            size=0,
+            search=RecordSearch(
+                query=filters.exists_field(EsRecordDataFieldNames.annotated_as),
+                include_default_aggregations=False,
+            ),
+        )
+
+        annotated_records = results.total
 
         results = self.__records__.search_records(
             dataset,
@@ -153,4 +164,6 @@ class LabelingService:
             results.aggregations
         )
 
-        return results.total, LabelingRuleMetrics.parse_obj(rule_metrics_summary)
+        metrics = LabelingRuleMetrics.parse_obj(rule_metrics_summary)
+
+        return results.total, annotated_records, metrics

--- a/src/rubrix/server/tasks/text_classification/service/service.py
+++ b/src/rubrix/server/tasks/text_classification/service/service.py
@@ -240,7 +240,9 @@ class TextClassificationService:
         """
         is_multi_label_dataset = self._is_dataset_multi_label(dataset)
         if is_multi_label_dataset is not None:
-            assert not is_multi_label_dataset, "Labeling rules are not supported for multi-label datasets"
+            assert (
+                not is_multi_label_dataset
+            ), "Labeling rules are not supported for multi-label datasets"
         self.__labeling__.add_rule(dataset, rule)
 
     def delete_labeling_rule(self, dataset: Dataset, rule_query: str):
@@ -289,12 +291,14 @@ class TextClassificationService:
         -------
 
         """
-        total, metrics = self.__labeling__.compute_rule_metrics(
+        total, annotated, metrics = self.__labeling__.compute_rule_metrics(
             dataset, rule_query=rule_query, label=label
         )
 
         return LabelingRuleMetrics(
             coverage=metrics.covered_records / total,
+            coverage_annotated=(metrics.correct_records + metrics.incorrect_records)
+            / annotated,
             correct=metrics.correct_records,
             incorrect=metrics.incorrect_records,
             precision=metrics.precision,

--- a/tests/client/sdk/text_classification/test_models.py
+++ b/tests/client/sdk/text_classification/test_models.py
@@ -21,6 +21,8 @@ from rubrix.client.models import TextClassificationRecord, TokenAttributions
 from rubrix.client.sdk.text_classification.models import (
     ClassPrediction,
     CreationTextClassificationRecord,
+    LabelingRule,
+    LabelingRuleMetrics,
     TextClassificationAnnotation,
     TextClassificationBulkData,
     TextClassificationQuery,
@@ -30,6 +32,8 @@ from rubrix.client.sdk.text_classification.models import (
 )
 from rubrix.server.tasks.text_classification.api.model import (
     TextClassificationBulkData as ServerTextClassificationBulkData,
+    LabelingRule as ServerLabelingRule,
+    LabelingRuleMetrics as ServerLabelingRuleMetrics,
 )
 from rubrix.server.tasks.text_classification.api.model import (
     TextClassificationQuery as ServerTextClassificationQuery,
@@ -48,6 +52,24 @@ def test_bulk_data_schema(helpers):
 def test_query_schema(helpers):
     client_schema = TextClassificationQuery.schema()
     server_schema = ServerTextClassificationQuery.schema()
+
+    assert helpers.remove_description(client_schema) == helpers.remove_description(
+        server_schema
+    )
+
+
+def test_labeling_rule_schema(helpers):
+    client_schema = LabelingRule.schema()
+    server_schema = ServerLabelingRule.schema()
+
+    assert helpers.remove_description(client_schema) == helpers.remove_description(
+        server_schema
+    )
+
+
+def test_labeling_rule_metrics_schema(helpers):
+    client_schema = LabelingRuleMetrics.schema()
+    server_schema = ServerLabelingRuleMetrics.schema()
 
     assert helpers.remove_description(client_schema) == helpers.remove_description(
         server_schema

--- a/tests/labeling/text_classification/test_rule.py
+++ b/tests/labeling/text_classification/test_rule.py
@@ -111,11 +111,33 @@ def test_dataset_rules(monkeypatch, log_dataset):
     [
         (
             Rule(query="neg*", label="LALA"),
-            RuleMetrics(correct=0, incorrect=1, coverage=0.5, precision=0),
+            RuleMetrics(
+                correct=0,
+                incorrect=1,
+                coverage=0.5,
+                coverage_annotated=0.5,
+                precision=0,
+            ),
         ),
         (
             Rule(query="neg*", label="negative"),
-            RuleMetrics(correct=1, incorrect=0, coverage=0.5, precision=1),
+            RuleMetrics(
+                correct=1,
+                incorrect=0,
+                coverage=0.5,
+                coverage_annotated=0.5,
+                precision=1,
+            ),
+        ),
+(
+            Rule(query="bad", label="negative"),
+            RuleMetrics(
+                correct=0,
+                incorrect=0,
+                coverage=0,
+                coverage_annotated=0,
+                precision=0,
+            ),
         ),
     ],
 )

--- a/tests/server/text_classification/test_api.py
+++ b/tests/server/text_classification/test_api.py
@@ -298,6 +298,8 @@ def test_sort_by_id_as_default():
 
 def test_some_sort_by():
     dataset = "test_some_sort_by"
+
+    expected_records_length = 50
     assert client.delete(f"/api/datasets/{dataset}").status_code == 200
     response = client.post(
         f"/api/datasets/{dataset}/TextClassification:bulk",
@@ -313,7 +315,7 @@ def test_some_sort_by():
                         },
                     }
                 )
-                for i in range(0, 100)
+                for i in range(0, expected_records_length)
             ],
         ).dict(by_alias=True),
     )
@@ -337,19 +339,8 @@ def test_some_sort_by():
     )
 
     results = TextClassificationSearchResults.parse_obj(response.json())
-    assert results.total == 100
-    assert list(map(lambda r: r.id, results.records)) == [
-        14,
-        19,
-        24,
-        29,
-        34,
-        39,
-        4,
-        44,
-        49,
-        54,
-    ]
+    assert results.total == expected_records_length
+    assert list(map(lambda r: r.id, results.records)) == [14, 19, 24, 29, 34, 39, 4, 44, 49, 9]
 
 
 def test_disable_aggregations_when_scroll():

--- a/tests/server/text_classification/test_api_rules.py
+++ b/tests/server/text_classification/test_api_rules.py
@@ -155,6 +155,7 @@ def test_rule_metric():
     metrics = LabelingRuleMetrics.parse_obj(response.json())
     assert metrics.total_records == 1
     assert metrics.coverage == 1
+    assert metrics.coverage_annotated == 1
     assert metrics.correct == 0
     assert metrics.incorrect == 1
     assert metrics.precision == 0
@@ -177,6 +178,7 @@ def test_rule_metric():
     metrics = LabelingRuleMetrics.parse_obj(response.json())
     assert metrics.total_records == 1
     assert metrics.coverage == 0
+    assert metrics.coverage_annotated == 0
     assert metrics.correct == 0
     assert metrics.incorrect == 0
     assert metrics.precision == 0


### PR DESCRIPTION
This PRs includes a new metric attribute for a single labeling rule summarizing coverage for annotated records.
