### PR TITLE
chore: exclude ipynb files from the end-of-file-fixer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
+        exclude_types: [text, jupyter]
     -   id: trailing-whitespace
 
 -   repo: https://github.com/psf/black


### PR DESCRIPTION
This PR excludes ipynb files from the end-of-file-fixer pre-commit hook, which gave me a lot of headaches when working with notebooks in pycharm.