### PR TITLE
Fix token alignment on CreationTokenClassificationRecord

### DIFF
--- a/src/rubrix/server/tasks/token_classification/api/model.py
+++ b/src/rubrix/server/tasks/token_classification/api/model.py
@@ -142,11 +142,11 @@ class CreationTokenClassificationRecord(BaseRecord[TokenClassificationAnnotation
                     current_mention = mention
                     jdx = idx
                     while (
-                        current_mention.lstrip().startswith(current_token)
+                        current_mention.strip().startswith(current_token)
                         and current_mention
                         and jdx <= len(tokens)
                     ):
-                        current_mention = current_mention.lstrip()
+                        current_mention = current_mention.strip()
                         current_mention = current_mention[len(current_token) :]
                         jdx += 1
                         if jdx < len(tokens):

--- a/tests/server/token_classification/test_model.py
+++ b/tests/server/token_classification/test_model.py
@@ -15,6 +15,7 @@
 
 import pytest
 from pydantic import ValidationError
+
 from rubrix._constants import MAX_KEYWORD_LENGTH
 from rubrix.server.tasks.token_classification.api.model import (
     EntitySpan,
@@ -115,7 +116,7 @@ def test_query_as_elasticsearch():
     assert query.as_elasticsearch() == {"ids": {"values": query.ids}}
 
 
-def test_misaligned_entity_mentions():
+def test_misaligned_entity_mentions_with_spaces_left():
     assert TokenClassificationRecord(
         text="according to analysts.\n     Dart Group Corp was not",
         tokens=[
@@ -133,6 +134,18 @@ def test_misaligned_entity_mentions():
         annotation=TokenClassificationAnnotation(
             agent="heuristics",
             entities=[EntitySpan(start=22, end=43, label="COMPANY", score=1.0)],
+            score=None,
+        ),
+    )
+
+
+def test_misaligned_entity_mentions_with_spaces_right():
+    assert TokenClassificationRecord(
+        text="\nvs 9.91 billion\n    Note\n REUTER\n",
+        tokens=["\n", "vs", "9.91", "billion", "\n    ", "Note", "\n ", "REUTER", "\n"],
+        annotation=TokenClassificationAnnotation(
+            agent="heuristics",
+            entities=[EntitySpan(start=4, end=21, label="MONEY", score=1.0)],
             score=None,
         ),
     )


### PR DESCRIPTION
Changed .lstrip() to .strip() on the check_annotation method of the
CreationTokenClassificationRecord class.

Added unit tests that cover both edge cases: newline followed by spaces
to the left of the annotated entity, and also newline followed by spaces
to the right of the annotated entity.