### PR TITLE
refactor(#945): add current search aggregations as metrics

### DIFF
--- a/src/rubrix/server/commons/es_helpers.py
+++ b/src/rubrix/server/commons/es_helpers.py
@@ -496,7 +496,7 @@ class aggregations:
                 return {
                     "terms": {
                         "field": field_name,
-                        "size": size,
+                        "size": size or aggregations.DEFAULT_AGGREGATION_SIZE,
                         "order": {"_count": "desc"},
                     }
                 }

--- a/src/rubrix/server/commons/es_wrapper.py
+++ b/src/rubrix/server/commons/es_wrapper.py
@@ -348,7 +348,9 @@ class ElasticsearchWrapper(LoggingMixin):
         except NotFoundError:
             return {}
 
-    def get_field_mapping(self, index: str, field_name: str) -> Dict[str, str]:
+    def get_field_mapping(
+        self, index: str, field_name: Optional[str] = None
+    ) -> Dict[str, str]:
         """
             Returns the mapping for a given field name (can be as wildcard notation). The result
         consist on a dictionary with full field name as key and its type as value
@@ -368,7 +370,7 @@ class ElasticsearchWrapper(LoggingMixin):
         """
         try:
             response = self.__client__.indices.get_field_mapping(
-                fields=field_name,
+                fields=field_name or "*",
                 index=index,
                 ignore_unavailable=False,
             )

--- a/src/rubrix/server/tasks/commons/dao/dao.py
+++ b/src/rubrix/server/tasks/commons/dao/dao.py
@@ -203,6 +203,11 @@ class DatasetRecordsDAO:
             doc_id=lambda _record: _record.get("id"),
         )
 
+    def get_metadata_schema(self, dataset: BaseDatasetDB) -> Dict[str, str]:
+        """Get metadata fields schema for provided dataset"""
+        records_index = dataset_records_index(dataset.id)
+        return self._es.get_field_mapping(index=records_index, field_name="metadata.*")
+
     def search_records(
         self,
         dataset: BaseDatasetDB,
@@ -264,11 +269,7 @@ class DatasetRecordsDAO:
                 aggregations.predicted(),
                 aggregations.words_cloud(),
                 aggregations.score(),
-                aggregations.custom_fields(
-                    self._es.get_field_mapping(
-                        index=records_index, field_name="metadata.*"
-                    )
-                ),
+                aggregations.custom_fields(self.get_metadata_schema(dataset)),
             ]:
                 if aggr:
                     aggr_results = self._es.search(
@@ -289,12 +290,13 @@ class DatasetRecordsDAO:
         )
         if search_aggregations:
             parsed_aggregations = parse_aggregations(search_aggregations)
-            parsed_aggregations = unflatten_dict(
-                parsed_aggregations, stop_keys=["metadata"]
-            )
 
-            result.words = parsed_aggregations.pop("words", {})
-            result.metadata = parsed_aggregations.pop("metadata", {})
+            if search.include_default_aggregations:
+                parsed_aggregations = unflatten_dict(
+                    parsed_aggregations, stop_keys=["metadata"]
+                )
+                result.words = parsed_aggregations.pop("words", {})
+                result.metadata = parsed_aggregations.pop("metadata", {})
             result.aggregations = parsed_aggregations
 
         return result

--- a/src/rubrix/server/tasks/commons/metrics/commons.py
+++ b/src/rubrix/server/tasks/commons/metrics/commons.py
@@ -1,7 +1,9 @@
 from rubrix.server.tasks.commons import EsRecordDataFieldNames, TaskStatus
 from rubrix.server.tasks.commons.metrics.model.base import (
     HistogramAggregation,
+    MetadataAggregations,
     TermsAggregation,
+    WordCloudAggregation,
 )
 
 
@@ -13,7 +15,8 @@ class CommonTasksMetrics:
             name="Text length distribution",
             description="Computes the input text length distribution",
             field=EsRecordDataFieldNames.words,
