### PR TITLE
fix(#1121):  Adjust search bar width

### DIFF
--- a/frontend/components/commons/header/filters/FiltersArea.vue
+++ b/frontend/components/commons/header/filters/FiltersArea.vue
@@ -157,6 +157,7 @@ export default {
   &__content {
     padding: 1em 0;
     position: relative;
+    max-width: calc(100% - 300px);
     .fixed-header & {
       padding: 0.5em 45px 0.5em 0;
     }
@@ -164,7 +165,6 @@ export default {
   &__searchbar {
     margin-right: 2em;
     width: 100%;
-    max-width: 610px;
     &.--extended {
       width: 100%;
       margin-right: 0;


### PR DESCRIPTION
This PR limits the width of the search bar for all devices to the available space allowing full display of the dropdown filters

Closes #1121
