### PR TITLE
refactor(#924): better client error management

### DIFF
--- a/src/rubrix/client/rubrix_client.py
+++ b/src/rubrix/client/rubrix_client.py
@@ -33,6 +33,7 @@ from rubrix.client.models import (
     TokenClassificationRecord,
 )
 from rubrix.client.sdk.client import AuthenticatedClient
+from rubrix.client.sdk.commons.errors import RubrixClientError
 from rubrix.client.sdk.commons.models import Response
 from rubrix.client.sdk.datasets.api import copy_dataset, delete_dataset, get_dataset
 from rubrix.client.sdk.datasets.models import CopyDatasetRequest, TaskType
@@ -67,6 +68,10 @@ from rubrix.client.sdk.token_classification.models import (
 )
 from rubrix.client.sdk.users.api import whoami
 from rubrix.client.sdk.users.models import User
+
+
+class InputValueError(RubrixClientError):
+    pass
 
 
 class RubrixClient:
@@ -168,7 +173,7 @@ class RubrixClient:
         """
 
         if not name:
-            raise Exception("Empty project name has been passed as argument.")
+            raise InputValueError("Empty project name has been passed as argument.")
 
         if isinstance(records, Record.__args__):
             records = [records]
@@ -180,7 +185,7 @@ class RubrixClient:
         try:
             record_type = type(records[0])
         except IndexError:
-            raise Exception("Empty record list has been passed as argument.")
+            raise InputValueError("Empty record list has been passed as argument.")
 
         # Check chunk_size <= length of training dataset not needed, as the Python slice system will adjust
         # a bigger-than-possible length to the whole list, having all input in the same chunk.
@@ -210,7 +215,7 @@ class RubrixClient:
 
         # Record type is not recognised
         else:
-            raise Exception(
+            raise InputValueError(
                 f"Unknown record type passed as argument for [{','.join(map(str, records[0:5]))}...] "
                 f"Available values are {Record.__args__}"
             )

--- a/src/rubrix/client/sdk/commons/errors.py
+++ b/src/rubrix/client/sdk/commons/errors.py
@@ -1,0 +1,45 @@
+class RubrixClientError(Exception):
+    pass
+
+
+class RubrixApiResponseError(RubrixClientError):
+
+    HTTP_STATUS: int
+
+    def __init__(self, **ctx):
+        self.ctx = ctx
+
+    def __str__(self):
+        return (
+            f"Rubrix server returned an error with http status: {self.HTTP_STATUS}"
+            f"\nError details: [{self.ctx}]"
+        )
+
+
+class NotFoundApiError(RubrixApiResponseError):
+    HTTP_STATUS = 404
+
+
+class ValidationApiError(RubrixApiResponseError):
+    HTTP_STATUS = 422
+    # TODO: Here we can process response and make human readable
+
+
+class BadRequestApiError(RubrixApiResponseError):
+    HTTP_STATUS = 400
+
+
+class UnauthorizedApiError(RubrixApiResponseError):
+    HTTP_STATUS = 401
+
+
+class ForbiddenApiError(RubrixApiResponseError):
+    HTTP_STATUS = 403
+
+
+class AlreadyExistsApiError(RubrixApiResponseError):
+    HTTP_STATUS = 409
+
+
+class GenericApiError(RubrixApiResponseError):
+    HTTP_STATUS = 500

--- a/src/rubrix/client/sdk/commons/errors_handler.py
+++ b/src/rubrix/client/sdk/commons/errors_handler.py
@@ -1,0 +1,36 @@
+from json import JSONDecodeError
+
+import httpx
+
+from rubrix.client.sdk.commons.errors import (
+    AlreadyExistsApiError,
+    BadRequestApiError,
+    ForbiddenApiError,
+    GenericApiError,
+    NotFoundApiError,
+    UnauthorizedApiError,
+    ValidationApiError,
+)
+
+
+def handle_response_error(
+    response: httpx.Response, parse_response: bool = True, **extra_args
+):
+    try:
+        response_content = response.json() if parse_response else {}
+    except JSONDecodeError:
+        response_content = {}
+
+    if response.status_code == BadRequestApiError.HTTP_STATUS:
+        raise BadRequestApiError(**response_content, **extra_args)
+    if response.status_code == UnauthorizedApiError.HTTP_STATUS:
+        raise UnauthorizedApiError(**response_content, **extra_args)
+    if response.status_code == AlreadyExistsApiError.HTTP_STATUS:
+        raise AlreadyExistsApiError(**response_content, **extra_args)
+    if response.status_code == ForbiddenApiError.HTTP_STATUS:
+        raise ForbiddenApiError(**response_content, **extra_args)
+    if response.status_code == NotFoundApiError.HTTP_STATUS:
+        raise NotFoundApiError(**response_content, **extra_args)
+    if response.status_code == ValidationApiError.HTTP_STATUS:
+        raise ValidationApiError(**response_content, **extra_args)
+    raise GenericApiError(**response_content)

--- a/src/rubrix/client/sdk/text2text/api.py
+++ b/src/rubrix/client/sdk/text2text/api.py
@@ -46,7 +46,7 @@ def bulk(
         json=json_body.dict(by_alias=True),
     )
 
-    return build_bulk_response(response)
+    return build_bulk_response(response, dataset=name)
 
 
 def data(

--- a/src/rubrix/client/sdk/text_classification/api.py
+++ b/src/rubrix/client/sdk/text_classification/api.py
@@ -55,7 +55,7 @@ def bulk(
         json=json_body.dict(by_alias=True),
     )
 
-    return build_bulk_response(response)
+    return build_bulk_response(response, dataset=name)
 
 
 def data(
@@ -119,4 +119,6 @@ def dataset_rule_metrics(
         timeout=client.get_timeout(),
     )
 
-    return build_typed_response(response, response_type_class=LabelingRuleMetricsSummary)
+    return build_typed_response(
+        response, response_type_class=LabelingRuleMetricsSummary
+    )

--- a/src/rubrix/client/sdk/token_classification/api.py
+++ b/src/rubrix/client/sdk/token_classification/api.py
@@ -49,7 +49,7 @@ def bulk(
         json=json_body.dict(by_alias=True),
     )
 
-    return build_bulk_response(response)
+    return build_bulk_response(response, dataset=name)
 
 
 def data(

--- a/src/rubrix/client/sdk/users/api.py
+++ b/src/rubrix/client/sdk/users/api.py
@@ -1,27 +1,9 @@
 import httpx
 
 from rubrix.client.sdk.client import AuthenticatedClient
-from rubrix.client.sdk.commons.models import ErrorMessage, HTTPValidationError, Response
+from rubrix.client.sdk.commons.errors_handler import handle_response_error
+from rubrix.client.sdk.commons.models import Response
 from rubrix.client.sdk.users.models import User
-
-
-def _parse_response(response: httpx.Response):
-    parsed_response = None
-    if response.status_code == 200:
-        parsed_response = User(**response.json())
-    elif response.status_code == 404:
-        parsed_response = ErrorMessage(**response.json())
-    elif response.status_code == 500:
-        parsed_response = ErrorMessage(**response.json())
-    elif response.status_code == 422:
-        parsed_response = HTTPValidationError(**response.json())
-
-    return Response(
-        status_code=response.status_code,
-        content=response.content,
-        headers=response.headers,
-        parsed=parsed_response,
-    )
 
 
 def whoami(client: AuthenticatedClient):
@@ -34,4 +16,12 @@ def whoami(client: AuthenticatedClient):
         timeout=client.get_timeout(),
     )
 
-    return _parse_response(response)
+    if response.status_code == 200:
+        return Response(
+            status_code=response.status_code,
+            content=response.content,
+            headers=response.headers,
+            parsed=User(**response.json()),
+        )
+
+    return handle_response_error(response, msg="Invalid credentials")

--- a/tests/client/sdk/commons/api.py
+++ b/tests/client/sdk/commons/api.py
@@ -51,7 +51,7 @@ def test_build_bulk_response(status_code, expected):
     httpx_response = HttpxResponse(
         status_code=status_code, content=server_response.json()
     )
-    response = build_bulk_response(httpx_response)
+    response = build_bulk_response(httpx_response, dataset="mock-dataset")
 
     assert isinstance(response, Response)
     assert isinstance(response.parsed, expected)

--- a/tests/client/sdk/datasets/test_api.py
+++ b/tests/client/sdk/datasets/test_api.py
@@ -17,6 +17,11 @@ import pytest
 
 from rubrix._constants import DEFAULT_API_KEY
 from rubrix.client.sdk.client import AuthenticatedClient
+from rubrix.client.sdk.commons.errors import (
+    GenericApiError,
+    NotFoundApiError,
+    ValidationApiError,
+)
 from rubrix.client.sdk.commons.models import (
     ErrorMessage,
     HTTPValidationError,
@@ -55,29 +60,12 @@ def test_get_dataset(sdk_client, monkeypatch):
 @pytest.mark.parametrize(
     "status_code, expected",
     [
-        (200, Dataset),
-        (404, ErrorMessage),
-        (500, ErrorMessage),
-        (422, HTTPValidationError),
+        (404, NotFoundApiError),
+        (500, GenericApiError),
+        (422, ValidationApiError),
     ],
 )
 def test_build_response(status_code, expected):
-    server_response = None
-    if status_code == 200:
-        server_response = Dataset(name="test", task=TaskType.text_classification)
-    elif status_code == 404:
-        server_response = ErrorMessage(detail="test")
-    elif status_code == 500:
-        server_response = ErrorMessage(detail="test")
-    elif status_code == 422:
-        server_response = HTTPValidationError(
-            detail=[ValidationError(loc=["test"], msg="test", type="test")]
-        )
-
-    httpx_response = httpx.Response(
-        status_code=status_code, content=server_response.json()
-    )
-    response = _build_response(httpx_response)
-
-    assert isinstance(response, Response)
-    assert isinstance(response.parsed, expected)
+    httpx_response = httpx.Response(status_code=status_code, content="boo")
+    with pytest.raises(expected):
+        _build_response(httpx_response, name="mock-ds")

--- a/tests/functional_tests/test_log_for_text_classification.py
+++ b/tests/functional_tests/test_log_for_text_classification.py
@@ -2,6 +2,7 @@ import pytest
 
 import rubrix
 from rubrix import TextClassificationRecord, TokenClassificationRecord
+from rubrix.client.sdk.commons.errors import ValidationApiError
 from rubrix.server.commons.settings import settings
 from rubrix.server.tasks.commons import MetadataLimitExceededError
 from tests.server.test_helpers import client, mocking_client
@@ -26,10 +27,7 @@ def test_log_records_with_multi_and_single_label_task(monkeypatch):
         ),
     ]
 
-    with pytest.raises(
-        Exception,
-        match="msg='All records must be single/multi labelled'",
-    ):
+    with pytest.raises(ValidationApiError):
         rubrix.log(
             records,
             name=dataset,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -23,6 +23,7 @@ import pytest
 import rubrix
 from rubrix.client import RubrixClient
 from rubrix.client.sdk.client import AuthenticatedClient
+from rubrix.client.sdk.commons.errors import UnauthorizedApiError
 
 
 @pytest.fixture
@@ -196,7 +197,7 @@ def test_init_token_auth_fail(mock_response_token_401):
         Mocked correct http response
     """
     rubrix._client = None  # assert empty client
-    with pytest.raises(Exception, match="Authentication error: invalid credentials."):
+    with pytest.raises(UnauthorizedApiError):
         rubrix.init(api_url="fake_url", api_key="422")
 
 


### PR DESCRIPTION
This PR changes how client handles incoming API errors.

The idea is to contextualize incoming errors by defining a client error hierarchy, including an operation context giving more details about inputs that raised the error.

Not totally cover solution discussed in #924 but it will help to understand the api error reason. Even more in combination with changes in #1031