### PR TITLE
feat(#735): add warning when agent but no prediction/annotation is provided

### DIFF
--- a/docs/reference/python/python_client.rst
+++ b/docs/reference/python/python_client.rst
@@ -19,3 +19,4 @@ Models
 
 .. automodule:: rubrix.client.models
    :members:
+   :exclude-members: BaseRecord, BulkResponse

--- a/src/rubrix/__init__.py
+++ b/src/rubrix/__init__.py
@@ -21,14 +21,21 @@ This module contains the interface to access Rubrix's REST API.
 import logging
 import os
 import re
-from typing import Iterable
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 import pandas
 import pkg_resources
 
 from rubrix._constants import DEFAULT_API_KEY
 from rubrix.client import RubrixClient
-from rubrix.client.models import *
+from rubrix.client.models import (
+    BulkResponse,
+    Record,
+    Text2TextRecord,
+    TextClassificationRecord,
+    TokenAttributions,
+    TokenClassificationRecord,
+)
 from rubrix.monitoring.model_monitor import monitor
 
 try:

--- a/src/rubrix/server/tasks/token_classification/service/service.py
+++ b/src/rubrix/server/tasks/token_classification/service/service.py
@@ -17,27 +17,22 @@ from typing import Iterable, List
 
 from fastapi import Depends
 
-from rubrix import MAX_KEYWORD_LENGTH
-from rubrix.server.commons.es_helpers import (
-    aggregations,
-    sort_by2elasticsearch,
-)
+from rubrix._constants import MAX_KEYWORD_LENGTH
+from rubrix.server.commons.es_helpers import aggregations, sort_by2elasticsearch
 from rubrix.server.datasets.model import Dataset
 from rubrix.server.tasks.commons import (
     BulkResponse,
     EsRecordDataFieldNames,
     SortableField,
 )
-from rubrix.server.tasks.commons.dao import (
-    extends_index_properties,
-)
+from rubrix.server.tasks.commons.dao import extends_index_properties
 from rubrix.server.tasks.commons.dao.dao import DatasetRecordsDAO, dataset_records_dao
 from rubrix.server.tasks.commons.dao.model import RecordSearch
 from rubrix.server.tasks.commons.metrics.service import MetricsService
 from rubrix.server.tasks.token_classification.api.model import (
-    CreationTokenClassificationRecord,
     MENTIONS_ES_FIELD_NAME,
     PREDICTED_MENTIONS_ES_FIELD_NAME,
+    CreationTokenClassificationRecord,
     TokenClassificationAggregations,
     TokenClassificationQuery,
     TokenClassificationRecord,
@@ -177,7 +172,7 @@ class TokenClassificationService:
             ),
             size=size,
             record_from=record_from,
-            exclude_fields=["metrics"] if exclude_metrics else None
+            exclude_fields=["metrics"] if exclude_metrics else None,
         )
         return TokenClassificationSearchResults(
             total=results.total,
@@ -239,8 +234,5 @@ def token_classification_service(
     """
     global _instance
     if not _instance:
-        _instance = TokenClassificationService(
-            dao=dao,
-            metrics=metrics
-        )
+        _instance = TokenClassificationService(dao=dao, metrics=metrics)
     return _instance

--- a/tests/client/test_models.py
+++ b/tests/client/test_models.py
@@ -17,10 +17,14 @@ import json
 import numpy
 import pytest
 from pydantic import ValidationError
-from rubrix._constants import MAX_KEYWORD_LENGTH
 
-from rubrix.client.models import Text2TextRecord, TextClassificationRecord
-from rubrix.client.models import TokenClassificationRecord
+from rubrix._constants import MAX_KEYWORD_LENGTH
+from rubrix.client.models import (
+    BaseRecord,
+    Text2TextRecord,
+    TextClassificationRecord,
+    TokenClassificationRecord,
+)
 
 
 @pytest.mark.parametrize(
@@ -92,3 +96,14 @@ def test_model_serialization_with_numpy_nan():
     )
 
     json_record = json.loads(record.json())
+
+
+def test_warning_when_only_agent():
+    with pytest.warns(
+        UserWarning, match="`prediction_agent` will not be logged to the server."
+    ):
+        BaseRecord(prediction_agent="mock")
+    with pytest.warns(
+        UserWarning, match="`annotation_agent` will not be logged to the server."
+    ):
+        BaseRecord(annotation_agent="mock")


### PR DESCRIPTION
Closes #735 
This PR adds a warning when a `*_agent` is provided but no corresponding `annotation`/`prediction`.
Also, some refactoring is done, introducing a base class for the records in which common checks are performed.