### PR TITLE
feat(#422): add possibility to load datasets as a `datasets.Dataset`

### DIFF
--- a/src/rubrix/client/rubrix_client.py
+++ b/src/rubrix/client/rubrix_client.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, Iterable, List, Optional, Union
 
 import httpx
 import pandas
+from packaging.version import parse as parse_version
 from tqdm.auto import tqdm
 
 from rubrix._constants import RUBRIX_WORKSPACE_HEADER_NAME
@@ -490,6 +491,11 @@ class _DatasetsFormatter:
             raise ModuleNotFoundError(
                 "'datasets' must be installed to use the `datasets` format! "
                 "You can install 'datasets' with the command: `pip install datasets>1.17.0`"
+            )
+        if not (parse_version(datasets.__version__) > parse_version("1.17.0")):
+            raise ImportError(
+                "Version >1.17.0 of 'datasets' must be installed to use the `datasets` format! "
+                "You can update 'datasets' with the command: `pip install -U datasets>1.17.0`"
             )
 
     def to_dataset(self, records: List[Record]) -> "datasets.Dataset":

--- a/src/rubrix/client/rubrix_client.py
+++ b/src/rubrix/client/rubrix_client.py
@@ -441,3 +441,89 @@ def _check_response_errors(response: Response) -> None:
             "Connection error: API is not responding. "
             "The API answered with a {} code: {}".format(http_status, response_data)
         )
+
+    def _records_to_dataset(self, records: List[Record]) -> "datasets.Dataset":
+        """Helper method to turn records into a `datasets.Dataset`"""
+        try:
+            import datasets
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                "'datasets' must be installed to use the `datasets` format! "
+                "You can install 'datasets' with the command: `pip install datasets>1.17.0`"
+            )
+
+        if isinstance(records[0], TextClassificationRecord):
+            return self._textclassification_to_dataset(records)
+        if isinstance(records[0], TokenClassificationRecord):
+            raise NotImplementedError
+        if isinstance(records[0], Text2TextRecord):
+            raise NotImplementedError
+
+    def _textclassification_to_dataset(records: List[Record]) -> "datasets.Dataset":
+        """Transform a list of `TextClassificationRecord`s into a `datasets.Dataset`"""
+        from datasets import ClassLabel, Dataset, Sequence, Value
+
+        dataset = Dataset.from_dict(
+            {
+                "inputs": [rec.inputs for rec in records],
+                "prediction": [
+                    [{"label": pred[0], "score": pred[1]} for pred in rec.prediction]
+                    if rec.prediction is not None
+                    else None
+                    for rec in records
+                ],
+                "prediction_agent": [rec.prediction_agent for rec in records],
+                "annotation": [rec.annotation for rec in records],
+                "annotation_agent": [rec.annotation_agent for rec in records],
+                "multi_label": [rec.multi_label for rec in records],
+                "ids": [rec.id for rec in records],
+                "metadata": [rec.metadata for rec in records],
+                "status": [rec.status for rec in records],
+                "event_timestamp": [rec.event_timestamp for rec in records],
+                "metrics": [rec.metrics for rec in records],
+                "explanation": [
+                    {
+                        key: list(map(dict, tokattr) for tokattr in tokattrs)
+                        for key, tokattrs in rec.explanation.items()
+                    }
+                    if rec.explanation is not None
+                    else None
+                    for rec in records
+                ],
+            }
+        )
+
+        # first the prediction labels, then the annotation labels, then remove None
+        labels = set(
+            [
+                pred["label"]
+                for preds in dataset["prediction"]
+                for pred in preds
+                if preds is not None
+            ]
+        ).union(
+            set(
+                [
+                    annot
+                    for annots in dataset["annotation"]
+                    for annot in annots
+                    if annots is not None
+                ]
+                if dataset["multi_label"][0]
+                else dataset["annotation"]
+            )
+        ) - set(
+            [None]
+        )
+
+        class_label = ClassLabel(names=sorted(list(labels)))
+
+        feature = [{"label": class_label, "score": Value("float64")}]
+        dataset.cast_column("prediction", feature=feature)
+
+        feature = (
+            Sequence(feature=class_label) if dataset["multi_label"][0] else class_label
+        )
+        dataset.cast_column("annotation", feature=feature)
+
+        return dataset

