### PR TITLE
fix(#1094): remove computed record fields returned in API results

### DIFF
--- a/src/rubrix/server/tasks/text_classification/api/model.py
+++ b/src/rubrix/server/tasks/text_classification/api/model.py
@@ -403,7 +403,7 @@ class CreationTextClassificationRecord(BaseRecord[TextClassificationAnnotation])
         allow_population_by_field_name = True
 
 
-class TextClassificationRecord(CreationTextClassificationRecord):
+class TextClassificationRecordDB(CreationTextClassificationRecord):
     """
     The main text classification task record
 
@@ -419,8 +419,6 @@ class TextClassificationRecord(CreationTextClassificationRecord):
     last_updated: datetime = None
     _predicted: Optional[PredictionStatus] = Field(alias="predicted")
 
-
-class TextClassificationRecordDB(TextClassificationRecord):
     def extended_fields(self) -> Dict[str, Any]:
         words = self.all_text()
         return {
@@ -430,6 +428,11 @@ class TextClassificationRecordDB(TextClassificationRecord):
             # Once words is remove we can normalize at record level
             "text": words,
         }
+
+
+class TextClassificationRecord(TextClassificationRecordDB):
+    def extended_fields(self) -> Dict[str, Any]:
+        return {}
 
 
 class TextClassificationBulkData(UpdateDatasetRequest):

--- a/src/rubrix/server/tasks/token_classification/api/model.py
+++ b/src/rubrix/server/tasks/token_classification/api/model.py
@@ -289,7 +289,7 @@ class CreationTokenClassificationRecord(BaseRecord[TokenClassificationAnnotation
         underscore_attrs_are_private = True
 
 
-class TokenClassificationRecord(CreationTokenClassificationRecord):
+class TokenClassificationRecordDB(CreationTokenClassificationRecord):
     """
     The main token classification task record
 
@@ -306,14 +306,6 @@ class TokenClassificationRecord(CreationTokenClassificationRecord):
     _predicted: Optional[PredictionStatus] = Field(alias="predicted")
 
     def extended_fields(self) -> Dict[str, Any]:
-        return {
-            **super().extended_fields(),
-            "raw_text": self.text,  # Maintain results compatibility
-        }
-
-
-class TokenClassificationRecordDB(TokenClassificationRecord):
-    def extended_fields(self) -> Dict[str, Any]:
         parent_fields = super().extended_fields()
         parent_fields.pop("raw_text")
 
@@ -329,6 +321,13 @@ class TokenClassificationRecordDB(TokenClassificationRecord):
                 for mention, entity in self.annotated_mentions()
             ],
             "words": self.all_text(),
+        }
+
+
+class TokenClassificationRecord(TokenClassificationRecordDB):
+    def extended_fields(self) -> Dict[str, Any]:
+        return {
+            "raw_text": self.text,  # Maintain results compatibility
         }
 
 

--- a/src/rubrix/server/tasks/token_classification/api/model.py
+++ b/src/rubrix/server/tasks/token_classification/api/model.py
@@ -306,11 +306,9 @@ class TokenClassificationRecordDB(CreationTokenClassificationRecord):
     _predicted: Optional[PredictionStatus] = Field(alias="predicted")
 
     def extended_fields(self) -> Dict[str, Any]:
