### PR TITLE
fix(api): include_metrics param only for search endpoints

### DIFF
--- a/src/rubrix/server/commons/api.py
+++ b/src/rubrix/server/commons/api.py
@@ -9,10 +9,6 @@ from rubrix._constants import RUBRIX_WORKSPACE_HEADER_NAME
 class CommonTaskQueryParams:
     """Common task query params"""
 
-    include_metrics: bool = Query(
-        False, description="If enabled, return related record metrics"
-    )
-
     __workspace_param__: str = Query(
         None,
         alias="workspace",

--- a/src/rubrix/server/tasks/text2text/api/api.py
+++ b/src/rubrix/server/tasks/text2text/api/api.py
@@ -109,6 +109,9 @@ def search_records(
     name: str,
     search: Text2TextSearchRequest = None,
     common_params: CommonTaskQueryParams = Depends(),
+    include_metrics: bool = Query(
+        False, description="If enabled, return related record metrics"
+    ),
     pagination: PaginationParams = Depends(),
     service: Text2TextService = Depends(text2text_service),
     datasets: DatasetsService = Depends(DatasetsService.get_instance),
@@ -123,6 +126,8 @@ def search_records(
         The dataset name
     common_params:
         The task common query params
+    include_metrics:
+        Flag to include metrics in results
     search:
         THe search query request
     pagination:
@@ -151,7 +156,7 @@ def search_records(
         sort_by=search.sort,
         record_from=pagination.from_,
         size=pagination.limit,
-        exclude_metrics=not common_params.include_metrics,
+        exclude_metrics=not include_metrics,
     )
 
     return result

--- a/src/rubrix/server/tasks/text_classification/api/api.py
+++ b/src/rubrix/server/tasks/text_classification/api/api.py
@@ -116,6 +116,9 @@ def search_records(
     name: str,
     search: TextClassificationSearchRequest = None,
     common_params: CommonTaskQueryParams = Depends(),
+    include_metrics: bool = Query(
+        False, description="If enabled, return related record metrics"
+    ),
     pagination: PaginationParams = Depends(),
     service: TextClassificationService = Depends(
         TextClassificationService.get_instance
@@ -134,6 +137,8 @@ def search_records(
         The search query request
     common_params:
         Common query params
+    include_metrics:
+        Flag to enable include metrics
     pagination:
         The pagination params
     service:
@@ -160,7 +165,7 @@ def search_records(
         sort_by=search.sort,
         record_from=pagination.from_,
         size=pagination.limit,
-        exclude_metrics=not common_params.include_metrics,
+        exclude_metrics=not include_metrics,
     )
 
     return result

--- a/src/rubrix/server/tasks/token_classification/api/api.py
+++ b/src/rubrix/server/tasks/token_classification/api/api.py
@@ -112,6 +112,9 @@ def search_records(
     name: str,
     search: TokenClassificationSearchRequest = None,
     common_params: CommonTaskQueryParams = Depends(),
+    include_metrics: bool = Query(
+        False, description="If enabled, return related record metrics"
+    ),
     pagination: PaginationParams = Depends(),
     service: TokenClassificationService = Depends(token_classification_service),
     datasets: DatasetsService = Depends(DatasetsService.get_instance),
@@ -128,6 +131,8 @@ def search_records(
         THe search query request
     common_params:
         Common query params
+    include_metrics:
+        include metrics flag
     pagination:
         The pagination params
     service:
@@ -155,7 +160,7 @@ def search_records(
         sort_by=search.sort,
         record_from=pagination.from_,
         size=pagination.limit,
-        exclude_metrics=not common_params.include_metrics,
+        exclude_metrics=not include_metrics,
     )
 
     return result


### PR DESCRIPTION
See #837 