### PR TITLE
fix(#1140): fix/make client models more consistent

### DIFF
--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -441,7 +441,7 @@ class DatasetForTokenClassification(DatasetBase):
             ...     "text": ["my example"],
             ...     "tokens": [["my", "example"]],
             ...     "prediction": [
-            ...         [{"label": "LABEL1", "start": 3, "end": 10, "score": 0.5}]
+            ...         [{"label": "LABEL1", "start": 3, "end": 10, "score": 1.0}]
             ...     ]
             ... })
             >>> DatasetForTokenClassification.from_datasets(ds)

--- a/src/rubrix/client/models.py
+++ b/src/rubrix/client/models.py
@@ -187,7 +187,7 @@ class TokenClassificationRecord(_Validators):
         prediction:
             A list of tuples containing the predictions for the record. The first entry of the tuple is the name of
             predicted entity, the second and third entry correspond to the start and stop character index of the entity.
-            EXPERIMENTAL: The fourth entry is optional and corresponds to the score of the entity.
+            The fourth entry is optional and corresponds to the score of the entity (a float number between 0 and 1).
         prediction_agent:
             Name of the prediction agent. By default, this is set to the hostname of your machine.
         annotation:
@@ -233,6 +233,21 @@ class TokenClassificationRecord(_Validators):
     event_timestamp: Optional[datetime.datetime] = None
 
     metrics: Optional[Dict[str, Any]] = None
+
+    @validator("prediction")
+    def add_default_score(
+        cls,
+        prediction: Optional[
+            List[Union[Tuple[str, int, int], Tuple[str, int, int, float]]]
+        ],
+    ):
+        """Adds the default score to the predictions if it is missing"""
+        if prediction is None:
+            return prediction
+        return [
+            (pred[0], pred[1], pred[2], 1.0) if len(pred) == 3 else pred
+            for pred in prediction
+        ]
 
 
 class Text2TextRecord(_Validators):

--- a/src/rubrix/client/models.py
+++ b/src/rubrix/client/models.py
@@ -292,9 +292,7 @@ class Text2TextRecord(_Validators):
         """Preprocess the predictions and wraps them in a tuple if needed"""
         if prediction is None:
             return prediction
