### PR TITLE
refactor(#1089): using opensearch client as default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elasticsearch: [ 7.4.2, 7.10.2, 7.14.2, 7.16.3 ]
+        elasticsearch: [ 7.4, 7.10.2, 7.14, 7.16 ]
     defaults:
       run:
         shell: bash -l {0}
@@ -40,9 +40,9 @@ jobs:
 
       - name: Setup ElasticSearch 🔎
         if: steps.filter.outputs.python_code == 'true'
-        uses: getong/elasticsearch-action@v1.2
+        uses: ankane/setup-elasticsearch@v1
         with:
-          elasticsearch version: ${{ matrix.elasticsearch }}
+          elasticsearch-version: ${{ matrix.elasticsearch }}
       - name: Setup Conda Env 🐍
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elasticsearch: [ 6.8, 7.0, 7.2, 7.4, 7.10.2, 7.14, 7.16, 7.17 ]
+        elasticsearch: [ 7.0, 7.2, 7.4, 7.10.2, 7.14, 7.16, 7.17 ]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elasticsearch: [ 7.4, 7.10.2, 7.14, 7.16 ]
+        elasticsearch: [ 6.8, 7.0, 7.2, 7.4, 7.10.2, 7.14, 7.16, 7.17 ]
     defaults:
       run:
         shell: bash -l {0}
@@ -43,13 +43,17 @@ jobs:
         uses: ankane/setup-elasticsearch@v1
         with:
           elasticsearch-version: ${{ matrix.elasticsearch }}
+
       - name: Setup Conda Env 🐍
         uses: conda-incubator/setup-miniconda@v2
+        if: steps.filter.outputs.python_code == 'true'
         with:
           environment-file: environment_dev.yml
           activate-environment: rubrix
+
       - name: Cache pip 👜
         uses: actions/cache@v2
+        if: steps.filter.outputs.python_code == 'true'
         env:
           # Increase this value to reset cache if setup.cfg has not changed
           CACHE_NUMBER: 0
@@ -153,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'release' }}
     needs:
-      - build
+      - deploy_docker
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elasticsearch: [ 7.0, 7.2, 7.4, 7.10.2, 7.14, 7.16, 7.17 ]
+        elasticsearch: [ 7.4, 7.10.2, 7.14, 7.16, 7.17 ]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ on:
     types: [published]
 
 jobs:
-  build:
-    name: Build python package
+  test:
+    name: Check tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -27,7 +27,6 @@ jobs:
     steps:
       - name: Checkout Code 🛎
         uses: actions/checkout@v2
-
       - name: Check affected files
         uses: dorny/paths-filter@v2
         id: filter
@@ -57,6 +56,7 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.cfg') }}
+
       - name: Run tests 📈
         if: steps.filter.outputs.python_code == 'true'
         run: |
@@ -71,10 +71,34 @@ jobs:
           files: ./coverage.xml
           flags: pytest
           fail_ci_if_error: true
+
+  build:
+    name: Build the python package
+    runs-on: ubuntu-latest
+    needs:
+    - test
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout Code 🛎
+        uses: actions/checkout@v2
+
+      - name: Cache pip 👜
+        uses: actions/cache@v2
+        env:
+          # Increase this value to reset cache if setup.cfg has not changed
+          CACHE_NUMBER: 0
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.cfg') }}
+
       - name: Build Package 🍟
         run: |
           pip install -U build
           scripts/build_distribution.sh
+
       - name: Upload package artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,6 @@ jobs:
   build:
     name: Build the python package
     runs-on: ubuntu-latest
-    needs:
-    - test
     defaults:
       run:
         shell: bash -l {0}
