### PR TITLE
[WeakLabels] Show nan instead of 0 for precision in summary

### DIFF
--- a/src/rubrix/labeling/text_classification/weak_labels.py
+++ b/src/rubrix/labeling/text_classification/weak_labels.py
@@ -348,7 +348,7 @@ class WeakLabels:
             )
 
             # precision
-            precision = np.nan_to_num(correct / (correct + incorrect))
+            precision = correct / (correct + incorrect)
 
             return pd.DataFrame(
                 {

--- a/tests/labeling/text_classification/test_weak_labels.py
+++ b/tests/labeling/text_classification/test_weak_labels.py
@@ -314,7 +314,7 @@ def test_summary(monkeypatch, rules):
             "conflicts": [1.0 / 4, 1.0 / 4, 0, 1.0 / 4],
             "correct": [1, 2, 0, 3],
             "incorrect": [1, 0, 0, 1],
-            "precision": [1.0 / 2, 2 / 2, 0, 3.0 / 4],
+            "precision": [1.0 / 2, 2 / 2, np.nan, 3.0 / 4],
         },
         index=["first_rule", "rule_1", "rubrix_rule", "total"],
     )


### PR DESCRIPTION
Quick fix and alignment to web app. `WeakLabels.summary` was showing a `0` when precision could not be computed (correct and incorrect were 0). Now a `np.nan` is shown, similar to the web app.