### PR TITLE
fix(#974): display the dropdown in the last record of the scroll

### DIFF
--- a/frontend/components/commons/results/ResultsList.vue
+++ b/frontend/components/commons/results/ResultsList.vue
@@ -219,14 +219,19 @@ export default {
     min-height: 140px;
   }
 }
-.scroller {
-  padding-bottom: 61px;
-  .fixed-header & {
-    padding-bottom: 200px;
-  }
-}
 </style>
 <style lang="scss">
+.vue-recycle-scroller__item-wrapper {
+  box-sizing: content-box;
+   padding-bottom: 61px;
+   .fixed-header & {
+    padding-bottom: 260px;
+   }
+ }
+.vue-recycle-scroller__item-view {
+  box-sizing: border-box;
+}
+
 $maxItemsperPage: 20;
 @for $i from 0 through $maxItemsperPage {
   .vue-recycle-scroller__item-view:nth-of-type(#{$i}) {

--- a/frontend/components/commons/results/ResultsList.vue
+++ b/frontend/components/commons/results/ResultsList.vue
@@ -223,7 +223,7 @@ export default {
 <style lang="scss">
 .vue-recycle-scroller__item-wrapper {
   box-sizing: content-box;
-   padding-bottom: 61px;
+   padding-bottom: 260px;
    .fixed-header & {
     padding-bottom: 260px;
    }

--- a/frontend/components/token-classifier/results/TextSpan.vue
+++ b/frontend/components/token-classifier/results/TextSpan.vue
@@ -67,7 +67,6 @@
           </ul>
         </span>
       </div>
-      <div v-if="showEntitiesSelector" class="overlay" />
     </span>
     <span class="span__whitespace" v-html="whiteSpace"></span>
   </span>
@@ -287,19 +286,6 @@ export default {
   &__whitespace {
     @include font-size(16px);
   }
-}
-
-.overlay {
-  background: white;
-  opacity: 0.5;
-  height: 100vh;
-  position: fixed;
-  width: 100vw;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 2;
 }
 
 // highlight word with overlay


### PR DESCRIPTION
fix #974
This PR enables the dropdown overlay on the last record in the token classifier scroll