### PR TITLE
refactor(#995): use sklearn classification_report for label model scores

### DIFF
--- a/docs/guides/weak-supervision.ipynb
+++ b/docs/guides/weak-supervision.ipynb
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "6b1e00af-c6f9-42aa-81aa-2976c9591b36",
    "metadata": {},
    "outputs": [
@@ -227,7 +227,7 @@
        "4                      i am 2,126,492,636 viewer :D﻿   -1.0      1  "
       ]
      },
-     "execution_count": 2,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "045700ef-62b7-44e2-95f9-0f966236303b",
    "metadata": {},
    "outputs": [],
@@ -338,7 +338,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "c7b3554c-9646-4f2b-ab33-13518566bb6e",
    "metadata": {},
    "outputs": [],
@@ -389,7 +389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "id": "f0584b8b-4b0d-4857-9e8b-9823d9172634",
    "metadata": {},
    "outputs": [
@@ -414,8 +414,9 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>polarity</th>\n",
+       "      <th>label</th>\n",
        "      <th>coverage</th>\n",
+       "      <th>annotated_coverage</th>\n",
        "      <th>overlaps</th>\n",
        "      <th>conflicts</th>\n",
        "      <th>correct</th>\n",
@@ -428,6 +429,7 @@
        "      <th>check out</th>\n",
        "      <td>{SPAM}</td>\n",
        "      <td>0.242919</td>\n",
+       "      <td>0.180</td>\n",
        "      <td>0.235839</td>\n",
        "      <td>0.029956</td>\n",
        "      <td>45</td>\n",
@@ -438,6 +440,7 @@
        "      <th>plz OR please</th>\n",
        "      <td>{SPAM}</td>\n",
        "      <td>0.090414</td>\n",
+       "      <td>0.080</td>\n",
        "      <td>0.081155</td>\n",
        "      <td>0.019608</td>\n",
        "      <td>20</td>\n",
@@ -448,6 +451,7 @@
        "      <th>subscribe</th>\n",
        "      <td>{SPAM}</td>\n",
        "      <td>0.106754</td>\n",
+       "      <td>0.120</td>\n",
        "      <td>0.083878</td>\n",
        "      <td>0.028867</td>\n",
        "      <td>30</td>\n",
@@ -458,6 +462,7 @@
        "      <th>my</th>\n",
        "      <td>{SPAM}</td>\n",
        "      <td>0.190632</td>\n",
+       "      <td>0.188</td>\n",
        "      <td>0.166667</td>\n",
        "      <td>0.049564</td>\n",
        "      <td>41</td>\n",
@@ -468,6 +473,7 @@
        "      <th>song</th>\n",
        "      <td>{HAM}</td>\n",
        "      <td>0.132898</td>\n",
+       "      <td>0.192</td>\n",
        "      <td>0.079521</td>\n",
        "      <td>0.033769</td>\n",
        "      <td>39</td>\n",
@@ -478,6 +484,7 @@
        "      <th>love</th>\n",
        "      <td>{HAM}</td>\n",
        "      <td>0.092048</td>\n",
+       "      <td>0.140</td>\n",
        "      <td>0.070261</td>\n",
        "      <td>0.031590</td>\n",
        "      <td>28</td>\n",
@@ -488,6 +495,7 @@
        "      <th>contains_http</th>\n",
        "      <td>{SPAM}</td>\n",
        "      <td>0.106209</td>\n",
+       "      <td>0.024</td>\n",
        "      <td>0.073529</td>\n",
        "      <td>0.049564</td>\n",
        "      <td>6</td>\n",
@@ -498,6 +506,7 @@
        "      <th>short_comment</th>\n",
        "      <td>{HAM}</td>\n",
        "      <td>0.245098</td>\n",
+       "      <td>0.368</td>\n",
        "      <td>0.110566</td>\n",
        "      <td>0.064270</td>\n",
        "      <td>84</td>\n",
@@ -508,6 +517,7 @@
        "      <th>regex_check_out</th>\n",
        "      <td>{SPAM}</td>\n",
        "      <td>0.226580</td>\n",
+       "      <td>0.180</td>\n",
        "      <td>0.226035</td>\n",
        "      <td>0.027778</td>\n",
        "      <td>45</td>\n",
@@ -518,6 +528,7 @@
        "      <th>total</th>\n",
        "      <td>{SPAM, HAM}</td>\n",
        "      <td>0.754902</td>\n",
+       "      <td>0.836</td>\n",
        "      <td>0.448802</td>\n",
        "      <td>0.120915</td>\n",
        "      <td>338</td>\n",
@@ -529,32 +540,32 @@
        "</div>"
       ],
       "text/plain": [
-       "                    polarity  coverage  overlaps  conflicts  correct  \\\n",
-       "check out             {SPAM}  0.242919  0.235839   0.029956       45   \n",
-       "plz OR please         {SPAM}  0.090414  0.081155   0.019608       20   \n",
-       "subscribe             {SPAM}  0.106754  0.083878   0.028867       30   \n",
-       "my                    {SPAM}  0.190632  0.166667   0.049564       41   \n",
-       "song                   {HAM}  0.132898  0.079521   0.033769       39   \n",
-       "love                   {HAM}  0.092048  0.070261   0.031590       28   \n",
-       "contains_http         {SPAM}  0.106209  0.073529   0.049564        6   \n",
-       "short_comment          {HAM}  0.245098  0.110566   0.064270       84   \n",
-       "regex_check_out       {SPAM}  0.226580  0.226035   0.027778       45   \n",
-       "total            {SPAM, HAM}  0.754902  0.448802   0.120915      338   \n",
+       "                       label  coverage  annotated_coverage  overlaps  \\\n",
+       "check out             {SPAM}  0.242919               0.180  0.235839   \n",
+       "plz OR please         {SPAM}  0.090414               0.080  0.081155   \n",
+       "subscribe             {SPAM}  0.106754               0.120  0.083878   \n",
+       "my                    {SPAM}  0.190632               0.188  0.166667   \n",
+       "song                   {HAM}  0.132898               0.192  0.079521   \n",
+       "love                   {HAM}  0.092048               0.140  0.070261   \n",
+       "contains_http         {SPAM}  0.106209               0.024  0.073529   \n",
+       "short_comment          {HAM}  0.245098               0.368  0.110566   \n",
+       "regex_check_out       {SPAM}  0.226580               0.180  0.226035   \n",
+       "total            {SPAM, HAM}  0.754902               0.836  0.448802   \n",
        "\n",
-       "                 incorrect  precision  \n",
-       "check out                0   1.000000  \n",
-       "plz OR please            0   1.000000  \n",
-       "subscribe                0   1.000000  \n",
-       "my                       6   0.872340  \n",
-       "song                     9   0.812500  \n",
-       "love                     7   0.800000  \n",
-       "contains_http            0   1.000000  \n",
-       "short_comment            8   0.913043  \n",
-       "regex_check_out          0   1.000000  \n",
-       "total                   30   0.918478  "
+       "                 conflicts  correct  incorrect  precision  \n",
+       "check out         0.029956       45          0   1.000000  \n",
+       "plz OR please     0.019608       20          0   1.000000  \n",
+       "subscribe         0.028867       30          0   1.000000  \n",
+       "my                0.049564       41          6   0.872340  \n",
+       "song              0.033769       39          9   0.812500  \n",
+       "love              0.031590       28          7   0.800000  \n",
+       "contains_http     0.049564        6          0   1.000000  \n",
+       "short_comment     0.064270       84          8   0.913043  \n",
+       "regex_check_out   0.027778       45          0   1.000000  \n",
+       "total             0.120915      338         30   0.918478  "
       ]
      },
