### PR TITLE
refactor(metrics): compute text length as metric

### DIFF
--- a/src/rubrix/server/tasks/commons/metrics/commons.py
+++ b/src/rubrix/server/tasks/commons/metrics/commons.py
@@ -1,5 +1,10 @@
+from typing import Any, ClassVar, Dict, List
+
 from rubrix.server.tasks.commons import EsRecordDataFieldNames, TaskStatus
 from rubrix.server.tasks.commons.metrics.model.base import (
+    BaseMetric,
+    BaseTaskMetrics,
+    GenericRecord,
     HistogramAggregation,
     MetadataAggregations,
     TermsAggregation,
@@ -7,14 +12,20 @@ from rubrix.server.tasks.commons.metrics.model.base import (
 )
 
 
-class CommonTasksMetrics:
+class CommonTasksMetrics(BaseTaskMetrics[GenericRecord]):
+    """Common task metrics"""
 
-    metrics = [
+    @classmethod
+    def record_metrics(cls, record: GenericRecord) -> Dict[str, Any]:
+        """Record metrics will persist the text_length"""
+        return {"text_length": len(record.all_text())}
+
+    metrics: ClassVar[List[BaseMetric]] = [
         HistogramAggregation(
             id="text_length",
             name="Text length distribution",
             description="Computes the input text length distribution",
-            field=EsRecordDataFieldNames.words,
+            field="metrics.text_length",
             # TODO(@frascuchon): This won't work once words is excluded from _source
             script="params._source.words.length()",
             fixed_interval=1,
@@ -41,7 +52,7 @@ class CommonTasksMetrics:
             name="Inputs words cloud",
             description="The words cloud for dataset inputs",
             # TODO(@frascuchon): This won't work once words is excluded from _source
-            default_field="words",
+            default_field=EsRecordDataFieldNames.words,
         ),
         MetadataAggregations(id="metadata", name="Metadata fields stats"),
         TermsAggregation(

--- a/src/rubrix/server/tasks/text_classification/metrics.py
+++ b/src/rubrix/server/tasks/text_classification/metrics.py
@@ -28,7 +28,7 @@ class F1Metric(PythonMetric):
 
     def apply(self, records: Iterable[TextClassificationRecord]) -> Any:
         filtered_records = list(filter(lambda r: r.predicted is not None, records))
-        # TODO: This must be precalculated with using a global dataset metric
+        # TODO: This must be precomputed with using a global dataset metric
         ds_labels = {
             label for record in filtered_records for label in record.annotated_as
         }

--- a/src/rubrix/server/tasks/token_classification/api/model.py
+++ b/src/rubrix/server/tasks/token_classification/api/model.py
@@ -388,18 +388,11 @@ class TokenClassificationQuery(BaseSearchQuery):
         query_text = filters.text_query(self.query_text)
         all_filters.extend(query_filters)
 
-        # TODO: use es_helpers
-        return {
-            "bool": {
-                "must": query_text or {"match_all": {}},
-                "filter": {
-                    "bool": {
-                        "should": all_filters,
-                        "minimum_should_match": len(all_filters),
-                    }
-                },
-            }
-        }
+        return filters.boolean_filter(
+            must_query=query_text,
+            should_filters=all_filters,
+            minimum_should_match=len(all_filters),
+        )
 
 
 class TokenClassificationSearchRequest(BaseModel):


### PR DESCRIPTION
This PR materializes the input text length as a record metrics.

Then, you will be able to filter by text length and in a future release, sort by input text length.