### PR TITLE
fix: convert pd.NaT to None for event_timestamp

### DIFF
--- a/src/rubrix/client/models.py
+++ b/src/rubrix/client/models.py
@@ -28,43 +28,45 @@ from rubrix._constants import MAX_KEYWORD_LENGTH
 from rubrix.server.commons.helpers import limit_value_length
 
 
-class _RootValidators(BaseModel):
-    """Base class for our record models that takes care of root validations"""
+class _Validators(BaseModel):
+    """Base class for our record models that takes care of general validations"""
 
-    @root_validator
-    def _check_value_length(cls, values):
+    @validator("metadata", check_fields=False)
+    def _check_value_length(cls, v):
         """Checks metadata values length and apply value truncation for large values"""
-        new_metadata = limit_value_length(
-            values["metadata"], max_length=MAX_KEYWORD_LENGTH
-        )
-        if new_metadata != values["metadata"]:
+        new_metadata = limit_value_length(v, max_length=MAX_KEYWORD_LENGTH)
+        if new_metadata != v:
             warnings.warn(
                 "Some metadata values exceed the max length. "
                 f"Those values will be truncated by keeping only the last {MAX_KEYWORD_LENGTH} characters."
             )
-            values["metadata"] = new_metadata
 
-        return values
+        return new_metadata
 
-    @root_validator
-    def _check_agents(cls, values):
-        """Triggers a warning when ONLY agents are provided"""
-        if (
-            values.get("annotation_agent") is not None
-            and values.get("annotation") is None
-        ):
-            warnings.warn(
-                "You provided an `annotation_agent`, but no `annotation`. The `annotation_agent` will not be logged to the server."
-            )
-        if (
-            values.get("prediction_agent") is not None
-            and values.get("prediction") is None
-        ):
+    @validator("prediction_agent", check_fields=False)
+    def _check_prediction_agent(cls, v, values):
+        """Triggers a warning when ONLY prediction agent is provided"""
+        if v and values["prediction"] is None:
             warnings.warn(
                 "You provided an `prediction_agent`, but no `prediction`. The `prediction_agent` will not be logged to the server."
             )
+        return v
 
-        return values
+    @validator("annotation_agent", check_fields=False)
+    def _check_annotation_agent(cls, v, values):
+        """Triggers a warning when ONLY annotation agent is provided"""
+        if v and values["annotation"] is None:
+            warnings.warn(
+                "You provided an `annotation_agent`, but no `annotation`. The `annotation_agent` will not be logged to the server."
+            )
+        return v
+
+    @validator("event_timestamp", check_fields=False)
+    def _nat_to_none(cls, v):
+        """Converts pandas `NaT`s to `None`s"""
+        if v is pd.NaT:
+            return None
+        return v
 
     @root_validator
     def _check_and_update_status(cls, values):
@@ -72,14 +74,6 @@ class _RootValidators(BaseModel):
         values["status"] = values.get("status") or (
             "Default" if values.get("annotation") is None else "Validated"
         )
-
-        return values
-
-    @root_validator
-    def _nat_to_none(cls, values):
-        """Converts pandas `NaT`s to `None`s"""
-        if values["event_timestamp"] is pd.NaT:
-            values["event_timestamp"] = None
 
         return values
 
@@ -115,7 +109,7 @@ class TokenAttributions(BaseModel):
     attributions: Dict[str, float] = Field(default_factory=dict)
 
 
-class TextClassificationRecord(_RootValidators):
+class TextClassificationRecord(_Validators):
     """Record for text classification
 
     Args:
@@ -181,7 +175,7 @@ class TextClassificationRecord(_RootValidators):
         return dict(text=inputs)
 
 
-class TokenClassificationRecord(_RootValidators):
+class TokenClassificationRecord(_Validators):
     """Record for a token classification task
 
     Args:
@@ -241,7 +235,7 @@ class TokenClassificationRecord(_RootValidators):
     metrics: Optional[Dict[str, Any]] = None
 
 
