### PR TITLE
Feat/advanced query dsl mode

### DIFF
--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -213,6 +213,10 @@ async function _updateViewSettings({ id, data }) {
 }
 
 async function _callSearchApi({ dataset, query, sort, size, from = 0 }) {
+  const { advancedQueryDsl } = $nuxt.$route.query;
+  if (advancedQueryDsl === null || advancedQueryDsl === "true") {
+    query.advanced_query_dsl = true;
+  }
   const { response } = await ObservationDataset.api().post(
     `/datasets/${dataset.name}/${dataset.task}:search?limit=${size}&from=${from}`,
     {

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,8 @@ server =
     smart-open
     brotli-asgi ~= 1.1.0
     Deprecated ~= 1.2.0
+    # Advanced query search dsl
+    luqum ~= 0.11.0
     # metrics
     scikit-learn >= 0.24.2
     # Words cloud

--- a/src/rubrix/client/sdk/text2text/models.py
+++ b/src/rubrix/client/sdk/text2text/models.py
@@ -105,6 +105,7 @@ class Text2TextQuery(BaseModel):
     ids: Optional[List[Union[str, int]]]
 
     query_text: str = Field(default=None)
+    advanced_query_dsl: bool = False
 
     annotated_by: List[str] = Field(default_factory=list)
     predicted_by: List[str] = Field(default_factory=list)

--- a/src/rubrix/client/sdk/text_classification/models.py
+++ b/src/rubrix/client/sdk/text_classification/models.py
@@ -140,6 +140,7 @@ class TextClassificationQuery(BaseModel):
     ids: Optional[List[Union[str, int]]]
 
     query_text: str = Field(default=None)
+    advanced_query_dsl: bool = False
     metadata: Optional[Dict[str, Union[str, List[str]]]] = None
 
     predicted_as: List[str] = Field(default_factory=list)

--- a/src/rubrix/client/sdk/token_classification/models.py
+++ b/src/rubrix/client/sdk/token_classification/models.py
@@ -129,6 +129,7 @@ class TokenClassificationQuery(BaseModel):
     ids: Optional[List[Union[str, int]]]
 
     query_text: str = Field(default=None)
+    advanced_query_dsl: bool = False
     metadata: Optional[Dict[str, Union[str, List[str]]]] = None
 
     predicted_as: List[str] = Field(default_factory=list)

--- a/src/rubrix/server/tasks/commons/dao/dao.py
+++ b/src/rubrix/server/tasks/commons/dao/dao.py
@@ -405,6 +405,11 @@ class DatasetRecordsDAO:
         )
         return index_name
 
+    def get_dataset_schema(self, dataset: BaseDatasetDB) -> Dict[str, Any]:
+        """Return inner elasticsearch index configuration"""
+        index_name = dataset_records_index(dataset.id)
+        return self._es.__client__.indices.get_mapping(index=index_name)
+
 
 _instance: Optional[DatasetRecordsDAO] = None
 

--- a/src/rubrix/server/tasks/search/model.py
+++ b/src/rubrix/server/tasks/search/model.py
@@ -34,7 +34,7 @@ class BaseSearchQuery(BaseModel):
     """
 
     query_text: Optional[str] = None
-    # advanced_query_text: bool = False
+    advanced_query_dsl: bool = False
 
     ids: Optional[List[Union[str, int]]]
 
@@ -46,6 +46,7 @@ class BaseSearchQuery(BaseModel):
     metadata: Optional[Dict[str, Union[str, List[str]]]] = None
 
     def as_elasticsearch(self) -> Dict[str, Any]:
+        # TODO: Hide transformations in DAO component
         raise NotImplementedError()
 
 

--- a/src/rubrix/server/tasks/search/query_builder.py
+++ b/src/rubrix/server/tasks/search/query_builder.py
@@ -32,14 +32,14 @@ class EsQueryBuilder:
             return query.as_elasticsearch()
 
         text_search = query.query_text
-        new_query = query.copy(exclude={"query_text"})
+        new_query = query.copy(update={"query_text": None})
 
         schema = self.__dao__.get_dataset_schema(dataset)
         schema = SchemaAnalyzer(schema)
         es_query_builder = ElasticsearchQueryBuilder(
             **{
                 **schema.query_builder_options(),
-                "default_field": "words",
+                "default_field": "text",
             }  # TODO: This will change
         )
 

--- a/src/rubrix/server/tasks/search/query_builder.py
+++ b/src/rubrix/server/tasks/search/query_builder.py
@@ -1,10 +1,11 @@
 from typing import Any, Dict, TypeVar
 
+from fastapi import Depends
 from luqum.elasticsearch import ElasticsearchQueryBuilder, SchemaAnalyzer
 from luqum.parser import parser
 
 from rubrix.server.commons import es_helpers
-from rubrix.server.datasets.model import Dataset
+from rubrix.server.datasets.model import BaseDatasetDB, Dataset
 from rubrix.server.tasks.commons.dao.dao import DatasetRecordsDAO
 from rubrix.server.tasks.search.model import BaseSearchQuery
 
@@ -12,16 +13,26 @@ SearchQuery = TypeVar("SearchQuery", bound=BaseSearchQuery)
 
 
 class EsQueryBuilder:
+    _INSTANCE: "EsQueryBuilder" = None
+
+    @classmethod
+    def get_instance(
+        cls, dao: DatasetRecordsDAO = Depends(DatasetRecordsDAO.get_instance)
+    ):
+        if not cls._INSTANCE:
+            cls._INSTANCE = cls(dao=dao)
+        return cls._INSTANCE
+
     def __init__(self, dao: DatasetRecordsDAO):
         self.__dao__ = dao
 
-    def __call__(self, dataset: Dataset, query: SearchQuery) -> Dict[str, Any]:
+    def __call__(self, dataset: BaseDatasetDB, query: SearchQuery) -> Dict[str, Any]:
 
         if not query.advanced_query_dsl or not query.query_text:
             return query.as_elasticsearch()
 
         text_search = query.query_text
-        query.query_text = None
+        new_query = query.copy(exclude={"query_text"})
 
         schema = self.__dao__.get_dataset_schema(dataset)
         schema = SchemaAnalyzer(schema)
@@ -36,5 +47,5 @@ class EsQueryBuilder:
         query_text = es_query_builder(query_tree)
 
         return es_helpers.filters.boolean_filter(
-            filter_query=query.as_elasticsearch(), must_query=query_text
+            filter_query=new_query.as_elasticsearch(), must_query=query_text
         )

--- a/src/rubrix/server/tasks/search/query_builder.py
+++ b/src/rubrix/server/tasks/search/query_builder.py
@@ -1,0 +1,37 @@
+from typing import Any, Dict, TypeVar
+
+from luqum.elasticsearch import ElasticsearchQueryBuilder, SchemaAnalyzer
+from luqum.parser import parser
+
+from rubrix.server.commons import es_helpers
+from rubrix.server.datasets.model import Dataset
+from rubrix.server.tasks.commons.dao.dao import DatasetRecordsDAO
+from rubrix.server.tasks.search.model import BaseSearchQuery
+
+SearchQuery = TypeVar("SearchQuery", bound=BaseSearchQuery)
+
+
+class EsQueryBuilder:
+    def __init__(self, dao: DatasetRecordsDAO):
+        self.__dao__ = dao
+
+    def __call__(self, dataset: Dataset, query: SearchQuery) -> Dict[str, Any]:
+        text_search = query.query_text
+        query.query_text = ""
+
+        if query.advanced_query_dsl:
+            schema = self.__dao__.get_dataset_schema(dataset)
+            schema = SchemaAnalyzer(schema)
+            es_query_builder = ElasticsearchQueryBuilder(
+                **schema.query_builder_options()
+            )
+
+            query_tree = parser.parse(query.query_text)
+            query_text = es_query_builder(query_tree)
+        else:
+            query_text = es_helpers.filters.text_query(text_search)
+
+        return es_helpers.filters.boolean_filter(
+            should_filters=[query_text, query.as_elasticsearch()],
+            minimum_should_match=2,
+        )

--- a/src/rubrix/server/tasks/search/service.py
+++ b/src/rubrix/server/tasks/search/service.py
@@ -9,6 +9,7 @@ from rubrix.server.tasks.commons.dao.dao import DatasetRecordsDAO
 from rubrix.server.tasks.commons.dao.model import RecordSearch
 from rubrix.server.tasks.commons.metrics.service import MetricsService
 from rubrix.server.tasks.search.model import BaseSearchQuery, SearchResults, SortConfig
+from rubrix.server.tasks.search.query_builder import EsQueryBuilder
 
 
 class SearchRecordsService:
@@ -17,6 +18,7 @@ class SearchRecordsService:
     def __init__(self, dao: DatasetRecordsDAO, metrics: MetricsService):
         self.__dao__ = dao
         self.__metrics__ = metrics
+        self.__query_builder__ = EsQueryBuilder(dao)  # TODO: use dependency injection
 
     @classmethod
     def get_instance(
@@ -45,8 +47,7 @@ class SearchRecordsService:
         results = self.__dao__.search_records(
             dataset,
             search=RecordSearch(
-                # TODO: This must be hidden inside dao implementation
-                query=query.as_elasticsearch(),
+                query=self.__query_builder__(dataset, query),
                 sort=sort_by2elasticsearch(
                     sort_config.sort_by,
                     valid_fields=[

--- a/src/rubrix/server/tasks/search/service.py
+++ b/src/rubrix/server/tasks/search/service.py
@@ -15,18 +15,28 @@ from rubrix.server.tasks.search.query_builder import EsQueryBuilder
 class SearchRecordsService:
     """Generic service for search records operations"""
 
-    def __init__(self, dao: DatasetRecordsDAO, metrics: MetricsService):
-        self.__dao__ = dao
-        self.__metrics__ = metrics
-        self.__query_builder__ = EsQueryBuilder(dao)  # TODO: use dependency injection
+    _INSTANCE: "SearchRecordsService" = None
 
     @classmethod
     def get_instance(
         cls,
         dao: DatasetRecordsDAO = Depends(DatasetRecordsDAO.get_instance),
         metrics: MetricsService = Depends(MetricsService.get_instance),
+        query_builder: EsQueryBuilder = Depends(EsQueryBuilder.get_instance),
     ):
-        return cls(dao=dao, metrics=metrics)
+        if not cls._INSTANCE:
+            cls._INSTANCE = cls(dao=dao, metrics=metrics, query_builder=query_builder)
+        return cls._INSTANCE
+
+    def __init__(
+        self,
+        dao: DatasetRecordsDAO,
+        metrics: MetricsService,
+        query_builder: EsQueryBuilder,
+    ):
+        self.__dao__ = dao
+        self.__metrics__ = metrics
+        self.__query_builder__ = query_builder
 
     def search(
         self,

--- a/src/rubrix/server/tasks/token_classification/api/model.py
+++ b/src/rubrix/server/tasks/token_classification/api/model.py
@@ -388,6 +388,7 @@ class TokenClassificationQuery(BaseSearchQuery):
         query_text = filters.text_query(self.query_text)
         all_filters.extend(query_filters)
 
+        # TODO: use es_helpers
         return {
             "bool": {
                 "must": query_text or {"match_all": {}},

--- a/tests/monitoring/test_transformers_monitoring.py
+++ b/tests/monitoring/test_transformers_monitoring.py
@@ -153,7 +153,10 @@ def check_zero_shot_results(
 
     if isinstance(text, list):
         text = text[0]
+    try:
         predictions = predictions[0]
+    except KeyError:
+        pass
 
     df = rubrix.load(dataset)
     assert len(df) == 1


### PR DESCRIPTION
This PR includes an advanced query dsl model that uses an [enhanced lucene query dsl sintax ](https://github.com/jurismarches/luqum) to enable queries with nested fields, for example.

This "advanced mode" is enabled by a query body parameter for the sake of the compatibility. This is not enabled for weak labels rules for now, until a feature validation.

You can test this feat from UI app by setting the `advancedQueryDsl` query parameter manually

The advanced query dsl will resolve requirements mentioned in recognai/roadmap#55