### PR TITLE
[LabelModel] Improve Snorkel to not modify the passed in WeakLabels object

### DIFF
--- a/src/rubrix/labeling/text_classification/label_models.py
+++ b/src/rubrix/labeling/text_classification/label_models.py
@@ -142,7 +142,7 @@ class Snorkel(LabelModel):
             }
 
         self._snorkel2weaklabels = {
-            val: key for key, val in self._weaklabels2snorkel.values()
+            val: key for key, val in self._weaklabels2snorkel.items()
         }
 
         # instantiate Snorkel's label model


### PR DESCRIPTION
Right now, the label model `Snorkel` (in contrast to the `FlyingSquid` label model) will modify the passed in `WeakLabels` object, if the label2int mapping is not compatible with the snorkel model (that is -1 for "abstention", and sequential integers for the labels). This is not done in a transparent way and can lead to confusion if you want to further use the `WeakLabels` object afterward.

This PRs modifies `Snorkel` so that it creates a remapped copy of the weak label matrix or annotation array, when using the `fit`, `predict` or `score` method. So the `WeakLabels` object is not modified.