### PR TITLE
fix(#1067): fix rule definition link when no labels are defined

### DIFF
--- a/frontend/components/text-classifier/labeling-rules/RuleEmptyQuery.vue
+++ b/frontend/components/text-classifier/labeling-rules/RuleEmptyQuery.vue
@@ -49,6 +49,7 @@
   </div>
 </template>
 <script>
+import { mapActions } from "vuex";
 import { DatasetViewSettings } from "@/models/DatasetViewSettings";
 
 export default {
@@ -96,11 +97,20 @@ export default {
     },
   },
   methods: {
+    ...mapActions({
+      changeViewMode: "entities/datasets/changeViewMode",
+    }),
     expandLabels() {
       this.shownLabels = this.filteredLabels.length;
     },
     collapseLabels() {
       this.shownLabels = this.maxVisibleLabels;
+    },
+    async changeToAnnotationViewMode() {
+      await this.changeViewMode({
+        dataset: this.dataset,
+        value: "annotate",
+      });
     },
   },
 };


### PR DESCRIPTION
This PR fixes link to annotation mode when there is not query and labels

Closes #1067