### PR TITLE
refactor: Rename 'exclude_missing_annotation' argument for WeakLabels.annotation

### DIFF
--- a/src/rubrix/labeling/text_classification/weak_labels.py
+++ b/src/rubrix/labeling/text_classification/weak_labels.py
@@ -279,9 +279,9 @@ class WeakLabels:
         """
         if exclude_missing_annotations is not None:
             warnings.warn(
-                "The 'exclude_missing_annotations' argument is deprecated and will be removed in the next minor release."
+                "'exclude_missing_annotations' is deprecated and will be removed in the next major release. "
                 "Please use the 'include_missing' argument.",
-                category=DeprecationWarning,
+                category=FutureWarning,
             )
             include_missing = not exclude_missing_annotations
 

--- a/src/rubrix/labeling/text_classification/weak_labels.py
+++ b/src/rubrix/labeling/text_classification/weak_labels.py
@@ -270,8 +270,8 @@ class WeakLabels:
         """Returns the annotation labels as an array of integers.
 
         Args:
-            include_missing: If True, returns an array of the length of the record list.
-                For this we will pad the array with the ``self.label2int[None]`` integer for records without an annotation.
+            include_missing: If True, returns an array of the length of the record list (``self.records()``).
+                For this we will fill the array with the ``self.label2int[None]`` integer for records without an annotation.
             exclude_missing_annotations: DEPRECATED
 
         Returns:

--- a/src/rubrix/labeling/text_classification/weak_labels.py
+++ b/src/rubrix/labeling/text_classification/weak_labels.py
@@ -12,6 +12,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import warnings
 from collections import Counter
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
@@ -261,17 +262,30 @@ class WeakLabels:
 
         return self._records
 
-    def annotation(self, exclude_missing_annotations: bool = True) -> np.ndarray:
+    def annotation(
+        self,
+        include_missing: bool = False,
+        exclude_missing_annotations: Optional[bool] = None,
+    ) -> np.ndarray:
         """Returns the annotation labels as an array of integers.
 
         Args:
-            exclude_missing_annotations: If True, excludes all entries with the ``self.label2int[None]`` integer,
-                that is all records for which there is an annotation missing.
+            include_missing: If True, returns an array of the length of the record list.
+                For this we will pad the array with the ``self.label2int[None]`` integer for records without an annotation.
+            exclude_missing_annotations: DEPRECATED
 
         Returns:
             The annotation array of integers.
         """
-        if not exclude_missing_annotations:
+        if exclude_missing_annotations is not None:
+            warnings.warn(
+                "The 'exclude_missing_annotations' argument is deprecated and will be removed in the next minor release."
+                "Please use the 'include_missing' argument.",
+                category=DeprecationWarning,
+            )
+            include_missing = not exclude_missing_annotations
+
+        if include_missing:
             return self._annotation_array
 
         return self._annotation_array[self._annotation_array != self._label2int[None]]

--- a/tests/labeling/text_classification/test_weak_labels.py
+++ b/tests/labeling/text_classification/test_weak_labels.py
@@ -241,6 +241,10 @@ def test_rules_matrix_records_annotation(monkeypatch):
         weak_labels.annotation(include_missing=True)
         == np.array([[-1, 0]], dtype=np.short)
     ).all()
+    with pytest.warns(
+        FutureWarning, match="'exclude_missing_annotations' is deprecated"
+    ):
+        weak_labels.annotation(exclude_missing_annotations=True)
 
 
 def test_summary(monkeypatch, rules):

--- a/tests/labeling/text_classification/test_weak_labels.py
+++ b/tests/labeling/text_classification/test_weak_labels.py
@@ -238,7 +238,7 @@ def test_rules_matrix_records_annotation(monkeypatch):
     ).all()
     assert (weak_labels.annotation() == np.array([[0]], dtype=np.short)).all()
     assert (
-        weak_labels.annotation(exclude_missing_annotations=False)
+        weak_labels.annotation(include_missing=True)
         == np.array([[-1, 0]], dtype=np.short)
     ).all()
 
@@ -398,7 +398,7 @@ def test_change_mapping(monkeypatch, rules):
         )
     ).all()
     assert (
-        weak_labels.annotation(exclude_missing_annotations=False)
+        weak_labels.annotation(include_missing=True)
         == np.array([2, 10, -10, 1, 2], dtype=np.short)
     ).all()
     assert weak_labels.label2int == new_mapping


### PR DESCRIPTION
This PR contains a renaming of the 'exclude_missin_annotation' arg to 'include_missing'. Default behavior stays the same.
This renaming is more adequate and improves consistency within the labeling module, where we normally have `include_*` arguments.