### PR TITLE
fix(#1002): Show 0 records overall metrics when no rules defined

### DIFF
--- a/frontend/components/text-classifier/labeling-rules/RulesMetrics.vue
+++ b/frontend/components/text-classifier/labeling-rules/RulesMetrics.vue
@@ -115,7 +115,7 @@ export default {
             )} <span class="records-number">(${this.$options.filters.formatNumber(
               Math.round(
                 this.metricsTotal.coverage * this.dataset.globalResults.total
-              )
+              ) || 0
             )} records)</span>`,
           },
           rule: {
@@ -134,7 +134,7 @@ export default {
               Math.round(
                 this.metricsTotal.coverage_annotated *
                   this.dataset.globalResults.total
-              )
+              ) || 0
             )} records)</span>`,
           },
           rule: {


### PR DESCRIPTION
fix #1002
This PR fixes "NaN records" in metrics when no rules in Rules Summary