### PR TITLE
refactor(#945): revert index config for text2text

### DIFF
--- a/src/rubrix/server/tasks/text2text/dao/es_config.py
+++ b/src/rubrix/server/tasks/text2text/dao/es_config.py
@@ -16,8 +16,12 @@ def text2text_mappings():
             ]
         ),
         "properties": {
-            "annotated_as": mappings.text_field(),
-            "predicted_as": mappings.text_field(),
+            # TODO: we will include this breaking changes 2 releases after
+            #  PR https://github.com/recognai/rubrix/pull/1018
+            # "annotated_as": mappings.text_field(),
+            # "predicted_as": mappings.text_field(),
+            "annotated_as": mappings.keyword_field(),
+            "predicted_as": mappings.keyword_field(),
             "text_predicted": mappings.words_text_field(),
             "score": {"type": "float"},
         },


### PR DESCRIPTION
This PR revert breaking changes to index configuration for text2text datasets.

This will allow publish work related to issue #945 with backward compatibility. Reverted changes will be publish following the established compatibility guides and once the release remains stable