### PR TITLE
refactor(search): using search service for dataset scan

### DIFF
--- a/src/rubrix/server/tasks/search/service.py
+++ b/src/rubrix/server/tasks/search/service.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Set, Type
+from typing import Iterable, List, Optional, Set, Type
 
 from fastapi import Depends
 
@@ -8,7 +8,12 @@ from rubrix.server.tasks.commons import BaseRecord, EsRecordDataFieldNames
 from rubrix.server.tasks.commons.dao.dao import DatasetRecordsDAO
 from rubrix.server.tasks.commons.dao.model import RecordSearch
 from rubrix.server.tasks.commons.metrics.service import MetricsService
-from rubrix.server.tasks.search.model import BaseSearchQuery, SearchResults, SortConfig
+from rubrix.server.tasks.search.model import (
+    BaseSearchQuery,
+    Record,
+    SearchResults,
+    SortConfig,
+)
 from rubrix.server.tasks.search.query_builder import EsQueryBuilder
 
 
@@ -91,3 +96,15 @@ class SearchRecordsService:
             records=[record_type.parse_obj(r) for r in results.records],
             metrics=metrics_results if metrics_results else {},
         )
+
+    def scan_records(
+        self,
+        dataset: Dataset,
+        query: BaseSearchQuery,
+        record_type: Type[BaseRecord],
+    ) -> Iterable[Record]:
+        """Scan records for a queried"""
+        for doc in self.__dao__.scan_dataset(
+            dataset, search=RecordSearch(query=self.__query_builder__(dataset, query))
+        ):
+            yield record_type.parse_obj(doc)

--- a/src/rubrix/server/tasks/text2text/service/service.py
+++ b/src/rubrix/server/tasks/text2text/service/service.py
@@ -161,10 +161,9 @@ class Text2TextService:
             the provided query filters. Optional
 
         """
-        for db_record in self.__dao__.scan_dataset(  # TODO: use search service instead
-            dataset, search=RecordSearch(query=query.as_elasticsearch())
-        ):
-            yield Text2TextRecord.parse_obj(db_record)
+        yield from self.__search__.scan_records(
+            dataset, query=query, record_type=Text2TextRecord
+        )
 
 
 _instance = None

--- a/src/rubrix/server/tasks/text_classification/service/service.py
+++ b/src/rubrix/server/tasks/text_classification/service/service.py
@@ -25,7 +25,6 @@ from rubrix.server.tasks.commons import (
     SortableField,
     TaskType,
 )
-from rubrix.server.tasks.commons.dao import extends_index_dynamic_templates
 from rubrix.server.tasks.commons.dao.dao import DatasetRecordsDAO, dataset_records_dao
 from rubrix.server.tasks.commons.dao.model import RecordSearch
 from rubrix.server.tasks.commons.metrics.service import MetricsService
@@ -47,10 +46,6 @@ from rubrix.server.tasks.text_classification.dao.es_config import (
 )
 from rubrix.server.tasks.text_classification.service.labeling_service import (
     LabelingService,
-)
-
-extends_index_dynamic_templates(
-    {"inputs": {"path_match": "inputs.*", "mapping": {"type": "text"}}}
 )
 
 
@@ -219,13 +214,12 @@ class TextClassificationService:
             the provided query filters. Optional
 
         """
-        for db_record in self.__dao__.scan_dataset(
-            dataset, search=RecordSearch(query=query.as_elasticsearch())
-        ):
-            yield TextClassificationRecord.parse_obj(db_record)
+        yield from self.__search__.scan_records(
+            dataset, query=query, record_type=TextClassificationRecord
+        )
 
     def _check_multi_label_integrity(
-        self, dataset: Dataset, records: List[TextClassificationRecord]
+        self, dataset: Dataset, records: List[CreationTextClassificationRecord]
     ):
         is_multi_label_dataset = self._is_dataset_multi_label(dataset)
         if is_multi_label_dataset is not None:

--- a/src/rubrix/server/tasks/token_classification/service/service.py
+++ b/src/rubrix/server/tasks/token_classification/service/service.py
@@ -182,10 +182,9 @@ class TokenClassificationService:
             the provided query filters. Optional
 
         """
-        for db_record in self.__dao__.scan_dataset(
-            dataset, search=RecordSearch(query=query.as_elasticsearch())
-        ):
-            yield TokenClassificationRecord.parse_obj(db_record)
+        yield from self.__search__.scan_records(
+            dataset, query=query, record_type=TokenClassificationRecord
+        )
 
 
 _instance = None


### PR DESCRIPTION
This PR make task service use the new `search.scan_records`, keeping hidden details about query transformations.

This will help in future for api search normalizations