### PR TITLE
docs(#1152): remove conda note about not having server dependencies

### DIFF
--- a/docs/getting_started/setup&installation.rst
+++ b/docs/getting_started/setup&installation.rst
@@ -29,10 +29,6 @@ Then you can install Rubrix with ``pip`` or ``conda``\.
 
    conda install -c conda-forge rubrix
 
-.. note::
-   Conda for now only installs the Python client of Rubrix.
-   This means, you have to launch the web app via :ref:`docker <launching-the-web-app-via-docker>` or :ref:`docker-compose <launching-the-web-app-via-docker-compose>`.
-
 
 2. Launch the web app
 ---------------------


### PR DESCRIPTION
The first step for #1152 

This PR removes the note from the docs, in which we state that conda does not install server dependencies.
**After the release** we have to update the conda recipe. 
