### PR TITLE
feat(#1127): raise startup app error from es connection error

### DIFF
--- a/src/rubrix/server/server.py
+++ b/src/rubrix/server/server.py
@@ -101,11 +101,10 @@ def configure_app_startup(app: FastAPI):
             raise ConfigError(
                 f"Your Elasticsearch endpoint at {settings.obfuscated_elasticsearch()} "
                 "is not available or not responding.\n"
-                "Please make sure your Elasticsearch instance is launched and correctly running and "
+                "Please make sure your Elasticsearch instance is launched and correctly running and\n"
                 "you have the necessary access permissions. "
                 "Once you have verified this, restart the Rubrix server.\n"
-                f"Error detail: [{error}]"
-            )
+            ) from error
 
 
 def configure_app_security(app: FastAPI):


### PR DESCRIPTION
By raising the error with `from` clause, you can separate errors details from the main error message. You will see an error like:

```bash
opensearchpy.exceptions.ConnectionTimeout: ConnectionTimeout caused by - ReadTimeoutError(HTTPConnectionPool(host='localhost', port=9200): Read timed out. (read timeout=10))

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/anaconda3/envs/rubrix/lib/python3.8/site-packages/starlette/routing.py", line 526, in lifespan
    async for item in self.lifespan_context(app):
  File "/usr/local/anaconda3/envs/rubrix/lib/python3.8/site-packages/starlette/routing.py", line 467, in default_lifespan
    await self.startup()
  File "/usr/local/anaconda3/envs/rubrix/lib/python3.8/site-packages/starlette/routing.py", line 502, in startup
    await handler()
  File "/usr/local/anaconda3/envs/rubrix/lib/python3.8/site-packages/rubrix/server/server.py", line 101, in configure_elasticsearch
    raise ConfigError(
pydantic.errors.ConfigError: Your Elasticsearch endpoint at http://localhost:9200 is not available or not responding.
Please make sure your Elasticsearch instance is launched and correctly running and
you have the necessary access permissions. Once you have verified this, restart the Rubrix server.
```

Closes #1127