### PR TITLE
perf: increase uvicorn version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ where = src
 server =
     # Basic dependencies
     fastapi ~= 0.63.0
-    uvicorn[standard] ~= 0.13.4
+    uvicorn[standard] >= 0.15.0,<0.18.0
     elasticsearch >= 7.4.0,<8.0.0
     smart-open
     brotli-asgi ~= 1.1.0


### PR DESCRIPTION
With the updated version of this dependency, we gain compatibility with gradio. I put an upper limit on the version so we don't run into surprises in the future.