### PR TITLE
feat(#982): Show filters in labelling rules view

### DIFF
--- a/frontend/components/commons/TaskSearch.vue
+++ b/frontend/components/commons/TaskSearch.vue
@@ -37,23 +37,12 @@ export default {
     annotationEnabled() {
       return this.dataset.viewSettings.viewMode === "annotate";
     },
-    currentViewMode() {
-      return this.dataset.viewSettings.viewMode;
-    },
     workspace() {
       return currentWorkspace(this.$route);
     },
   },
-  watch: {
-    async currentViewMode(n) {
-      if (n === "labelling-rules") {
-        await this.resetSearch({ dataset: this.dataset });
-      }
-    },
-  },
   methods: {
     ...mapActions({
-      resetSearch: "entities/datasets/resetSearch",
       fetchDataset: "entities/datasets/fetchByName",
     }),
   },

--- a/frontend/components/commons/header/filters/FiltersArea.vue
+++ b/frontend/components/commons/header/filters/FiltersArea.vue
@@ -21,13 +21,11 @@
       <div class="container">
         <div class="filters__row">
           <SearchBar
-            :expand-searchbar="expandSearchbar"
             class="filters__searchbar"
             :dataset="dataset"
             @submit="onTextQuerySearch"
           />
           <FiltersList
-            v-if="!expandSearchbar"
             :dataset="dataset"
             @applyFilter="onApplyFilter"
             @applyMetaFilter="onApplyMetaFilter"
@@ -50,10 +48,6 @@ export default {
     dataset: {
       type: Object,
       default: () => ({}),
-    },
-    expandSearchbar: {
-      type: Boolean,
-      default: false,
     },
   },
   data: () => ({
@@ -125,6 +119,13 @@ export default {
   padding-top: 0;
   padding-bottom: 0;
   margin-left: 0;
+  padding-right: calc(4em + 45px);
+  .--metrics & {
+    @include media(">desktop") {
+      padding-right: calc(294px + 100px);
+      transition: padding 0.1s ease-in-out;
+    }
+  }
   &--intro {
     padding-top: 2em;
     margin-bottom: 1.5em;
@@ -156,13 +157,14 @@ export default {
   &__content {
     padding: 1em 0;
     position: relative;
-    padding-right: 45px;
     .fixed-header & {
       padding: 0.5em 45px 0.5em 0;
     }
   }
   &__searchbar {
     margin-right: 2em;
+    width: 100%;
+    max-width: 450px;
     &.--extended {
       width: 100%;
       margin-right: 0;

--- a/frontend/components/commons/header/filters/FiltersList.vue
+++ b/frontend/components/commons/header/filters/FiltersList.vue
@@ -298,6 +298,7 @@ $number-size: 18px;
     }
     &__item {
       position: relative;
+      flex-shrink: 0;
     }
     &__sort {
       svg {
@@ -323,6 +324,7 @@ $number-size: 18px;
       color: $font-secondary;
       @include font-size(15px);
       font-family: $sff;
+      white-space: nowrap;
       &:hover {
         background: palette(grey, smooth);
       }

--- a/frontend/components/commons/header/filters/HeaderTitle.vue
+++ b/frontend/components/commons/header/filters/HeaderTitle.vue
@@ -18,7 +18,7 @@
 <template>
   <div class="container">
     <h2 class="title">
-      {{ title }} records ({{ dataset.results.total | formatNumber }})
+      Records <template v-if="filtersApplied.length">with filters applied</template> ({{ dataset.results.total | formatNumber }})
     </h2>
   </div>
 </template>
@@ -35,6 +35,11 @@ export default {
       required: true,
     },
   },
+  computed: {
+    filtersApplied() {
+      return Object.values(this.dataset.query).filter(v => v && Object.values(v).length);
+    }
+  }
 };
 </script>
 <style lang="scss" scoped>

--- a/frontend/components/commons/header/filters/HeaderTitle.vue
+++ b/frontend/components/commons/header/filters/HeaderTitle.vue
@@ -18,7 +18,10 @@
 <template>
   <div class="container">
     <h2 class="title">
-      Records <template v-if="filtersApplied.length">with filters applied</template> ({{ dataset.results.total | formatNumber }})
+      Records
+      <template v-if="filtersApplied.length">with filters applied</template> ({{
+        dataset.results.total | formatNumber
+      }})
     </h2>
   </div>
 </template>
@@ -37,9 +40,11 @@ export default {
   },
   computed: {
     filtersApplied() {
-      return Object.values(this.dataset.query).filter(v => v && Object.values(v).length);
-    }
-  }
+      return Object.values(this.dataset.query).filter(
+        (v) => v && Object.values(v).length
+      );
+    },
+  },
 };
 </script>
 <style lang="scss" scoped>

--- a/frontend/components/commons/header/filters/SearchBar.vue
+++ b/frontend/components/commons/header/filters/SearchBar.vue
@@ -17,7 +17,6 @@
 
 <template>
   <form
-    :class="{ '--extended': expandSearchbar }"
     @submit.prevent="submit(query)"
   >
     <div :class="['searchbar__container', { active: query }]">
@@ -103,14 +102,12 @@ export default {
   margin-left: auto;
   pointer-events: all;
   border-radius: 5px;
+  min-width: 100%;
   &__container {
     position: relative;
-    max-width: 280px;
     margin-right: auto;
     margin-left: 0;
-    .--extended & {
-      min-width: 100%;
-    }
+    min-width: 100%;
   }
   &__button {
     cursor: pointer;
@@ -129,9 +126,6 @@ export default {
   }
   &:hover {
     box-shadow: 0px 3px 8px 3px rgba(222, 222, 222, 0.4);
-  }
-  .--extended & {
-    min-width: 100%;
   }
 }
 </style>

--- a/frontend/components/text-classifier/header/TextClassificationHeader.vue
+++ b/frontend/components/text-classifier/header/TextClassificationHeader.vue
@@ -24,7 +24,6 @@
     />
     <filters-area
       v-if="!dataset.viewSettings.visibleRulesList"
-      :expand-searchbar="viewMode === 'labelling-rules'"
       :dataset="dataset"
     />
     <explain-help-info v-if="isExplainedRecord" :dataset="dataset" />

--- a/frontend/components/text-classifier/labeling-rules/RuleDefinition.vue
+++ b/frontend/components/text-classifier/labeling-rules/RuleDefinition.vue
@@ -30,7 +30,10 @@
       </div>
     </div>
     <p class="rule__records" v-if="dataset.results.total > 0">
-      Records <template v-if="filtersApplied.length">with filters applied</template> ({{ dataset.results.total | formatNumber }})
+      Records
+      <template v-if="filtersApplied.length">with filters applied</template> ({{
+        dataset.results.total | formatNumber
+      }})
     </p>
   </div>
 </template>
@@ -93,8 +96,10 @@ export default {
       return this.dataset.labelingRulesMetrics;
     },
     filtersApplied() {
-      return Object.values(this.dataset.query).filter(v => v && Object.values(v).length);
-    }
+      return Object.values(this.dataset.query).filter(
+        (v) => v && Object.values(v).length
+      );
+    },
   },
   methods: {
     async updateCurrentRule({ query, label }) {

--- a/frontend/components/text-classifier/labeling-rules/RuleDefinition.vue
+++ b/frontend/components/text-classifier/labeling-rules/RuleDefinition.vue
@@ -30,7 +30,7 @@
       </div>
     </div>
     <p class="rule__records" v-if="dataset.results.total > 0">
-      Records ({{ dataset.results.total | formatNumber }})
+      Records with filter applied ({{ dataset.results.total | formatNumber }})
     </p>
   </div>
 </template>

--- a/frontend/components/text-classifier/labeling-rules/RuleDefinition.vue
+++ b/frontend/components/text-classifier/labeling-rules/RuleDefinition.vue
@@ -30,7 +30,7 @@
       </div>
     </div>
     <p class="rule__records" v-if="dataset.results.total > 0">
-      Records with filter applied ({{ dataset.results.total | formatNumber }})
+      Records <template v-if="filtersApplied.length">with filters applied</template> ({{ dataset.results.total | formatNumber }})
     </p>
   </div>
 </template>
@@ -92,6 +92,9 @@ export default {
     rulesMetrics() {
       return this.dataset.labelingRulesMetrics;
     },
+    filtersApplied() {
+      return Object.values(this.dataset.query).filter(v => v && Object.values(v).length);
+    }
   },
   methods: {
     async updateCurrentRule({ query, label }) {

--- a/frontend/components/text-classifier/labeling-rules/RuleEmptyQuery.vue
+++ b/frontend/components/text-classifier/labeling-rules/RuleEmptyQuery.vue
@@ -43,7 +43,7 @@
         >.
       </p>
     </div>
-    <div class="empty-query">
+    <div v-if="labels.length" class="empty-query">
       <p><strong>Introduce a query</strong> to define a rule.</p>
     </div>
   </div>

--- a/frontend/components/text-classifier/labeling-rules/RuleLabelsDefinition.vue
+++ b/frontend/components/text-classifier/labeling-rules/RuleLabelsDefinition.vue
@@ -70,16 +70,14 @@
       </p>
     </div>
     <p class="rule__info" v-if="ruleInfo">{{ ruleInfo }}</p>
-    <template v-else>
-      <p class="rule__info" v-if="ruleSaveInfo" v-html="ruleSaveInfo" />
-      <re-button
-        :disabled="!selectedLabelsVModel.length"
-        class="feedback-interactions__button button-primary"
-        @click="saveRule"
-      >
-        Save rule</re-button
-      >
-    </template>
+    <re-button
+      v-else
+      :disabled="!selectedLabelsVModel.length"
+      class="feedback-interactions__button button-primary"
+      @click="saveRule"
+    >
+      Save rule</re-button
+    >
   </div>
 </template>
 <script>
@@ -131,11 +129,6 @@ export default {
         this.dataset.findRuleByQuery(this.currentRule.query, this.selectedLabel)
       ) {
         return "This query with this label are already saved as rule";
-      }
-    },
-    ruleSaveInfo() {
-      if (this.currentRule && this.selectedLabelsVModel.length && !this.dataset.findRuleByQuery(this.currentRule.query, this.selectedLabel)) {
-        return `Rule will apply to the <strong>${this.coveredRecords} records</strong> conteining "${this.query}" regardless of the filters applied`
       }
     },
     coveredRecords() {

--- a/frontend/components/text-classifier/labeling-rules/RuleLabelsDefinition.vue
+++ b/frontend/components/text-classifier/labeling-rules/RuleLabelsDefinition.vue
@@ -21,11 +21,7 @@
       <p class="rule__description">{{ query }}</p>
       <p class="rule__records">
         Records:
-        <strong>{{
-          isNaN(currentRuleMetrics.records)
-            ? "-"
-            : $options.filters.formatNumber(currentRuleMetrics.records)
-        }}</strong>
+        <strong>{{coveredRecords}}</strong>
       </p>
     </div>
     <div class="rule__labels" v-if="labels.length">
@@ -74,14 +70,16 @@
       </p>
     </div>
     <p class="rule__info" v-if="ruleInfo">{{ ruleInfo }}</p>
-    <re-button
-      v-else
-      :disabled="!selectedLabelsVModel.length"
-      class="feedback-interactions__button button-primary"
-      @click="saveRule"
-    >
-      Save rule</re-button
-    >
+    <template v-else>
+      <p class="rule__info" v-if="ruleSaveInfo" v-html="ruleSaveInfo" />
+      <re-button
+        :disabled="!selectedLabelsVModel.length"
+        class="feedback-interactions__button button-primary"
+        @click="saveRule"
+      >
+        Save rule</re-button
+      >
+    </template>
   </div>
 </template>
 <script>
@@ -135,7 +133,14 @@ export default {
         return "This query with this label are already saved as rule";
       }
     },
-
+    ruleSaveInfo() {
+      if (this.currentRule && this.selectedLabelsVModel.length && !this.dataset.findRuleByQuery(this.currentRule.query, this.selectedLabel)) {
+        return `Rule will apply to the <strong>${this.coveredRecords} records</strong> conteining "${this.query}" regardless of the filters applied`
+      }
+    },
+    coveredRecords() {
+      return isNaN(this.currentRuleMetrics.records) ? "-" : this.$options.filters.formatNumber(this.currentRuleMetrics.records)
+    },
     maxVisibleLabels() {
       return DatasetViewSettings.MAX_VISIBLE_LABELS;
     },

--- a/frontend/components/text-classifier/labeling-rules/RuleLabelsDefinition.vue
+++ b/frontend/components/text-classifier/labeling-rules/RuleLabelsDefinition.vue
@@ -21,7 +21,7 @@
       <p class="rule__description">{{ query }}</p>
       <p class="rule__records">
         Records:
-        <strong>{{coveredRecords}}</strong>
+        <strong>{{ coveredRecords }}</strong>
       </p>
     </div>
     <div class="rule__labels" v-if="labels.length">
@@ -132,7 +132,9 @@ export default {
       }
     },
     coveredRecords() {
-      return isNaN(this.currentRuleMetrics.records) ? "-" : this.$options.filters.formatNumber(this.currentRuleMetrics.records)
+      return isNaN(this.currentRuleMetrics.records)
+        ? "-"
+        : this.$options.filters.formatNumber(this.currentRuleMetrics.records);
     },
     maxVisibleLabels() {
       return DatasetViewSettings.MAX_VISIBLE_LABELS;

--- a/frontend/components/text-classifier/labeling-rules/RulesManagement.vue
+++ b/frontend/components/text-classifier/labeling-rules/RulesManagement.vue
@@ -189,7 +189,7 @@ export default {
     metricsForRule(rule) {
       const metrics = this.perRuleMetrics[rule.query];
       if (!metrics) {
-        return {}
+        return {};
       }
       return {
         coverage: this.$options.filters.percent(metrics.coverage),


### PR DESCRIPTION
closes #982

This PR adds filters in the tagging rules, removes the resetting of filters when accessing this view and expands the search bar in filters row.