### PR TITLE
UI: show rules without precision properly

### DIFF
--- a/frontend/components/text-classifier/labeling-rules/RulesManagement.vue
+++ b/frontend/components/text-classifier/labeling-rules/RulesManagement.vue
@@ -164,7 +164,7 @@ export default {
           correct: this.metricsByLabel[r.query].correct,
           incorrect: this.metricsByLabel[r.query].incorrect,
           precision: this.$options.filters.percent(
-            this.metricsByLabel[r.query].precision
+            this.metricsByLabel[r.query].precision || 0
           ),
           created_at: r.created_at,
         };

--- a/frontend/components/text-classifier/labeling-rules/RulesManagement.vue
+++ b/frontend/components/text-classifier/labeling-rules/RulesManagement.vue
@@ -163,9 +163,9 @@ export default {
           ),
           correct: this.metricsByLabel[r.query].correct,
           incorrect: this.metricsByLabel[r.query].incorrect,
-          precision: this.$options.filters.percent(
-            this.metricsByLabel[r.query].precision || 0
-          ),
+          precision: this.metricsByLabel[r.query].precision ? this.$options.filters.percent(
+            this.metricsByLabel[r.query].precision
+          ) : '-',
           created_at: r.created_at,
         };
       });

--- a/frontend/components/text-classifier/labeling-rules/RulesManagement.vue
+++ b/frontend/components/text-classifier/labeling-rules/RulesManagement.vue
@@ -163,7 +163,7 @@ export default {
           ),
           correct: this.metricsByLabel[r.query].correct,
           incorrect: this.metricsByLabel[r.query].incorrect,
-          precision: this.metricsByLabel[r.query].precision ? this.$options.filters.percent(
+          precision: !isNaN(this.metricsByLabel[r.query].precision) ? this.$options.filters.percent(
             this.metricsByLabel[r.query].precision
           ) : '-',
           created_at: r.created_at,

--- a/frontend/components/text-classifier/labeling-rules/RulesMetrics.vue
+++ b/frontend/components/text-classifier/labeling-rules/RulesMetrics.vue
@@ -97,10 +97,10 @@ export default {
     },
     placeholderFields() {
       return [
-        "Precision",
-        "Correct/incorrect",
         "Coverage",
         "Annotated coverage",
+        "Precision",
+        "Correct/incorrect",
       ];
     },
     metrics() {

--- a/frontend/components/text-classifier/labeling-rules/RulesMetrics.vue
+++ b/frontend/components/text-classifier/labeling-rules/RulesMetrics.vue
@@ -254,7 +254,7 @@ export default {
     },
     getValuesByMetricType(type) {
       return Object.keys(this.metricsByRules).map((key) => {
-        return this.metricsByRules[key][type];
+        return this.metricsByRules[key][type] || 0;
       });
     },
     getTotal(type) {


### PR DESCRIPTION
fix #917

also fixes the order of the metrics while loading

see #896