### PR TITLE
docs(#994): Change setup guide to recommend using python to start the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ pip install rubrix[server]
 
 If you don't have [Elasticsearch (ES)]() running, make sure you have `Docker` installed and run:
 
+> :information_source: **Check [our documentation](https://rubrix.readthedocs.io/en/stable/getting_started/setup%26installation.html) for further options and configurations regarding Elasticsearch.**
+
 ```bash
 docker run -d \
  --name elasticsearch-for-rubrix \
@@ -105,8 +107,6 @@ docker run -d \
  docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
 
 ```
-
-> :information_source: **Check [our documentation](https://rubrix.readthedocs.io/en/stable/getting_started/setup%26installation.html) for further options and configurations regarding Elasticsearch.**
 
 Then simply run:
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Getting started with Rubrix is as easy as:
 pip install rubrix[server]
 ```
 
-If you don't have [Elasticsearch (ES)]() running, make sure you have `Docker` installed and run:
+If you don't have [Elasticsearch (ES)](https://www.elastic.co/elasticsearch) running, make sure you have `Docker` installed and run:
 
 > :information_source: **Check [our documentation](https://rubrix.readthedocs.io/en/stable/getting_started/setup%26installation.html) for further options and configurations regarding Elasticsearch.**
 

--- a/README.md
+++ b/README.md
@@ -88,82 +88,38 @@ Why Rubrix?
 
 ## Get started
 
-To get started you need to follow three steps:
-
-1. Install the Python client
-2. Launch the web app
-3. Start logging data
-
-🆕 **Rubrix Cloud Beta**: Use Rubrix on a scalable cloud infrastructure without installing the server. [Join the waiting list](https://www.rubrix.ml/rubrix-cloud/)
-
-### 1. Install the Python client
-
-You can install the Python client with `pip` or `conda`.
-
-**with pip**
-
-```bash
-pip install rubrix
-```
-
-**with conda**
-
-```sh
-conda install -c conda-forge rubrix
-```
-
-### 2. Launch the web app
-
-There are two ways to launch the web app:
-
-- a) Using [docker-compose](https://docs.docker.com/compose/) (**recommended**).
-- b) Executing the server code manually
-
-#### a) Using docker-compose (recommended)
-
-Create a folder:
-
-```bash
-mkdir rubrix && cd rubrix
-```
-
-and launch the docker-contained web app with the following command:
-
-```bash
-wget -O docker-compose.yml https://git.io/rb-docker && docker-compose up
-```
-
-This is the recommended way because it automatically includes an
-[Elasticsearch](https://www.elastic.co/elasticsearch/) instance, Rubrix's main persistence layer.
-
-#### b) Executing the server code manually
-
-When executing the server code manually you need to provide an [Elasticsearch](https://www.elastic.co/elasticsearch/) instance yourself.
-
-1. First you need to install
-   [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/install-elasticsearch.html)
-   (we recommend version 7.10) and launch an Elasticsearch instance.
-   For MacOS and Windows there are
-   [Homebrew formulae](https://www.elastic.co/guide/en/elasticsearch/reference/7.13/brew.html) and a
-   [msi package](https://www.elastic.co/guide/en/elasticsearch/reference/current/windows.html), respectively.
-2. Install the Python client together with its server dependencies:
+Getting started with Rubrix is as easy as:
 
 ```bash
 pip install rubrix[server]
 ```
 
-3. Launch a local instance of the web app
+If you don't have [Elasticsearch (ES)]() running, make sure you have `Docker` installed and run:
 
 ```bash
-python -m rubrix.server
+docker run -d \
+ --name elasticsearch-for-rubrix \
+ -p 9200:9200 -p 9300:9300 \
+ -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
+ -e "discovery.type=single-node" \
+ docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+
 ```
 
-By default, the Rubrix server will look for your Elasticsearch endpoint at `http://localhost:9200`.
-But you can customize this by setting the `ELASTICSEARCH` environment variable.
+> :information_source: **Check [our documentation](https://rubrix.readthedocs.io/en/stable/getting_started/setup%26installation.html) for further options and configurations regarding Elasticsearch.**
 
-### 3. Start logging data
+Then simply run:
 
-The following code will log one record into a data set called `example-dataset`:
+```bash
+python -m rubrix
+```
+
+Afterward, you should be able to access the web app at http://localhost:6900/.
+**The default username and password are** `rubrix` **and** `1234`.
+
+> 🆕 **Rubrix Cloud Beta**: Use Rubrix on a scalable cloud infrastructure without installing the server. [Join the waiting list](https://www.rubrix.ml/rubrix-cloud/)
+
+The following code will log one record into a dataset called `example-dataset`:
 
 ```python
 import rubrix as rb
@@ -175,10 +131,8 @@ rb.log(
 ```
 
 If you go to your Rubrix web app at http://localhost:6900/, you should see your first dataset.
-**The default username and password are `rubrix` and `1234`**.
-You can also check the REST API docs at http://localhost:6900/api/docs.
 
-Congratulations! You are ready to start working with Rubrix. You can continue reading a working example below.
+**Congratulations! You are ready to start working with Rubrix.** You can continue reading for a working example below.
 
 To better understand what's possible take a look at Rubrix's [Cookbook](https://rubrix.rtfd.io/en/stable/guides/cookbook.html)
 

--- a/docs/getting_started/advanced_setup_guides.rst
+++ b/docs/getting_started/advanced_setup_guides.rst
@@ -61,13 +61,13 @@ But you can customize this by setting the ``ELASTICSEARCH`` environment variable
 
 Since the Rubrix server is built on fastapi, you can launch it using **uvicorn** directly:
 
-.. code-block::
+.. code-block:: bash
 
    uvicorn rubrix:app
 
 *(for Rubrix versions below 0.9 you can launch the server via)*
 
-.. code-block::
+.. code-block:: bash
 
    uvicorn rubrix.server.server:app
 

--- a/docs/getting_started/advanced_setup_guides.rst
+++ b/docs/getting_started/advanced_setup_guides.rst
@@ -109,7 +109,7 @@ and launch the docker-contained web app with the following command:
 
 .. code-block:: bash
 
-   wget -O docker-compose.yml https://raw.githubusercontent.com/recognai/rubrix/master/docker-compose.yaml && docker-compose up
+   wget -O docker-compose.yml https://raw.githubusercontent.com/recognai/rubrix/master/docker-compose.yaml && docker-compose up -d
 
 This is a convenient way because it automatically includes an
 `Elasticsearch <https://www.elastic.co/elasticsearch/>`__ instance, Rubrix's main persistent layer.

--- a/docs/getting_started/advanced_setup_guides.rst
+++ b/docs/getting_started/advanced_setup_guides.rst
@@ -29,10 +29,10 @@ For MacOS and Windows, Elasticsearch also provides `homebrew formulae <https://w
 We recommend ES version 7.10 to work with Rubrix.
 
 .. warning::
-   Keep in mind, if you `docker rm` your ES container, you will loose all your datasets in Rubrix!
+   Keep in mind, if you ```docker rm``` your ES container, you will loose all your datasets in Rubrix!
 
 
-.. _server_configurations:
+.. _server-configurations:
 
 Server configurations
 ---------------------
@@ -115,7 +115,7 @@ This is a convenient way because it automatically includes an
 `Elasticsearch <https://www.elastic.co/elasticsearch/>`__ instance, Rubrix's main persistent layer.
 
 .. warning::
-   Keep in mind, if you execute `docker-compose down`, you will loose all your datasets in Rubrix!
+   Keep in mind, if you execute ``docker-compose down``, you will loose all your datasets in Rubrix!
 
 
 .. _configure-elasticsearch-role-users:
@@ -156,7 +156,7 @@ Note that provided analyzers names should be defined as built-in ones. If you wa
 customized analyzer, you should create it inside an index_template matching Rubrix index names (`.rubrix*.records-v0),
 and then provide the analyzer name using the specific environment variable.
 
-.. _deploy-to-aws-instance-using-docker-machine
+.. _deploy-to-aws-instance-using-docker-machine:
 
 Deploy to aws instance using docker-machine
 -------------------------------------------

--- a/docs/getting_started/advanced_setup_guides.rst
+++ b/docs/getting_started/advanced_setup_guides.rst
@@ -29,7 +29,7 @@ For MacOS and Windows, Elasticsearch also provides `homebrew formulae <https://w
 We recommend ES version 7.10 to work with Rubrix.
 
 .. warning::
-   Keep in mind, if you ```docker rm``` your ES container, you will loose all your datasets in Rubrix!
+   Keep in mind, if you ``docker rm`` your ES container, you will loose all your datasets in Rubrix!
 
 
 .. _server-configurations:

--- a/docs/getting_started/advanced_setup_guides.rst
+++ b/docs/getting_started/advanced_setup_guides.rst
@@ -12,24 +12,43 @@ Here we provide some advanced setup guides:
    :local:
    :depth: 1
 
-.. _setting-up-ES-via-docker:
+.. _setting-up-elasticsearch-via-docker:
 
-Setting up ES via docker
-------------------------
+Setting up Elasticsearch via docker
+-----------------------------------
 
-Setting up Elasticsearch via docker is straight forward.
+Setting up Elasticsearch (ES) via docker is straight forward.
 Simply run following command:
 
 .. code-block::
 
-   docker run -p 127.0.0.1:9200:9200 -p 127.0.0.1:9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.10.0
+   docker run -d \
+   --name elasticsearch-for-rubrix \
+   -p 9200:9200 -p 9300:9300 \
+   -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
+   -e "discovery.type=single-node" \
+   docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+
+This will create an ES docker container named *"elasticsearch-for-rubrix"* that will run in the background.
+To see the logs of the container, you can run:
+
+.. code-block::
+
+   docker logs elasticsearch-for-rubrix
+
+Or you can stop/start the container via:
+
+.. code-block::
+
+   docker stop elasticsearch-for-rubrix
+   docker start elasticsearch-for-rubrix
+
+.. warning::
+   Keep in mind, if you remove your container with ``docker rm elasticsearch-for-rubrix``, you will loose all your datasets in Rubrix!
 
 For more details about the ES installation with docker, see their `official documentation <https://www.elastic.co/guide/en/elasticsearch/reference/7.10/docker.html>`__.
 For MacOS and Windows, Elasticsearch also provides `homebrew formulae <https://www.elastic.co/guide/en/elasticsearch/reference/7.10/brew.html>`__ and a `msi package <https://www.elastic.co/guide/en/elasticsearch/reference/7.10/windows.html>`__, respectively.
 We recommend ES version 7.10 to work with Rubrix.
-
-.. warning::
-   Keep in mind, if you ``docker rm`` your ES container, you will loose all your datasets in Rubrix!
 
 
 .. _server-configurations:

--- a/docs/getting_started/advanced_setup_guides.rst
+++ b/docs/getting_started/advanced_setup_guides.rst
@@ -6,14 +6,63 @@
 Advanced setup guides
 =====================
 
-Here we provide some advanced setup guides, in case you want to use docker, configure your own Elasticsearch instance or install the cutting-edge master version.
+Here we provide some advanced setup guides:
 
-.. _using-docker:
+.. contents::
+   :local:
+   :depth: 1
 
-Using docker
-------------
+.. _setting-up-ES-via-docker
 
-You can use vanilla docker to run our image of the server.
+Setting up ES via docker
+------------------------
+
+Setting up Elasticsearch via docker is straight forward.
+Simply run following command:
+
+.. code-block::
+
+   docker run -p 127.0.0.1:9200:9200 -p 127.0.0.1:9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.10.0
+
+For more details about the ES installation with docker, see their `official documentation <https://www.elastic.co/guide/en/elasticsearch/reference/7.10/docker.html>`__.
+For MacOS and Windows, Elasticsearch also provides `homebrew formulae <https://www.elastic.co/guide/en/elasticsearch/reference/7.10/brew.html>`__ and a `msi package <https://www.elastic.co/guide/en/elasticsearch/reference/7.10/windows.html>`__, respectively.
+We recommend ES version 7.10 to work with Rubrix.
+
+.. warning::
+   Keep in mind, if you `docker rm` your ES container, you will loose all your datasets in Rubrix!
+
+
+.. _server_configurations
+
+Server configurations
+---------------------
+
+By default, the :ref:`Rubrix server <...>` will look for your ES endpoint at ``http://localhost:9200``.
+But you can customize this by setting the ``ELASTICSEARCH`` environment variable.
+
+Since the Rubrix server is built on fastapi, you can launch it using **uvicorn** directly:
+
+.. code-block::
+
+   uvicorn rubrix:app
+
+*(for Rubrix versions below 0.9 you can launch the server via)*
+
+.. code-block::
+
+   uvicorn rubrix.server.server:app
+
+For more details about fastapi and uvicorn, see `here <https://fastapi.tiangolo.com/deployment/manually/#run-a-server-manually-uvicorn>`_
+
+Fastapi also provides beautiful REST API docs that you can check at `http://localhost:6900/api/docs <http://localhost:6900/api/docs>`__.
+
+
+.. _launching-the-web-app-via-docker:
+
+Launching the web app via docker
+--------------------------------
+
+You can use vanilla docker to run our image of the web app.
 First, pull the image from the `Docker Hub <https://hub.docker.com/>`_:
 
 .. code-block:: shell
@@ -43,9 +92,35 @@ To stop the Rubrix server, just stop the container:
 
 If you want to deploy your own Elasticsearch cluster via docker, we refer you to the excellent guide on the `Elasticsearch homepage <https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html>`_
 
+.. _launching-the-web-app-via-docker-compose:
+
+Launching the web app via docker-compose
+----------------------------------------
+
+For this method you first need to install `Docker Compose <https://docs.docker.com/compose/install/>`__.
+
+Then, create a folder:
+
+.. code-block:: bash
+
+   mkdir rubrix && cd rubrix
+
+and launch the docker-contained web app with the following command:
+
+.. code-block:: bash
+
+   wget -O docker-compose.yml https://raw.githubusercontent.com/recognai/rubrix/master/docker-compose.yaml && docker-compose up
+
+This is a convenient way because it automatically includes an
+`Elasticsearch <https://www.elastic.co/elasticsearch/>`__ instance, Rubrix's main persistent layer.
+
+.. warning::
+   Keep in mind, if you execute `docker-compose down`, you will loose all your datasets in Rubrix!
+
+
 .. _configure-elasticsearch-role-users:
 
-Configure elasticsearch role/users
+Configure Elasticsearch role/users
 ----------------------------------
 
 If you have an Elasticsearch instance and want to share resources with other applications, you can easily configure it for Rubrix.
@@ -81,6 +156,7 @@ Note that provided analyzers names should be defined as built-in ones. If you wa
 customized analyzer, you should create it inside an index_template matching Rubrix index names (`.rubrix*.records-v0),
 and then provide the analyzer name using the specific environment variable.
 
+.. _deploy-to-aws-instance-using-docker-machine
 
 Deploy to aws instance using docker-machine
 -------------------------------------------
@@ -176,8 +252,6 @@ Accessing Rubrix
 ^^^^^^^^^^^^^^^^
 
 In our case http://52.213.178.33
-
-
 
 
 .. _install-from-master:

--- a/docs/getting_started/advanced_setup_guides.rst
+++ b/docs/getting_started/advanced_setup_guides.rst
@@ -12,7 +12,7 @@ Here we provide some advanced setup guides:
    :local:
    :depth: 1
 
-.. _setting-up-ES-via-docker
+.. _setting-up-ES-via-docker:
 
 Setting up ES via docker
 ------------------------
@@ -32,7 +32,7 @@ We recommend ES version 7.10 to work with Rubrix.
    Keep in mind, if you `docker rm` your ES container, you will loose all your datasets in Rubrix!
 
 
-.. _server_configurations
+.. _server_configurations:
 
 Server configurations
 ---------------------

--- a/docs/getting_started/advanced_setup_guides.rst
+++ b/docs/getting_started/advanced_setup_guides.rst
@@ -20,7 +20,7 @@ Setting up Elasticsearch via docker
 Setting up Elasticsearch (ES) via docker is straight forward.
 Simply run following command:
 
-.. code-block::
+.. code-block:: bash
 
    docker run -d \
    --name elasticsearch-for-rubrix \
@@ -32,13 +32,13 @@ Simply run following command:
 This will create an ES docker container named *"elasticsearch-for-rubrix"* that will run in the background.
 To see the logs of the container, you can run:
 
-.. code-block::
+.. code-block:: bash
 
    docker logs elasticsearch-for-rubrix
 
 Or you can stop/start the container via:
 
-.. code-block::
+.. code-block:: bash
 
    docker stop elasticsearch-for-rubrix
    docker start elasticsearch-for-rubrix

--- a/docs/getting_started/setup&installation.rst
+++ b/docs/getting_started/setup&installation.rst
@@ -30,7 +30,7 @@ Then you can install Rubrix with ``pip`` or ``conda``\.
    conda install -c conda-forge rubrix
 
 .. note::
-   Conda only installs the Python client of Rubrix.
+   Conda for now only installs the Python client of Rubrix.
    This means, you have to launch the web app via :ref:`docker <launching-the-web-app-via-docker>` or :ref:`docker-compose <launching-the-web-app-via-docker-compose>`.
 
 

--- a/docs/getting_started/setup&installation.rst
+++ b/docs/getting_started/setup&installation.rst
@@ -38,7 +38,7 @@ Then you can install Rubrix with ``pip`` or ``conda``\.
 ---------------------
 
 Rubrix uses `Elasticsearch (ES) <https://www.elastic.co/elasticsearch/>`__ as its main persistent layer.
-**If you do not have an ES instance running on your machine**, we recommend setting one up :ref:`via docker <setting-up-es-via-docker>`.
+**If you do not have an ES instance running on your machine**, we recommend setting one up :ref:`via docker <setting-up-elasticsearch-via-docker>`.
 
 You can start the Rubrix web app via Python.
 

--- a/docs/getting_started/setup&installation.rst
+++ b/docs/getting_started/setup&installation.rst
@@ -3,7 +3,8 @@
 Setup and installation
 ======================
 
-In this guide, we will help you to get up and running with Rubrix. Basically, you need to:
+In this guide, we will help you to get up and running with Rubrix.
+Basically, you need to:
 
 1. Install Rubrix
 2. Launch the web app
@@ -30,7 +31,8 @@ Then you can install Rubrix with ``pip`` or ``conda``\.
 
 .. note::
    Conda only installs the Python client of Rubrix.
-   This means, you have to launch the web app via docker or docker-compose.
+   This means, you have to launch the web app via :ref:`docker <launching-the-web-app-via-docker>` or :ref:`docker-compose <launching-the-web-app-via-docker-compose>`.
+
 
 2. Launch the web app
 ---------------------

--- a/docs/getting_started/setup&installation.rst
+++ b/docs/getting_started/setup&installation.rst
@@ -42,7 +42,7 @@ Rubrix uses `Elasticsearch (ES) <https://www.elastic.co/elasticsearch/>`__ as it
 
 You can start the Rubrix web app via Python.
 
-.. code-block::
+.. code-block:: bash
 
    python -m rubrix
 

--- a/docs/getting_started/setup&installation.rst
+++ b/docs/getting_started/setup&installation.rst
@@ -5,12 +5,12 @@ Setup and installation
 
 In this guide, we will help you to get up and running with Rubrix. Basically, you need to:
 
-1. Install the Python client
+1. Install Rubrix
 2. Launch the web app
 3. Start logging data
 
-1. Install the Rubrix Python client
-------------------------------------
+1. Install Rubrix
+-----------------
 
 First, make sure you have Python 3.7 or above installed.
 
@@ -20,7 +20,7 @@ Then you can install Rubrix with ``pip`` or ``conda``\.
 
 .. code-block:: bash
 
-   pip install rubrix
+   pip install rubrix[server]
 
 **with conda**
 
@@ -28,85 +28,34 @@ Then you can install Rubrix with ``pip`` or ``conda``\.
 
    conda install -c conda-forge rubrix
 
+.. note::
+   Conda only installs the Python client of Rubrix.
+   This means, you have to launch the web app via docker or docker-compose.
 
 2. Launch the web app
 ---------------------
 
-There are two ways to launch the webapp:
+Rubrix uses `Elasticsearch (ES) <https://www.elastic.co/elasticsearch/>`__ as its main persistent layer.
+**If you do not have an ES instance running on your machine**, we recommend setting one up :ref:`via docker <setting-up-es-via-docker>`.
 
-a. Using `docker-compose <https://docs.docker.com/compose/>`__ (**recommended**).
-b. Executing the server code manually
-
-a) Using ``docker-compose`` (recommended)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-For this method you first need to install `Docker Compose <https://docs.docker.com/compose/install/>`__.
-
-Then, create a folder:
-
-.. code-block:: bash
-
-   mkdir rubrix && cd rubrix
-
-and launch the docker-contained web app with the following command:
-
-.. code-block:: bash
-
-   wget -O docker-compose.yml https://raw.githubusercontent.com/recognai/rubrix/master/docker-compose.yaml && docker-compose up
-
-This is the recommended way because it automatically includes an
-`Elasticsearch <https://www.elastic.co/elasticsearch/>`__ instance, Rubrix's main persistent layer.
-
-b) Executing the server code manually
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-When executing the server code manually you need to provide an
-`Elasticsearch <https://www.elastic.co/elasticsearch/>`__ instance yourself.
-This method may be preferred if you
-(1) want to avoid or cannot use ``Docker``,
-(2) have an existing Elasticsearch service, or
-(3) want to have full control over your Elasticsearch configuration.
-
-1. First you need to install
-   `Elasticsearch <https://www.elastic.co/guide/en/elasticsearch/reference/7.10/install-elasticsearch.html>`__
-   (we recommend version 7.10) and launch an Elasticsearch instance.
-   For MacOS and Windows there are
-   `Homebrew formulae <https://www.elastic.co/guide/en/elasticsearch/reference/7.13/brew.html>`__ and a
-   `msi package <https://www.elastic.co/guide/en/elasticsearch/reference/current/windows.html>`__, respectively.
-
-2. Install the Rubrix Python library together with its server dependencies:
-
-.. code-block:: bash
-
-   pip install rubrix[server]
-
-3. Launch a local instance of the Rubrix web app
+You can start the Rubrix web app via Python.
 
 .. code-block::
 
    python -m rubrix
 
-By default, the Rubrix server will look for your Elasticsearch endpoint at ``http://localhost:9200``.
-But you can customize this by setting the ``ELASTICSEARCH`` environment variable.
+Afterward, you should be able to access the web app at `http://localhost:6900/ <http://localhost:6900/>`__.
+**The default username and password are** ``rubrix`` **and** ``1234`` (see the `user management guide <user-management.ipynb>`_ to configure this).
 
-**If you are already running an Elasticsearch instance for other applications and want to share it with Rubrix**, please refer to our :ref:`advanced setup guide <configure-elasticsearch-role-users>`.
+Have a look at our :ref:`advanced setup guides <advanced-setup-guides>` if you want to (among other things):
 
-Uvicorn
-"""""""
+- :ref:`configure the Rubrix server <server-configurations>`
+- :ref:`share an ES instance with other applications <configure-elasticsearch-role-users>`
+- :ref:`deploy Rubrix on an AWS instance <deploy-to-aws-instance-using-docker-machine>`
 
-Since the Rubrix server is built on fastapi, you can launch it using **uvicorn**:
-
-.. code-block::
-
-   uvicorn rubrix:app
-
-*(for older rubrix version you should launch as)*
-
-.. code-block::
-
-   uvicorn rubrix.server.server:app
-
-See more details `here <https://fastapi.tiangolo.com/deployment/manually/#run-a-server-manually-uvicorn>`_
+.. note::
+   You can also launch the web app via :ref:`docker <launching-the-web-app-via-docker>` or :ref:`docker-compose <launching-the-web-app-via-docker-compose>`.
+   For the latter you do not need a running ES instance.
 
 3. Start logging data
 ---------------------
@@ -123,19 +72,8 @@ The following code will log one record into a data set called ``example-dataset`
    )
 
 If you now go to your Rubrix app at `http://localhost:6900/ <http://localhost:6900/>`__ , you will find your first data set.
-**The default username and password are** ``rubrix`` **and** ``1234`` (see the `user management guide <user-management.ipynb>`_ to configure this).
-You can also check the REST API docs at `http://localhost:6900/api/docs <http://localhost:6900/api/docs>`__.
 
-Congratulations! You are ready to start working with Rubrix.
-
-Please refer to our :ref:`advanced setup guides <advanced-setup-guides>` if you want to:
-
-- setup Rubrix using docker
-- share the Elasticsearch instance with other applications
-- deploy Rubrix on an AWS instance
-- manage users in Rubrix
-
-.. **If you want to setup Rubrix using docker, share the Elasticsearch instance with other applications,  or manage users in the Rubrix server**, please refer to our :ref:`advanced setup guides <advanced-setup-guides>`.
+**Congratulations! You are ready to start working with Rubrix.**
 
 Next steps
 ----------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,12 +35,14 @@ Quickstart
 
 Getting started with Rubrix is easy, let's see a quick example using the 🤗 ``transformers`` and ``datasets`` libraries:
 
-
-Make sure you have ``Docker`` installed and run (check the :ref:`setup and installation section <setup-and-installation>` for a more detailed installation process):
-
 .. code-block:: bash
 
    pip install rubrix[server] transformers[torch] datasets
+
+If you don't have `Elasticsearch (ES) <https://www.elastic.co/elasticsearch>`__ running, make sure you have `Docker` installed and run:
+
+.. note::
+   Check the :ref:`setup and installation section <setup-and-installation>` for further options and configurations regarding Elasticsearch.
 
 .. code-block:: bash
 
@@ -52,11 +54,14 @@ Make sure you have ``Docker`` installed and run (check the :ref:`setup and insta
    docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
 
 
-And then run:
+Then simply run:
 
 .. code-block:: bash
 
    python -m rubrix
+
+Afterward, you should be able to access the web app at `http://localhost:6900/ <http://localhost:6900/>`__.
+**The default username and password are** ``rubrix`` **and** ``1234``.
 
 Now, let's see an example: **Bootstraping data annotation with a zero-shot classifier**
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,22 +40,19 @@ Make sure you have ``Docker`` installed and run (check the :ref:`setup and insta
 
 .. code-block:: bash
 
-   mkdir rubrix && cd rubrix
+   pip install rubrix[server] transformers[torch] datasets
+
+.. code-block:: bash
+
+   docker run -p 127.0.0.1:9200:9200 -p 127.0.0.1:9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.10.0
 
 And then run:
 
 .. code-block:: bash
 
-   wget -O docker-compose.yml https://git.io/rb-docker && docker-compose up
-
-Install Rubrix python library (and ``transformers``, ``pytorch`` and ``datasets`` libraries for this example):
-
-.. code-block:: bash
-
-   pip install rubrix transformers datasets torch
+   python -m rubrix
 
 Now, let's see an example: **Bootstraping data annotation with a zero-shot classifier**
-
 
 **Why**:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,7 +44,13 @@ Make sure you have ``Docker`` installed and run (check the :ref:`setup and insta
 
 .. code-block:: bash
 
-   docker run -p 127.0.0.1:9200:9200 -p 127.0.0.1:9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.10.0
+   docker run -d \
+   --name elasticsearch-for-rubrix \
+   -p 9200:9200 -p 9300:9300 \
+   -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
+   -e "discovery.type=single-node" \
+   docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+
 
 And then run:
 


### PR DESCRIPTION
Closes #994

Updates the docs to recommend the "python way" of starting the server.
@frascuchon Could you double check the docker commands, as well as the statements about loosing the data when doing `docker rm` or `docker-compose down`?
@dvsrepo If you are ok with the proposal, I will basically copy the Setup&Installation guide to the github Readme.

[New quickstart](https://rubrix.readthedocs.io/en/feat-improve_installation_guide/index.html#quickstart)
[New Setup&Installation](https://rubrix.readthedocs.io/en/feat-improve_installation_guide/getting_started/setup%26installation.html#setup-and-installation)
[New advanced setup guide](https://rubrix.readthedocs.io/en/feat-improve_installation_guide/getting_started/advanced_setup_guides.html#advanced-setup-guides)