### PR TITLE
feat(#924): parse validation error, including submitted information

### DIFF
--- a/src/rubrix/client/sdk/commons/api.py
+++ b/src/rubrix/client/sdk/commons/api.py
@@ -40,7 +40,7 @@ from rubrix.client.sdk.commons.models import (
 
 
 def build_bulk_response(
-    response: httpx.Response, dataset: str
+    response: httpx.Response, name: str, body: Any
 ) -> Response[BulkResponse]:
 
     if 200 <= response.status_code < 400:
@@ -51,7 +51,7 @@ def build_bulk_response(
             parsed=BulkResponse(**response.json()),
         )
 
-    return handle_response_error(response, dataset=dataset)
+    return handle_response_error(response, name=name, body=body)
 
 
 T = TypeVar("T")

--- a/src/rubrix/client/sdk/commons/errors.py
+++ b/src/rubrix/client/sdk/commons/errors.py
@@ -12,7 +12,7 @@ class RubrixApiResponseError(RubrixClientError):
     def __str__(self):
         return (
             f"Rubrix server returned an error with http status: {self.HTTP_STATUS}"
-            f"\nError details: [{self.ctx}]"
+            + f"\nError details: [{self.ctx}]"
         )
 
 
@@ -22,7 +22,26 @@ class NotFoundApiError(RubrixApiResponseError):
 
 class ValidationApiError(RubrixApiResponseError):
     HTTP_STATUS = 422
-    # TODO: Here we can process response and make human readable
+
+    def __init__(self, client_ctx, params, **ctx):
+
+        for error in params.get("errors", []):
+            current_level = client_ctx
+            for loc in error["loc"]:
+                new_value = None
+                try:
+                    new_value = current_level[loc]
+                except KeyError:
+                    pass
+                if new_value is None:
+                    break
+                if hasattr(new_value, "dict"):
+                    new_value = new_value.dict()
+                current_level = new_value
+            error["value"] = current_level
+
+        # TODO: parse error details and match with client context
+        super().__init__(**ctx, params=params)
 
 
 class BadRequestApiError(RubrixApiResponseError):

--- a/src/rubrix/client/sdk/commons/errors_handler.py
+++ b/src/rubrix/client/sdk/commons/errors_handler.py
@@ -14,23 +14,30 @@ from rubrix.client.sdk.commons.errors import (
 
 
 def handle_response_error(
-    response: httpx.Response, parse_response: bool = True, **extra_args
+    response: httpx.Response, parse_response: bool = True, **client_ctx
 ):
     try:
         response_content = response.json() if parse_response else {}
     except JSONDecodeError:
         response_content = {}
+    error_type = GenericApiError
+    error_detail = response_content.get("detail")
+    error_args = error_detail if error_detail else response_content
 
     if response.status_code == BadRequestApiError.HTTP_STATUS:
-        raise BadRequestApiError(**response_content, **extra_args)
+        error_type = BadRequestApiError
     if response.status_code == UnauthorizedApiError.HTTP_STATUS:
-        raise UnauthorizedApiError(**response_content, **extra_args)
+        error_type = UnauthorizedApiError
     if response.status_code == AlreadyExistsApiError.HTTP_STATUS:
-        raise AlreadyExistsApiError(**response_content, **extra_args)
+        error_type = AlreadyExistsApiError
     if response.status_code == ForbiddenApiError.HTTP_STATUS:
-        raise ForbiddenApiError(**response_content, **extra_args)
+        error_type = ForbiddenApiError
     if response.status_code == NotFoundApiError.HTTP_STATUS:
-        raise NotFoundApiError(**response_content, **extra_args)
+        error_type = NotFoundApiError
     if response.status_code == ValidationApiError.HTTP_STATUS:
-        raise ValidationApiError(**response_content, **extra_args)
-    raise GenericApiError(**response_content)
+        error_type = ValidationApiError
+
+    if error_type == ValidationApiError:
+        error_args["client_ctx"] = client_ctx
+
+    raise error_type(**error_args)

--- a/src/rubrix/client/sdk/datasets/api.py
+++ b/src/rubrix/client/sdk/datasets/api.py
@@ -27,7 +27,7 @@ from rubrix.client.sdk.datasets.models import CopyDatasetRequest, Dataset
 def get_dataset(
     client: AuthenticatedClient,
     name: str,
-) -> Response[Union[Dataset, ErrorMessage, HTTPValidationError]]:
+) -> Response[Dataset]:
     url = "{}/api/datasets/{name}".format(client.base_url, name=name)
 
     response = httpx.get(
@@ -44,7 +44,7 @@ def copy_dataset(
     client: AuthenticatedClient,
     name: str,
     json_body: CopyDatasetRequest,
-) -> Response[Union[Dataset, ErrorMessage, HTTPValidationError]]:
+) -> Response[Dataset]:
     url = "{}/api/datasets/{name}:copy".format(client.base_url, name=name)
 
     response = httpx.put(

--- a/src/rubrix/client/sdk/text2text/api.py
+++ b/src/rubrix/client/sdk/text2text/api.py
@@ -46,7 +46,7 @@ def bulk(
         json=json_body.dict(by_alias=True),
     )
 
-    return build_bulk_response(response, dataset=name)
+    return build_bulk_response(response, name=name, body=json_body)
 
 
 def data(

--- a/src/rubrix/client/sdk/text_classification/api.py
+++ b/src/rubrix/client/sdk/text_classification/api.py
@@ -42,7 +42,7 @@ def bulk(
     client: AuthenticatedClient,
     name: str,
     json_body: TextClassificationBulkData,
-) -> Response[Union[BulkResponse, ErrorMessage, HTTPValidationError]]:
+) -> Response[BulkResponse]:
     url = "{}/api/datasets/{name}/TextClassification:bulk".format(
         client.base_url, name=name
     )
@@ -55,7 +55,7 @@ def bulk(
         json=json_body.dict(by_alias=True),
     )
 
-    return build_bulk_response(response, dataset=name)
+    return build_bulk_response(response, name=name, body=json_body)
 
 
 def data(

--- a/src/rubrix/client/sdk/token_classification/api.py
+++ b/src/rubrix/client/sdk/token_classification/api.py
@@ -49,7 +49,7 @@ def bulk(
         json=json_body.dict(by_alias=True),
     )
 
-    return build_bulk_response(response, dataset=name)
+    return build_bulk_response(response, name=name, body=json_body)
 
 
 def data(

--- a/tests/client/sdk/commons/api.py
+++ b/tests/client/sdk/commons/api.py
@@ -51,7 +51,7 @@ def test_build_bulk_response(status_code, expected):
     httpx_response = HttpxResponse(
         status_code=status_code, content=server_response.json()
     )
-    response = build_bulk_response(httpx_response, dataset="mock-dataset")
+    response = build_bulk_response(httpx_response, name="mock-dataset", body={})
 
     assert isinstance(response, Response)
     assert isinstance(response.parsed, expected)

--- a/tests/client/sdk/datasets/test_api.py
+++ b/tests/client/sdk/datasets/test_api.py
@@ -66,6 +66,9 @@ def test_get_dataset(sdk_client, monkeypatch):
     ],
 )
 def test_build_response(status_code, expected):
-    httpx_response = httpx.Response(status_code=status_code, content="boo")
+    httpx_response = httpx.Response(
+        status_code=status_code,
+        json={"detail": {"code": "error.code", "params": {"foo": "bar"}}},
+    )
     with pytest.raises(expected):
         _build_response(httpx_response, name="mock-ds")

--- a/tests/client/test_rubrix_client.py
+++ b/tests/client/test_rubrix_client.py
@@ -132,7 +132,10 @@ def test_delete_with_errors(monkeypatch, status, error_type):
 
     def send_mock_response_with_http_status(status: int):
         def inner(*args, **kwargs):
-            return httpx.Response(status_code=status, json={"message": "Mock"})
+            return httpx.Response(
+                status_code=status,
+                json={"detail": {"code": "error:code", "params": {"message": "Mock"}}},
+            )
 
         return inner
 


### PR DESCRIPTION
This PR is the last part of error handling improvement work detailed in #924. 

The idea is complete validation error detail (generally raised by pydantic validators) with the info was sent. In the future, client must include validations.

Closes #924 