-        if all([isinstance(pred, tuple) for pred in prediction]):
-            return prediction
-        return [(text, 1.0) for text in prediction]
+        return [(pred, 1.0) if isinstance(pred, str) else pred for pred in prediction]
 
 
 Record = Union[TextClassificationRecord, TokenClassificationRecord, Text2TextRecord]

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -60,6 +60,13 @@ def singlelabel_textclassification_records(
             status="Default",
         ),
         rb.TextClassificationRecord(
+            inputs={"text": "mock2", "context": "mock2"},
+            prediction=[("a", 0.5), ("b", 0.2)],
+            prediction_agent="mock2_pagent",
+            id=3,
+            status="Discarded",
+        ),
+        rb.TextClassificationRecord(
             inputs={"text": "mock3", "context": "mock3"},
             annotation="a",
             annotation_agent="mock_aagent",
@@ -142,6 +149,14 @@ def multilabel_textclassification_records(request) -> List[rb.TextClassification
             status="Default",
         ),
         rb.TextClassificationRecord(
+            inputs={"text": "mock2", "context": "mock2"},
+            prediction=[("a", 0.5), ("b", 0.2)],
+            prediction_agent="mock2_pagent",
+            multi_label=True,
+            id=3,
+            status="Discarded",
+        ),
+        rb.TextClassificationRecord(
             inputs={"text": "mock3", "context": "mock3"},
             annotation=["a"],
             annotation_agent="mock_aagent",
@@ -212,6 +227,14 @@ def tokenclassification_records(request) -> List[rb.TokenClassificationRecord]:
             metadata={"mock_metadata": "mock"},
         ),
         rb.TokenClassificationRecord(
+            text="This is a secondd example",
+            tokens=["This", "is", "a", "secondd", "example"],
+            prediction=[("a", 5, 7), ("b", 8, 9, 0.5)],
+            prediction_agent="mock_pagent",
+            id=3,
+            status="Default",
+        ),
+        rb.TokenClassificationRecord(
             text="This is a third example",
             tokens=["This", "is", "a", "third", "example"],
             annotation=[("a", 0, 4), ("b", 16, 23)],
@@ -278,16 +301,15 @@ def text2text_records(request) -> List[rb.Text2TextRecord]:
             event_timestamp=datetime.datetime(2000, 1, 1),
             metadata={"mock_metadata": "mock"},
         ),
-        # TODO: provide bug fix for this record
-        # rb.Text2TextRecord(
-        #     text="This is a second example",
-        #     prediction=[("Das ist ein Beispielll", 0.9), "Esto es un ejemplooo"],
-        #     prediction_agent="mock_pagent",
-        #     id="two",
-        #     event_timestamp=datetime.datetime(2000, 1, 1),
-        #     metadata={"mock_metadata": "mock"},
-        #     metrics={},
-        # ),
+        rb.Text2TextRecord(
+            text="This is a second example",
+            prediction=["Esto es un ejemplooo", ("Das ist ein Beispielll", 0.9)],
+            prediction_agent="mock_pagent",
+            id=3,
+            event_timestamp=datetime.datetime(2000, 1, 1),
+            metadata={"mock_metadata": "mock"},
+            metrics={},
+        ),
         rb.Text2TextRecord(
             text="This is a third example",
             annotation="C'est une très bonne baguette",

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -75,7 +75,7 @@ def test_to_dataframe(monkeypatch, singlelabel_textclassification_records):
     df = DatasetBase(singlelabel_textclassification_records).to_pandas()
 
     assert isinstance(df, pd.DataFrame)
-    assert len(df) == 4
+    assert len(df) == 5
     assert list(df.columns) == list(TextClassificationRecord.__fields__)
 
 
@@ -155,7 +155,7 @@ def test_iter_len_getitem(monkeypatch, singlelabel_textclassification_records):
     for record, expected in zip(dataset, singlelabel_textclassification_records):
         assert record == expected
 
-    assert len(dataset) == 4
+    assert len(dataset) == 5
     assert dataset[1] is singlelabel_textclassification_records[1]
 
 
@@ -172,9 +172,9 @@ def test_setitem_delitem(monkeypatch, singlelabel_textclassification_records):
 
     assert dataset._records[0] is record
 
-    assert len(dataset) == 4
+    assert len(dataset) == 5
     del dataset[1]
-    assert len(dataset) == 3
+    assert len(dataset) == 4
 
     with pytest.raises(
         WrongRecordTypeError,
@@ -258,6 +258,7 @@ class TestDatasetForTokenClassification:
                 "label": datasets.Value("string"),
                 "start": datasets.Value("int64"),
                 "end": datasets.Value("int64"),
+                "score": datasets.Value("float64"),
             }
         ]
         assert dataset_ds.features["annotation"] == [

--- a/tests/client/test_models.py
+++ b/tests/client/test_models.py
@@ -79,6 +79,25 @@ def test_token_classification_record(annotation, status, expected_status):
     assert record.status == expected_status
 
 
+@pytest.mark.parametrize(
+    "prediction,expected",
+    [
+        (None, None),
+        ([("mock", 0, 4)], [("mock", 0, 4, 1.0)]),
+        ([("mock", 0, 4, 0.5)], [("mock", 0, 4, 0.5)]),
+        (
+            [("mock", 0, 4), ("mock", 0, 4, 0.5)],
+            [("mock", 0, 4, 1.0), ("mock", 0, 4, 0.5)],
+        ),
+    ],
+)
+def test_token_classification_prediction_validator(prediction, expected):
+    record = TokenClassificationRecord(
+        text="this", tokens=["this"], prediction=prediction
+    )
+    assert record.prediction == expected
+
+
 def test_text_classification_record_none_inputs():
     """Test validation error for None in inputs"""
     with pytest.raises(ValidationError):
@@ -137,3 +156,17 @@ def test_nat_to_none():
 
     record = MockRecord(event_timestamp=pd.NaT)
     assert record.event_timestamp is None
+
+
+@pytest.mark.parametrize(
+    "prediction,expected",
+    [
+        (None, None),
+        (["mock"], [("mock", 1.0)]),
+        ([("mock", 0.5)], [("mock", 0.5)]),
+        (["mock", ("mock", 0.5)], [("mock", 1.0), ("mock", 0.5)]),
+    ],
+)
+def test_text2text_prediction_validator(prediction, expected):
+    record = Text2TextRecord(text="mock", prediction=prediction)
+    assert record.prediction == expected

--- a/tests/client/test_rubrix_client.py
+++ b/tests/client/test_rubrix_client.py
@@ -23,7 +23,9 @@ import pytest
 
 import rubrix
 from rubrix import (
+    DatasetForText2Text,
     DatasetForTextClassification,
+    DatasetForTokenClassification,
     Text2TextRecord,
     TextClassificationRecord,
 )
@@ -150,12 +152,13 @@ def test_delete_with_errors(monkeypatch, status, error_type):
         rubrix.delete("dataset")
 
 
-# TODO: Add tokenclassification and text2text records after their client models are updated, see issue #1140
 @pytest.mark.parametrize(
     "records, dataset_class",
     [
         ("singlelabel_textclassification_records", DatasetForTextClassification),
         ("multilabel_textclassification_records", DatasetForTextClassification),
+        ("tokenclassification_records", DatasetForTokenClassification),
+        ("text2text_records", DatasetForText2Text),
     ],
 )
 def test_general_log_load(monkeypatch, request, records, dataset_class):
@@ -169,10 +172,13 @@ def test_general_log_load(monkeypatch, request, records, dataset_class):
 
     records = request.getfixturevalue(records)
 
+    # log single records
     rubrix.log(records[0], name=dataset_names[0])
     dataset = rubrix.load(dataset_names[0], as_pandas=False)
+    records[0].metrics = dataset[0].metrics
     assert dataset[0] == records[0]
 
+    # log list of records
     rubrix.log(records, name=dataset_names[1])
     dataset = rubrix.load(dataset_names[1], as_pandas=False)
     assert len(dataset) == len(records)
@@ -180,6 +186,7 @@ def test_general_log_load(monkeypatch, request, records, dataset_class):
         expected.metrics = record.metrics
         assert record == expected
 
+    # log dataset
     rubrix.log(dataset_class(records), name=dataset_names[2])
     dataset = rubrix.load(dataset_names[2], as_pandas=False)
     assert len(dataset) == len(records)


### PR DESCRIPTION
Closes #1140 

This PR fixes/improves a bit the `score` handling in the `TokenClassificationRecord` and `Text2TextRecord`. This enables the support of "entity scores" in the `DatasetForTokenClassification`.

Also includes some more testing.