### PR TITLE
feat(#1036): remove prediction ok/ko in labelling rules

### DIFF
--- a/frontend/components/text-classifier/results/RecordTextClassification.vue
+++ b/frontend/components/text-classifier/results/RecordTextClassification.vue
@@ -47,7 +47,7 @@
     <div v-if="!annotationEnabled" class="record__labels">
       <template v-if="record.annotation">
         <svgicon
-          v-if="record.predicted"
+          v-if="record.predicted && !labellingRulesView"
           :class="['icon__predicted', record.predicted]"
           width="20"
           height="20"
@@ -86,6 +86,9 @@ export default {
   computed: {
     annotationEnabled() {
       return this.dataset.viewSettings.viewMode === "annotate";
+    },
+    labellingRulesView() {
+      return this.dataset.viewSettings.viewMode === "labelling-rules";
     },
     allowValidate() {
       const isBinary =


### PR DESCRIPTION
closes #1036
This PR removes prediction ok/ko info from records in labelling rules