### PR TITLE
fix(statics): handle 404 errors for static files

### DIFF
--- a/src/rubrix/server/commons/static_rewrite.py
+++ b/src/rubrix/server/commons/static_rewrite.py
@@ -12,8 +12,10 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from typing import Union
 
 from fastapi.staticfiles import StaticFiles
+from starlette.exceptions import HTTPException
 from starlette.responses import Response
 from starlette.types import Scope
 
@@ -22,7 +24,17 @@ class RewriteStaticFiles(StaticFiles):
     """Simple server rewrite implementation for SPI apps"""
 
     async def get_response(self, path: str, scope: Scope) -> Response:
-        response = await super().get_response(path, scope)
-        if self.html and response.status_code == 404:
-            response = await super().get_response(path="", scope=scope)
-        return response
+        try:
+            response = await super().get_response(path, scope)
+            return await self._handle_response(response, scope)
+        except HTTPException as ex:
+            return await self._handle_response(ex, scope)
+
+    async def _handle_response(
+        self, response_or_error: Union[Response, HTTPException], scope
+    ):
+        if self.html and (response_or_error.status_code == 404):
+            return await super().get_response(path="", scope=scope)
+        if isinstance(response_or_error, HTTPException):
+            raise response_or_error
+        return response_or_error


### PR DESCRIPTION
This PR allows refresh pages in rubrix app, since the default behaviour is a 404 response message.

The `starlette.get_response` behind has changed since some release and now, we must catch `HTTPException` too.

This fix will allow open datasets in another tab, for example. 