### PR TITLE
Fix(#1027): Improve client models by reordering fields + forbidding extra args

### DIFF
--- a/src/rubrix/client/models.py
+++ b/src/rubrix/client/models.py
@@ -74,6 +74,9 @@ class _RootValidators(BaseModel):
 
         return values
 
+    class Config:
+        extra = "forbid"
+
 
 class BulkResponse(BaseModel):
     """Summary response when logging records to the Rubrix server.
@@ -229,7 +232,7 @@ class TokenClassificationRecord(_RootValidators):
     metrics: Optional[Dict[str, Any]] = None
 
 
-class Text2TextRecord(BaseRecord):
+class Text2TextRecord(_RootValidators):
     """Record for a text to text task
 
     Args:

--- a/tests/client/test_models.py
+++ b/tests/client/test_models.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import json
+from typing import Any, Optional
 
 import numpy
 import pytest
@@ -20,10 +21,10 @@ from pydantic import ValidationError
 
 from rubrix._constants import MAX_KEYWORD_LENGTH
 from rubrix.client.models import (
-    BaseRecord,
     Text2TextRecord,
     TextClassificationRecord,
     TokenClassificationRecord,
+    _RootValidators,
 )
 
 
@@ -99,11 +100,32 @@ def test_model_serialization_with_numpy_nan():
 
 
 def test_warning_when_only_agent():
+    class MockRecord(_RootValidators):
+        prediction: Optional[Any] = None
+        prediction_agent: Optional[str] = None
+        annotation: Optional[Any] = None
+        annotation_agent: Optional[str] = None
+        metadata: Optional[Any] = None
+        status: Optional[str] = None
+
     with pytest.warns(
         UserWarning, match="`prediction_agent` will not be logged to the server."
     ):
-        BaseRecord(prediction_agent="mock")
+        MockRecord(prediction_agent="mock")
     with pytest.warns(
         UserWarning, match="`annotation_agent` will not be logged to the server."
     ):
-        BaseRecord(annotation_agent="mock")
+        MockRecord(annotation_agent="mock")
+
+
+def test_forbid_extra():
+    class MockRecord(_RootValidators):
+        prediction: Optional[Any] = None
+        prediction_agent: Optional[str] = None
+        annotation: Optional[Any] = None
+        annotation_agent: Optional[str] = None
+        metadata: Optional[Any] = None
+        status: Optional[str] = None
+
+    with pytest.raises(ValidationError):
+        MockRecord(extra="mock")


### PR DESCRIPTION
Closes #1027 

With this PR the client models raise an error when extra arguments are provided. The error message is not the clearest though, but i did not find a way to modify this. @frascuchon Do you know how to customize validation error messages in pydantic?

It also fixes the order of the fields in the models. This is important when converting the records into a DataFrame/Dataset, so that when displaying a DataFrame the order of the columns is more or less meaningful.