-        parent_fields = super().extended_fields()
-        parent_fields.pop("raw_text")
 
         return {
-            **parent_fields,
+            **super().extended_fields(),
             # See ../service/service.py
             PREDICTED_MENTIONS_ES_FIELD_NAME: [
                 {"mention": mention, "entity": entity.label, "score": entity.score}

--- a/tests/server/text2text/test_model.py
+++ b/tests/server/text2text/test_model.py
@@ -25,6 +25,35 @@ def test_sentences_sorted_by_score():
     assert record.prediction.sentences[2].score == 0.5
 
 
+def test_model_dict():
+    record = Text2TextRecord(
+        id=0,
+        text="The input text",
+        prediction=Text2TextAnnotation(
+            agent="test_sentences_sorted_by_score",
+            sentences=[
+                Text2TextPrediction(text="sentence 1", score=0.6),
+                Text2TextPrediction(text="sentence 2", score=0.5),
+                Text2TextPrediction(text="sentence 3", score=1.0),
+            ],
+        ),
+    )
+    assert record.dict(exclude_none=True) == {
+        "id": 0,
+        "metrics": {},
+        "prediction": {
+            "agent": "test_sentences_sorted_by_score",
+            "sentences": [
+                {"score": 1.0, "text": "sentence 3"},
+                {"score": 0.6, "text": "sentence 1"},
+                {"score": 0.5, "text": "sentence 2"},
+            ],
+        },
+        "status": "Default",
+        "text": "The input text",
+    }
+
+
 def test_query_as_elasticsearch():
     query = Text2TextQuery(ids=[1, 2, 3])
     assert query.as_elasticsearch() == {"ids": {"values": query.ids}}

--- a/tests/server/text_classification/test_model.py
+++ b/tests/server/text_classification/test_model.py
@@ -16,11 +16,9 @@ import pytest
 from pydantic import ValidationError
 
 from rubrix._constants import MAX_KEYWORD_LENGTH
-
 from rubrix.server.commons.settings import settings
 from rubrix.server.tasks.commons import TaskStatus
 from rubrix.server.tasks.text_classification import TextClassificationQuery
-
 from rubrix.server.tasks.text_classification.api import (
     ClassPrediction,
     PredictionStatus,
@@ -52,6 +50,35 @@ def test_metadata_with_object_list():
     }
     record = TextClassificationRecord.parse_obj(data)
     assert list(record.metadata.keys()) == ["mails"]
+
+
+def test_model_dict():
+    record = TextClassificationRecord.parse_obj(
+        {
+            "id": 1,
+            "inputs": {"text": "This is a text"},
+            "annotation": {
+                "agent": "test",
+                "labels": [{"class": "A"}, {"class": "B"}],
+            },
+            "multi_label": True,
+        }
+    )
+
+    assert record.dict(exclude_none=True) == {
+        "annotation": {
+            "agent": "test",
+            "labels": [
+                {"class_label": "A", "score": 1.0},
+                {"class_label": "B", "score": 1.0},
+            ],
+        },
+        "id": 1,
+        "inputs": {"text": "This is a text"},
+        "metrics": {},
+        "multi_label": True,
+        "status": "Default",
+    }
 
 
 def test_single_label_with_multiple_annotation():

--- a/tests/server/token_classification/test_model.py
+++ b/tests/server/token_classification/test_model.py
@@ -77,6 +77,33 @@ def test_entities_with_spaces():
     )
 
 
+def test_model_dict():
+    record = TokenClassificationRecord(
+        id="1",
+        text="This is  a  great  space",
+        tokens=["This", "is", " ", "a", " ", "great", " ", "space"],
+        prediction=TokenClassificationAnnotation(
+            agent="test",
+            entities=[
+                EntitySpan(start=9, end=24, label="test"),
+            ],
+        ),
+    )
+
+    assert record.dict(exclude_none=True) == {
+        "id": 1,
+        "metrics": {},
+        "prediction": {
+            "agent": "test",
+            "entities": [{"end": 24, "label": "test", "score": 1.0, "start": 9}],
+        },
+        "raw_text": "This is  a  great  space",
+        "status": "Default",
+        "text": "This is  a  great  space",
+        "tokens": ["This", "is", " ", "a", " ", "great", " ", "space"],
+    }
+
+
 def test_too_long_metadata():
     text = "On one ones o no"
     record = TokenClassificationRecord.parse_obj(


### PR DESCRIPTION
Work done In this PR will simplify work in #945.

Closes #1094 

