### PR TITLE
fix(rules): prevent division by zero

### DIFF
--- a/src/rubrix/client/sdk/text_classification/models.py
+++ b/src/rubrix/client/sdk/text_classification/models.py
@@ -185,10 +185,11 @@ class LabelingRule(BaseModel):
 class LabelingRuleMetricsSummary(BaseModel):
     """Metrics generated for a labeling rule"""
 
-    coverage: float
-    coverage_annotated: float
-    correct: float
-    incorrect: float
-    precision: float
+    coverage: Optional[float] = None
+    coverage_annotated: Optional[float] = None
+    correct: Optional[float] = None
+    incorrect: Optional[float] = None
+    precision: Optional[float] = None
 
     total_records: int
+    annotated_records: int

--- a/src/rubrix/labeling/text_classification/rule.py
+++ b/src/rubrix/labeling/text_classification/rule.py
@@ -110,9 +110,9 @@ class Rule:
         return {
             "coverage": metrics.coverage,
             "annotated_coverage": metrics.coverage_annotated,
-            "correct": int(metrics.correct),
-            "incorrect": int(metrics.incorrect),
-            "precision": metrics.precision,
+            "correct": int(metrics.correct) if metrics.correct is not None else None,
+            "incorrect": int(metrics.incorrect) if metrics.incorrect is not None else None,
+            "precision": metrics.precision if metrics.precision is not None else None,
         }
 
     def __call__(self, record: TextClassificationRecord) -> Optional[str]:

--- a/src/rubrix/server/tasks/text_classification/api/model.py
+++ b/src/rubrix/server/tasks/text_classification/api/model.py
@@ -92,13 +92,14 @@ class LabelingRule(CreateLabelingRule):
 class LabelingRuleMetricsSummary(BaseModel):
     """Metrics generated for a labeling rule"""
 
-    coverage: float
-    coverage_annotated: float
-    correct: float
-    incorrect: float
-    precision: float
+    coverage: Optional[float] = None
+    coverage_annotated: Optional[float] = None
+    correct: Optional[float] = None
+    incorrect: Optional[float] = None
+    precision: Optional[float] = None
 
     total_records: int
+    annotated_records: int
 
 
 class DatasetLabelingRulesMetricsSummary(BaseModel):

--- a/src/rubrix/server/tasks/text_classification/service/service.py
+++ b/src/rubrix/server/tasks/text_classification/service/service.py
@@ -363,14 +363,20 @@ class TextClassificationService:
             dataset, rule_query=rule_query, label=label
         )
 
+        coverage = metrics.covered_records / total if total > 0 else None
+        coverage_annotated = (
+            (metrics.correct_records + metrics.incorrect_records) / annotated
+            if annotated > 0
+            else None
+        )
         return LabelingRuleMetricsSummary(
-            coverage=metrics.covered_records / total,
-            coverage_annotated=(metrics.correct_records + metrics.incorrect_records)
-            / annotated,
-            correct=metrics.correct_records,
-            incorrect=metrics.incorrect_records,
-            precision=metrics.precision,
             total_records=total,
+            annotated_records=annotated,
+            coverage=coverage,
+            coverage_annotated=coverage_annotated,
+            correct=metrics.correct_records if annotated > 0 else None,
+            incorrect=metrics.incorrect_records if annotated > 0 else None,
+            precision=metrics.precision if annotated > 0 else None,
         )
 
     def compute_overall_rules_metrics(self, dataset: Dataset):


### PR DESCRIPTION
This PR prevent `Division by zero` errors computing rule metrics without annotated records. 

Also includes annotated_records as part of rule api metrics response.