### PR TITLE
Feat/multi labels labeling rules

### DIFF
--- a/src/rubrix/client/sdk/text_classification/models.py
+++ b/src/rubrix/client/sdk/text_classification/models.py
@@ -181,7 +181,8 @@ class LabelingRule(BaseModel):
 
     """
 
-    label: str
+    label: str = None
+    labels: List[str] = Field(default_factory=list)
     query: str
     description: Optional[str] = None
     author: str

--- a/src/rubrix/server/commons/helpers.py
+++ b/src/rubrix/server/commons/helpers.py
@@ -84,7 +84,7 @@ def unflatten_dict(
 
     """
     resultDict = {}
-
+    stop_keys = stop_keys or []
     for key, value in data.items():
         if key is not None:
             parts = key.split(sep)

--- a/src/rubrix/server/tasks/text_classification/api/api.py
+++ b/src/rubrix/server/tasks/text_classification/api/api.py
@@ -326,7 +326,9 @@ async def create_rule(
 async def compute_rule_metrics(
     name: str,
     query: str,
-    label: Optional[str] = Query(None, description="Label related to query rule"),
+    labels: Optional[List[str]] = Query(
+        None, description="Label related to query rule", alias="label"
+    ),
     common_params: CommonTaskQueryParams = Depends(),
     service: TextClassificationService = Depends(
         TextClassificationService.get_instance
@@ -342,7 +344,7 @@ async def compute_rule_metrics(
     )
 
     return service.compute_rule_metrics(
-        Dataset.parse_obj(dataset), rule_query=query, label=label
+        Dataset.parse_obj(dataset), rule_query=query, labels=labels
     )
 
 
@@ -459,7 +461,7 @@ async def update_rule(
     rule = service.update_labeling_rule(
         Dataset.parse_obj(dataset),
         rule_query=query,
-        label=update.label,
+        labels=update.labels,
         description=update.description,
     )
     return rule

--- a/src/rubrix/server/tasks/text_classification/api/model.py
+++ b/src/rubrix/server/tasks/text_classification/api/model.py
@@ -37,10 +37,29 @@ from rubrix.server.tasks.search.model import BaseSearchQuery
 
 
 class UpdateLabelingRule(BaseModel):
-    label: str = Field(description="The label associated with the rule")
+    label: Optional[str] = Field(
+        default=None, description="@Deprecated::The label associated with the rule."
+    )
+    labels: List[str] = Field(
+        default_factory=list,
+        description="For multi label problems, a list of labels. "
+        "It will replace the `label` field",
+    )
     description: Optional[str] = Field(
         None, description="A brief description of the rule"
     )
+
+    @root_validator
+    def initialize_labels(cls, values):
+        label = values.get("label", None)
+        labels = values.get("labels", [])
+
+        if label:
+            labels.append(label)
+            values["labels"] = list(set(labels))
+
+        assert len(labels) >= 1, f"No labels was provided in rule {values}"
+        return values
 
 
 class CreateLabelingRule(UpdateLabelingRule):

--- a/src/rubrix/server/tasks/text_classification/service/labeling_service.py
+++ b/src/rubrix/server/tasks/text_classification/service/labeling_service.py
@@ -68,11 +68,11 @@ class LabelingRulesMetric(ElasticsearchMetric):
 
         if labels is not None:
             for label in labels:
-                label = self._encode_label_name(label)
                 rule_label_annotated_filter = filters.annotated_as([label])
+                encoded_label = self._encode_label_name(label)
                 aggr_filters.update(
                     {
-                        f"{label}.correct_records": filters.boolean_filter(
+                        f"{encoded_label}.correct_records": filters.boolean_filter(
                             filter_query=annotated_records_filter,
                             should_filters=[
                                 rule_query_filter,
@@ -80,7 +80,7 @@ class LabelingRulesMetric(ElasticsearchMetric):
                             ],
                             minimum_should_match=2,
                         ),
-                        f"{label}.incorrect_records": filters.boolean_filter(
+                        f"{encoded_label}.incorrect_records": filters.boolean_filter(
                             filter_query=annotated_records_filter,
                             must_query=rule_query_filter,
                             must_not_query=rule_label_annotated_filter,

--- a/tests/server/text_classification/test_api_rules.py
+++ b/tests/server/text_classification/test_api_rules.py
@@ -256,7 +256,19 @@ def test_rule_metrics_with_missing_label(mocked_client):
             },
         ),
         (
-            CreateLabelingRule(query="ejemplo", label="OK"),
+            CreateLabelingRule(query="ejemplo", label="test.bad"),
+            {
+                "annotated_records": 1,
+                "correct": 0.0,
+                "coverage": 1.0,
+                "coverage_annotated": 1.0,
+                "incorrect": 1.0,
+                "precision": 0.0,
+                "total_records": 1,
+            },
+        ),
+        (
+            CreateLabelingRule(query="ejemplo", label="o.k."),
             {
                 "annotated_records": 1,
                 "correct": 1.0,
@@ -291,7 +303,7 @@ def test_rule_metrics_with_missing_label(mocked_client):
             },
         ),
         (
-            CreateLabelingRule(query="ejemplo", labels=["A", "OK"]),
+            CreateLabelingRule(query="ejemplo", labels=["A", "o.k."]),
             {
                 "annotated_records": 1,
                 "correct": 1.0,
@@ -308,7 +320,7 @@ def test_rule_metrics_with_missing_label_for_stored_rule(
     mocked_client, rule, expected_metrics
 ):
     dataset = "test_rule_metrics_with_missing_label_for_stored_rule"
-    log_some_records(mocked_client, dataset, annotation="OK")
+    log_some_records(mocked_client, dataset, annotation="o.k.")
     mocked_client.post(
         f"/api/datasets/TextClassification/{dataset}/labeling/rules", json=rule.dict()
     )
@@ -374,6 +386,20 @@ def test_create_rules_and_then_log(mocked_client):
                 "total_records": 1,
             },
             None,
+        ),
+        (
+            [
+                CreateLabelingRule(query="ejemplo", label="TEST"),
+                CreateLabelingRule(query="bad request", label="bad.label"),
+                CreateLabelingRule(query="other", labels=["A", "B", "good.label"]),
+            ],
+            {
+                "annotated_records": 1,
+                "coverage": 1.0,
+                "coverage_annotated": 1.0,
+                "total_records": 1,
+            },
+            "good.label",
         ),
     ],
 )


### PR DESCRIPTION
This PR changes labeling rules api actions to enable multiple labels.

Client and UI remain intact and will be updated in future PRs. 

The changes keep backward compatibility. 

See #1144