### PR TITLE
fix(Breadcrumbs): copy workspace from the breadcrumbs when dataset loading has errors

### DIFF
--- a/frontend/components/core/ReBreadcrumbs.vue
+++ b/frontend/components/core/ReBreadcrumbs.vue
@@ -35,7 +35,7 @@
         class="breadcrumbs__copy"
         href="#"
         @click.prevent="
-          copyToClipboard(breadcrumbs[breadcrumbs.length - 1].name)
+          copyToClipboard(filteredBreadcrumbs[filteredBreadcrumbs.length - 1].name)
         "
       >
         <svgicon name="copy" width="12" height="13" />


### PR DESCRIPTION
see #844
This PR allows copying the workspace from the breadcrumbs when the dataset has an error.