### PR TITLE
fix(#800): limit number of metadata fields

### DIFF
--- a/src/rubrix/server/commons/settings.py
+++ b/src/rubrix/server/commons/settings.py
@@ -67,6 +67,10 @@ class ApiSettings(BaseSettings):
 
     namespace: str = Field(default=None, regex=r"^[a-z]+$")
 
+    metadata_fields_limit: int = Field(
+        default=50, gt=0, le=100, description="Max number of fields in metadata"
+    )
+
     @property
     def dataset_index_name(self) -> str:
         ns = self.namespace
@@ -82,10 +86,12 @@ class ApiSettings(BaseSettings):
         return self.__DATASETS_RECORDS_INDEX_NAME__.replace("<NAMESPACE>", f".{ns}")
 
     class Config:
+        # TODO: include a common prefix for all rubrix env vars.
         fields = {
+            "metadata_fields_limit": {"env": "RUBRIX_METADATA_FIELDS_LIMIT"},
             "namespace": {
                 "env": "RUBRIX_NAMESPACE",
-            }
+            },
         }
 
 

--- a/src/rubrix/server/tasks/commons/api/errors.py
+++ b/src/rubrix/server/tasks/commons/api/errors.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+from pydantic import PydanticValueError
+
+
+class MetadataLimitExceededError(PydanticValueError):
+    code = "metadata.limit_exceeded"
+    msg_template = (
+        "Number of keys in metadata ({meta_len}) exceeds the configured limit ({limit})"
+    )
+
+    @classmethod
+    def new_error(cls, found_len: int, limit: int) -> "MetadataLimitExceededError":
+        return cls(meta_len=found_len, limit=limit)

--- a/src/rubrix/server/tasks/commons/api/model.py
+++ b/src/rubrix/server/tasks/commons/api/model.py
@@ -203,16 +203,6 @@ class BaseRecord(GenericModel, Generic[Annotation]):
             metadata = limit_value_length(metadata, max_length=MAX_KEYWORD_LENGTH)
         return metadata
 
-    @validator(
-        "metadata",
-    )
-    def check_metadata_limit(cls, metadata: Dict[str, Any]) -> Dict[str, Any]:
-        if len(metadata) > settings.metadata_fields_limit:
-            raise MetadataLimitExceededError.new_error(
-                len(metadata), limit=settings.metadata_fields_limit
-            )
-        return metadata
-
     @validator("status", always=True)
     def fill_default_value(cls, status: TaskStatus):
         """Fastapi validator for set default task status"""

--- a/tests/server/text_classification/test_model.py
+++ b/tests/server/text_classification/test_model.py
@@ -37,23 +37,6 @@ def test_flatten_metadata():
     assert list(record.metadata.keys()) == ["mail.subject", "mail.body"]
 
 
-@pytest.mark.parametrize("metadata_length", [1, 50, 51, 100])
-def test_metadata_limits(metadata_length):
-    data = {
-        "inputs": {"text": "bogh"},
-        "metadata": {k: k for k in range(0, metadata_length)},
-    }
-    if metadata_length <= settings.metadata_fields_limit:
-        TextClassificationRecord.parse_obj(data)
-    else:
-        with pytest.raises(
-            ValidationError,
-            match=f"Number of keys in metadata \({metadata_length}\) "
-            f"exceeds the configured limit \({settings.metadata_fields_limit}\)",
-        ):
-            TextClassificationRecord.parse_obj(data)
-
-
 def test_metadata_with_object_list():
     data = {
         "inputs": {"text": "bogh"},

--- a/tests/server/text_classification/test_model.py
+++ b/tests/server/text_classification/test_model.py
@@ -12,11 +12,12 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
 import pytest
 from pydantic import ValidationError
-from rubrix.server.tasks.commons import TaskStatus
+
 from rubrix._constants import MAX_KEYWORD_LENGTH
+from rubrix.server.commons.settings import settings
+from rubrix.server.tasks.commons import TaskStatus
 from rubrix.server.tasks.text_classification.api import (
     ClassPrediction,
     PredictionStatus,
@@ -36,6 +37,23 @@ def test_flatten_metadata():
     assert list(record.metadata.keys()) == ["mail.subject", "mail.body"]
 
 
+@pytest.mark.parametrize("metadata_length", [1, 50, 51, 100])
+def test_metadata_limits(metadata_length):
+    data = {
+        "inputs": {"text": "bogh"},
+        "metadata": {k: k for k in range(0, metadata_length)},
+    }
+    if metadata_length <= settings.metadata_fields_limit:
+        TextClassificationRecord.parse_obj(data)
+    else:
+        with pytest.raises(
+            ValidationError,
+            match=f"Number of keys in metadata \({metadata_length}\) "
+            f"exceeds the configured limit \({settings.metadata_fields_limit}\)",
+        ):
+            TextClassificationRecord.parse_obj(data)
+
+
 def test_metadata_with_object_list():
     data = {
         "inputs": {"text": "bogh"},
@@ -52,12 +70,18 @@ def test_metadata_with_object_list():
 
 def test_single_label_with_multiple_annotation():
 
-    with pytest.raises(ValidationError, match="Single label record must include only one annotation label"):
+    with pytest.raises(
+        ValidationError,
+        match="Single label record must include only one annotation label",
+    ):
         TextClassificationRecord.parse_obj(
             {
                 "inputs": {"text": "This is a text"},
-                "annotation": {"agent": "test", "labels": [{"class": "A"}, {"class": "B"}]},
-                "multi_label": False
+                "annotation": {
+                    "agent": "test",
+                    "labels": [{"class": "A"}, {"class": "B"}],
+                },
+                "multi_label": False,
             }
         )
 


### PR DESCRIPTION
This PR adds validations to check limits for stored metadata fields in a dataset.

The default metadata limits is configurable by environment var and for the future, could be a per-index configuration

This  PR together with #990 will close #800