### PR TITLE
refactor(#945): add text search field for text class datasets

### DIFF
--- a/src/rubrix/server/tasks/commons/api/model.py
+++ b/src/rubrix/server/tasks/commons/api/model.py
@@ -264,7 +264,11 @@ class BaseRecord(GenericModel, Generic[Annotation]):
         properties than commons (predicted, annotated_as,....) could implement
         this method.
         """
-        return {}
+        return {
+            # This allow query by text:.... or text.exact:....
+            # Once words is remove we can normalize at record level
+            "text": self.words
+        }
 
     def dict(self, *args, **kwargs) -> "DictStrAny":
         """

--- a/tests/server/text_classification/test_api.py
+++ b/tests/server/text_classification/test_api.py
@@ -559,3 +559,41 @@ def test_wrong_text_query():
             "params": {"message": "Failed to parse query [!]"},
         }
     }
+
+
+def test_search_using_text():
+    dataset = "test_search_using_text"
+    assert client.delete(f"/api/datasets/{dataset}").status_code == 200
+
+    client.post(
+        f"/api/datasets/{dataset}/TextClassification:bulk",
+        data=TextClassificationBulkData(
+            records=[
+                TextClassificationRecord(
+                    **{
+                        "id": 0,
+                        "inputs": {"data": "Esto es un ejemplo de Texto"},
+                        "metadata": {"field.one": 1, "field.two": 2},
+                    }
+                ),
+            ],
+        ).json(by_alias=True),
+    )
+
+    response = client.post(
+        f"/api/datasets/{dataset}/TextClassification:search",
+        json=TextClassificationSearchRequest(
+            query=TextClassificationQuery(query_text="text: texto")
+        ).dict(),
+    )
+    assert response.status_code == 200
+    assert response.json()["total"] == 1
+
+    response = client.post(
+        f"/api/datasets/{dataset}/TextClassification:search",
+        json=TextClassificationSearchRequest(
+            query=TextClassificationQuery(query_text="text.exact: texto")
+        ).dict(),
+    )
+    assert response.status_code == 200
+    assert response.json()["total"] == 0


### PR DESCRIPTION
This PR add the `text` field to elasticsearch documents for text classification. So, you can do search as `text:....` or `text.exact:...`. This is not the default search text and should be incrementally included. 

Just a work step in tasks described in #945 