### PR TITLE
feat(#945): change es analyzers using environment variables

### DIFF
--- a/docs/getting_started/advanced_setup_guides.rst
+++ b/docs/getting_started/advanced_setup_guides.rst
@@ -73,13 +73,13 @@ Below you can see a screenshot for setting up a new *rubrix* Role and its permis
 Change elasticsearch index analyzers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-As default, for index text fields, rubrix use the `standard` analyzer and the `whitespace` for accurate
-text searches. If those analyzers does not feat your data, you can change by using the environment variables
+By default, for indexing text fields, Rubrix uses the `standard` analyzer for general search and the `whitespace` analyzer for more exact queries (required by certain rules in the weak supervision module).
+ If those analyzers don't fit your use case, you can change them using the following environment variables:
 `RUBRIX_DEFAULT_ES_SEARCH_ANALYZER` and `RUBRIX_EXACT_ES_SEARCH_ANALYZER`.
 
 Note that provided analyzers names should be defined as built-in ones. If you want to use a
-customized analyzer, you should create it inside an index_template matching the rubrix index names (`.rubrix*.records-v0),
-and then provide the analyzer name using the convenient environment variable.
+customized analyzer, you should create it inside an index_template matching Rubrix index names (`.rubrix*.records-v0),
+and then provide the analyzer name using the specific environment variable.
 
 
 Deploy to aws instance using docker-machine

--- a/docs/getting_started/advanced_setup_guides.rst
+++ b/docs/getting_started/advanced_setup_guides.rst
@@ -57,9 +57,9 @@ All you need to take into account is:
 
 * Rubrix creates an index template for these indices, so you may provide related template privileges to this ES role.
 
-Rubrix uses the ``ELASTICSEARCH`` environment variable to set the ES connection. 
+Rubrix uses the ``ELASTICSEARCH`` environment variable to set the ES connection.
 
-You can provide the credentials using the following scheme: 
+You can provide the credentials using the following scheme:
 
 .. code-block:: bash
 
@@ -68,6 +68,18 @@ You can provide the credentials using the following scheme:
 Below you can see a screenshot for setting up a new *rubrix* Role and its permissions:
 
 :raw-html-m2r:`<img src="https://user-images.githubusercontent.com/2518789/142883104-f4f20cf0-34a0-47ff-8ee3-ab9f4644271c.png"/>`
+
+
+Change elasticsearch index analyzers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As default, for index text fields, rubrix use the `standard` analyzer and the `whitespace` for accurate
+text searches. If those analyzers does not feat your data, you can change by using the environment variables
+`RUBRIX_DEFAULT_ES_SEARCH_ANALYZER` and `RUBRIX_EXACT_ES_SEARCH_ANALYZER`.
+
+Note that provided analyzers names should be defined as built-in ones. If you want to use a
+customized analyzer, you should create it inside an index_template matching the rubrix index names (`.rubrix*.records-v0),
+and then provide the analyzer name using the convenient environment variable.
 
 
 Deploy to aws instance using docker-machine

--- a/src/rubrix/server/commons/settings.py
+++ b/src/rubrix/server/commons/settings.py
@@ -55,17 +55,22 @@ class ApiSettings(BaseSettings):
     __DATASETS_INDEX_NAME__ = ".rubrix<NAMESPACE>.datasets-v0"
     __DATASETS_RECORDS_INDEX_NAME__ = ".rubrix<NAMESPACE>.dataset.{}.records-v0"
 
-    only_bulk_api: bool = False
     elasticsearch: str = "http://localhost:9200"
     cors_origins: List[str] = ["*"]
 
     docs_enabled: bool = True
 
+    namespace: str = Field(default=None, regex=r"^[a-z]+$")
+
+    # Analyzer configuration
+    default_es_search_analyzer: str = "standard"
+    exact_es_search_analyzer: str = "whitespace"
+    # This line will be enabled once words field won't be used anymore
+    # wordcloud_es_search_analyzer: str = "multilingual_stop_analyzer"
+
     es_records_index_shards: int = 1
     es_records_index_replicas: int = 0
     disable_es_index_template_creation: bool = False
-
-    namespace: str = Field(default=None, regex=r"^[a-z]+$")
 
     metadata_fields_limit: int = Field(
         default=50, gt=0, le=100, description="Max number of fields in metadata"
@@ -92,6 +97,10 @@ class ApiSettings(BaseSettings):
             "namespace": {
                 "env": "RUBRIX_NAMESPACE",
             },
+            "default_es_search_analyzer": {
+                "env": "RUBRIX_DEFAULT_ES_SEARCH_ANALYZER",
+            },
+            "exact_es_search_analyzer": {"env": "RUBRIX_EXACT_ES_SEARCH_ANALYZER"},
         }
 
 

--- a/src/rubrix/server/tasks/commons/dao/es_config.py
+++ b/src/rubrix/server/tasks/commons/dao/es_config.py
@@ -32,14 +32,24 @@ class mappings:
     @staticmethod
     def words_text_field():
         """Mappings config for old `word` field. Deprecated"""
+
+        default_analyzer = settings.default_es_search_analyzer
+        exact_analyzer = settings.exact_es_search_analyzer
+
+        if default_analyzer == "standard":
+            default_analyzer = MULTILINGUAL_STOP_ANALYZER_REF
+
+        if exact_analyzer == "whitespace":
+            exact_analyzer = EXTENDED_ANALYZER_REF
+
         return {
             "type": "text",
             "fielddata": True,
-            "analyzer": MULTILINGUAL_STOP_ANALYZER_REF,
+            "analyzer": default_analyzer,
             "fields": {
                 "extended": {
                     "type": "text",
-                    "analyzer": EXTENDED_ANALYZER_REF,
+                    "analyzer": exact_analyzer,
                 }
             },
         }
@@ -47,11 +57,14 @@ class mappings:
     @staticmethod
     def text_field():
         """Mappings config for textual field"""
+        default_analyzer = settings.default_es_search_analyzer
+        exact_analyzer = settings.exact_es_search_analyzer
+
         return {
             "type": "text",
-            "analyzer": "standard",
+            "analyzer": default_analyzer,
             "fields": {
-                "exact": {"type": "text", "analyzer": "whitespace"},
+                "exact": {"type": "text", "analyzer": exact_analyzer},
                 "wordcloud": {
                     "type": "text",
                     "analyzer": MULTILINGUAL_STOP_ANALYZER_REF,


### PR DESCRIPTION
Since rubrix stops using index template for dataset records index creation (See #1018), there is no way to customize the text fields analyzer.

This PR includes a basic mechanism to change the es analyzers. In the future, this parameters could be as part of dataset settings when creating a new dataset.