-class Text2TextRecord(_RootValidators):
+class Text2TextRecord(_Validators):
     """Record for a text to text task
 
     Args:

--- a/src/rubrix/client/models.py
+++ b/src/rubrix/client/models.py
@@ -21,6 +21,7 @@ import datetime
 import warnings
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+import pandas as pd
 from pydantic import BaseModel, Field, root_validator, validator
 
 from rubrix._constants import MAX_KEYWORD_LENGTH
@@ -71,6 +72,14 @@ class _RootValidators(BaseModel):
         values["status"] = values.get("status") or (
             "Default" if values.get("annotation") is None else "Validated"
         )
+
+        return values
+
+    @root_validator
+    def _nat_to_none(cls, values):
+        """Converts pandas `NaT`s to `None`s"""
+        if values["event_timestamp"] is pd.NaT:
+            values["event_timestamp"] = None
 
         return values
 

--- a/tests/client/test_models.py
+++ b/tests/client/test_models.py
@@ -26,7 +26,7 @@ from rubrix.client.models import (
     Text2TextRecord,
     TextClassificationRecord,
     TokenClassificationRecord,
-    _RootValidators,
+    _Validators,
 )
 
 
@@ -41,9 +41,14 @@ from rubrix.client.models import (
 )
 def test_text_classification_record(annotation, status, expected_status):
     """Just testing its dynamic defaults"""
-    record = TextClassificationRecord(
-        inputs={"text": "test"}, annotation=annotation, status=status
-    )
+    if status:
+        record = TextClassificationRecord(
+            inputs={"text": "test"}, annotation=annotation, status=status
+        )
+    else:
+        record = TextClassificationRecord(
+            inputs={"text": "test"}, annotation=annotation
+        )
     assert record.status == expected_status
 
 
@@ -102,14 +107,11 @@ def test_model_serialization_with_numpy_nan():
 
 
 def test_warning_when_only_agent():
-    class MockRecord(_RootValidators):
+    class MockRecord(_Validators):
         prediction: Optional[Any] = None
         prediction_agent: Optional[str] = None
         annotation: Optional[Any] = None
         annotation_agent: Optional[str] = None
-        metadata: Optional[Any] = None
-        status: Optional[str] = None
-        event_timestamp: Optional[datetime.datetime] = None
 
     with pytest.warns(
         UserWarning, match="`prediction_agent` will not be logged to the server."
@@ -122,24 +124,16 @@ def test_warning_when_only_agent():
 
 
 def test_forbid_extra():
-    class MockRecord(_RootValidators):
-        prediction: Optional[Any] = None
-        prediction_agent: Optional[str] = None
-        annotation: Optional[Any] = None
-        annotation_agent: Optional[str] = None
-        metadata: Optional[Any] = None
-        status: Optional[str] = None
-        event_timestamp: Optional[datetime.datetime] = None
+    class MockRecord(_Validators):
+        mock: str
 
     with pytest.raises(ValidationError):
-        MockRecord(extra="mock")
+        MockRecord(mock="mock", extra_argument="mock")
 
 
 def test_nat_to_none():
-    class MockRecord(_RootValidators):
+    class MockRecord(_Validators):
         event_timestamp: Optional[datetime.datetime] = None
-        metadata: Optional[Any] = None
-        status: Optional[str] = None
 
     record = MockRecord(event_timestamp=pd.NaT)
     assert record.event_timestamp is None

--- a/tests/client/test_models.py
+++ b/tests/client/test_models.py
@@ -109,6 +109,7 @@ def test_warning_when_only_agent():
         annotation_agent: Optional[str] = None
         metadata: Optional[Any] = None
         status: Optional[str] = None
+        event_timestamp: Optional[datetime.datetime] = None
 
     with pytest.warns(
         UserWarning, match="`prediction_agent` will not be logged to the server."
@@ -128,6 +129,7 @@ def test_forbid_extra():
         annotation_agent: Optional[str] = None
         metadata: Optional[Any] = None
         status: Optional[str] = None
+        event_timestamp: Optional[datetime.datetime] = None
 
     with pytest.raises(ValidationError):
         MockRecord(extra="mock")

--- a/tests/client/test_models.py
+++ b/tests/client/test_models.py
@@ -12,10 +12,12 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import datetime
 import json
 from typing import Any, Optional
 
 import numpy
+import pandas as pd
 import pytest
 from pydantic import ValidationError
 
@@ -129,3 +131,13 @@ def test_forbid_extra():
 
     with pytest.raises(ValidationError):
         MockRecord(extra="mock")
+
+
+def test_nat_to_none():
+    class MockRecord(_RootValidators):
+        event_timestamp: Optional[datetime.datetime] = None
+        metadata: Optional[Any] = None
+        status: Optional[str] = None
+
+    record = MockRecord(event_timestamp=pd.NaT)
+    assert record.event_timestamp is None


### PR DESCRIPTION
When providing a pandas `NaT` as `event_timestamp`, the server response is:
```python
import rubrix as rb

rec = rb.TextClassificationRecord(inputs="test", event_timestamp=pd.NaT)
rb.log(rec, "test")
""" output
ValidationApiError: Rubrix server returned an error with http status: 422
Error details: [{'code': 'rubrix.api.errors::ValidationError', 'params': {'model': 'Request', 'errors': [{'loc': ['body', 'records', 0, 'event_timestamp'], 'msg': 'invalid datetime format', 'type': 'value_error.datetime', 'value': 'NaT'}]}}]
"""
```
This PR converts pandas `NaT` to `None` when provided as input to a Rubrix client model.