### PR TITLE
refactor(#945): using new search service

### DIFF
--- a/src/rubrix/server/tasks/search/model.py
+++ b/src/rubrix/server/tasks/search/model.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
+
+from pydantic import BaseModel, Field
+from pydantic.generics import GenericModel
+
+from rubrix.server.tasks.commons import BaseRecord, SortableField, TaskStatus
+
+
+class BaseSearchQuery(BaseModel):
+
+    """
+    Base search query fields
+
+    Attributes:
+    -----------
+    ids: Optional[List[Union[str, int]]]
+        Record ids list
+
+    query_text: str
+        Text query over inputs
+
+    metadata: Optional[Dict[str, Union[str, List[str]]]]
+        Text query over metadata fields. Default=None
+
+    predicted_by: List[str]
+        List of predicted agents
+
+    annotated_by: List[str]
+        List of annotation agents
+
+    status: List[TaskStatus]
+        List of task status
+
+    """
+
+    query_text: Optional[str] = None
+    # advanced_query_text: bool = False
+
+    ids: Optional[List[Union[str, int]]]
+
+    annotated_by: List[str] = Field(default_factory=list)
+    predicted_by: List[str] = Field(default_factory=list)
+
+    status: List[TaskStatus] = Field(default_factory=list)
+
+    metadata: Optional[Dict[str, Union[str, List[str]]]] = None
+
+    def as_elasticsearch(self) -> Dict[str, Any]:
+        raise NotImplementedError()
+
+
+class SortConfig(BaseModel):
+    shuffle: bool = False
+
+    sort_by: List[SortableField] = Field(default_factory=list)
+    valid_fields: List[str] = Field(default_factory=list)
+
+
+Record = TypeVar("Record", bound=BaseRecord)
+
+
+class SearchResults(BaseModel):
+    total: int
+
+    records: List[Record]
+    metrics: Dict[str, Any] = Field(default_factory=dict)

--- a/src/rubrix/server/tasks/search/service.py
+++ b/src/rubrix/server/tasks/search/service.py
@@ -1,0 +1,82 @@
+from typing import List, Optional, Set, Type
+
+from fastapi import Depends
+
+from rubrix.server.commons.es_helpers import sort_by2elasticsearch
+from rubrix.server.datasets.model import Dataset
+from rubrix.server.tasks.commons import BaseRecord, EsRecordDataFieldNames
+from rubrix.server.tasks.commons.dao.dao import DatasetRecordsDAO
+from rubrix.server.tasks.commons.dao.model import RecordSearch
+from rubrix.server.tasks.commons.metrics.service import MetricsService
+from rubrix.server.tasks.search.model import BaseSearchQuery, SearchResults, SortConfig
+
+
+class SearchRecordsService:
+    """Generic service for search records operations"""
+
+    def __init__(self, dao: DatasetRecordsDAO, metrics: MetricsService):
+        self.__dao__ = dao
+        self.__metrics__ = metrics
+
+    @classmethod
+    def get_instance(
+        cls,
+        dao: DatasetRecordsDAO = Depends(DatasetRecordsDAO.get_instance),
+        metrics: MetricsService = Depends(MetricsService.get_instance),
+    ):
+        return cls(dao=dao, metrics=metrics)
+
+    def search(
+        self,
+        dataset: Dataset,
+        query: BaseSearchQuery,
+        sort_config: SortConfig,
+        record_type: Type[BaseRecord],
+        record_from: int = 0,
+        size: int = 100,
+        exclude_metrics: bool = True,
+        metrics: Optional[Set[str]] = None,
+    ) -> SearchResults:
+
+        if record_from > 0:
+            metrics = None
+
+        exclude_fields = ["metrics.*"] if exclude_metrics else None
+        results = self.__dao__.search_records(
+            dataset,
+            search=RecordSearch(
+                # TODO: This must be hidden inside dao implementation
+                query=query.as_elasticsearch(),
+                sort=sort_by2elasticsearch(
+                    sort_config.sort_by,
+                    valid_fields=[
+                        "metadata",
+                        EsRecordDataFieldNames.last_updated,
+                        EsRecordDataFieldNames.score,
+                        EsRecordDataFieldNames.predicted,
+                        EsRecordDataFieldNames.predicted_as,
+                        EsRecordDataFieldNames.predicted_by,
+                        EsRecordDataFieldNames.annotated_as,
+                        EsRecordDataFieldNames.annotated_by,
+                        EsRecordDataFieldNames.status,
+                        EsRecordDataFieldNames.event_timestamp,
+                    ],
+                ),
+                include_default_aggregations=False,
+            ),
+            size=size,
+            record_from=record_from,
+            exclude_fields=exclude_fields,
+        )
+        metrics_results = {
+            metric: self.__metrics__.summarize_metric(
+                dataset=dataset, metric=metric, query=query
+            )
+            for metric in metrics or []
+        }
+
+        return SearchResults(
+            total=results.total,
+            records=[record_type.parse_obj(r) for r in results.records],
+            metrics=metrics_results if metrics_results else {},
+        )

--- a/src/rubrix/server/tasks/text2text/api/model.py
+++ b/src/rubrix/server/tasks/text2text/api/model.py
@@ -15,7 +15,7 @@
 
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, validator
 
@@ -30,9 +30,9 @@ from rubrix.server.tasks.commons.api.model import (
     PredictionStatus,
     ScoreRange,
     SortableField,
-    TaskStatus,
     TaskType,
 )
+from rubrix.server.tasks.search.model import BaseSearchQuery
 
 
 class ExtendedEsRecordDataFieldNames(str, Enum):
@@ -167,7 +167,7 @@ class Text2TextBulkData(UpdateDatasetRequest):
     records: List[CreationText2TextRecord]
 
 
-class Text2TextQuery(BaseModel):
+class Text2TextQuery(BaseSearchQuery):
     """
     API Filters for text2text
 
@@ -195,19 +195,8 @@ class Text2TextQuery(BaseModel):
 
     """
 
-    ids: Optional[List[Union[str, int]]]
-
-    query_text: str = Field(default=None)
-
-    annotated_by: List[str] = Field(default_factory=list)
-    predicted_by: List[str] = Field(default_factory=list)
-
     score: Optional[ScoreRange] = Field(default=None)
-
-    status: List[TaskStatus] = Field(default_factory=list)
-
     predicted: Optional[PredictionStatus] = Field(default=None, nullable=True)
-    metadata: Optional[Dict[str, Union[str, List[str]]]] = None
 
     def as_elasticsearch(self) -> Dict[str, Any]:
         """Build an elasticsearch query part from search query"""

--- a/src/rubrix/server/tasks/text2text/service/service.py
+++ b/src/rubrix/server/tasks/text2text/service/service.py
@@ -17,7 +17,6 @@ from typing import Iterable, List, Optional
 
 from fastapi import Depends
 
-from rubrix.server.commons.es_helpers import aggregations, sort_by2elasticsearch
 from rubrix.server.datasets.model import Dataset
 from rubrix.server.tasks.commons import (
     BulkResponse,
@@ -25,13 +24,13 @@ from rubrix.server.tasks.commons import (
     SortableField,
     TaskType,
 )
-from rubrix.server.tasks.commons.dao import extends_index_properties
 from rubrix.server.tasks.commons.dao.dao import DatasetRecordsDAO, dataset_records_dao
 from rubrix.server.tasks.commons.dao.model import RecordSearch
 from rubrix.server.tasks.commons.metrics.service import MetricsService
+from rubrix.server.tasks.search.model import SortConfig
+from rubrix.server.tasks.search.service import SearchRecordsService
 from rubrix.server.tasks.text2text.api.model import (
     CreationText2TextRecord,
-    ExtendedEsRecordDataFieldNames,
     Text2TextQuery,
     Text2TextRecord,
     Text2TextRecordDB,
@@ -50,10 +49,12 @@ class Text2TextService:
     def __init__(
         self,
         dao: DatasetRecordsDAO,
+        search: SearchRecordsService,
         metrics: MetricsService,
     ):
         self.__dao__ = dao
         self.__metrics__ = metrics
+        self.__search__ = search
 
         self.__dao__.register_task_mappings(TaskType.text2text, text2text_mappings())
 
@@ -100,42 +101,46 @@ class Text2TextService:
             The matched records with aggregation info for specified task_meta.py
 
         """
-        results = self.__dao__.search_records(
+
+        results = self.__search__.search(
             dataset,
-            search=RecordSearch(
-                query=query.as_elasticsearch(),
-                sort=sort_by2elasticsearch(
-                    sort_by,
-                    valid_fields=[
-                        "metadata",
-                        EsRecordDataFieldNames.predicted_as,
-                        EsRecordDataFieldNames.predicted_by,
-                        EsRecordDataFieldNames.annotated_as,
-                        EsRecordDataFieldNames.annotated_by,
-                        EsRecordDataFieldNames.status,
-                        EsRecordDataFieldNames.last_updated,
-                        EsRecordDataFieldNames.event_timestamp,
-                    ],
-                ),
-                aggregations={
-                    ExtendedEsRecordDataFieldNames.text_predicted: aggregations.terms_aggregation(
-                        ExtendedEsRecordDataFieldNames.text_predicted
-                    )
-                },
-            ),
+            query=query,
             size=size,
             record_from=record_from,
-            exclude_fields=["metrics"] if exclude_metrics else None,
+            record_type=Text2TextRecord,
+            sort_config=SortConfig(
+                sort_by=sort_by,
+                valid_fields=[
+                    "metadata",
+                    EsRecordDataFieldNames.predicted_as,
+                    EsRecordDataFieldNames.annotated_as,
+                    EsRecordDataFieldNames.predicted_by,
+                    EsRecordDataFieldNames.annotated_by,
+                    EsRecordDataFieldNames.status,
+                    EsRecordDataFieldNames.last_updated,
+                    EsRecordDataFieldNames.event_timestamp,
+                ],
+            ),
+            exclude_metrics=exclude_metrics,
+            metrics={
+                "words_cloud",
+                "predicted_by",
+                "annotated_by",
+                "status_distribution",
+                "metadata",
+                "score",
+            },
         )
+
+        if results.metrics:
+            results.metrics["words"] = results.metrics["words_cloud"]
+            results.metrics["status"] = results.metrics["status_distribution"]
+
         return Text2TextSearchResults(
             total=results.total,
-            records=[Text2TextRecord.parse_obj(r) for r in results.records],
-            aggregations=Text2TextSearchAggregations(
-                **results.aggregations,
-                words=results.words,
-                metadata=results.metadata or {},
-            )
-            if results.aggregations
+            records=results.records,
+            aggregations=Text2TextSearchAggregations.parse_obj(results.metrics)
+            if results.metrics
             else None,
         )
 
@@ -156,7 +161,7 @@ class Text2TextService:
             the provided query filters. Optional
 
         """
-        for db_record in self.__dao__.scan_dataset(
+        for db_record in self.__dao__.scan_dataset(  # TODO: use search service instead
             dataset, search=RecordSearch(query=query.as_elasticsearch())
         ):
             yield Text2TextRecord.parse_obj(db_record)
@@ -168,6 +173,7 @@ _instance = None
 def text2text_service(
     dao: DatasetRecordsDAO = Depends(dataset_records_dao),
     metrics: MetricsService = Depends(MetricsService.get_instance),
+    search: SearchRecordsService = Depends(SearchRecordsService.get_instance),
 ) -> Text2TextService:
     """
     Creates a dataset record service instance
@@ -185,5 +191,5 @@ def text2text_service(
     """
     global _instance
     if not _instance:
-        _instance = Text2TextService(dao=dao, metrics=metrics)
+        _instance = Text2TextService(dao=dao, metrics=metrics, search=search)
     return _instance

--- a/src/rubrix/server/tasks/text_classification/api/model.py
+++ b/src/rubrix/server/tasks/text_classification/api/model.py
@@ -33,6 +33,7 @@ from rubrix.server.tasks.commons.api.model import (
     TaskStatus,
     TaskType,
 )
+from rubrix.server.tasks.search.model import BaseSearchQuery
 
 
 class UpdateLabelingRule(BaseModel):
@@ -461,48 +462,30 @@ class TextClassificationBulkData(UpdateDatasetRequest):
         return records
 
 
-class TextClassificationQuery(BaseModel):
+class TextClassificationQuery(BaseSearchQuery):
     """
     API Filters for text classification
 
     Attributes:
     -----------
-    ids: Optional[List[Union[str, int]]]
-        Record ids list
-
-    query_text: str
-        Text query over inputs
-    metadata: Optional[Dict[str, Union[str, List[str]]]]
-        Text query over metadata fields. Default=None
 
     predicted_as: List[str]
         List of predicted terms
+
     annotated_as: List[str]
         List of annotated terms
-    annotated_by: List[str]
-        List of annotation agents
-    predicted_by: List[str]
-        List of predicted agents
-    status: List[TaskStatus]
-        List of task status
+
     predicted: Optional[PredictionStatus]
         The task prediction status
+
     uncovered_by_rules:
         Only return records that are NOT covered by these rules.
 
     """
 
-    ids: Optional[List[Union[str, int]]]
-
-    query_text: str = Field(default=None)
-    metadata: Optional[Dict[str, Union[str, List[str]]]] = None
-
     predicted_as: List[str] = Field(default_factory=list)
     annotated_as: List[str] = Field(default_factory=list)
-    annotated_by: List[str] = Field(default_factory=list)
-    predicted_by: List[str] = Field(default_factory=list)
     score: Optional[ScoreRange] = Field(default=None)
-    status: List[TaskStatus] = Field(default_factory=list)
     predicted: Optional[PredictionStatus] = Field(default=None, nullable=True)
 
     uncovered_by_rules: List[str] = Field(

--- a/src/rubrix/server/tasks/token_classification/api/model.py
+++ b/src/rubrix/server/tasks/token_classification/api/model.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from pydantic import BaseModel, Field, root_validator, validator
 
@@ -29,9 +29,9 @@ from rubrix.server.tasks.commons import (
     PredictionStatus,
     ScoreRange,
     SortableField,
-    TaskStatus,
     TaskType,
 )
+from rubrix.server.tasks.search.model import BaseSearchQuery
 
 PREDICTED_MENTIONS_ES_FIELD_NAME = "predicted_mentions"
 MENTIONS_ES_FIELD_NAME = "mentions"
@@ -344,46 +344,25 @@ class TokenClassificationBulkData(UpdateDatasetRequest):
     records: List[CreationTokenClassificationRecord]
 
 
-class TokenClassificationQuery(BaseModel):
+class TokenClassificationQuery(BaseSearchQuery):
     """
     API Filters for text classification
 
     Attributes:
     -----------
-    ids: Optional[List[Union[str, int]]]
-        Record ids list
-
-    query_text: str
-        Text query over inputs
-    metadata: Optional[Dict[str, Union[str, List[str]]]]
-        Text query over metadata fields. Default=None
 
     predicted_as: List[str]
         List of predicted terms
     annotated_as: List[str]
         List of annotated terms
-    annotated_by: List[str]
-        List of annotation agents
-    predicted_by: List[str]
-        List of predicted agents
-    status: List[TaskStatus]
-        List of task status
     predicted: Optional[PredictionStatus]
         The task prediction status
 
     """
 
-    ids: Optional[List[Union[str, int]]]
-
-    query_text: str = Field(default=None)
-    metadata: Optional[Dict[str, Union[str, List[str]]]] = None
-
     predicted_as: List[str] = Field(default_factory=list)
     annotated_as: List[str] = Field(default_factory=list)
-    annotated_by: List[str] = Field(default_factory=list)
-    predicted_by: List[str] = Field(default_factory=list)
     score: Optional[ScoreRange] = Field(default=None)
-    status: List[TaskStatus] = Field(default_factory=list)
     predicted: Optional[PredictionStatus] = Field(default=None, nullable=True)
 
     def as_elasticsearch(self) -> Dict[str, Any]:

--- a/tests/server/text_classification/test_api.py
+++ b/tests/server/text_classification/test_api.py
@@ -15,9 +15,6 @@
 
 from datetime import datetime
 
-import pytest
-
-from rubrix.server.commons.errors import InvalidTextSearchError
 from rubrix.server.datasets.model import Dataset
 from rubrix.server.tasks.commons import BulkResponse, PredictionStatus
 from rubrix.server.tasks.text_classification.api import (
@@ -208,7 +205,7 @@ def test_partial_record_update():
         json=bulk.dict(by_alias=True),
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 200, response.json()
     bulk_response = BulkResponse.parse_obj(response.json())
     assert bulk_response.failed == 0
     assert bulk_response.processed == 1


### PR DESCRIPTION
This PR includes the implementation for `SearchRecordsService` class and changes all task services search method, that will use the new implemented service.

This will help in a future to normalize api task search and simplify development.