-            script="params._source.words.length()",  # TODO(@frascuchon): This won't work once words is excluded from _source
+            # TODO(@frascuchon): This won't work once words is excluded from _source
+            script="params._source.words.length()",
             fixed_interval=1,
         ),
         TermsAggregation(
@@ -32,5 +35,29 @@ class CommonTasksMetrics:
             description="The dataset record status distribution",
             field=EsRecordDataFieldNames.status,
             fixed_size=len(TaskStatus),
+        ),
+        WordCloudAggregation(
+            id="words_cloud",
+            name="Inputs words cloud",
+            description="The words cloud for dataset inputs",
+            # TODO(@frascuchon): This won't work once words is excluded from _source
+            default_field="words",
+        ),
+        MetadataAggregations(id="metadata", name="Metadata fields stats"),
+        TermsAggregation(
+            id="predicted_by",
+            name="Predicted by distribution",
+            field="predicted_by",
+        ),
+        TermsAggregation(
+            id="annotated_by",
+            name="Annotated by distribution",
+            field="annotated_by",
+        ),
+        HistogramAggregation(
+            id="score",
+            name="Score record distribution",
+            field="score",
+            fixed_interval=0.001,
         ),
     ]

--- a/src/rubrix/server/tasks/commons/metrics/model/base.py
+++ b/src/rubrix/server/tasks/commons/metrics/model/base.py
@@ -14,7 +14,10 @@ from pydantic import BaseModel, root_validator
 from pydantic.generics import GenericModel
 
 from rubrix.server.commons.es_helpers import aggregations
+from rubrix.server.commons.helpers import unflatten_dict
+from rubrix.server.datasets.model import Dataset
 from rubrix.server.tasks.commons import BaseRecord
+from rubrix.server.tasks.commons.dao.dao import DatasetRecordsDAO
 
 GenericRecord = TypeVar("GenericRecord", bound=BaseRecord)
 
@@ -194,7 +197,7 @@ class HistogramAggregation(ElasticsearchMetric):
     script: Optional[Union[str, Dict[str, Any]]] = None
     fixed_interval: Optional[float] = None
 
