### PR TITLE
fix(#1008): set the event_timestamp when annotating TextClassifier

### DIFF
--- a/frontend/models/Common.js
+++ b/frontend/models/Common.js
@@ -22,8 +22,8 @@ class BaseRecord {
   annotation;
   predicted;
   status;
-
   selected;
+  event_timestamp;
 
   constructor({
     id,
@@ -33,6 +33,7 @@ class BaseRecord {
     predicted,
     status,
     selected,
+    event_timestamp,
   }) {
     this.id = id;
     this.metadata = metadata;
@@ -41,6 +42,7 @@ class BaseRecord {
     this.predicted = predicted;
     this.status = status;
     this.selected = selected || false;
+    this.event_timestamp = event_timestamp;
   }
 
   recordTitle() {

--- a/frontend/models/TextClassification.js
+++ b/frontend/models/TextClassification.js
@@ -26,13 +26,11 @@ class TextClassificationRecord extends BaseRecord {
     explanation,
     multi_label,
     predicted_as,
-    event_timestamp,
     ...superData
   }) {
     super(superData);
     this.inputs = inputs;
     this.explanation = explanation;
-    this.event_timestamp = event_timestamp,
     this.multi_label = multi_label;
     this.predicted_as = predicted_as;
   }

--- a/frontend/models/TextClassification.js
+++ b/frontend/models/TextClassification.js
@@ -26,11 +26,13 @@ class TextClassificationRecord extends BaseRecord {
     explanation,
     multi_label,
     predicted_as,
+    event_timestamp,
     ...superData
   }) {
     super(superData);
     this.inputs = inputs;
     this.explanation = explanation;
+    this.event_timestamp = event_timestamp,
     this.multi_label = multi_label;
     this.predicted_as = predicted_as;
   }


### PR DESCRIPTION
fix #1008