@@ -94,6 +92,11 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ env.CACHE_NUMBER }}-${{ hashFiles('setup.cfg') }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
       - name: Build Package 🍟
         run: |
           pip install -U build
@@ -109,7 +112,8 @@ jobs:
     name: Build latest docker image
     runs-on: ubuntu-latest
     needs:
-    - build
+      - test
+      - build
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
   build:
     name: Build python package
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        elasticsearch: [ 7.4.2, 7.10.2, 7.14.2, 7.16.3 ]
     defaults:
       run:
         shell: bash -l {0}
@@ -40,7 +43,7 @@ jobs:
         if: steps.filter.outputs.python_code == 'true'
         uses: getong/elasticsearch-action@v1.2
         with:
-          elasticsearch version: 7.4.2
+          elasticsearch version: ${{ matrix.elasticsearch }}
       - name: Setup Conda Env 🐍
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -6,7 +6,6 @@ ENV USERS_DB=/config/.users.yml
 
 RUN wget -O /wait-for-it.sh https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh \
  && chmod +x /wait-for-it.sh \
- && pip install "elasticsearch==7.13.0" \
  && find /packages/*.whl -exec pip install {}[server] \;
 
 # See <https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker#module_name>

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ server =
     # Basic dependencies
     fastapi ~= 0.63.0
     uvicorn[standard] ~= 0.13.4
-    elasticsearch >= 7.4.0,<8.0.0
+    opensearch-py
     smart-open
     brotli-asgi ~= 1.1.0
     Deprecated ~= 1.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ server =
     # Basic dependencies
     fastapi ~= 0.63.0
     uvicorn[standard] ~= 0.13.4
-    opensearch-py
+    opensearch-py ~= 1.0.0
     smart-open
     brotli-asgi ~= 1.1.0
     Deprecated ~= 1.2.0

--- a/src/rubrix/server/commons/errors/base_errors.py
+++ b/src/rubrix/server/commons/errors/base_errors.py
@@ -151,6 +151,16 @@ class EntityNotFoundError(RubrixServerError):
         self.type = type.__name__
 
 
+class ClosedDatasetError(BadRequestError):
+    def __init__(self, name: str):
+        self.name = name
+
+
+class MissingDatasetRecordsError(BadRequestError):
+    def __init__(self, message: str):
+        self.message = message
+
+
 __ALL__ = [
     BadRequestError,
     EntityNotFoundError,
@@ -158,4 +168,6 @@ __ALL__ = [
     EntityAlreadyExistsError,
     ValidationError,
     GenericRubrixServerError,
+    ClosedDatasetError,
+    MissingDatasetRecordsError,
 ]

--- a/src/rubrix/server/commons/es_wrapper.py
+++ b/src/rubrix/server/commons/es_wrapper.py
@@ -16,10 +16,9 @@
 from typing import Any, Callable, Dict, Iterable, List, Optional
 
 import deprecated
-import elasticsearch
-from elasticsearch import Elasticsearch, NotFoundError, RequestError
-from elasticsearch.helpers import bulk as es_bulk
-from elasticsearch.helpers import scan as es_scan
+from opensearchpy import NotFoundError, OpenSearch, OpenSearchException, RequestError
+from opensearchpy.helpers import bulk as es_bulk
+from opensearchpy.helpers import scan as es_scan
 
 from rubrix.logging import LoggingMixin
 from rubrix.server.commons.errors import InvalidTextSearchError
@@ -30,6 +29,19 @@ except ModuleNotFoundError:
     import json
 
 from .settings import settings
+
+
+class ClosedIndexError(Exception):
+    pass
+
+
+class IndexNotFoundError(Exception):
+    pass
+
+
+class GenericSearchError(Exception):
+    def __init__(self, origin_error: Exception):
+        self.origin_error = origin_error
 
 
 class ElasticsearchWrapper(LoggingMixin):
@@ -52,12 +64,12 @@ class ElasticsearchWrapper(LoggingMixin):
         """
 
         if cls._INSTANCE is None:
-            es_client = Elasticsearch(hosts=settings.elasticsearch)
+            es_client = OpenSearch(hosts=settings.elasticsearch)
             cls._INSTANCE = cls(es_client)
 
         return cls._INSTANCE
 
-    def __init__(self, es_client: Elasticsearch):
+    def __init__(self, es_client: OpenSearch):
         self.__client__ = es_client
 
     @property
@@ -136,14 +148,18 @@ class ElasticsearchWrapper(LoggingMixin):
             )
         except RequestError as rex:
 
-            if rex.error != "search_phase_execution_exception":
-                raise rex
+            if rex.error == "search_phase_execution_exception":
+                detail = rex.info["error"]
+                detail = detail.get("root_cause")
+                detail = detail[0].get("reason") if detail else rex.info["error"]
 
-            detail = rex.info["error"]
-            detail = detail.get("root_cause")
-            detail = detail[0].get("reason") if detail else rex.info["error"]
+                raise InvalidTextSearchError(detail)
 
-            raise InvalidTextSearchError(detail)
+            if rex.error == "index_closed_exception":
+                raise ClosedIndexError(index)
+            raise GenericSearchError(rex)
+        except OpenSearchException as ex:
+            raise GenericSearchError(ex)
 
     def create_index(
         self,
@@ -241,7 +257,7 @@ class ElasticsearchWrapper(LoggingMixin):
         """
         try:
             return self.__client__.get(index=index, id=doc_id)
-        except elasticsearch.exceptions.NotFoundError:
+        except NotFoundError:
             return None
 
     def delete_document(self, index: str, doc_id: str):
@@ -514,6 +530,13 @@ class ElasticsearchWrapper(LoggingMixin):
             body={"properties": {field_name: mapping}},
         )
 
+    def get_cluster_info(self) -> Dict[str, Any]:
+        """Returns basic about es cluster"""
+        try:
+            return self.__client__.info()
+        except OpenSearchException as ex:
+            return {"error": ex}
+
 
 _instance = None  # The singleton instance
 
@@ -534,7 +557,6 @@ def create_es_wrapper() -> ElasticsearchWrapper:
 
     global _instance
     if _instance is None:
-        es_client = Elasticsearch(hosts=settings.elasticsearch)
-        _instance = ElasticsearchWrapper(es_client)
+        _instance = ElasticsearchWrapper.get_instance()
 
     return _instance

--- a/src/rubrix/server/server.py
+++ b/src/rubrix/server/server.py
@@ -20,7 +20,6 @@ This module configures the global fastapi application
 import os
 from pathlib import Path
 
-import elasticsearch
 from brotli_asgi import BrotliMiddleware
 from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
@@ -88,6 +87,8 @@ def configure_app_statics(app: FastAPI):
 def configure_app_startup(app: FastAPI):
     @app.on_event("startup")
     async def configure_elasticsearch():
+        import opensearchpy
+
         try:
             es_wrapper = create_es_wrapper()
             dataset_records: DatasetRecordsDAO = DatasetRecordsDAO(es_wrapper)
@@ -96,7 +97,7 @@ def configure_app_startup(app: FastAPI):
             )
             datasets.init()
             dataset_records.init()
-        except elasticsearch.exceptions.ConnectionError as error:
+        except opensearchpy.exceptions.ConnectionError as error:
             raise ConfigError(
                 f"Your Elasticsearch endpoint at {settings.obfuscated_elasticsearch()} "
                 "is not available or not responding.\n"

--- a/src/rubrix/server/tasks/commons/dao/dao.py
+++ b/src/rubrix/server/tasks/commons/dao/dao.py
@@ -20,9 +20,15 @@ from typing import Any, Dict, Iterable, List, Optional, Type, TypeVar
 import deprecated
 from fastapi import Depends
 
+from rubrix.server.commons.errors import ClosedDatasetError, MissingDatasetRecordsError
 from rubrix.server.commons.es_helpers import aggregations, parse_aggregations
 from rubrix.server.commons.es_settings import DATASETS_RECORDS_INDEX_NAME
-from rubrix.server.commons.es_wrapper import ElasticsearchWrapper, create_es_wrapper
+from rubrix.server.commons.es_wrapper import (
+    ClosedIndexError,
+    ElasticsearchWrapper,
+    IndexNotFoundError,
+    create_es_wrapper,
+)
 from rubrix.server.commons.helpers import unflatten_dict
 from rubrix.server.commons.settings import settings
 from rubrix.server.datasets.model import BaseDatasetDB
@@ -239,7 +245,15 @@ class DatasetRecordsDAO:
             "sort": search.sort or [{"_id": {"order": "asc"}}],
             "aggs": aggregation_requests,
         }
-        results = self._es.search(index=records_index, query=es_query, size=size)
+
+        try:
+            results = self._es.search(index=records_index, query=es_query, size=size)
+        except ClosedIndexError:
+            raise ClosedDatasetError(dataset.name)
+        except IndexNotFoundError:
+            raise MissingDatasetRecordsError(
+                f"No records index found for dataset {dataset.name}"
+            )
 
         if compute_aggregations and search.include_default_aggregations:
             current_aggrs = results.get("aggregations", {})

--- a/src/rubrix/server/tasks/text_classification/service/service.py
+++ b/src/rubrix/server/tasks/text_classification/service/service.py
@@ -15,10 +15,9 @@
 
 from typing import Iterable, List, Optional
 
-from elasticsearch import NotFoundError
 from fastapi import Depends
 
-from rubrix.server.commons.errors import EntityNotFoundError, MissingInputParamError
+from rubrix.server.commons.errors import MissingDatasetRecordsError
 from rubrix.server.commons.es_helpers import aggregations, sort_by2elasticsearch
 from rubrix.server.datasets.model import Dataset
 from rubrix.server.tasks.commons import (
@@ -228,7 +227,7 @@ class TextClassificationService:
                 size=1,
                 exclude_fields=["metrics", "metadata"],
             )
-        except NotFoundError:
+        except MissingDatasetRecordsError:  # No records index yet
             return None
         records = [TextClassificationRecord.parse_obj(r) for r in results.records]
         if records:

--- a/tests/server/datasets/test_api.py
+++ b/tests/server/datasets/test_api.py
@@ -121,9 +121,12 @@ def test_open_and_close_dataset():
     assert client.put(f"/api/datasets/{dataset}:close").status_code == 200
 
     response = client.post(f"/api/datasets/{dataset}/TextClassification:search")
-    assert response.status_code == 500
+    assert response.status_code == 400
     assert response.json() == {
-        "detail": {"code": "elasticsearch.exceptions.RequestError", "params": {}}
+        "detail": {
+            "code": "rubrix.api.errors::ClosedDatasetError",
+            "params": {"name": dataset},
+        }
     }
 
     assert client.put(f"/api/datasets/{dataset}:open").status_code == 200

--- a/tests/server/datasets/test_dao.py
+++ b/tests/server/datasets/test_dao.py
@@ -13,17 +13,23 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import elasticsearch
 import pytest
 
+from rubrix.server.commons.errors import ClosedDatasetError
 from rubrix.server.commons.es_wrapper import create_es_wrapper
 from rubrix.server.datasets.dao import DatasetsDAO
 from rubrix.server.datasets.model import DatasetDB
 from rubrix.server.tasks.commons import TaskType
 from rubrix.server.tasks.commons.dao.dao import dataset_records_dao
+from rubrix.server.tasks.text_classification.dao.es_config import (
+    text_classification_mappings,
+)
 
 es_wrapper = create_es_wrapper()
 records = dataset_records_dao(es_wrapper)
+records.register_task_mappings(
+    TaskType.text_classification, text_classification_mappings()
+)
 dao = DatasetsDAO.get_instance(es_wrapper, records)
 
 
@@ -45,9 +51,7 @@ def test_close_dataset():
     )
 
     dao.close(created)
-    with pytest.raises(
-        elasticsearch.exceptions.RequestError, match="index_closed_exception"
-    ):
+    with pytest.raises(ClosedDatasetError, match=dataset):
         records.search_records(dataset=created)
 
     dao.open(created)


### PR DESCRIPTION
This PR replaces the oficial elasticsearch client  by the opensearch-py client. That is full compatible  and avoid error referred in #1089

Also refactor the github actions file for:

-  Check different supported elasticsearch versions.
- Separate test and build jobs


Closes #1089 