### PR TITLE
fix(#945): validate label for single label text classification dataset

### DIFF
--- a/frontend/components/text-classifier/results/RecordTextClassification.vue
+++ b/frontend/components/text-classifier/results/RecordTextClassification.vue
@@ -133,15 +133,10 @@ export default {
     },
     async onValidate(record) {
       let modelPrediction = {};
-      let labels = record.predicted_as.map((pred) => ({
+      modelPrediction.labels = record.predicted_as.map((pred) => ({
         class: pred,
         score: 1,
       }));
-      if (this.dataset.isMultiLabel) {
-        modelPrediction.labels = labels;
-      } else {
-        modelPrediction.labels = [labels.shift()];
-      }
       // TODO: do not validate records without labels
       await this.validateAnnotations({
         dataset: this.dataset,

--- a/frontend/components/text-classifier/results/RecordTextClassification.vue
+++ b/frontend/components/text-classifier/results/RecordTextClassification.vue
@@ -133,10 +133,15 @@ export default {
     },
     async onValidate(record) {
       let modelPrediction = {};
-      modelPrediction.labels = record.predicted_as.map((pred) => ({
+      let labels = record.predicted_as.map((pred) => ({
         class: pred,
         score: 1,
       }));
+      if (this.dataset.isMultiLabel) {
+        modelPrediction.labels = labels;
+      } else {
+        modelPrediction.labels = [labels.shift()];
+      }
       // TODO: do not validate records without labels
       await this.validateAnnotations({
         dataset: this.dataset,

--- a/frontend/models/TextClassification.js
+++ b/frontend/models/TextClassification.js
@@ -36,7 +36,11 @@ class TextClassificationRecord extends BaseRecord {
     if (this.prediction === undefined) {
       return [];
     }
-    return this.prediction.labels.map((p) => p.class);
+    let labels = this.prediction.labels;
+    if (this.multi_label) {
+      return labels.filter((l) => l.score > 0.5).map((l) => l.class);
+    }
+    return [this.prediction.labels[0].class];
   }
 }
 

--- a/frontend/specs/components/text-classification/results/RecordTextClassification.spec.js
+++ b/frontend/specs/components/text-classification/results/RecordTextClassification.spec.js
@@ -1,0 +1,61 @@
+import { mount } from "@vue/test-utils";
+import Component from "@/components/text-classifier/results/RecordTextClassification";
+
+import { TextClassificationRecord } from "@/models/TextClassification";
+
+const $route = {
+  query: {},
+};
+
+function mountComponent() {
+  return mount(Component, {
+    propsData: {
+      record: new TextClassificationRecord({
+        inputs: {
+          text: "My text",
+          multi_label: true,
+          prediction: {
+            agent: "test",
+            labels: [
+              { class: "Test", score: 0.6 },
+              { class: "A", score: 0.4 },
+              { class: "B", score: 0.2 },
+            ],
+          },
+        },
+      }),
+      dataset: {
+        task: "TextClassification",
+        query: {
+          text: "mock test",
+        },
+        viewSettings: {
+          annotationEnabled: false,
+        },
+        labels: ["Test", "A", "B"],
+      },
+    },
+    mocks: {
+      $route,
+    },
+  });
+}
+
+describe("RecordTextClassification", () => {
+  let spy = jest.spyOn(console, "error");
+  afterEach(() => spy.mockReset());
+
+  test("Required property", () => {
+    expect(() => {
+      mount(Component);
+      expect(spy).toBeCalledWith(
+        expect.stringContaining('[Vue warn]: Missing required prop: "dataset"')
+      );
+    }).toThrowError(TypeError);
+  });
+
+  test("renders properly", () => {
+    const wrapper = mountComponent();
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/frontend/specs/components/text-classification/results/__snapshots__/RecordTextClassification.spec.js.snap
+++ b/frontend/specs/components/text-classification/results/__snapshots__/RecordTextClassification.spec.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RecordTextClassification renders properly 1`] = `
+<div class="record">
+  <div class="record--left">
+    <recordinputs data="[object Object]" query-text="mock test"></recordinputs>
+    <classifierexplorationarea dataset="[object Object]" record="[object Object]"></classifierexplorationarea>
+    <!---->
+  </div>
+  <div class="record__labels">
+    <!---->
+  </div>
+</div>
+`;


### PR DESCRIPTION
This PR fixes record prediction validation for single label text classification

Closes #1118
Fixes changes applied in #1075