-    def aggregation_request(self, interval: float) -> Dict[str, Any]:
+    def aggregation_request(self, interval: Optional[float] = None) -> Dict[str, Any]:
         if self.fixed_interval:
             interval = self.fixed_interval
         return {
@@ -266,3 +269,34 @@ class NestedHistogramAggregation(NestedPathElasticsearchMetric):
 
     def inner_aggregation(self, interval: float) -> Dict[str, Any]:
         return self.histogram.aggregation_request(interval)
+
+
+class WordCloudAggregation(ElasticsearchMetric):
+    default_field: str
+
+    def aggregation_request(
+        self, text_field: str = None, size: int = None
+    ) -> Dict[str, Any]:
+        field = text_field or self.default_field
+        return TermsAggregation(
+            id=f"{self.id}_{field}" if text_field else self.id,
+            name=f"Words cloud for field {field}",
+            field=field,
+        ).aggregation_request(size=size)
+
+
+class MetadataAggregations(ElasticsearchMetric):
+    def aggregation_request(
+        self,
+        dataset: Dataset,
+        dao: DatasetRecordsDAO,
+        size: int = None,
+    ) -> Dict[str, Any]:
+
+        return aggregations.custom_fields(
+            fields_definitions=dao.get_metadata_schema(dataset), size=size
+        )
+
+    def aggregation_result(self, aggregation_result: Dict[str, Any]) -> Dict[str, Any]:
+        data = unflatten_dict(aggregation_result, stop_keys=["metadata"])
+        return data.get("metadata", {})

--- a/src/rubrix/server/tasks/commons/metrics/service.py
+++ b/src/rubrix/server/tasks/commons/metrics/service.py
@@ -164,7 +164,9 @@ class MetricsService:
             The metric summary result
 
         """
-        metric_params = self._filter_metric_params(metric, metric_params)
+        metric_params = self._filter_metric_params(
+            metric, {**metric_params, "dataset": dataset, "dao": self.__dao__}
+        )
         metric_aggregation = metric.aggregation_request(**metric_params)
         results = self.__dao__.search_records(
             dataset,

--- a/src/rubrix/server/tasks/text_classification/metrics.py
+++ b/src/rubrix/server/tasks/text_classification/metrics.py
@@ -126,6 +126,16 @@ class TextClassificationMetrics(BaseTaskMetrics[TextClassificationRecord]):
     """Configured metrics for text classification task"""
 
     metrics: ClassVar[List[BaseMetric]] = CommonTasksMetrics.metrics + [
+        TermsAggregation(
+            id="predicted_as",
+            name="Predicted labels distribution",
+            field="predicted_as",
+        ),
+        TermsAggregation(
+            id="annotated_as",
+            name="Annotated labels distribution",
+            field="annotated_as",
+        ),
         F1Metric(
             id="F1",
             name="F1 Metrics for single-label",

--- a/src/rubrix/server/tasks/token_classification/metrics.py
+++ b/src/rubrix/server/tasks/token_classification/metrics.py
@@ -111,6 +111,16 @@ class EntityCapitalness(NestedPathElasticsearchMetric):
         }
 
 
+class MentionsByEntityDistribution(NestedPathElasticsearchMetric):
+    def inner_aggregation(self):
+        return {
+            self.id: aggregations.bidimentional_terms_aggregations(
+                field_name_x=f"{self.nested_path}.label",
+                field_name_y=f"{self.nested_path}.value",
+            )
+        }
+
+
 class EntityConsistency(NestedPathElasticsearchMetric):
     """Computes the entity consistency distribution"""
 
@@ -512,6 +522,12 @@ class TokenClassificationMetrics(BaseTaskMetrics[TokenClassificationRecord]):
             nested_path=_PREDICTED_MENTIONS_NAMESPACE,
             length_field="chars_length",
         ),
+        MentionsByEntityDistribution(
+            id="predicted_mentions_distribution",
+            name="Predicted mentions distribution by entity",
+            description="Computes predicted mentions distribution against its labels",
+            nested_path=_PREDICTED_MENTIONS_NAMESPACE,
+        ),
         EntityConsistency(
             id="predicted_entity_consistency",
             name="Entity label consistency for predictions",
@@ -558,6 +574,12 @@ class TokenClassificationMetrics(BaseTaskMetrics[TokenClassificationRecord]):
             nested_path=_ANNOTATED_MENTIONS_NAMESPACE,
             length_field="chars_length",
         ),
+        MentionsByEntityDistribution(
+            id="annotated_mentions_distribution",
+            name="Annotated mentions distribution by entity",
+            description="Computes annotated mentions distribution against its labels",
+            nested_path=_ANNOTATED_MENTIONS_NAMESPACE,
+        ),
         EntityConsistency(
             id="annotated_entity_consistency",
             name="Entity label consistency for annotations",
@@ -569,6 +591,16 @@ class TokenClassificationMetrics(BaseTaskMetrics[TokenClassificationRecord]):
     ]
 
     metrics: ClassVar[List[BaseMetric]] = CommonTasksMetrics.metrics + [
+        TermsAggregation(
+            id="predicted_as",
+            name="Predicted labels distribution",
+            field="predicted_as",
+        ),
+        TermsAggregation(
+            id="annotated_as",
+            name="Annotated labels distribution",
+            field="annotated_as",
+        ),
         *_TOKENS_METRICS,
         *_PREDICTED_METRICS,
         *_ANNOTATED_METRICS,

--- a/tests/server/metrics/test_api.py
+++ b/tests/server/metrics/test_api.py
@@ -109,14 +109,16 @@ def test_dataset_for_text2text():
 
 
 def test_dataset_for_token_classification():
-    text = "This is a text"
+    text = "This is a contaminated text"
+    metadata = {"metadata": {"field": 1}}
+    prediction = {"prediction": {"entities": [], "agent": "test", "score": 0.3}}
     records = [
         TokenClassificationRecord.parse_obj(data)
         for data in [
-            {"text": text, "tokens": text.split(" ")},
-            {"text": text, "tokens": text.split(" ")},
-            {"text": text, "tokens": text.split(" ")},
-            {"text": text, "tokens": text.split(" ")},
+            {"text": text, "tokens": text.split(" "), **metadata, **prediction},
+            {"text": text, "tokens": text.split(" "), **metadata, **prediction},
+            {"text": text, "tokens": text.split(" "), **metadata, **prediction},
+            {"text": text, "tokens": text.split(" "), **metadata, **prediction},
         ]
     ]
 
@@ -143,7 +145,7 @@ def test_dataset_for_token_classification():
             json={},
         )
 
-        assert response.status_code == 200
+        assert response.status_code == 200, response.json()
         summary = response.json()
 
         if not ("predicted" in metric_id or "annotated" in metric_id):
@@ -183,7 +185,7 @@ def test_dataset_metrics():
 
     metrics = client.get(f"/api/datasets/TextClassification/{dataset}/metrics").json()
 
-    assert len(metrics) == COMMON_METRICS_LENGTH + 3
+    assert len(metrics) == COMMON_METRICS_LENGTH + 5
 
     response = client.post(
         f"/api/datasets/TextClassification/{dataset}/metrics/missing_metric:summary",


### PR DESCRIPTION
This PR define missing current aggregation in search as dataset metrics. For example we can find `predicted_as` or `annotated_by` as a metric for token classification datasets.

This is a part of work for better search model interaction