### PR TITLE
feat (search): allow to filtering record metrics fields in search

### DIFF
--- a/src/rubrix/server/commons/api.py
+++ b/src/rubrix/server/commons/api.py
@@ -9,6 +9,10 @@ from rubrix._constants import RUBRIX_WORKSPACE_HEADER_NAME
 class CommonTaskQueryParams:
     """Common task query params"""
 
+    include_metrics: bool = Query(
+        False, description="If enabled, return related record metrics"
+    )
+
     __workspace_param__: str = Query(
         None,
         alias="workspace",

--- a/src/rubrix/server/tasks/commons/dao/dao.py
+++ b/src/rubrix/server/tasks/commons/dao/dao.py
@@ -196,6 +196,7 @@ class DatasetRecordsDAO:
         search: Optional[RecordSearch] = None,
         size: int = 100,
         record_from: int = 0,
+        exclude_fields: List[str] = None,
     ) -> RecordSearchResults:
         """
         SearchRequest records under a dataset given a search parameters.
@@ -210,6 +211,8 @@ class DatasetRecordsDAO:
             Number of records to retrieve (for pagination)
         record_from:
             Record from witch retrieve records (for pagination)
+        exclude_fields:
+            a list of fields to exclude from result source. Wildcard are accepted
         Returns
         -------
             The search result
@@ -245,6 +248,7 @@ class DatasetRecordsDAO:
             aggregation_requests = None
 
         es_query = {
+            "_source": {"excludes": exclude_fields or []},
             "size": size,
             "from": record_from,
             "query": search.query or {"match_all": {}},

--- a/src/rubrix/server/tasks/commons/dao/dao.py
+++ b/src/rubrix/server/tasks/commons/dao/dao.py
@@ -210,9 +210,9 @@ class DatasetRecordsDAO:
         size:
             Number of records to retrieve (for pagination)
         record_from:
-            Record from witch retrieve records (for pagination)
+            Record from which to retrieve the records (for pagination)
         exclude_fields:
-            a list of fields to exclude from result source. Wildcard are accepted
+            a list of fields to exclude from the result source. Wildcards are accepted
         Returns
         -------
             The search result

--- a/src/rubrix/server/tasks/text2text/api/api.py
+++ b/src/rubrix/server/tasks/text2text/api/api.py
@@ -151,6 +151,7 @@ def search_records(
         sort_by=search.sort,
         record_from=pagination.from_,
         size=pagination.limit,
+        exclude_metrics=not common_params.include_metrics,
     )
 
     return result

--- a/src/rubrix/server/tasks/text2text/service/service.py
+++ b/src/rubrix/server/tasks/text2text/service/service.py
@@ -93,6 +93,7 @@ class Text2TextService:
         sort_by: List[SortableField],
         record_from: int = 0,
         size: int = 100,
+        exclude_metrics: bool = True,
     ) -> Text2TextSearchResults:
         """
         Run a search in a dataset
@@ -141,6 +142,7 @@ class Text2TextService:
             ),
             size=size,
             record_from=record_from,
+            exclude_fields=["metrics"] if exclude_metrics else None,
         )
         return Text2TextSearchResults(
             total=results.total,

--- a/src/rubrix/server/tasks/text_classification/api/api.py
+++ b/src/rubrix/server/tasks/text_classification/api/api.py
@@ -160,6 +160,7 @@ def search_records(
         sort_by=search.sort,
         record_from=pagination.from_,
         size=pagination.limit,
+        exclude_metrics=not common_params.include_metrics,
     )
 
     return result

--- a/src/rubrix/server/tasks/text_classification/service/service.py
+++ b/src/rubrix/server/tasks/text_classification/service/service.py
@@ -112,6 +112,7 @@ class TextClassificationService:
         sort_by: List[SortableField],
         record_from: int = 0,
         size: int = 100,
+        exclude_metrics: bool = True,
     ) -> TextClassificationSearchResults:
         """
         Run a search in a dataset
@@ -155,6 +156,7 @@ class TextClassificationService:
             ),
             size=size,
             record_from=record_from,
+            exclude_fields=["metrics"] if exclude_metrics else None,
         )
         return TextClassificationSearchResults(
             total=results.total,
@@ -208,6 +210,7 @@ class TextClassificationService:
             dataset,
             search=RecordSearch(include_default_aggregations=False),
             size=1,
+            exclude_fields=["metrics", "metadata"],
         )
         records = [TextClassificationRecord.parse_obj(r) for r in results.records]
         if records:

--- a/src/rubrix/server/tasks/token_classification/api/api.py
+++ b/src/rubrix/server/tasks/token_classification/api/api.py
@@ -155,6 +155,7 @@ def search_records(
         sort_by=search.sort,
         record_from=pagination.from_,
         size=pagination.limit,
+        exclude_metrics=not common_params.include_metrics,
     )
 
     return result

--- a/src/rubrix/server/tasks/token_classification/service/service.py
+++ b/src/rubrix/server/tasks/token_classification/service/service.py
@@ -111,6 +111,7 @@ class TokenClassificationService:
         sort_by: List[SortableField],
         record_from: int = 0,
         size: int = 100,
+        exclude_metrics: bool = True,
     ) -> TokenClassificationSearchResults:
         """
         Run a search in a dataset
@@ -176,6 +177,7 @@ class TokenClassificationService:
             ),
             size=size,
             record_from=record_from,
+            exclude_fields=["metrics"] if exclude_metrics else None
         )
         return TokenClassificationSearchResults(
             total=results.total,


### PR DESCRIPTION
This PRs includes query param for task search for exclude metrics fields on each record. This can make it lighter in cases where these metrics are not needed