### PR TITLE
chore(#994): simplify server start

### DIFF
--- a/docs/getting_started/setup&installation.rst
+++ b/docs/getting_started/setup&installation.rst
@@ -84,12 +84,29 @@ This method may be preferred if you
 
 .. code-block::
 
-   python -m rubrix.server
+   python -m rubrix
 
 By default, the Rubrix server will look for your Elasticsearch endpoint at ``http://localhost:9200``.
 But you can customize this by setting the ``ELASTICSEARCH`` environment variable.
 
 **If you are already running an Elasticsearch instance for other applications and want to share it with Rubrix**, please refer to our :ref:`advanced setup guide <configure-elasticsearch-role-users>`.
+
+Uvicorn
+"""""""
+
+Since, rubrix server is built using fastapi, you can launch rubrix server using **uvicorn** ASGI server:
+
+.. code-block::
+
+   uvicorn rubrix:app
+
+*(for older rubrix version you should launch as)*
+
+.. code-block::
+
+   uvicorn rubrix.server.server:app
+
+See more details `here <https://fastapi.tiangolo.com/deployment/manually/#run-a-server-manually-uvicorn>`_
 
 3. Start logging data
 ---------------------

--- a/docs/getting_started/setup&installation.rst
+++ b/docs/getting_started/setup&installation.rst
@@ -94,7 +94,7 @@ But you can customize this by setting the ``ELASTICSEARCH`` environment variable
 Uvicorn
 """""""
 
-Since, rubrix server is built using fastapi, you can launch rubrix server using **uvicorn** ASGI server:
+Since the Rubrix server is built on fastapi, you can launch it using **uvicorn**:
 
 .. code-block::
 

--- a/src/rubrix/__init__.py
+++ b/src/rubrix/__init__.py
@@ -38,13 +38,29 @@ from rubrix.client.models import (
 )
 from rubrix.monitoring.model_monitor import monitor
 
+_LOGGER = logging.getLogger(__name__)
+
 try:
     __version__ = pkg_resources.get_distribution(__name__).version
 except pkg_resources.DistributionNotFound:
     # package is not installed
     pass
 
-_LOGGER = logging.getLogger(__name__)
+try:
+    from rubrix.server.server import app
+except ModuleNotFoundError as ex:
+    module_name = ex.name
+
+    def fallback_app(*args, **kwargs):
+        raise RuntimeError(
+            "\n"
+            f"Cannot start rubrix server. Some dependencies was not found:[{module_name}].\n"
+            "Please, install missing modules or reinstall rubrix with server extra deps:\n"
+            "pip install rubrix[server]"
+        )
+
+    app = fallback_app
+
 
 _client: Optional[
     RubrixClient

--- a/src/rubrix/__main__.py
+++ b/src/rubrix/__main__.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     import uvicorn
 
     uvicorn.run(
-        "rubrix.server.server:app",
+        "rubrix:app",
         port=6900,
         host="0.0.0.0",
         access_log=True,

--- a/src/rubrix/server/__main__.py
+++ b/src/rubrix/server/__main__.py
@@ -1,0 +1,24 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(
+        "rubrix.server.server:app",
+        port=6900,
+        host="0.0.0.0",
+        access_log=True,
+    )

--- a/src/rubrix/server/__main__.py
+++ b/src/rubrix/server/__main__.py
@@ -12,9 +12,16 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import warnings
 
 if __name__ == "__main__":
     import uvicorn
+
+    warnings.warn(
+        "\n'python -m rubrix.server' command is deprecated and will be removed in the next major release. "
+        "\nPlease use 'python -m rubrix' instead",
+        category=FutureWarning,
+    )
 
     uvicorn.run(
         "rubrix.server.server:app",


### PR DESCRIPTION
This PR changes how to launch rubrix server to:

```bash
python -m rubrix
```

The old command (`python -m rubrix.server`) is also available 

Also, include setup info about uvicorn setup. Basically, you can launch rubrix server using uvicorn:

```bash
uvicorn rubrix:app
```

