### PR TITLE
fix(rules): prevent lost rules with dataset updates

### DIFF
--- a/src/rubrix/server/commons/es_wrapper.py
+++ b/src/rubrix/server/commons/es_wrapper.py
@@ -383,7 +383,8 @@ class ElasticsearchWrapper(LoggingMixin):
         """
         if partial_update:
             self.__client__.update(index=index, id=doc_id, body={"doc": document})
-        self.__client__.index(index=index, id=doc_id, body=document)
+        else:
+            self.__client__.index(index=index, id=doc_id, body=document)
 
     def open_index(self, index: str):
         """

--- a/src/rubrix/server/datasets/dao.py
+++ b/src/rubrix/server/datasets/dao.py
@@ -166,6 +166,7 @@ class DatasetsDAO:
             index=DATASETS_INDEX_NAME,
             doc_id=dataset_id,
             document=self._dataset_to_es_doc(dataset),
+            partial_update=True,
         )
         return dataset
 


### PR DESCRIPTION
This PR fixes problem with lost dataset rules after annotation (or even logging new records). Found after intensive @dcfidalgo  feature testing. Thanks @dcfidalgo !



This must be included to the very first release
