### PR TITLE
docs(#1089): remove pip install elasticsearch from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ docker run -d \
  -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
  -e "discovery.type=single-node" \
  docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
-pip install "elasticsearch<7.14.0"
 ```
 
 Then simply run:

--- a/docs/getting_started/advanced_setup_guides.rst
+++ b/docs/getting_started/advanced_setup_guides.rst
@@ -29,7 +29,7 @@ Simply run the following command:
      -e "discovery.type=single-node" \
      docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
 
-This will create an ES docker container named *"elasticsearch-for-rubrix"* that will run in the background, and it will also install the appropriate client.
+This will create an ES docker container named *"elasticsearch-for-rubrix"* that will run in the background.
 
 To see the logs of the container, you can run:
 

--- a/docs/getting_started/advanced_setup_guides.rst
+++ b/docs/getting_started/advanced_setup_guides.rst
@@ -28,7 +28,6 @@ Simply run the following command:
      -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
      -e "discovery.type=single-node" \
      docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
-   pip install "elasticsearch<7.14.0"
 
 This will create an ES docker container named *"elasticsearch-for-rubrix"* that will run in the background, and it will also install the appropriate client.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,7 +52,6 @@ If you don't have `Elasticsearch (ES) <https://www.elastic.co/elasticsearch>`__ 
      -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
      -e "discovery.type=single-node" \
      docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
-   pip install "elasticsearch<7.14.0"
 
 
 Then simply run:


### PR DESCRIPTION
Since rubrix uses the opensearch client module, we don't need conditional install for elasticsearch anymore.

See #1091 