### PR TITLE
fix(#977) Remove redirection when accessing login

### DIFF
--- a/frontend/middleware/auth-guard.js
+++ b/frontend/middleware/auth-guard.js
@@ -16,8 +16,8 @@
  */
 
 export default ({ $auth, route, redirect }) => {
-  switch (route.path) {
-    case "/login":
+  switch (route.name) {
+    case "login" :
       break;
     default:
       if (!$auth.loggedIn) {


### PR DESCRIPTION
fix #977
This PR removes the redirect url when accessing /login or /login/