### PR TITLE
fix(ui): align records and global action layouts

### DIFF
--- a/frontend/components/commons/results/ResultsList.vue
+++ b/frontend/components/commons/results/ResultsList.vue
@@ -178,9 +178,6 @@ export default {
     .fixed-header & {
       padding-bottom: 200px;
     }
-    &::-webkit-scrollbar {
-      -webkit-appearance: none;
-    }
     .--metrics & {
       @include media(">desktop") {
         width: 100%;


### PR DESCRIPTION
records list and global actions were not aligned because the empty scrollbar

<img width="362" alt="Captura de pantalla 2021-12-16 a las 23 57 40" src="https://user-images.githubusercontent.com/2518789/146532019-53f50074-c277-4d94-871c-a62468b11248.png">