--- a/src/rubrix/client/rubrix_client.py
+++ b/src/rubrix/client/rubrix_client.py
@@ -17,6 +17,7 @@
 
 import logging
 import socket
+import warnings
 from enum import Enum
 from typing import Any, Dict, Iterable, List, Optional, Union
 
@@ -286,6 +287,17 @@ class RubrixClient:
         Returns:
             The dataset in a format defined by the `format` argument.
         """
+        if as_pandas is not None:
+            warnings.warn(
+                "'as_pandas' is deprecated and will be removed in the next major release. "
+                "Please use the 'format' argument.",
+                category=FutureWarning,
+            )
+            if as_pandas is True:
+                format = DatasetFormat("pandas")
+            elif as_pandas is False:
+                format = DatasetFormat("rubrix")
+
         if isinstance(format, str):
             format = DatasetFormat(format)
 

--- a/tests/client/test_rubrix_client.py
+++ b/tests/client/test_rubrix_client.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 
 import datetime
+from curses import meta
 from time import sleep
 from typing import Iterable
 
@@ -22,7 +23,8 @@ import pandas
 import pytest
 
 import rubrix
-from rubrix import Text2TextRecord, TextClassificationRecord
+from rubrix import Text2TextRecord, TextClassificationRecord, TokenAttributions
+from rubrix.client.rubrix_client import _textclassification_to_dataset
 from rubrix.server.tasks.text_classification import TextClassificationSearchResults
 from tests.server.test_api import create_some_data_for_text_classification
 from tests.server.test_helpers import client, mocking_client
@@ -490,3 +492,31 @@ def test_load_sort(monkeypatch):
     assert list(df.id) == [1, 2, 11]
     df = rubrix.load(name=dataset, ids=["1str", "2str", "11str"])
     assert list(df.id) == ["11str", "1str", "2str"]
+
+
+def test_textclassification_to_dataset(monkeypatch):
+    records = [
+        TextClassificationRecord(
+            inputs={"text": "mock", "context": "mock"},
+            prediction=[("a", 0.5), ("b", 0.5)],
+            prediction_agent="mock_pagent",
+            annotation="a",
+            annotation_agent="mock_aagent",
+            multi_label=False,
+            id=1,
+            event_timestamp=datetime.datetime.now(),
+            metadata={"test": "test"},
+            explanation={
+                "text": [
+                    TokenAttributions(token="mock", attributions={"a": 0.1, "b": 0.5})
+                ]
+            },
+            status="Validated",
+            metrics={},
+        ),
+        TextClassificationRecord(inputs="test", metadata={"test": 1}),
+    ]
+
+    ds = _textclassification_to_dataset(records)
+    print(ds.features)
+    assert False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,152 @@
+import datetime
+from typing import List
+
+import pytest
+
+import rubrix as rb
+from rubrix.client.sdk.datasets.models import TaskType
+from rubrix.client.sdk.text_classification.models import (
+    CreationTextClassificationRecord,
+    TextClassificationBulkData,
+)
+from tests.server.test_helpers import client
+
+
+@pytest.fixture(scope="session")
+def singlelabel_textclassification_records(
+    request,
+) -> List[rb.TextClassificationRecord]:
+    return [
+        rb.TextClassificationRecord(
+            inputs={"text": "mock", "context": "mock"},
+            prediction=[("a", 0.5), ("b", 0.5)],
+            prediction_agent="mock_pagent",
+            annotation="a",
+            annotation_agent="mock_aagent",
+            id="one",
+            event_timestamp=datetime.datetime(2000, 1, 1),
+            metadata={"mock_metadata": "mock"},
+            explanation={
+                "text": [
+                    rb.TokenAttributions(
+                        token="mock", attributions={"a": 0.1, "b": 0.5}
+                    )
+                ]
+            },
+            status="Validated",
+            metrics={},
+        ),
+        rb.TextClassificationRecord(
+            inputs={"text": "mock2", "context": "mock2"},
+            prediction=[("a", 0.5), ("b", 0.2)],
+            prediction_agent="mock2_pagent",
+            id="two",
+            event_timestamp=datetime.datetime(2000, 2, 1),
+            metadata={"mock2_metadata": "mock2"},
+            explanation={
+                "text": [
+                    rb.TokenAttributions(
+                        token="mock2", attributions={"a": 0.7, "b": 0.2}
+                    )
+                ]
+            },
+            status="Default",
+            metrics={},
+        ),
+    ]
+
+
+@pytest.fixture(scope="session")
+def log_singlelabel_textclassification_records(
+    request,
+    singlelabel_textclassification_records,
+) -> str:
+    dataset_name = "singlelabel_textclassification_records"
+    client.delete(f"/api/datasets/{dataset_name}")
+
+    client.post(
+        f"/api/datasets/{dataset_name}/{TaskType.text_classification}:bulk",
+        json=TextClassificationBulkData(
+            tags={
+                "env": "test",
+                "task": TaskType.text_classification,
+                "multi_label": False,
+            },
+            records=[
+                CreationTextClassificationRecord.from_client(rec)
+                for rec in singlelabel_textclassification_records
+            ],
+        ).dict(by_alias=True),
+    )
+
+    return dataset_name
+
+
+@pytest.fixture(scope="session")
+def multilabel_textclassification_records(request) -> List[rb.TextClassificationRecord]:
+    return [
+        rb.TextClassificationRecord(
+            inputs={"text": "mock", "context": "mock"},
+            prediction=[("a", 0.6), ("b", 0.4)],
+            prediction_agent="mock_pagent",
+            annotation=["a", "b"],
+            annotation_agent="mock_aagent",
+            multi_label=True,
+            id="one",
+            event_timestamp=datetime.datetime(2000, 1, 1),
+            metadata={"mock_metadata": "mock"},
+            explanation={
+                "text": [
+                    rb.TokenAttributions(
+                        token="mock", attributions={"a": 0.1, "b": 0.5}
+                    )
+                ]
+            },
+            status="Validated",
+            metrics={},
+        ),
+        rb.TextClassificationRecord(
+            inputs={"text": "mock2", "context": "mock2"},
+            prediction=[("a", 0.5), ("b", 0.2)],
+            prediction_agent="mock2_pagent",
+            multi_label=True,
+            id="two",
+            event_timestamp=datetime.datetime(2000, 2, 1),
+            metadata={"mock2_metadata": "mock2"},
+            explanation={
+                "text": [
+                    rb.TokenAttributions(
+                        token="mock2", attributions={"a": 0.7, "b": 0.2}
+                    )
+                ]
+            },
+            status="Default",
+            metrics={},
+        ),
+    ]
+
+
+@pytest.fixture(scope="session")
+def log_multilabel_textclassification_records(
+    request,
+    multilabel_textclassification_records,
+) -> str:
+    dataset_name = "multilabel_textclassification_records"
+    client.delete(f"/api/datasets/{dataset_name}")
+
+    client.post(
+        f"/api/datasets/{dataset_name}/{TaskType.text_classification}:bulk",
+        json=TextClassificationBulkData(
+            tags={
+                "env": "test",
+                "task": TaskType.text_classification,
+                "multi_label": True,
+            },
+            records=[
+                CreationTextClassificationRecord.from_client(rec)
+                for rec in multilabel_textclassification_records
+            ],
+        ).dict(by_alias=True),
+    )
+
+    return dataset_name


### PR DESCRIPTION
Closes #422 

Adds a new `format` argument to the `rb.load` method. `format` can be one of `pandas`, `rubrix`, or `datasets`, and defines the output format/type of the returned dataset.  