### PR TITLE
feat(rules): allow compute partial query rule metrics

### DIFF
--- a/src/rubrix/server/tasks/text_classification/service/service.py
+++ b/src/rubrix/server/tasks/text_classification/service/service.py
@@ -336,8 +336,10 @@ class TextClassificationService:
             The provided rule query. If already created in dataset, the ``label``
             param will be omitted
         label:
-            Label used for rule metrics. If not provided, defined in stored rule will be used
-            if rule is found, else related label metrics won't be computed
+            Label used for rule metrics. If not provided and no rule was stored with provided query,
+            no precision will be computed. Otherwise, the store rule label will be used for metrics
+            computation
+
 
         Returns
         -------

--- a/src/rubrix/server/tasks/text_classification/service/service.py
+++ b/src/rubrix/server/tasks/text_classification/service/service.py
@@ -337,6 +337,7 @@ class TextClassificationService:
             param will be omitted
         label:
             Label used for rule metrics. If not provided, defined in stored rule will be used
+            if rule is found, else related label metrics won't be computed
 
         Returns
         -------
@@ -352,12 +353,6 @@ class TextClassificationService:
                 if rule.query == rule_query:
                     label = rule.label
                     break
-
-        if label is None:
-            raise MissingInputParamError(
-                "`label` param was not provided and rule is not stored for dataset. "
-                "You must either an already created rule or specify the label for metrics computation"
-            )
 
         total, annotated, metrics = self.__labeling__.compute_rule_metrics(
             dataset, rule_query=rule_query, label=label

--- a/src/rubrix/server/tasks/text_classification/service/service.py
+++ b/src/rubrix/server/tasks/text_classification/service/service.py
@@ -336,10 +336,9 @@ class TextClassificationService:
             The provided rule query. If already created in dataset, the ``label``
             param will be omitted
         label:
-            Label used for rule metrics. If not provided and no rule was stored with provided query,
-            no precision will be computed. Otherwise, the store rule label will be used for metrics
-            computation
-
+            Label used for the rule metrics. If not provided and no rule was stored with the 
+            provided query, no precision will be computed. 
+            Otherwise, the label from the stored rule will be used to compute the metrics.
 
         Returns
         -------

--- a/tests/labeling/text_classification/test_rule.py
+++ b/tests/labeling/text_classification/test_rule.py
@@ -157,7 +157,7 @@ def test_load_rules(monkeypatch, log_dataset):
                 annotated_coverage=0.0,
                 correct=0,
                 incorrect=0,
-                precision=0.0,
+                precision=None,
             ),
         ),
     ],

--- a/tests/server/text_classification/test_api_rules.py
+++ b/tests/server/text_classification/test_api_rules.py
@@ -11,7 +11,9 @@ from rubrix.server.tasks.text_classification import (
 from tests.server.test_helpers import client
 
 
-def log_some_records(dataset: str, annotation: str = None, multi_label: bool = False, delete:bool=True):
+def log_some_records(
+    dataset: str, annotation: str = None, multi_label: bool = False, delete: bool = True
+):
     if delete:
         assert client.delete(f"/api/datasets/{dataset}").status_code == 200
 
@@ -191,10 +193,14 @@ def test_rule_metrics_with_missing_label():
     response = client.get(
         f"/api/datasets/TextClassification/{dataset}/labeling/rules/a query/metrics"
     )
-    assert response.status_code == 400
+    assert response.status_code == 200, response.json()
     assert response.json() == {
-        "detail": "`label` param was not provided and rule is not stored for dataset. "
-        "You must either an already created rule or specify the label for metrics computation"
+        "coverage": 0.0,
+        "coverage_annotated": 0.0,
+        "correct": 0.0,
+        "incorrect": 0.0,
+        "total_records": 1,
+        "annotated_records": 1,
     }
 
 
@@ -322,4 +328,4 @@ def test_rule_metric():
     assert metrics.coverage_annotated == 0
     assert metrics.correct == 0
     assert metrics.incorrect == 0
-    assert metrics.precision == 0
+    assert metrics.precision is None


### PR DESCRIPTION
rule label is not required when rule is not saved. This will compute only query coverages.

Also set precision to `None` when annotation coverage is 0.

See #895 