-     "execution_count": 12,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -614,7 +625,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "15888261",
    "metadata": {},
    "outputs": [],
@@ -630,9 +641,7 @@
    "id": "293d163f-ba08-424c-93de-ef0420531ca9",
    "metadata": {},
    "source": [
-    "Let's go on and evaluate this baseline.\n",
-    "To break ties when there is no majority vote, we choose the _\"random\"_ policy that randomly selects one of the tied labels. \n",
-    "In this way we avoid a bias towards label models that produce fewer but more certain weak labels, and makes the comparison between the different label models fairer."
+    "Let's go on and evaluate this baseline. "
    ]
   },
   {
@@ -646,9 +655,41 @@
     "majority_model.score(\n",
     "    L=weak_labels.matrix(has_annotation=True),\n",
     "    Y=weak_labels.annotation(),\n",
-    "    tie_break_policy=\"random\",\n",
+    "    tie_break_policy=\n",
     ")\n",
-    "# {'accuracy': 0.844}"
+    "# {'accuracy': 0.96}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3521799b-2714-4863-9003-e2fc91c4f41b",
+   "metadata": {},
+   "source": [
+    "An accuracy of 0.96 seems surprisingly high, but you need to keep in mind that we simply excluded the records from the evaluation, for which the model abstained (that is a tie in the votes or no votes at all).\n",
+    "So let's account for this and correct the accuracy by assuming the model performs like a random classifier for these abstained records."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7e672df-a6a4-4336-b042-a8edc4e4eed4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# predictions including abstentions (-1)\n",
+    "test_predictions = majority_model.predict(L=weak_labels.matrix(has_annotation=True))\n",
+    "\n",
+    "n_total = len(test_predictions)\n",
+    "n_abstentions = (test_predictions == -1).sum()\n",
+    "\n",
+    "# correct accuracy, assuming a random classifier for the abstentions\n",
+    "{\n",
+    "    \"accuracy\": (\n",
+    "        (1 - (n_abstentions / n_total)) * 0.96 + \\\n",
+    "        n_abstentions / n_total * 0.5\n",
+    "    )\n",
+    "}\n",
+    "# {'accuracy': 0.868}"
    ]
   },
   {
@@ -656,15 +697,16 @@
    "id": "a619247f-3d9d-44ae-bb9f-d07c9120c1dc",
    "metadata": {},
    "source": [
-    "As we will see further down, an accuracy of 0.844 is a very decent baseline.\n",
-    "Choosing to simply ignore tiebreaks and abstentions (by setting the tiebreak policy to _\"abstain\"_), we would obtain an accuracy of nearly 0.96.\n",
+    "As we will see further down, **an accuracy of 0.868** is still a very decent baseline.\n",
     "\n",
-    "When predicting weak labels to train a down-stream model, you probably want to discard the abstentions and tiebreaks."
+    "To get a noisy estimate of this effect, you can also set the _\"tie_break_policy\"_ argument: `majority_model.score(..., tie_break_policy=\"random\")`.\n",
+    "\n",
+    "When predicting weak labels to train a down-stream model, however, you probably want to discard the abstentions."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "id": "b8de05c3-84ef-40de-8f73-0157a4aa1074",
    "metadata": {},
    "outputs": [],
@@ -689,7 +731,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 240,
+   "execution_count": 36,
    "id": "39e06fd0-caa6-4707-a667-030b52ad4be9",
    "metadata": {},
    "outputs": [
@@ -721,27 +763,27 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>Hey I&amp;#39;m a British youtuber!!&lt;br /&gt;I upload...</td>\n",
+       "      <td>Check out Melbourne shuffle, everybody!﻿</td>\n",
        "      <td>SPAM</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>NOKIA spotted﻿</td>\n",
+       "      <td>I love this song﻿</td>\n",
        "      <td>HAM</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>Dance :)﻿</td>\n",
+       "      <td>I fuckin love this song!&lt;br /&gt;&lt;br /&gt;&lt;br /&gt;Afte...</td>\n",
        "      <td>HAM</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>You guys should check out this EXTRAORDINARY w...</td>\n",
+       "      <td>Check out this video on YouTube:﻿</td>\n",
        "      <td>SPAM</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>Need money ? check my channel and subscribe,so...</td>\n",
+       "      <td>Who&amp;#39;s watching in 2015 Subscribe for me !﻿</td>\n",
        "      <td>SPAM</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -751,28 +793,28 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1579</th>\n",
-       "      <td>Please check out my acoustic cover channel :) ...</td>\n",
+       "      <td>Hey guys! Im a 12 yr old music producer. I mak...</td>\n",
        "      <td>SPAM</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1580</th>\n",
-       "      <td>PLEASE SUBSCRIBE ME!!!!!!!!!!!!!!!!!!!!!!!!!!!...</td>\n",
-       "      <td>SPAM</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1581</th>\n",
-       "      <td>&lt;a href=\"http://www.gofundme.com/Helpmypitbull...</td>\n",
+       "      <td>Hey, check out my new website!! This site is a...</td>\n",
        "      <td>SPAM</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1582</th>\n",
-       "      <td>I love this song so much!:-D I've heard it so ...</td>\n",
+       "      <td>:3﻿</td>\n",
        "      <td>HAM</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1585</th>\n",
-       "      <td>Check out this video on YouTube:﻿</td>\n",
+       "      <th>1583</th>\n",
+       "      <td>Hey! I'm NERDY PEACH and I'm a new youtuber an...</td>\n",
        "      <td>SPAM</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1584</th>\n",
+       "      <td>Are those real animals﻿</td>\n",
+       "      <td>HAM</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -781,22 +823,22 @@
       ],
       "text/plain": [
        "                                                   text label\n",
-       "0     Hey I&#39;m a British youtuber!!<br />I upload...  SPAM\n",
-       "1                                        NOKIA spotted﻿   HAM\n",
-       "2                                             Dance :)﻿   HAM\n",
-       "3     You guys should check out this EXTRAORDINARY w...  SPAM\n",
-       "4     Need money ? check my channel and subscribe,so...  SPAM\n",
+       "0              Check out Melbourne shuffle, everybody!﻿  SPAM\n",
+       "1                                     I love this song﻿   HAM\n",
+       "2     I fuckin love this song!<br /><br /><br />Afte...   HAM\n",
+       "3                     Check out this video on YouTube:﻿  SPAM\n",
+       "4        Who&#39;s watching in 2015 Subscribe for me !﻿  SPAM\n",
        "...                                                 ...   ...\n",
-       "1579  Please check out my acoustic cover channel :) ...  SPAM\n",
-       "1580  PLEASE SUBSCRIBE ME!!!!!!!!!!!!!!!!!!!!!!!!!!!...  SPAM\n",
-       "1581  <a href=\"http://www.gofundme.com/Helpmypitbull...  SPAM\n",
-       "1582  I love this song so much!:-D I've heard it so ...   HAM\n",
-       "1585                  Check out this video on YouTube:﻿  SPAM\n",
+       "1579  Hey guys! Im a 12 yr old music producer. I mak...  SPAM\n",
+       "1580  Hey, check out my new website!! This site is a...  SPAM\n",
+       "1582                                                :3﻿   HAM\n",
+       "1583  Hey! I'm NERDY PEACH and I'm a new youtuber an...  SPAM\n",
+       "1584                            Are those real animals﻿   HAM\n",
        "\n",
        "[1055 rows x 2 columns]"
       ]
      },
-     "execution_count": 240,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -853,14 +895,55 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "id": "9c82339f-561d-4c59-89ee-c49ddbe8da83",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "              precision    recall  f1-score   support\n",
+      "\n",
+      "        SPAM       0.96      0.93      0.94        95\n",
+      "         HAM       0.94      0.96      0.95       114\n",
+      "\n",
+      "    accuracy                           0.95       209\n",
+      "   macro avg       0.95      0.95      0.95       209\n",
+      "weighted avg       0.95      0.95      0.95       209\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# we check its performance\n",
+    "print(snorkel_model.score(output_str=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27d3e81f-e1ac-4203-8641-e721981aa0a6",
+   "metadata": {},
+   "source": [
+    "At first sight, the model seems to perform worse than the majority vote baseline.\n",
+    "However, let's again correct the accuracy for the abstentions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a9700f2-5e88-4926-8f2f-d3acada5c166",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# we check its performance\n",
-    "snorkel_model.score(tie_break_policy=\"abstain\")\n",
-    "# {'accuracy': 0.848, ...}"
+    "# correct accuracy, assuming a random classifier for the abstentions\n",
+    "{ \n",
+    "    \"accuracy\": (\n",
+    "        209/len(weak_labels.annotation())*0.95 + \\\n",
+    "        (1-209/len(weak_labels.annotation()))*0.5\n",
+    "    )\n",
+    "}\n",
+    "# {'accuracy': 0.8761999999999999}"
    ]
   },
   {
@@ -868,7 +951,7 @@
    "id": "075463f3-8695-4d28-af24-8860b2efd691",
    "metadata": {},
    "source": [
-    "When choosing to simply ignore tiebreaks and abstentions in the score (by setting the tiebreak policy to _\"abstain\"_), we would obtain an accuracy of about 0.95.\n",
+    "Now we can see that with **an accuracy of 0.876**, its performance over the whole test set is actually slightly better.\n",
     "\n",
     "After fitting your label model, you can quickly explore its predictions, before building a training set for training a downstream text classifier. \n",
     "This step is useful for validation, manual revision, or defining score thresholds for accepting labels from your label model (for example, only considering labels with a score greater then 0.8.)"
@@ -898,7 +981,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 225,
+   "execution_count": 49,
    "id": "4e18b365-5412-47c7-b0e6-e140bd0c2dc6",
    "metadata": {},
    "outputs": [
@@ -930,27 +1013,27 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>Hey I&amp;#39;m a British youtuber!!&lt;br /&gt;I upload...</td>\n",
+       "      <td>Check out Melbourne shuffle, everybody!﻿</td>\n",
        "      <td>SPAM</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>NOKIA spotted﻿</td>\n",
+       "      <td>I love this song﻿</td>\n",
        "      <td>HAM</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>Dance :)﻿</td>\n",
+       "      <td>I fuckin love this song!&lt;br /&gt;&lt;br /&gt;&lt;br /&gt;Afte...</td>\n",
        "      <td>HAM</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>You guys should check out this EXTRAORDINARY w...</td>\n",
+       "      <td>Check out this video on YouTube:﻿</td>\n",
        "      <td>SPAM</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>Need money ? check my channel and subscribe,so...</td>\n",
+       "      <td>Who&amp;#39;s watching in 2015 Subscribe for me !﻿</td>\n",
        "      <td>SPAM</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -960,28 +1043,28 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1172</th>\n",
-       "      <td>Please check out my acoustic cover channel :) ...</td>\n",
+       "      <td>Hey guys! Im a 12 yr old music producer. I mak...</td>\n",
        "      <td>SPAM</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1173</th>\n",
-       "      <td>PLEASE SUBSCRIBE ME!!!!!!!!!!!!!!!!!!!!!!!!!!!...</td>\n",
+       "      <td>Hey, check out my new website!! This site is a...</td>\n",
        "      <td>SPAM</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1174</th>\n",
-       "      <td>&lt;a href=\"http://www.gofundme.com/Helpmypitbull...</td>\n",
-       "      <td>SPAM</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1175</th>\n",
-       "      <td>I love this song so much!:-D I've heard it so ...</td>\n",
+       "      <td>:3﻿</td>\n",
        "      <td>HAM</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1176</th>\n",
-       "      <td>Check out this video on YouTube:﻿</td>\n",
+       "      <th>1175</th>\n",
+       "      <td>Hey! I'm NERDY PEACH and I'm a new youtuber an...</td>\n",
        "      <td>SPAM</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1176</th>\n",
+       "      <td>Are those real animals﻿</td>\n",
+       "      <td>HAM</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -990,22 +1073,22 @@
       ],
       "text/plain": [
        "                                                   text label\n",
-       "0     Hey I&#39;m a British youtuber!!<br />I upload...  SPAM\n",
-       "1                                        NOKIA spotted﻿   HAM\n",
-       "2                                             Dance :)﻿   HAM\n",
-       "3     You guys should check out this EXTRAORDINARY w...  SPAM\n",
-       "4     Need money ? check my channel and subscribe,so...  SPAM\n",
+       "0              Check out Melbourne shuffle, everybody!﻿  SPAM\n",
+       "1                                     I love this song﻿   HAM\n",
+       "2     I fuckin love this song!<br /><br /><br />Afte...   HAM\n",
+       "3                     Check out this video on YouTube:﻿  SPAM\n",
+       "4        Who&#39;s watching in 2015 Subscribe for me !﻿  SPAM\n",
        "...                                                 ...   ...\n",
-       "1172  Please check out my acoustic cover channel :) ...  SPAM\n",
-       "1173  PLEASE SUBSCRIBE ME!!!!!!!!!!!!!!!!!!!!!!!!!!!...  SPAM\n",
-       "1174  <a href=\"http://www.gofundme.com/Helpmypitbull...  SPAM\n",
-       "1175  I love this song so much!:-D I've heard it so ...   HAM\n",
-       "1176                  Check out this video on YouTube:﻿  SPAM\n",
+       "1172  Hey guys! Im a 12 yr old music producer. I mak...  SPAM\n",
+       "1173  Hey, check out my new website!! This site is a...  SPAM\n",
+       "1174                                                :3﻿   HAM\n",
+       "1175  Hey! I'm NERDY PEACH and I'm a new youtuber an...  SPAM\n",
+       "1176                            Are those real animals﻿   HAM\n",
        "\n",
        "[1177 rows x 2 columns]"
       ]
      },
-     "execution_count": 225,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1069,22 +1152,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 51,
    "id": "2d81dbf5-edf9-4c8c-a876-5fcb16d73090",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "              precision    recall  f1-score   support\n",
+      "\n",
+      "        SPAM       0.93      0.91      0.92        95\n",
+      "         HAM       0.92      0.95      0.94       114\n",
+      "\n",
+      "    accuracy                           0.93       209\n",
+      "   macro avg       0.93      0.93      0.93       209\n",
+      "weighted avg       0.93      0.93      0.93       209\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "# we check its performance\n",
-    "flyingsquid_model.score(tie_break_policy=\"random\")\n",
-    "# {'accuracy': 0.832, ...}"
+    "print(flyingsquid_model.score(output_str=True))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d282da18-cc57-437a-bfd1-c13a9ac1aec4",
+   "id": "b287726d-c4c6-424b-9ed8-e8453702744c",
    "metadata": {},
    "source": [
-    "When choosing to simply ignore tiebreaks and abstentions in the score (by setting the tiebreak policy to _\"abstain\"_), we would obtain an accuracy of about 0.93.\n",
+    "Again, let's correct the accuracy for the abstentions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4641b855-ef30-4d84-a917-532a7ba12be5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# correct accuracy, assuming a random classifier for the abstentions\n",
+    "{ \n",
+    "    \"accuracy\": (\n",
+    "        209/len(weak_labels.annotation())*0.93 + \\\n",
+    "        (1-209/len(weak_labels.annotation()))*0.5\n",
+    "    )\n",
+    "}\n",
+    "# {'accuracy': 0.85948}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "678757c6-9ceb-46f2-949f-5fd10cb8685b",
+   "metadata": {},
+   "source": [
+    "Here, it really seems that with **an accuracy of 0.859**, the performance over the whole test set is actually slightly worse than the baseline of the majority vote.\n",
     "\n",
     "After fitting your label model, you can quickly explore its predictions, before building a training set for training a downstream text classifier. \n",
     "This step is useful for validation, manual revision, or defining score thresholds for accepting labels from your label model (for example, only considering labels with a score greater then 0.8.)"
@@ -1489,7 +1612,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1503,7 +1626,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/src/rubrix/labeling/text_classification/label_models.py
+++ b/src/rubrix/labeling/text_classification/label_models.py
@@ -287,8 +287,8 @@ class Snorkel(LabelModel):
     def score(
         self,
         tie_break_policy: Union[TieBreakPolicy, str] = "abstain",
-        output_dict: bool = False,
-    ) -> Dict[str, float]:
+        output_str: bool = False,
+    ) -> Union[Dict[str, float], str]:
         """Returns some scores/metrics of the label model with respect to the annotated records.
 
         The metrics are:
@@ -309,10 +309,10 @@ class Snorkel(LabelModel):
 
                 The last two policies can introduce quite a bit of noise, especially when the tie is among many labels,
                 as is the case when all of the labeling functions abstained.
-            output_dict: If True, return output as dict.
+            output_str: If True, return output as nicely formatted string.
 
         Returns:
-            The scores/metrics as a nicely formatted str or dictionary.
+            The scores/metrics in a dictionary or as a nicely formatted str.
 
         .. note:: Metrics are only calculated over non-abstained predictions!
 
@@ -362,7 +362,7 @@ class Snorkel(LabelModel):
             annotation,
             predictions[idx],
             target_names=target_names[: annotation.max() + 1],
-            output_dict=output_dict,
+            output_dict=not output_str,
         )
 
 
@@ -604,8 +604,8 @@ class FlyingSquid(LabelModel):
         self,
         tie_break_policy: Union[TieBreakPolicy, str] = "abstain",
         verbose: bool = False,
-        output_dict: bool = False,
-    ) -> Union[str, Dict[str, float]]:
+        output_str: bool = False,
+    ) -> Union[Dict[str, float], str]:
         """Returns some scores/metrics of the label model with respect to the annotated records.
 
         The metrics are:
@@ -626,10 +626,10 @@ class FlyingSquid(LabelModel):
                 The last policy can introduce quite a bit of noise, especially when the tie is among many labels,
                 as is the case when all of the labeling functions abstained.
             verbose: If True, print out messages of the progress to stderr.
-            output_dict: If True, return output as dict.
+            output_str: If True, return output as nicely formatted string.
 
         Returns:
-            The scores/metrics as a nicely formatted str or dictionary.
+            The scores/metrics in a dictionary or as a nicely formatted str.
 
         .. note:: Metrics are only calculated over non-abstained predictions!
 
@@ -688,7 +688,7 @@ class FlyingSquid(LabelModel):
             annotation,
             prediction,
             target_names=self._labels[: annotation.max() + 1],
-            output_dict=output_dict,
+            output_dict=not output_str,
         )
 
 

--- a/src/rubrix/labeling/text_classification/label_models.py
+++ b/src/rubrix/labeling/text_classification/label_models.py
@@ -319,14 +319,6 @@ class Snorkel(LabelModel):
         Raises:
             MissingAnnotationError: If the ``weak_labels`` do not contain annotated records.
         """
-        try:
-            from sklearn.metrics import classification_report
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError(
-                "'sklearn' must be installed to compute the metrics! "
-                "You can install 'sklearn' with the command: `pip install scikit-learn`"
-            )
-
         if isinstance(tie_break_policy, str):
             tie_break_policy = TieBreakPolicy(tie_break_policy)
 
@@ -638,12 +630,13 @@ class FlyingSquid(LabelModel):
             MissingAnnotationError: If the ``weak_labels`` do not contain annotated records.
         """
         try:
-            from sklearn.metrics import classification_report
+            import sklearn
         except ModuleNotFoundError:
             raise ModuleNotFoundError(
                 "'sklearn' must be installed to compute the metrics! "
                 "You can install 'sklearn' with the command: `pip install scikit-learn`"
             )
+        from sklearn.metrics import classification_report
 
         if isinstance(tie_break_policy, str):
             tie_break_policy = TieBreakPolicy(tie_break_policy)

--- a/src/rubrix/labeling/text_classification/label_models.py
+++ b/src/rubrix/labeling/text_classification/label_models.py
@@ -319,6 +319,8 @@ class Snorkel(LabelModel):
         Raises:
             MissingAnnotationError: If the ``weak_labels`` do not contain annotated records.
         """
+        from sklearn.metrics import classification_report
+
         if isinstance(tie_break_policy, str):
             tie_break_policy = TieBreakPolicy(tie_break_policy)
 

--- a/tests/labeling/text_classification/test_label_models.py
+++ b/tests/labeling/text_classification/test_label_models.py
@@ -264,8 +264,6 @@ class TestSnorkel:
         assert metrics["accuracy"] == pytest.approx(expected)
         assert list(metrics.keys())[:3] == ["negative", "positive", "neutral"]
 
-        assert isinstance(label_model.score(output_str=True), str)
-
     def test_score_without_annotations(self, weak_labels):
         weak_labels._annotation_array = np.array([], dtype=np.short)
         label_model = Snorkel(weak_labels)

--- a/tests/labeling/text_classification/test_label_models.py
+++ b/tests/labeling/text_classification/test_label_models.py
@@ -259,10 +259,12 @@ class TestSnorkel:
         )
 
         label_model = Snorkel(weak_labels)
-        metrics = label_model.score(tie_break_policy=policy, output_dict=True)
+        metrics = label_model.score(tie_break_policy=policy)
 
         assert metrics["accuracy"] == pytest.approx(expected)
         assert list(metrics.keys())[:3] == ["negative", "positive", "neutral"]
+
+        assert isinstance(label_model.score(output_str=True), str)
 
     def test_score_without_annotations(self, weak_labels):
         weak_labels._annotation_array = np.array([], dtype=np.short)
@@ -281,7 +283,7 @@ class TestSnorkel:
         label_model = Snorkel(weak_labels_from_guide)
         label_model.fit(seed=43)
 
-        metrics = label_model.score(output_dict=True)
+        metrics = label_model.score()
         assert metrics["accuracy"] == pytest.approx(0.8947368421052632)
 
         records = label_model.predict()
@@ -484,11 +486,13 @@ class TestFlyingSquid:
         monkeypatch.setattr(FlyingSquid, "_predict", mock_predict)
 
         label_model = FlyingSquid(weak_labels)
-        metrics = label_model.score(output_dict=True)
+        metrics = label_model.score()
 
         assert "accuracy" in metrics
         assert metrics["accuracy"] == pytest.approx(1.0)
         assert list(metrics.keys())[:3] == ["negative", "positive", "neutral"]
+
+        assert isinstance(label_model.score(output_str=True), str)
 
     @pytest.mark.parametrize(
         "tbp,vrb,expected", [("abstain", False, 1.0), ("random", True, 2 / 3.0)]
@@ -504,7 +508,7 @@ class TestFlyingSquid:
         monkeypatch.setattr(FlyingSquid, "_predict", mock_predict)
 
         label_model = FlyingSquid(weak_labels)
-        metrics = label_model.score(tie_break_policy=tbp, verbose=vrb, output_dict=True)
+        metrics = label_model.score(tie_break_policy=tbp, verbose=vrb)
 
         assert metrics["accuracy"] == pytest.approx(expected)
         if tbp == "abstain":
@@ -523,7 +527,7 @@ class TestFlyingSquid:
         label_model = FlyingSquid(weak_labels_from_guide)
         label_model.fit()
 
-        metrics = label_model.score(output_dict=True)
+        metrics = label_model.score()
         assert metrics["accuracy"] == pytest.approx(0.9282296650717703)
 
         records = label_model.predict()

--- a/tests/labeling/text_classification/test_label_models.py
+++ b/tests/labeling/text_classification/test_label_models.py
@@ -475,6 +475,13 @@ class TestFlyingSquid:
         with pytest.raises(NotFittedError, match="not fitted yet"):
             label_model.score()
 
+    def test_score_sklearn_not_installed(self, monkeypatch, weak_labels):
+        monkeypatch.setitem(sys.modules, "sklearn", None)
+
+        label_model = FlyingSquid(weak_labels)
+        with pytest.raises(ModuleNotFoundError, match="pip install scikit-learn"):
+            label_model.score()
+
     def test_score(self, monkeypatch, weak_labels):
         def mock_predict(self, weak_label_matrix, verbose):
             assert verbose is False


### PR DESCRIPTION
Closes #995

I show this new "feature" (the new `output_str` argument) in the weak supervision guide, i also improved the model evaluation part of this guide.