### PR TITLE
fix(cleanlab): set cleanlab n_jobs=1 as default

### DIFF
--- a/src/rubrix/labeling/text_classification/label_errors.py
+++ b/src/rubrix/labeling/text_classification/label_errors.py
@@ -41,7 +41,7 @@ def find_label_errors(
     records: List[TextClassificationRecord],
     sort_by: Union[str, SortBy] = "likelihood",
     metadata_key: str = "label_error_candidate",
-    n_jobs: int = 1,
+    n_jobs: Optional[int] = 1,
     **kwargs,
 ) -> List[TextClassificationRecord]:
     """Finds potential annotation/label errors in your records using [cleanlab](https://github.com/cleanlab/cleanlab).
@@ -56,8 +56,8 @@ def find_label_errors(
             - "prediction": sort the returned records by the probability of the prediction (highest probability first)
             - "none": do not sort the returned records
         metadata_key: The key added to the record's metadata that holds the order, if ``sort_by`` is not "none".
-        n_jobs : Number of processing threads used by multiprocessing. Default 1, what it's mean no parallel processing
-            is applied. Set to None to use the number of processing threads on your CPU
+        n_jobs : Number of processing threads used by multiprocessing. If None, uses the number of threads
+            on your CPU. Defaults to 1, which removes parallel processing. 
         **kwargs: Passed on to `cleanlab.pruning.get_noise_indices`
 
     Returns:

--- a/src/rubrix/labeling/text_classification/label_errors.py
+++ b/src/rubrix/labeling/text_classification/label_errors.py
@@ -41,6 +41,7 @@ def find_label_errors(
     records: List[TextClassificationRecord],
     sort_by: Union[str, SortBy] = "likelihood",
     metadata_key: str = "label_error_candidate",
+    n_jobs: int = 1,
     **kwargs,
 ) -> List[TextClassificationRecord]:
     """Finds potential annotation/label errors in your records using [cleanlab](https://github.com/cleanlab/cleanlab).
@@ -55,6 +56,8 @@ def find_label_errors(
             - "prediction": sort the returned records by the probability of the prediction (highest probability first)
             - "none": do not sort the returned records
         metadata_key: The key added to the record's metadata that holds the order, if ``sort_by`` is not "none".
+        n_jobs : Number of processing threads used by multiprocessing. Default 1, what it's mean no parallel processing
+            is applied. Set to None to use the number of processing threads on your CPU
         **kwargs: Passed on to `cleanlab.pruning.get_noise_indices`
 
     Returns:
@@ -96,7 +99,7 @@ def find_label_errors(
     # construct "noisy" label vector and probability matrix of the predictions
     s, psx = _construct_s_and_psx(records)
 
-    indices = get_noise_indices(s, psx, **kwargs)
+    indices = get_noise_indices(s, psx, n_jobs=n_jobs, **kwargs)
 
     records_with_label_errors = np.array(records)[indices].tolist()
 

--- a/tests/labeling/text_classification/test_label_errors.py
+++ b/tests/labeling/text_classification/test_label_errors.py
@@ -116,7 +116,7 @@ def test_sort_by(monkeypatch, sort_by, expected):
 def test_kwargs(monkeypatch, records):
     is_multi_label = records[0].multi_label
 
-    def mock_get_noise_indices(s, psx, **kwargs):
+    def mock_get_noise_indices(s, psx, n_jobs, **kwargs):
         assert kwargs == {
             "multi_label": is_multi_label,
             "sorted_index_method": "normalized_margin",


### PR DESCRIPTION
This  PR disable default parallel processing for `cleanlab.pruning.get_noise_indices` that could bring problems or make systems inestables.

Most of the times github actions are failing because of this.

See https://github.com/recognai/rubrix/runs/4982205560?check_suite_focus=true as example


Include also commit 6f62dc5