### PR TITLE
refactor(labeling rules): optional label for rule metrics

### DIFF
--- a/src/rubrix/client/sdk/text_classification/api.py
+++ b/src/rubrix/client/sdk/text_classification/api.py
@@ -31,7 +31,7 @@ from rubrix.client.sdk.commons.models import (
 )
 from rubrix.client.sdk.text_classification.models import (
     LabelingRule,
-    LabelingRuleMetrics,
+    LabelingRuleMetricsSummary,
     TextClassificationBulkData,
     TextClassificationQuery,
     TextClassificationRecord,
@@ -106,7 +106,7 @@ def dataset_rule_metrics(
     name: str,
     query: str,
     label: str,
-) -> Response[Union[LabelingRuleMetrics, HTTPValidationError, ErrorMessage]]:
+) -> Response[Union[LabelingRuleMetricsSummary, HTTPValidationError, ErrorMessage]]:
 
     url = "{}/api/datasets/TextClassification/{name}/labeling/rules/{query}/metrics?label={label}".format(
         client.base_url, name=name, query=query, label=label
@@ -119,4 +119,4 @@ def dataset_rule_metrics(
         timeout=client.get_timeout(),
     )
 
-    return build_typed_response(response, response_type_class=LabelingRuleMetrics)
+    return build_typed_response(response, response_type_class=LabelingRuleMetricsSummary)

--- a/src/rubrix/client/sdk/text_classification/models.py
+++ b/src/rubrix/client/sdk/text_classification/models.py
@@ -182,7 +182,7 @@ class LabelingRule(BaseModel):
     created_at: datetime = None
 
 
-class LabelingRuleMetrics(BaseModel):
+class LabelingRuleMetricsSummary(BaseModel):
     """Metrics generated for a labeling rule"""
 
     coverage: float

--- a/src/rubrix/server/tasks/text_classification/api/api.py
+++ b/src/rubrix/server/tasks/text_classification/api/api.py
@@ -28,9 +28,9 @@ from rubrix.server.tasks.commons.api import BulkResponse, PaginationParams, Task
 from rubrix.server.tasks.commons.helpers import takeuntil
 from rubrix.server.tasks.text_classification.api.model import (
     CreateLabelingRule,
-    DatasetLabelingRulesMetrics,
+    DatasetLabelingRulesMetricsSummary,
     LabelingRule,
-    LabelingRuleMetrics,
+    LabelingRuleMetricsSummary,
     TextClassificationBulkData,
     TextClassificationQuery,
     TextClassificationRecord,
@@ -301,14 +301,14 @@ async def create_rule(
 async def query_metrics(
     name: str,
     query: str,
-    label: str = Query(..., description="Label related to query rule"),
+    label: Optional[str] = Query(None, description="Label related to query rule"),
     common_params: CommonTaskQueryParams = Depends(),
     service: TextClassificationService = Depends(
         TextClassificationService.get_instance
     ),
     datasets: DatasetsService = Depends(DatasetsService.get_instance),
     current_user: User = Security(auth.get_user, scopes=[]),
-) -> LabelingRuleMetrics:
+) -> LabelingRuleMetricsSummary:
     dataset = datasets.find_by_name(
         name,
         task=TASK_TYPE,
@@ -330,7 +330,7 @@ async def query_metrics(
     ),
     datasets: DatasetsService = Depends(DatasetsService.get_instance),
     current_user: User = Security(auth.get_user, scopes=[]),
-) -> DatasetLabelingRulesMetrics:
+) -> DatasetLabelingRulesMetricsSummary:
     dataset = datasets.find_by_name(
         name,
         task=TASK_TYPE,

--- a/src/rubrix/server/tasks/text_classification/api/model.py
+++ b/src/rubrix/server/tasks/text_classification/api/model.py
@@ -82,7 +82,7 @@ class LabelingRule(CreateLabelingRule):
     created_at: Optional[datetime] = Field(default_factory=datetime.utcnow)
 
 
-class LabelingRuleMetrics(BaseModel):
+class LabelingRuleMetricsSummary(BaseModel):
     """Metrics generated for a labeling rule"""
 
     coverage: float
@@ -94,7 +94,7 @@ class LabelingRuleMetrics(BaseModel):
     total_records: int
 
 
-class DatasetLabelingRulesMetrics(BaseModel):
+class DatasetLabelingRulesMetricsSummary(BaseModel):
     coverage: float
     coverage_annotated: float
 

--- a/tests/client/sdk/text_classification/test_models.py
+++ b/tests/client/sdk/text_classification/test_models.py
@@ -33,7 +33,7 @@ from rubrix.client.sdk.text_classification.models import (
 from rubrix.server.tasks.text_classification.api.model import (
     TextClassificationBulkData as ServerTextClassificationBulkData,
     LabelingRule as ServerLabelingRule,
-    LabelingRuleMetrics as ServerLabelingRuleMetrics,
+    LabelingRuleMetricsSummary as ServerLabelingRuleMetrics,
 )
 from rubrix.server.tasks.text_classification.api.model import (
     TextClassificationQuery as ServerTextClassificationQuery,

--- a/tests/client/sdk/text_classification/test_models.py
+++ b/tests/client/sdk/text_classification/test_models.py
@@ -22,7 +22,7 @@ from rubrix.client.sdk.text_classification.models import (
     ClassPrediction,
     CreationTextClassificationRecord,
     LabelingRule,
-    LabelingRuleMetrics,
+    LabelingRuleMetricsSummary,
     TextClassificationAnnotation,
     TextClassificationBulkData,
     TextClassificationQuery,
@@ -33,7 +33,7 @@ from rubrix.client.sdk.text_classification.models import (
 from rubrix.server.tasks.text_classification.api.model import (
     TextClassificationBulkData as ServerTextClassificationBulkData,
     LabelingRule as ServerLabelingRule,
-    LabelingRuleMetricsSummary as ServerLabelingRuleMetrics,
+    LabelingRuleMetricsSummary as ServerLabelingRuleMetricsSummary,
 )
 from rubrix.server.tasks.text_classification.api.model import (
     TextClassificationQuery as ServerTextClassificationQuery,
@@ -68,8 +68,8 @@ def test_labeling_rule_schema(helpers):
 
 
 def test_labeling_rule_metrics_schema(helpers):
-    client_schema = LabelingRuleMetrics.schema()
-    server_schema = ServerLabelingRuleMetrics.schema()
+    client_schema = LabelingRuleMetricsSummary.schema()
+    server_schema = ServerLabelingRuleMetricsSummary.schema()
 
     assert helpers.remove_description(client_schema) == helpers.remove_description(
         server_schema


### PR DESCRIPTION
THis PR includes a minor changes to make optional the `label` query param rule metrics computation if provided rule query is already stored in dataset


Also include a minimal name change to API rule metrics classes, adding the `Summary` suffix.


See #745

