### PR TITLE
fix(#945): include default aggregations for text2text

### DIFF
--- a/src/rubrix/server/commons/es_helpers.py
+++ b/src/rubrix/server/commons/es_helpers.py
@@ -588,6 +588,7 @@ class aggregations:
             "score": {
                 "range": {
                     "field": EsRecordDataFieldNames.score,
+                    "keyed": True,
                     "ranges": [
                         {"from": _from / ten_decimals, "to": _to / ten_decimals}
                         for _from, _to in zip(

--- a/src/rubrix/server/tasks/text2text/service/service.py
+++ b/src/rubrix/server/tasks/text2text/service/service.py
@@ -123,7 +123,6 @@ class Text2TextService:
                         ExtendedEsRecordDataFieldNames.text_predicted
                     )
                 },
-                include_default_aggregations=False,
             ),
             size=size,
             record_from=record_from,

--- a/tests/server/text2text/test_api.py
+++ b/tests/server/text2text/test_api.py
@@ -52,7 +52,7 @@ def test_search_records():
     assert results.total == 2
     assert results.records[0].predicted is None
 
-    assert results.aggregations.dict() == {
+    assert results.aggregations.dict(exclude={"score"}) == {
         "annotated_as": {},
         "annotated_by": {},
         "annotated_text": {},
@@ -61,29 +61,6 @@ def test_search_records():
         "predicted_as": {},
         "predicted_by": {"test": 1},
         "predicted_text": {},
-        "score": {
-            "0.0-0.05": 0,
-            "0.05-0.1": 0,
-            "0.1-0.15": 0,
-            "0.15-0.2": 0,
-            "0.2-0.25": 0,
-            "0.25-0.3": 0,
-            "0.3-0.35": 0,
-            "0.35-0.4": 0,
-            "0.4-0.45": 0,
-            "0.45-0.5": 0,
-            "0.5-0.55": 0,
-            "0.55-0.6": 0,
-            "0.6-0.65": 1,
-            "0.65-0.7": 0,
-            "0.7-0.75": 0,
-            "0.75-0.8": 0,
-            "0.8-0.85": 0,
-            "0.85-0.9": 0,
-            "0.9-0.95": 0,
-            "0.95-1.0": 0,
-            "1.0-*": 0,
-        },
         "status": {"Default": 2},
         "words": {"data": 2, "ånother": 1},
     }

--- a/tests/server/text2text/test_api.py
+++ b/tests/server/text2text/test_api.py
@@ -51,3 +51,39 @@ def test_search_records():
     results = Text2TextSearchResults.parse_obj(response.json())
     assert results.total == 2
     assert results.records[0].predicted is None
+
+    assert results.aggregations.dict() == {
+        "annotated_as": {},
+        "annotated_by": {},
+        "annotated_text": {},
+        "metadata": {"field_one": {"value one": 1}},
+        "predicted": {},
+        "predicted_as": {},
+        "predicted_by": {"test": 1},
+        "predicted_text": {},
+        "score": {
+            "0.0-0.05": 0,
+            "0.05-0.1": 0,
+            "0.1-0.15": 0,
+            "0.15-0.2": 0,
+            "0.2-0.25": 0,
+            "0.25-0.3": 0,
+            "0.3-0.35": 0,
+            "0.35-0.4": 0,
+            "0.4-0.45": 0,
+            "0.45-0.5": 0,
+            "0.5-0.55": 0,
+            "0.55-0.6": 0,
+            "0.6-0.65": 1,
+            "0.65-0.7": 0,
+            "0.7-0.75": 0,
+            "0.75-0.8": 0,
+            "0.8-0.85": 0,
+            "0.85-0.9": 0,
+            "0.9-0.95": 0,
+            "0.95-1.0": 0,
+            "1.0-*": 0,
+        },
+        "status": {"Default": 2},
+        "words": {"data": 2, "ånother": 1},
+    }

--- a/tests/server/text_classification/test_api.py
+++ b/tests/server/text_classification/test_api.py
@@ -168,10 +168,39 @@ def test_create_records_for_text_classification():
     assert response.status_code == 200
     results = TextClassificationSearchResults.parse_obj(response.json())
     assert results.total == 1
-    assert results.aggregations.predicted_as == {"Mocking": 1}
-    assert results.aggregations.status == {"Default": 1}
-    assert results.aggregations.score
-    assert results.aggregations.predicted == {}
+    assert results.aggregations.dict() == {
+        "annotated_as": {},
+        "annotated_by": {},
+        "metadata": {},
+        "predicted": {},
+        "predicted_as": {"Mocking": 1},
+        "predicted_by": {"test": 1},
+        "score": {
+            "0.0-0.05": 0,
+            "0.05-0.1": 0,
+            "0.1-0.15": 0,
+            "0.15-0.2": 0,
+            "0.2-0.25": 0,
+            "0.25-0.3": 0,
+            "0.3-0.35": 0,
+            "0.35-0.4": 0,
+            "0.4-0.45": 0,
+            "0.45-0.5": 0,
+            "0.5-0.55": 0,
+            "0.55-0.6": 0,
+            "0.6-0.65": 0,
+            "0.65-0.7": 1,
+            "0.7-0.75": 0,
+            "0.75-0.8": 0,
+            "0.8-0.85": 0,
+            "0.85-0.9": 0,
+            "0.9-0.95": 0,
+            "0.95-1.0": 0,
+            "1.0-*": 0,
+        },
+        "status": {"Default": 1},
+        "words": {"data": 1},
+    }
 
 
 def test_partial_record_update():

--- a/tests/server/text_classification/test_api.py
+++ b/tests/server/text_classification/test_api.py
@@ -168,36 +168,13 @@ def test_create_records_for_text_classification():
     assert response.status_code == 200
     results = TextClassificationSearchResults.parse_obj(response.json())
     assert results.total == 1
-    assert results.aggregations.dict() == {
+    assert results.aggregations.dict(exclude={"score"}) == {
         "annotated_as": {},
         "annotated_by": {},
         "metadata": {},
         "predicted": {},
         "predicted_as": {"Mocking": 1},
         "predicted_by": {"test": 1},
-        "score": {
-            "0.0-0.05": 0,
-            "0.05-0.1": 0,
-            "0.1-0.15": 0,
-            "0.15-0.2": 0,
-            "0.2-0.25": 0,
-            "0.25-0.3": 0,
-            "0.3-0.35": 0,
-            "0.35-0.4": 0,
-            "0.4-0.45": 0,
-            "0.45-0.5": 0,
-            "0.5-0.55": 0,
-            "0.55-0.6": 0,
-            "0.6-0.65": 0,
-            "0.65-0.7": 1,
-            "0.7-0.75": 0,
-            "0.75-0.8": 0,
-            "0.8-0.85": 0,
-            "0.85-0.9": 0,
-            "0.9-0.95": 0,
-            "0.95-1.0": 0,
-            "1.0-*": 0,
-        },
         "status": {"Default": 1},
         "words": {"data": 1},
     }

--- a/tests/server/token_classification/test_api.py
+++ b/tests/server/token_classification/test_api.py
@@ -198,6 +198,43 @@ def test_create_records_for_token_classification(
     response = client.post(search_url)
     assert response.status_code == 200, response.json()
     results = TokenClassificationSearchResults.parse_obj(response.json())
+
+    assert results.aggregations.dict() == {
+        "annotated_as": {"TEST": 1},
+        "annotated_by": {"test": 1},
+        "mentions": {"TEST": {"This": 1}},
+        "metadata": {"field_one": {"value one": 1}, "field_two": {"value 2": 1}},
+        "predicted": {"ok": 1},
+        "predicted_as": {"TEST": 1},
+        "predicted_by": {"test": 1},
+        "predicted_mentions": {"TEST": {"This": 1}},
+        "score": {
+            "0.0-0.05": 0,
+            "0.05-0.1": 0,
+            "0.1-0.15": 0,
+            "0.15-0.2": 0,
+            "0.2-0.25": 0,
+            "0.25-0.3": 0,
+            "0.3-0.35": 0,
+            "0.35-0.4": 0,
+            "0.4-0.45": 0,
+            "0.45-0.5": 0,
+            "0.5-0.55": 0,
+            "0.55-0.6": 0,
+            "0.6-0.65": 0,
+            "0.65-0.7": 0,
+            "0.7-0.75": 0,
+            "0.75-0.8": 0,
+            "0.8-0.85": 0,
+            "0.85-0.9": 0,
+            "0.9-0.95": 0,
+            "0.95-1.0": 0,
+            "1.0-*": 0,
+        },
+        "status": {"Default": 1},
+        "words": {},
+    }
+
     assert "This" in results.aggregations.predicted_mentions[entity_label]
     assert "This" in results.aggregations.mentions[entity_label]
     for record in results.records:

--- a/tests/server/token_classification/test_api.py
+++ b/tests/server/token_classification/test_api.py
@@ -199,7 +199,7 @@ def test_create_records_for_token_classification(
     assert response.status_code == 200, response.json()
     results = TokenClassificationSearchResults.parse_obj(response.json())
 
-    assert results.aggregations.dict() == {
+    assert results.aggregations.dict(exclude={"score"}) == {
         "annotated_as": {"TEST": 1},
         "annotated_by": {"test": 1},
         "mentions": {"TEST": {"This": 1}},
@@ -208,29 +208,6 @@ def test_create_records_for_token_classification(
         "predicted_as": {"TEST": 1},
         "predicted_by": {"test": 1},
         "predicted_mentions": {"TEST": {"This": 1}},
-        "score": {
-            "0.0-0.05": 0,
-            "0.05-0.1": 0,
-            "0.1-0.15": 0,
-            "0.15-0.2": 0,
-            "0.2-0.25": 0,
-            "0.25-0.3": 0,
-            "0.3-0.35": 0,
-            "0.35-0.4": 0,
-            "0.4-0.45": 0,
-            "0.45-0.5": 0,
-            "0.5-0.55": 0,
-            "0.55-0.6": 0,
-            "0.6-0.65": 0,
-            "0.65-0.7": 0,
-            "0.7-0.75": 0,
-            "0.75-0.8": 0,
-            "0.8-0.85": 0,
-            "0.85-0.9": 0,
-            "0.9-0.95": 0,
-            "0.95-1.0": 0,
-            "1.0-*": 0,
-        },
         "status": {"Default": 1},
         "words": {},
     }


### PR DESCRIPTION
Since last changes related to #945, default aggregations are not returned as part of search response, so filters for Text2Text are not shown in app