### PR TITLE
feat(#1144): weak multi labels

### DIFF
--- a/docs/reference/python/python_labeling.rst
+++ b/docs/reference/python/python_labeling.rst
@@ -17,8 +17,7 @@ Labeling tools for the text classification task.
    :exclude-members: RuleNotAppliedError
 
 .. automodule:: rubrix.labeling.text_classification.weak_labels
-   :members:
-   :exclude-members: WeakLabelsError, DuplicatedRuleNameError, NoRecordsFoundError, MultiLabelError, MissingLabelError
+   :members: WeakLabels, WeakMultiLabels
 
 .. automodule:: rubrix.labeling.text_classification.label_models
    :members:

--- a/docs/reference/python/python_labeling.rst
+++ b/docs/reference/python/python_labeling.rst
@@ -20,9 +20,7 @@ Labeling tools for the text classification task.
    :members: WeakLabels, WeakMultiLabels
 
 .. automodule:: rubrix.labeling.text_classification.label_models
-   :members:
-   :exclude-members: TieBreakPolicy, LabelModelError, MissingAnnotationError, TooFewRulesError, NotFittedError
+   :members: Snorkel, FlyingSquid
 
 .. automodule:: rubrix.labeling.text_classification.label_errors
-   :members:
-   :exclude-members: SortBy, LabelErrorsException, NoRecordsError, MissingPredictionError
+   :members: find_label_errors

--- a/src/rubrix/labeling/text_classification/__init__.py
+++ b/src/rubrix/labeling/text_classification/__init__.py
@@ -16,4 +16,4 @@
 from .label_errors import find_label_errors
 from .label_models import FlyingSquid, Snorkel
 from .rule import Rule, load_rules
-from .weak_labels import WeakLabels
+from .weak_labels import WeakLabels, WeakMultiLabels

--- a/src/rubrix/labeling/text_classification/rule.py
+++ b/src/rubrix/labeling/text_classification/rule.py
@@ -25,7 +25,7 @@ class Rule:
 
     Args:
         query: An ElasticSearch query with the `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_.
-        label: The label associated to the query.
+        label: The label associated to the query. Can also be a list of labels.
         name: An optional name for the rule to be used as identifier in the
             `rubrix.labeling.text_classification.WeakLabels` class. By default, we will use the ``query`` string.
 
@@ -42,7 +42,7 @@ class Rule:
     def __init__(
         self,
         query: str,
-        label: str,
+        label: Union[str, List[str]],
         name: Optional[str] = None,
         author: Optional[str] = None,
     ):
@@ -58,7 +58,7 @@ class Rule:
         return self._query
 
     @property
-    def label(self) -> str:
+    def label(self) -> Union[str, List[str]]:
         """The rule label"""
         return self._label
 
@@ -117,14 +117,16 @@ class Rule:
             "precision": metrics.precision if metrics.precision is not None else None,
         }
 
-    def __call__(self, record: TextClassificationRecord) -> Optional[str]:
+    def __call__(
+        self, record: TextClassificationRecord
+    ) -> Optional[Union[str, List[str]]]:
         """Check if the given record is among the matching ids from the ``self.apply`` call.
 
         Args:
             record: The record to be labelled.
 
         Returns:
-            A label if the record id is among the matching ids, otherwise None.
+            A label or list of labels if the record id is among the matching ids, otherwise None.
 
         Raises:
             RuleNotAppliedError: If the rule was not applied to the dataset before.

--- a/src/rubrix/labeling/text_classification/weak_labels.py
+++ b/src/rubrix/labeling/text_classification/weak_labels.py
@@ -257,7 +257,7 @@ class WeakLabels(WeakLabelsBase):
         >>> def awesome_rule(record: TextClassificationRecord) -> str:
         ...     return "Positive" if "awesome" in record.inputs["text"] else None
         >>> another_rule = Rule(query="good OR best", label="Positive")
-        >>> weak_labels = WeakLabels(rules=[awesome_rule, another_rule], dataset="my_dataset")
+        >>> weak_labels = WeakLabels(dataset="my_dataset", rules=[awesome_rule, another_rule])
         >>> weak_labels.matrix()
         >>> weak_labels.summary()
         >>>
@@ -657,7 +657,7 @@ class WeakMultiLabels(WeakLabelsBase):
         >>> def awesome_rule(record: TextClassificationRecord) -> str:
         ...     return ["Positive", "Slang"] if "next level" in record.inputs["text"] else None
         >>> another_rule = Rule(query="amped OR psyched", label=["Positive", "Slang"])
-        >>> weak_labels = WeakLabels(rules=[awesome_rule, another_rule], dataset="my_dataset")
+        >>> weak_labels = WeakLabels(dataset="my_dataset", rules=[awesome_rule, another_rule])
         >>> weak_labels.matrix()
         >>> weak_labels.summary()
     """

--- a/src/rubrix/labeling/text_classification/weak_labels.py
+++ b/src/rubrix/labeling/text_classification/weak_labels.py
@@ -26,8 +26,10 @@ from rubrix.client.models import TextClassificationRecord
 from rubrix.labeling.text_classification.rule import Rule, load_rules
 
 
-class WeakLabels:
-    """Computes the weak labels of a dataset by applying a given list of rules.
+class WeakLabelsBase:
+    """Base class for the weak label classes.
+
+    Tries to facilitate the implementations, avoids code duplications.
 
     Args:
         dataset: Name of the dataset to which the rules will be applied.
@@ -37,42 +39,11 @@ class WeakLabels:
         query: An optional ElasticSearch query with the
             `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_
             to filter the dataset before applying the rules.
-        label2int: An optional dict, mapping the labels to integers. Remember that the return type ``None`` means
-            abstention (e.g. ``{None: -1}``). By default, we will build a mapping on the fly when applying the rules.
 
     Raises:
         NoRulesFoundError: When you do not provide rules, and the dataset has no rules either.
         DuplicatedRuleNameError: When you provided multiple rules with the same name.
         NoRecordsFoundError: When the filtered dataset is empty.
-        MultiLabelError: When trying to get weak labels for a multi-label text classification task.
-        MissingLabelError: When provided with a ``label2int`` dict, and a
-            weak label or annotation label is not present in its keys.
-
-    Examples:
-        Get the weak label matrix from a dataset with rules:
-
-        >>> weak_labels = WeakLabels(dataset="my_dataset")
-        >>> weak_labels.matrix()
-        >>> weak_labels.summary()
-
-        Get the weak label matrix from rules defined in Python:
-
-        >>> def awesome_rule(record: TextClassificationRecord) -> str:
-        ...     return "Positive" if "awesome" in record.inputs["text"] else None
-        >>> another_rule = Rule(query="good OR best", label="Positive")
-        >>> weak_labels = WeakLabels(rules=[awesome_rule, another_rule], dataset="my_dataset")
-        >>> weak_labels.matrix()
-        >>> weak_labels.summary()
-
-        Use the WeakLabels object with snorkel's LabelModel:
-
-        >>> from snorkel.labeling.model import LabelModel
-        >>> label_model = LabelModel()
-        >>> label_model.fit(L_train=weak_labels.matrix(has_annotation=False))
-        >>> label_model.score(L=weak_labels.matrix(has_annotation=True), Y=weak_labels.annotation())
-        >>> label_model.predict(L=weak_labels.matrix(has_annotation=False))
-
-        For a builtin integration with Snorkel, see `rubrix.labeling.text_classification.Snorkel`.
     """
 
     def __init__(
@@ -81,7 +52,6 @@ class WeakLabels:
         rules: Optional[List[Callable]] = None,
         ids: Optional[List[Union[int, str]]] = None,
         query: Optional[str] = None,
-        label2int: Optional[Dict[Optional[str], int]] = None,
     ):
         if not isinstance(dataset, str):
             raise TypeError(
@@ -132,20 +102,197 @@ class WeakLabels:
                 + (f" with ids {ids}." if ids else ".")
             )
 
+    @property
+    def rules(self) -> List[Callable]:
+        """The rules (labeling functions) that were used to produce the weak labels."""
+        return self._rules
+
+    def records(
+        self, has_annotation: Optional[bool] = None
+    ) -> List[TextClassificationRecord]:
+        """Returns the records corresponding to the weak label matrix
+
+        Args:
+            has_annotation: If True, return only the records that have an annotation. If False, return only the records
+                that have NO annotation. By default, we return all the records.
+
+        Returns:
+            A list of records, or optionally just a part of them.
+        """
+        if has_annotation is True:
+            return [rec for rec in self._records if rec.annotation is not None]
+        if has_annotation is False:
+            return [rec for rec in self._records if rec.annotation is None]
+
+        return list(self._records)
+
+    def matrix(self, has_annotation: Optional[bool] = None) -> np.ndarray:
+        """Returns the weak label matrix, or optionally just a part of it.
+
+        Args:
+            has_annotation: If True, return only the part of the matrix that has a corresponding annotation.
+                If False, return only the part of the matrix that has NOT a corresponding annotation.
+                By default, we return the whole weak label matrix.
+
+        Returns:
+            The weak label matrix, or optionally just a part of it.
+        """
+        raise NotImplementedError
+
+    def annotation(
+        self,
+        include_missing: bool = False,
+    ) -> np.ndarray:
+        """Returns the annotation labels.
+
+        Args:
+            include_missing: If True, returns an array of the length of the record list (``self.records()``).
+
+        Returns:
+            The annotation labels.
+        """
+        raise NotImplementedError
+
+    def summary(
+        self,
+        normalize_by_coverage: bool = False,
+        annotation: Optional[np.ndarray] = None,
+    ) -> pd.DataFrame:
+        """Returns a summary statistics for each rule:
+
+        Args:
+            normalize_by_coverage: Normalize the overlaps and conflicts by the respective coverage.
+            annotation: An optional array holding the annotations.
+                By default, we will use ``self.annotation(include_missing=True)``.
+
+        Returns:
+            The summary statistics for each rule in a pandas DataFrame.
+        """
+        raise NotImplementedError
+
+    def show_records(
+        self,
+        labels: Optional[List[str]] = None,
+        rules: Optional[List[Union[str, int]]] = None,
+    ) -> pd.DataFrame:
+        """Shows records in a pandas DataFrame, optionally filtered by weak labels and non-abstaining rules.
+
+        If you provide both ``labels`` and ``rules``, we take the intersection of both filters.
+
+        Args:
+            labels: All of these labels are in the record's weak labels. If None, do not filter by labels.
+            rules: All of these rules did not abstain for the record. If None, do not filter by rules.
+                You can refer to the rules by their (function) name or by their index in the ``self.rules`` list.
+
+        Returns:
+            The optionally filtered records as a pandas DataFrame.
+        """
+        raise NotImplementedError
+
+    def _compute_overlaps_conflicts(
+        self,
+        has_weak_label: np.ndarray,
+        has_overlaps_or_conflicts: np.ndarray,
+        coverage: np.ndarray,
+        normalize_by_coverage: bool,
+    ) -> np.ndarray:
+        """Helper method to compute the overlaps/conflicts and optionally normalize them by the respective coverage
+
+        Args:
+            has_weak_label: 2D boolean matrix (i, j) that indicates if the record i has a weak label from rule j.
+            has_overlaps_or_conflicts: Array that indicates if the record has overlapping/conflicting weak labels.
+            coverage: Array of coverages for each rule
+            normalize_by_coverage: Normalize the overlaps/conflicts by the respective coverage.
+
+        Returns:
+            Array of fractions of overlaps/conflicts for each rule, optionally normalized by their coverages.
+        """
+        overlaps_or_conflicts = (
+            has_weak_label
+            * np.repeat(has_overlaps_or_conflicts, len(self._rules)).reshape(
+                has_weak_label.shape
+            )
+        ).sum(axis=0) / len(self._records)
+        # total
+        overlaps_or_conflicts = np.append(
+            overlaps_or_conflicts, has_overlaps_or_conflicts.sum() / len(self._records)
+        )
+
+        if normalize_by_coverage:
+            overlaps_or_conflicts /= coverage
+            return np.nan_to_num(overlaps_or_conflicts)
+
+        return overlaps_or_conflicts
+
+
+class WeakLabels(WeakLabelsBase):
+    """Computes the weak labels of a single-label text classification dataset by applying a given list of rules.
+
+    Args:
+        dataset: Name of the dataset to which the rules will be applied.
+        rules: A list of rules (labeling functions). They must return a string, or ``None`` in case of abstention.
+            If None, we will use the rules of the dataset (Default).
+        ids: An optional list of record ids to filter the dataset before applying the rules.
+        query: An optional ElasticSearch query with the
+            `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_
+            to filter the dataset before applying the rules.
+        label2int: An optional dict, mapping the labels to integers. Remember that the return type ``None`` means
+            abstention (e.g. ``{None: -1}``). By default, we will build a mapping on the fly when applying the rules.
+
+    Raises:
+        NoRulesFoundError: When you do not provide rules, and the dataset has no rules either.
+        DuplicatedRuleNameError: When you provided multiple rules with the same name.
+        NoRecordsFoundError: When the filtered dataset is empty.
+        MultiLabelError: When trying to get weak labels for a multi-label text classification task.
+        MissingLabelError: When provided with a ``label2int`` dict, and a
+            weak label or annotation label is not present in its keys.
+
+    Examples:
+        >>> # Get the weak label matrix from a dataset with rules:
+        >>> weak_labels = WeakLabels(dataset="my_dataset")
+        >>> weak_labels.matrix()
+        >>> weak_labels.summary()
+        >>>
+        >>> # Get the weak label matrix from rules defined in Python:
+        >>> def awesome_rule(record: TextClassificationRecord) -> str:
+        ...     return "Positive" if "awesome" in record.inputs["text"] else None
+        >>> another_rule = Rule(query="good OR best", label="Positive")
+        >>> weak_labels = WeakLabels(rules=[awesome_rule, another_rule], dataset="my_dataset")
+        >>> weak_labels.matrix()
+        >>> weak_labels.summary()
+        >>>
+        >>> # Use the WeakLabels object with snorkel's LabelModel:
+        >>> from snorkel.labeling.model import LabelModel
+        >>> label_model = LabelModel()
+        >>> label_model.fit(L_train=weak_labels.matrix(has_annotation=False))
+        >>> label_model.score(L=weak_labels.matrix(has_annotation=True), Y=weak_labels.annotation())
+        >>> label_model.predict(L=weak_labels.matrix(has_annotation=False))
+        >>>
+        >>> # For a builtin integration with Snorkel, see `rubrix.labeling.text_classification.Snorkel`.
+    """
+
+    def __init__(
+        self,
+        dataset: str,
+        rules: Optional[List[Callable]] = None,
+        ids: Optional[List[Union[int, str]]] = None,
+        query: Optional[str] = None,
+        label2int: Optional[Dict[Optional[str], int]] = None,
+    ):
+        super().__init__(dataset=dataset, rules=rules, ids=ids, query=query)
+
         if self._records[0].multi_label:
             raise MultiLabelError(
                 "For multi-label text classification, use the `rb.labeling.text_classification.WeakMultiLabels` class."
             )
 
         # apply rules -> create the weak label matrix, annotation array, final label2int mapping
-        self._matrix, self._annotation_array, self._label2int = self._apply_rules(
-            label2int
-        )
+        self._matrix, self._annotation, self._label2int = self._apply_rules(label2int)
         self._int2label = {v: k for k, v in self._label2int.items()}
 
     def _apply_rules(
         self, label2int: Optional[Dict[str, int]]
-    ) -> Tuple[np.ndarray, np.ndarray, Dict[str, int]]:
+    ) -> Tuple[np.ndarray, np.ndarray, Dict[Optional[str], int]]:
         """Apply the rules to the dataset.
 
         Args:
@@ -218,11 +365,6 @@ class WeakLabels:
         return weak_label_matrix, annotation_array, _label2int
 
     @property
-    def rules(self) -> List[Callable]:
-        """The rules (labeling functions) that were used to produce the weak labels."""
-        return self._rules
-
-    @property
     def label2int(self) -> Dict[Optional[str], int]:
         """The dictionary that maps weak/annotation labels to integers."""
         return self._label2int
@@ -244,30 +386,11 @@ class WeakLabels:
             The weak label matrix, or optionally just a part of it.
         """
         if has_annotation is True:
-            return self._matrix[self._annotation_array != self._label2int[None]]
+            return self._matrix[self._annotation != self._label2int[None]]
         if has_annotation is False:
-            return self._matrix[self._annotation_array == self._label2int[None]]
+            return self._matrix[self._annotation == self._label2int[None]]
 
         return self._matrix
-
-    def records(
-        self, has_annotation: Optional[bool] = None
-    ) -> List[TextClassificationRecord]:
-        """Returns the records corresponding to the weak label matrix.
-
-        Args:
-            has_annotation: If True, return only the records that have an annotation. If False, return only the records
-                that have NO annotation. By default, we return all the records.
-
-        Returns:
-            A list of records, or optionally just a part of them.
-        """
-        if has_annotation is True:
-            return [rec for rec in self._records if rec.annotation is not None]
-        if has_annotation is False:
-            return [rec for rec in self._records if rec.annotation is None]
-
-        return list(self._records)
 
     def annotation(
         self,
@@ -293,9 +416,9 @@ class WeakLabels:
             include_missing = not exclude_missing_annotations
 
         if include_missing:
-            return self._annotation_array
+            return self._annotation
 
-        return self._annotation_array[self._annotation_array != self._label2int[None]]
+        return self._annotation[self._annotation != self._label2int[None]]
 
     def summary(
         self,
@@ -322,6 +445,7 @@ class WeakLabels:
         Returns:
             The summary statistics for each rule in a pandas DataFrame.
         """
+        annotation = annotation if annotation is not None else self._annotation
         has_weak_label = self._matrix != self._label2int[None]
 
         # polarity (label)
@@ -364,14 +488,9 @@ class WeakLabels:
         index = list(self._rules_name2index.keys()) + ["total"]
 
         # only add annotated_coverage, correct, incorrect and precision if we have annotations
-        if (
-            any(self._annotation_array != self._label2int[None])
-            or annotation is not None
-        ):
+        has_annotation = annotation != self._label2int[None]
+        if any(has_annotation):
             # annotated coverage
-            has_annotation = (
-                annotation if annotation is not None else self._annotation_array
-            ) != self._label2int[None]
             annotated_coverage = (
                 has_weak_label[has_annotation].sum(axis=0) / has_annotation.sum()
             )
@@ -384,7 +503,7 @@ class WeakLabels:
             # correct/incorrect
             correct, incorrect = self._compute_correct_incorrect(
                 has_weak_label,
-                annotation if annotation is not None else self._annotation_array,
+                annotation if annotation is not None else self._annotation,
             )
 
             # precision
@@ -413,31 +532,6 @@ class WeakLabels:
             },
             index=index,
         )
-
-    def _compute_overlaps_conflicts(
-        self,
-        has_weak_label: np.ndarray,
-        has_overlaps_or_conflicts: np.ndarray,
-        coverage: np.ndarray,
-        normalize_by_coverage: bool,
-    ) -> np.ndarray:
-        """Helper method to compute the overlaps/conflicts and optionally normalize them by the respective coverage"""
-        overlaps_or_conflicts = (
-            has_weak_label
-            * np.repeat(has_overlaps_or_conflicts, len(self._rules)).reshape(
-                has_weak_label.shape
-            )
-        ).sum(axis=0) / len(self._records)
-        # total
-        overlaps_or_conflicts = np.append(
-            overlaps_or_conflicts, has_overlaps_or_conflicts.sum() / len(self._records)
-        )
-
-        if normalize_by_coverage:
-            overlaps_or_conflicts /= coverage
-            return np.nan_to_num(overlaps_or_conflicts)
-
-        return overlaps_or_conflicts
 
     def _compute_correct_incorrect(
         self, has_weak_label: np.ndarray, annotation: np.ndarray
@@ -523,19 +617,19 @@ class WeakLabels:
                 )
             # compute masks
             label_masks[label] = self._matrix == self._label2int[label]
-            annotation_masks[label] = self._annotation_array == self._label2int[label]
+            annotation_masks[label] = self._annotation == self._label2int[label]
 
         # swap integers
         for label in self._label2int:
             self._matrix[label_masks[label]] = label2int[label]
-            self._annotation_array[annotation_masks[label]] = label2int[label]
+            self._annotation[annotation_masks[label]] = label2int[label]
 
         # update mapping dicts
         self._label2int = label2int.copy()
         self._int2label = {val: key for key, val in self._label2int.items()}
 
 
-class WeakMultiLabels:
+class WeakMultiLabels(WeakLabelsBase):
     """Computes the weak labels of a multi-label text classification dataset by applying a given list of rules.
 
     Args:
@@ -552,6 +646,20 @@ class WeakMultiLabels:
         DuplicatedRuleNameError: When you provided multiple rules with the same name.
         SingleLabelError: When trying to get weak labels for a single-label text classification task.
         NoRecordsFoundError: When the filtered dataset is empty.
+
+    Examples:
+        >>> # Get the 3 dimensional weak label matrix from a dataset with rules:
+        >>> weak_labels = WeakLabels(dataset="my_dataset")
+        >>> weak_labels.matrix()
+        >>> weak_labels.summary()
+        >>>
+        >>> # Get the 3 dimensional weak label matrix from rules defined in Python:
+        >>> def awesome_rule(record: TextClassificationRecord) -> str:
+        ...     return ["Positive", "Slang"] if "next level" in record.inputs["text"] else None
+        >>> another_rule = Rule(query="amped OR psyched", label=["Positive", "Slang"])
+        >>> weak_labels = WeakLabels(rules=[awesome_rule, another_rule], dataset="my_dataset")
+        >>> weak_labels.matrix()
+        >>> weak_labels.summary()
     """
 
     def __init__(
@@ -561,62 +669,15 @@ class WeakMultiLabels:
         ids: Optional[List[Union[int, str]]] = None,
         query: Optional[str] = None,
     ):
-        if not isinstance(dataset, str):
-            raise TypeError(
-                f"The name of the dataset must be a string, but you provided: {dataset}"
-            )
-        self._dataset = dataset
-
-        self._rules = rules or load_rules(dataset)
-        if not self._rules:
-            raise NoRulesFoundError(
-                f"No rules were found in the given dataset '{dataset}'"
-            )
-
-        self._rules_index2name = {
-            # covers our Rule class, snorkel's LabelingFunction class and arbitrary methods
-            index: (
-                getattr(rule, "name", None)
-                or (
-                    getattr(rule, "__name__", None)
-                    # allow multiple lambda functions
-                    if getattr(rule, "__name__", None) != "<lambda>"
-                    else None
-                )
-                or f"rule_{index}"
-            )
-            for index, rule in enumerate(self._rules)
-        }
-        # raise error if there are duplicates
-        counts = Counter(self._rules_index2name.values())
-        if len(counts.keys()) < len(self._rules):
-            raise DuplicatedRuleNameError(
-                f"Following rule names are duplicated x times: { {key: val for key, val in counts.items() if val > 1} }"
-                " Please make sure to provide unique rule names."
-            )
-        self._rules_name2index = {
-            val: key for key, val in self._rules_index2name.items()
-        }
-
-        # load records and check compatibility
-        self._records: DatasetForTextClassification = load(
-            dataset, query=query, ids=ids, as_pandas=False
-        )
-        if not self._records:
-            raise NoRecordsFoundError(
-                f"No records found in dataset '{dataset}'"
-                + (f" with query '{query}'" if query else "")
-                + (" and" if query and ids else "")
-                + (f" with ids {ids}." if ids else ".")
-            )
+        super().__init__(dataset=dataset, rules=rules, ids=ids, query=query)
 
         if not self._records[0].multi_label:
             raise SingleLabelError(
                 "For single-label text classification, use the `rb.labeling.text_classification.WeakLabels` class."
             )
 
-        # apply rules -> create the weak label tensor, annotation matrix, label list
-        self._tensor, self._annotation_matrix, self._labels = self._apply_rules()
+        # apply rules -> create the weak label matrix (3D), annotation (2D), label list
+        self._matrix, self._annotation, self._labels = self._apply_rules()
 
     def _apply_rules(self) -> Tuple[np.ndarray, np.ndarray, List[str]]:
         # call apply on the ElasticSearch rules
@@ -633,8 +694,8 @@ class WeakMultiLabels:
                 labels += [ann for ann in rec.annotation]
         labels = sorted(list(set(labels)))
 
-        # create weak label tensor, annotation matrix
-        weak_label_tensor = np.empty(
+        # create weak label matrix (3D), annotation matrix
+        weak_label_matrix = np.empty(
             (len(self._records), len(self._rules), len(labels)), dtype=np.short
         )
         annotation_matrix = np.empty((len(self._records), len(labels)), dtype=np.short)
@@ -652,71 +713,47 @@ class WeakMultiLabels:
                     dtype=np.short,
                 )
 
-            # SECOND: fill weak label tensor
+            # SECOND: fill weak label matrix (3D)
             for m, rule in enumerate(self._rules):
                 weak_labels: Optional[Union[str, List[str]]] = rule(record)
                 if isinstance(weak_labels, str):
                     weak_labels: Optional[List[str]] = [weak_labels]
 
                 if weak_labels is None:
-                    weak_label_tensor[n, m] = -1 * np.ones(len(labels))
+                    weak_label_matrix[n, m] = -1 * np.ones(len(labels))
                 else:
-                    weak_label_tensor[n, m] = np.array(
+                    weak_label_matrix[n, m] = np.array(
                         [1 if label in weak_labels else 0 for label in labels],
                         dtype=np.short,
                     )
 
-        return weak_label_tensor, annotation_matrix, labels
-
-    @property
-    def rules(self) -> List[Callable]:
-        """The rules (labeling functions) that were used to produce the weak labels."""
-        return self._rules
+        return weak_label_matrix, annotation_matrix, labels
 
     @property
     def labels(self) -> List[str]:
         """The labels of the multi-label text classification dataset."""
         return self._labels
 
-    def tensor(self, has_annotation: Optional[bool] = None) -> np.ndarray:
-        """Returns the weak label tensor, or optionally just a part of it.
+    def matrix(self, has_annotation: Optional[bool] = None) -> np.ndarray:
+        """Returns the 3 dimensional weak label matrix, or optionally just a part of it.
 
         It has the dimensions ("nr of record" x "nr of rules" x "nr of labels").
         It holds a 1 or 0 in case a rule votes for a label or not. If the rule abstains, it holds a -1 for each label.
 
         Args:
-            has_annotation: If True, return only the part of the tensor that has a corresponding annotation.
-                If False, return only the part of the tensor that has NOT a corresponding annotation.
-                By default, we return the whole weak label tensor.
+            has_annotation: If True, return only the part of the matrix that has a corresponding annotation.
+                If False, return only the part of the matrix that has NOT a corresponding annotation.
+                By default, we return the whole weak label matrix.
 
         Returns:
-            The weak label tensor, or optionally just a part of it.
+            The 3 dimensional weak label matrix, or optionally just a part of it.
         """
         if has_annotation is True:
-            return self._tensor[self._annotation_matrix.sum(1) >= 0]
+            return self._matrix[self._annotation.sum(1) >= 0]
         if has_annotation is False:
-            return self._tensor[self._annotation_matrix.sum(1) < 0]
+            return self._matrix[self._annotation.sum(1) < 0]
 
-        return self._tensor
-
-    def records(
-        self, has_annotation: Optional[bool] = None
-    ) -> List[TextClassificationRecord]:
-        """Returns the records corresponding to the weak label tensor
-
-        Args:
-            has_annotation: If True, return only the records that have an annotation. If False, return only the records
-                that have NO annotation. By default, we return all the records.
-
-        Returns:
-            A list of records, or optionally just a part of them.
-        """
-        if has_annotation is True:
-            return [rec for rec in self._records if rec.annotation is not None]
-        if has_annotation is False:
-            return [rec for rec in self._records if rec.annotation is None]
-
-        return list(self._records)
+        return self._matrix
 
     def annotation(
         self,
@@ -736,9 +773,9 @@ class WeakMultiLabels:
             The annotation labels as a matrix of integers.
         """
         if include_missing:
-            return self._annotation_matrix
+            return self._annotation
 
-        return self._annotation_matrix[self._annotation_matrix.sum(1) >= 0]
+        return self._annotation[self._annotation.sum(1) >= 0]
 
     def summary(
         self,
@@ -763,7 +800,8 @@ class WeakMultiLabels:
         Returns:
             The summary statistics for each rule in a pandas DataFrame.
         """
-        has_weak_label = self._tensor.sum(2) >= 0
+        annotation = annotation if annotation is not None else self._annotation
+        has_weak_label = self._matrix.sum(2) >= 0
 
         # polarity (label)
         polarity = [
@@ -773,7 +811,7 @@ class WeakMultiLabels:
                     # get indices of votes
                     for i in np.nonzero(
                         # remove abstentions
-                        self._tensor[:, m, :][self._tensor[:, m, :].sum(1) >= 0]
+                        self._matrix[:, m, :][self._matrix[:, m, :].sum(1) >= 0]
                     )[1]
                 ]
             )
@@ -798,13 +836,9 @@ class WeakMultiLabels:
         index = list(self._rules_name2index.keys()) + ["total"]
 
         # only add annotated_coverage, correct, incorrect and precision if we have annotations
-        if any(self._annotation_matrix != -1) or annotation is not None:
+        has_annotation = annotation.sum(1) >= 0
+        if any(has_annotation):
             # annotated coverage
-            has_annotation = (
-                annotation
-                if annotation is not None
-                else self._annotation_matrix.sum(1) >= 0
-            )
             annotated_coverage = (
                 has_weak_label[has_annotation].sum(axis=0) / has_annotation.sum()
             )
@@ -816,8 +850,7 @@ class WeakMultiLabels:
 
             # correct/incorrect
             correct, incorrect = self._compute_correct_incorrect(
-                has_weak_label,
-                annotation if annotation is not None else self._annotation_matrix,
+                has_weak_label, annotation
             )
 
             # precision
@@ -845,46 +878,25 @@ class WeakMultiLabels:
             index=index,
         )
 
-    def _compute_overlaps_conflicts(
-        self,
-        has_weak_label: np.ndarray,
-        has_overlaps_or_conflicts: np.ndarray,
-        coverage: np.ndarray,
-        normalize_by_coverage: bool,
-    ) -> np.ndarray:
-        """Helper method to compute the overlaps/conflicts and optionally normalize them by the respective coverage"""
-        overlaps_or_conflicts = (
-            has_weak_label
-            * np.repeat(has_overlaps_or_conflicts, len(self._rules)).reshape(
-                has_weak_label.shape
-            )
-        ).sum(axis=0) / len(self._records)
-        # total
-        overlaps_or_conflicts = np.append(
-            overlaps_or_conflicts, has_overlaps_or_conflicts.sum() / len(self._records)
-        )
-
-        if normalize_by_coverage:
-            overlaps_or_conflicts /= coverage
-            return np.nan_to_num(overlaps_or_conflicts)
-
-        return overlaps_or_conflicts
-
     def _compute_correct_incorrect(
         self, has_weak_label: np.ndarray, annotation: np.ndarray
     ) -> Tuple[np.ndarray, np.ndarray]:
         """Helper method to compute the correctly and incorrectly predicted annotations by the rules"""
-        # transform annotation to matrix/tensor
-        annotation = np.repeat(annotation, len(self._rules)).reshape(self._tensor.shape)
+        # transform annotation to tensor
+        annotation = np.repeat(annotation, len(self._rules)).reshape(self._matrix.shape)
 
-        # correct
-        correct_with_abstain = (annotation == self._tensor).sum(2)
+        # correct, we don't want to count the "correct non predictions"
+        correct_with_abstain = ((annotation == self._matrix) & (self._matrix == 1)).sum(
+            2
+        )
         correct = np.where(has_weak_label, correct_with_abstain, False).sum(axis=0)
 
-        # incorrect
-        incorrect_with_abstain = (annotation != self._tensor).sum(2)
+        # incorrect, we don't want to count the "misses", since we focus on precision, not recall
+        incorrect_with_abstain = (
+            (annotation != self._matrix) & (self._matrix == 1)
+        ).sum(2)
         incorrect = np.where(
-            has_weak_label & (annotation != -1),
+            has_weak_label & (annotation.sum(2) >= 0),
             incorrect_with_abstain,
             False,
         ).sum(axis=0)
@@ -912,7 +924,7 @@ class WeakMultiLabels:
         # get labels mask
         if labels is not None:
             labels = [self._labels.index(label) for label in labels]
-            idx_by_labels = np.any((self._tensor.sum(1) > 0)[:, labels], axis=0)
+            idx_by_labels = np.all(((self._matrix == 1).sum(1) > 0)[:, labels], axis=1)
         else:
             idx_by_labels = np.ones_like(self._records).astype(bool)
 
@@ -922,7 +934,7 @@ class WeakMultiLabels:
                 self._rules_name2index[rule] if isinstance(rule, str) else rule
                 for rule in rules
             ]
-            idx_by_rules = (self._tensor[:, rules, :].sum(axis=2) >= 0).sum(
+            idx_by_rules = (self._matrix[:, rules, :].sum(axis=2) >= 0).sum(
                 axis=1
             ) == len(rules)
         else:

--- a/src/rubrix/labeling/text_classification/weak_labels.py
+++ b/src/rubrix/labeling/text_classification/weak_labels.py
@@ -644,7 +644,6 @@ class WeakMultiLabels(WeakLabelsBase):
     Raises:
         NoRulesFoundError: When you do not provide rules, and the dataset has no rules either.
         DuplicatedRuleNameError: When you provided multiple rules with the same name.
-        SingleLabelError: When trying to get weak labels for a single-label text classification task.
         NoRecordsFoundError: When the filtered dataset is empty.
 
     Examples:
@@ -670,11 +669,6 @@ class WeakMultiLabels(WeakLabelsBase):
         query: Optional[str] = None,
     ):
         super().__init__(dataset=dataset, rules=rules, ids=ids, query=query)
-
-        if not self._records[0].multi_label:
-            raise SingleLabelError(
-                "For single-label text classification, use the `rb.labeling.text_classification.WeakLabels` class."
-            )
 
         # apply rules -> create the weak label matrix (3D), annotation (2D), label list
         self._matrix, self._annotation, self._labels = self._apply_rules()
@@ -975,8 +969,4 @@ class MultiLabelError(WeakLabelsError):
 
 
 class MissingLabelError(WeakLabelsError):
-    pass
-
-
-class SingleLabelError(WeakLabelsError):
     pass

--- a/tests/functional_tests/test_log_for_token_classification.py
+++ b/tests/functional_tests/test_log_for_token_classification.py
@@ -450,7 +450,7 @@ def test_search_keywords(mocked_client):
     dataset = "test_search_keywords"
     from datasets import load_dataset
 
-    dataset_ds = load_dataset("rubrix/gutenberg_spacy-ner_sm", split="train")
+    dataset_ds = load_dataset("rubrix/gutenberg_spacy-ner", split="train")
     dataset_rb = rubrix.read_datasets(dataset_ds, task="TokenClassification")
 
     rubrix.delete(dataset)

--- a/tests/labeling/text_classification/test_label_models.py
+++ b/tests/labeling/text_classification/test_label_models.py
@@ -265,7 +265,7 @@ class TestSnorkel:
         assert list(metrics.keys())[:3] == ["negative", "positive", "neutral"]
 
     def test_score_without_annotations(self, weak_labels):
-        weak_labels._annotation_array = np.array([], dtype=np.short)
+        weak_labels._annotation = np.array([], dtype=np.short)
         label_model = Snorkel(weak_labels)
 
         with pytest.raises(MissingAnnotationError, match="need annotated records"):

--- a/tests/labeling/text_classification/test_weak_labels.py
+++ b/tests/labeling/text_classification/test_weak_labels.py
@@ -31,7 +31,6 @@ from rubrix.labeling.text_classification.weak_labels import (
     MultiLabelError,
     NoRecordsFoundError,
     NoRulesFoundError,
-    SingleLabelError,
     WeakLabelsBase,
 )
 
@@ -536,17 +535,6 @@ class TestWeakLabels:
 
 
 class TestWeakMultiLabels:
-    def test_single_label_error(self, monkeypatch):
-        def mock_load(*args, **kwargs):
-            return [TextClassificationRecord(inputs="test", multi_label=False)]
-
-        monkeypatch.setattr(
-            "rubrix.labeling.text_classification.weak_labels.load", mock_load
-        )
-
-        with pytest.raises(SingleLabelError):
-            WeakMultiLabels(rules=[lambda x: None], dataset="mock")
-
     def test_apply(
         self,
         log_multilabel_dataset,

--- a/tests/labeling/text_classification/test_weak_labels.py
+++ b/tests/labeling/text_classification/test_weak_labels.py
@@ -12,9 +12,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Union
 
-import httpx
 import numpy as np
 import pandas as pd
 import pytest
@@ -24,6 +23,7 @@ from rubrix.client.sdk.text_classification.models import (
     CreationTextClassificationRecord,
     TextClassificationBulkData,
 )
+from rubrix.labeling.text_classification import WeakLabels, WeakMultiLabels
 from rubrix.labeling.text_classification.rule import Rule
 from rubrix.labeling.text_classification.weak_labels import (
     DuplicatedRuleNameError,
@@ -31,7 +31,8 @@ from rubrix.labeling.text_classification.weak_labels import (
     MultiLabelError,
     NoRecordsFoundError,
     NoRulesFoundError,
-    WeakLabels,
+    SingleLabelError,
+    WeakLabelsBase,
 )
 
 
@@ -90,352 +91,637 @@ def rules(monkeypatch) -> List[Callable]:
     return [first_rule, rule2, rubrix_rule]
 
 
-def test_duplicated_rule_name_error():
-    rules = [Rule(query="mock", label="mock"), Rule(query="mock", label="not mock")]
-    with pytest.raises(DuplicatedRuleNameError, match="'mock': 2"):
-        WeakLabels(rules=rules, dataset="mock")
-
-
-def test_multi_label_error(monkeypatch):
-    def mock_load(*args, **kwargs):
-        return [TextClassificationRecord(inputs="test", multi_label=True)]
-
-    monkeypatch.setattr(
-        "rubrix.labeling.text_classification.weak_labels.load", mock_load
-    )
-
-    with pytest.raises(MultiLabelError):
-        WeakLabels(rules=[lambda x: None], dataset="mock")
-
-
-def test_no_records_found_error(monkeypatch):
-    def mock_load(*args, **kwargs):
-        return []
-
-    monkeypatch.setattr(
-        "rubrix.labeling.text_classification.weak_labels.load", mock_load
-    )
-
-    with pytest.raises(
-        NoRecordsFoundError, match="No records found in dataset 'mock'."
-    ):
-        WeakLabels(rules=[lambda x: None], dataset="mock")
-    with pytest.raises(
-        NoRecordsFoundError,
-        match="No records found in dataset 'mock' with query 'mock'.",
-    ):
-        WeakLabels(rules=[lambda x: None], dataset="mock", query="mock")
-    with pytest.raises(
-        NoRecordsFoundError, match="No records found in dataset 'mock' with ids \[-1\]."
-    ):
-        WeakLabels(rules=[lambda x: None], dataset="mock", ids=[-1])
-    with pytest.raises(
-        NoRecordsFoundError,
-        match="No records found in dataset 'mock' with query 'mock' and with ids \[-1\].",
-    ):
-        WeakLabels(rules=[lambda x: None], dataset="mock", query="mock", ids=[-1])
-
-
-@pytest.mark.parametrize(
-    "label2int, expected_label2int, expected_matrix, expected_annotation_array",
-    [
-        (
-            None,
-            {None: -1, "negative": 0, "positive": 1},
-            np.array([[0, -1, 1], [-1, 1, 1], [-1, 1, -1]], dtype=np.short),
-            np.array([0, 1, -1], dtype=np.short),
-        ),
-        (
-            {None: -10, "negative": 50, "positive": 10},
-            {None: -10, "negative": 50, "positive": 10},
-            np.array([[50, -10, 10], [-10, 10, 10], [-10, 10, -10]], dtype=np.short),
-            np.array([50, 10, -10], dtype=np.short),
-        ),
-        ({}, None, None, None),
-        ({None: -1}, None, None, None),
-        ({None: -1, "negative": 0}, None, None, None),
-    ],
-)
-def test_apply(
-    monkeypatch,
-    mocked_client,
-    log_dataset,
-    rules,
-    label2int,
-    expected_label2int,
-    expected_matrix,
-    expected_annotation_array,
-):
-    monkeypatch.setattr(httpx, "get", mocked_client.get)
-    monkeypatch.setattr(httpx, "stream", mocked_client.stream)
-
-    if label2int == {}:
-        with pytest.raises(MissingLabelError) as error:
-            WeakLabels(rules=rules, dataset=log_dataset, label2int=label2int)
-        assert "required abstention label" in str(error)
-        return
-    elif label2int == {None: -1}:
-        with pytest.raises(MissingLabelError) as error:
-            WeakLabels(rules=rules, dataset=log_dataset, label2int=label2int)
-        assert "annotation label" in str(error)
-        return
-    elif label2int == {None: -1, "negative": 0}:
-        with pytest.raises(MissingLabelError) as error:
-            WeakLabels(rules=rules, dataset=log_dataset, label2int=label2int)
-        assert "weak label" in str(error)
-        return
-
-    weak_labels = WeakLabels(rules=rules, dataset=log_dataset, label2int=label2int)
-
-    # check that all `Rule.apply`s are called
-    assert weak_labels._rules[-1]._matching_ids == {1: None, 2: None}
-
-    assert weak_labels.label2int == expected_label2int
-    assert weak_labels.int2label == {v: k for k, v in expected_label2int.items()}
-    assert (weak_labels.matrix() == expected_matrix).all()
-    assert (weak_labels._annotation_array == expected_annotation_array).all()
-
-
-def test_rules_matrix_records_annotation(monkeypatch):
-    expected_records = [
-        TextClassificationRecord(inputs="test without annot"),
-        TextClassificationRecord(inputs="test with annot", annotation="positive"),
+@pytest.fixture
+def log_multilabel_dataset(mocked_client) -> str:
+    dataset_name = "test_dataset_for_multilabel_applier"
+    mocked_client.delete(f"/api/datasets/{dataset_name}")
+    records = [
+        CreationTextClassificationRecord.parse_obj(
+            {
+                "inputs": {"text": text},
+                "annotation": {
+                    "labels": [{"class": label, "score": 1} for label in labels],
+                    "agent": "test",
+                }
+                if labels is not None
+                else None,
+                "multi_label": True,
+                "id": idx,
+            }
+        )
+        for text, labels, idx in zip(
+            ["negative", "negative and positive", "None"],
+            [["negative"], ["negative", "positive"], None],
+            [1, 2, 3],
+        )
     ]
-
-    def mock_load(*args, **kwargs):
-        return expected_records
-
-    monkeypatch.setattr(
-        "rubrix.labeling.text_classification.weak_labels.load", mock_load
+    mocked_client.post(
+        f"/api/datasets/{dataset_name}/TextClassification:bulk",
+        json=TextClassificationBulkData(
+            records=records,
+        ).dict(by_alias=True),
     )
 
+    return dataset_name
+
+
+@pytest.fixture
+def multilabel_rules(monkeypatch) -> List[Callable]:
+    def first_rule(record: TextClassificationRecord) -> Optional[Union[str, List[str]]]:
+        if "negative" in record.inputs["text"]:
+            return []
+
+    def rule2(record: TextClassificationRecord) -> Optional[Union[str, List[str]]]:
+        if "positive" in record.inputs["text"]:
+            return ["negative", "positive"]
+
+    rule2.__name__ = ""
+
     def mock_apply(self, *args, **kwargs):
-        weak_label_matrix = np.array([[0, 1], [-1, 0]], dtype=np.short)
-        annotation_array = np.array([-1, 0], dtype=np.short)
-        label2int = {None: -1, "negative": 0, "positive": 1}
-        return weak_label_matrix, annotation_array, label2int
+        self._matching_ids = {1: None, 2: None}
 
-    monkeypatch.setattr(WeakLabels, "_apply_rules", mock_apply)
+    monkeypatch.setattr(Rule, "apply", mock_apply)
 
-    weak_labels = WeakLabels(rules=[lambda x: "mock"] * 2, dataset="mock")
+    rubrix_rule = Rule(query="mock", label="positive", name="rubrix_rule")
 
-    # records property
-    assert len(weak_labels.records()) == 2
-    assert weak_labels.records(has_annotation=True) == [expected_records[1]]
-    assert weak_labels.records(has_annotation=False) == [expected_records[0]]
-    assert isinstance(weak_labels.records()[0], TextClassificationRecord)
+    return [first_rule, rule2, rubrix_rule]
 
-    # rules property
-    assert len(weak_labels.rules) == 2
-    assert weak_labels._rules_name2index == {"rule_0": 0, "rule_1": 1}
-    assert weak_labels.rules[0](None) == "mock"
 
-    assert (
-        weak_labels.matrix(has_annotation=False) == np.array([[0, 1]], dtype=np.short)
-    ).all()
-    assert (
-        weak_labels.matrix(has_annotation=True) == np.array([[-1, 0]], dtype=np.short)
-    ).all()
-    assert (weak_labels.annotation() == np.array([[0]], dtype=np.short)).all()
-    assert (
-        weak_labels.annotation(include_missing=True)
-        == np.array([[-1, 0]], dtype=np.short)
-    ).all()
-    with pytest.warns(
-        FutureWarning, match="'exclude_missing_annotations' is deprecated"
+class TestWeakLabelsBase:
+    def test_dataset_type_error(self):
+        with pytest.raises(TypeError, match="must be a string, but you provided"):
+            WeakLabelsBase([1, 2, 3])
+
+    def test_rules_from_dataset(self, monkeypatch, log_dataset):
+        mock_rules = [Rule(query="mock", label="mock")]
+        monkeypatch.setattr(
+            "rubrix.labeling.text_classification.weak_labels.load_rules",
+            lambda x: mock_rules,
+        )
+
+        wl = WeakLabelsBase(log_dataset)
+        assert wl.rules is mock_rules
+
+    def test_norulesfounderror(self, monkeypatch):
+        monkeypatch.setattr(
+            "rubrix.labeling.text_classification.weak_labels.load_rules", lambda x: []
+        )
+
+        with pytest.raises(NoRulesFoundError, match="No rules were found"):
+            WeakLabelsBase("mock")
+
+    def test_duplicated_rule_name_error(self):
+        rules = [Rule(query="mock", label="mock"), Rule(query="mock", label="not mock")]
+        with pytest.raises(DuplicatedRuleNameError, match="'mock': 2"):
+            WeakLabelsBase(rules=rules, dataset="mock")
+
+    def test_no_records_found_error(self, monkeypatch):
+        def mock_load(*args, **kwargs):
+            return []
+
+        monkeypatch.setattr(
+            "rubrix.labeling.text_classification.weak_labels.load", mock_load
+        )
+
+        with pytest.raises(
+            NoRecordsFoundError, match="No records found in dataset 'mock'."
+        ):
+            WeakLabels(rules=[lambda x: None], dataset="mock")
+        with pytest.raises(
+            NoRecordsFoundError,
+            match="No records found in dataset 'mock' with query 'mock'.",
+        ):
+            WeakLabels(rules=[lambda x: None], dataset="mock", query="mock")
+        with pytest.raises(
+            NoRecordsFoundError,
+            match="No records found in dataset 'mock' with ids \[-1\].",
+        ):
+            WeakLabels(rules=[lambda x: None], dataset="mock", ids=[-1])
+        with pytest.raises(
+            NoRecordsFoundError,
+            match="No records found in dataset 'mock' with query 'mock' and with ids \[-1\].",
+        ):
+            WeakLabels(rules=[lambda x: None], dataset="mock", query="mock", ids=[-1])
+
+    def test_rules_records_properties(self, monkeypatch):
+        expected_records = [
+            TextClassificationRecord(inputs="test without annot"),
+            TextClassificationRecord(inputs="test with annot", annotation="positive"),
+        ]
+
+        def mock_load(*args, **kwargs):
+            return expected_records
+
+        monkeypatch.setattr(
+            "rubrix.labeling.text_classification.weak_labels.load", mock_load
+        )
+
+        weak_labels = WeakLabelsBase(rules=[lambda x: "mock"] * 2, dataset="mock")
+
+        # records property
+        assert len(weak_labels.records()) == 2
+        assert weak_labels.records(has_annotation=True) == [expected_records[1]]
+        assert weak_labels.records(has_annotation=False) == [expected_records[0]]
+        assert isinstance(weak_labels.records()[0], TextClassificationRecord)
+
+        # rules property
+        assert len(weak_labels.rules) == 2
+        assert weak_labels._rules_name2index == {"rule_0": 0, "rule_1": 1}
+        assert weak_labels.rules[0](None) == "mock"
+
+
+class TestWeakLabels:
+    def test_multi_label_error(self, monkeypatch):
+        def mock_load(*args, **kwargs):
+            return [TextClassificationRecord(inputs="test", multi_label=True)]
+
+        monkeypatch.setattr(
+            "rubrix.labeling.text_classification.weak_labels.load", mock_load
+        )
+
+        with pytest.raises(MultiLabelError):
+            WeakLabels(rules=[lambda x: None], dataset="mock")
+
+    @pytest.mark.parametrize(
+        "label2int, expected_label2int, expected_matrix, expected_annotation_array",
+        [
+            (
+                None,
+                {None: -1, "negative": 0, "positive": 1},
+                np.array([[0, -1, 1], [-1, 1, 1], [-1, 1, -1]], dtype=np.short),
+                np.array([0, 1, -1], dtype=np.short),
+            ),
+            (
+                {None: -10, "negative": 50, "positive": 10},
+                {None: -10, "negative": 50, "positive": 10},
+                np.array(
+                    [[50, -10, 10], [-10, 10, 10], [-10, 10, -10]], dtype=np.short
+                ),
+                np.array([50, 10, -10], dtype=np.short),
+            ),
+            ({}, None, None, None),
+            ({None: -1}, None, None, None),
+            ({None: -1, "negative": 0}, None, None, None),
+        ],
+    )
+    def test_apply(
+        self,
+        monkeypatch,
+        log_dataset,
+        rules,
+        label2int,
+        expected_label2int,
+        expected_matrix,
+        expected_annotation_array,
     ):
-        weak_labels.annotation(exclude_missing_annotations=True)
+        if label2int == {}:
+            with pytest.raises(MissingLabelError, match="required abstention label"):
+                WeakLabels(rules=rules, dataset=log_dataset, label2int=label2int)
+            return
+        elif label2int == {None: -1}:
+            with pytest.raises(MissingLabelError, match="annotation label"):
+                WeakLabels(rules=rules, dataset=log_dataset, label2int=label2int)
+            return
+        elif label2int == {None: -1, "negative": 0}:
+            with pytest.raises(MissingLabelError, match="weak label"):
+                WeakLabels(rules=rules, dataset=log_dataset, label2int=label2int)
+            return
 
+        weak_labels = WeakLabels(rules=rules, dataset=log_dataset, label2int=label2int)
 
-def test_summary(monkeypatch, rules):
-    def mock_load(*args, **kwargs):
-        return [TextClassificationRecord(inputs="test")] * 4
+        # check that all `Rule.apply`s are called
+        assert weak_labels._rules[-1]._matching_ids == {1: None, 2: None}
 
-    monkeypatch.setattr(
-        "rubrix.labeling.text_classification.weak_labels.load", mock_load
-    )
+        assert weak_labels.label2int == expected_label2int
+        assert weak_labels.int2label == {v: k for k, v in expected_label2int.items()}
+        assert (weak_labels.matrix() == expected_matrix).all()
+        assert (weak_labels._annotation == expected_annotation_array).all()
 
-    def mock_apply(self, *args, **kwargs):
-        weak_label_matrix = np.array(
-            [[0, 1, -1], [-1, 0, -1], [-1, -1, -1], [1, 1, -1]], dtype=np.short
+    def test_matrix_annotation_properties(self, monkeypatch):
+        expected_records = [
+            TextClassificationRecord(inputs="test without annot"),
+            TextClassificationRecord(inputs="test with annot", annotation="positive"),
+        ]
+
+        def mock_load(*args, **kwargs):
+            return expected_records
+
+        monkeypatch.setattr(
+            "rubrix.labeling.text_classification.weak_labels.load", mock_load
         )
-        # weak_label_matrix = np.random.randint(-1, 30, (int(1e5), 50), dtype=np.short)
-        annotation_array = np.array([-1, -1, -1, -1], dtype=np.short)
-        # annotation_array = np.random.randint(-1, 30, int(1e5), dtype=np.short)
-        label2int = {None: -1, "negative": 0, "positive": 1}
-        # label2int = {k: v for k, v in zip(["None"]+list(range(30)), list(range(-1, 30)))}
-        return weak_label_matrix, annotation_array, label2int
 
-    monkeypatch.setattr(WeakLabels, "_apply_rules", mock_apply)
+        def mock_apply(self, *args, **kwargs):
+            weak_label_matrix = np.array([[0, 1], [-1, 0]], dtype=np.short)
+            annotation_array = np.array([-1, 0], dtype=np.short)
+            label2int = {None: -1, "negative": 0, "positive": 1}
+            return weak_label_matrix, annotation_array, label2int
 
-    weak_labels = WeakLabels(rules=rules, dataset="mock")
+        monkeypatch.setattr(WeakLabels, "_apply_rules", mock_apply)
 
-    summary = weak_labels.summary()
-    expected = pd.DataFrame(
-        {
-            "label": [
-                {"negative", "positive"},
-                {"negative", "positive"},
-                set(),
-                {"negative", "positive"},
-            ],
-            "coverage": [2.0 / 4, 3.0 / 4, 0, 3.0 / 4],
-            "overlaps": [2.0 / 4, 2.0 / 4, 0, 2.0 / 4],
-            "conflicts": [1.0 / 4, 1.0 / 4, 0, 1.0 / 4],
-        },
-        index=["first_rule", "rule_1", "rubrix_rule", "total"],
-    )
-    pd.testing.assert_frame_equal(summary, expected)
+        weak_labels = WeakLabels(rules=[lambda x: "mock"] * 2, dataset="mock")
 
-    summary = weak_labels.summary(normalize_by_coverage=True)
-    expected = pd.DataFrame(
-        {
-            "label": [
-                {"negative", "positive"},
-                {"negative", "positive"},
-                set(),
-                {"negative", "positive"},
-            ],
-            "coverage": [2.0 / 4, 3.0 / 4, 0, 3.0 / 4],
-            "overlaps": [2.0 / 2, 2.0 / 3, 0, 2.0 / 3],
-            "conflicts": [1.0 / 2, 1.0 / 3, 0, 1.0 / 3],
-        },
-        index=["first_rule", "rule_1", "rubrix_rule", "total"],
-    )
-    pd.testing.assert_frame_equal(summary, expected)
+        assert (
+            weak_labels.matrix(has_annotation=False)
+            == np.array([[0, 1]], dtype=np.short)
+        ).all()
+        assert (
+            weak_labels.matrix(has_annotation=True)
+            == np.array([[-1, 0]], dtype=np.short)
+        ).all()
+        assert (weak_labels.annotation() == np.array([[0]], dtype=np.short)).all()
+        assert (
+            weak_labels.annotation(include_missing=True)
+            == np.array([[-1, 0]], dtype=np.short)
+        ).all()
+        with pytest.warns(
+            FutureWarning, match="'exclude_missing_annotations' is deprecated"
+        ):
+            weak_labels.annotation(exclude_missing_annotations=True)
 
-    summary = weak_labels.summary(annotation=np.array([1, -1, 0, 1]))
-    expected = pd.DataFrame(
-        {
-            "label": [
-                {"negative", "positive"},
-                {"negative", "positive"},
-                set(),
-                {"negative", "positive"},
-            ],
-            "coverage": [2.0 / 4, 3.0 / 4, 0, 3.0 / 4],
-            "annotated_coverage": [2.0 / 3, 2.0 / 3, 0, 2.0 / 3],
-            "overlaps": [2.0 / 4, 2.0 / 4, 0, 2.0 / 4],
-            "conflicts": [1.0 / 4, 1.0 / 4, 0, 1.0 / 4],
-            "correct": [1, 2, 0, 3],
-            "incorrect": [1, 0, 0, 1],
-            "precision": [1.0 / 2, 2 / 2, np.nan, 3.0 / 4],
-        },
-        index=["first_rule", "rule_1", "rubrix_rule", "total"],
-    )
-    pd.testing.assert_frame_equal(summary, expected)
+    def test_summary(self, monkeypatch, rules):
+        def mock_load(*args, **kwargs):
+            return [TextClassificationRecord(inputs="test")] * 4
 
-
-def test_show_records(monkeypatch, rules):
-    def mock_load(*args, **kwargs):
-        return [TextClassificationRecord(inputs="test", id=i) for i in range(5)]
-
-    monkeypatch.setattr(
-        "rubrix.labeling.text_classification.weak_labels.load", mock_load
-    )
-
-    def mock_apply(self, *args, **kwargs):
-        weak_label_matrix = np.array(
-            [[0, 1, -1], [2, 0, -1], [-1, -1, -1], [1, 1, -1], [-1, 0, 2]],
-            dtype=np.short,
+        monkeypatch.setattr(
+            "rubrix.labeling.text_classification.weak_labels.load", mock_load
         )
-        annotation_array = np.array([0, 1, -1, 2, 0], dtype=np.short)
-        label2int = {None: -1, "negative": 0, "positive": 1, "neutral": 2}
-        return weak_label_matrix, annotation_array, label2int
 
-    monkeypatch.setattr(WeakLabels, "_apply_rules", mock_apply)
+        def mock_apply(self, *args, **kwargs):
+            weak_label_matrix = np.array(
+                [[0, 1, -1], [-1, 0, -1], [-1, -1, -1], [1, 1, -1]], dtype=np.short
+            )
+            # weak_label_matrix = np.random.randint(-1, 30, (int(1e5), 50), dtype=np.short)
+            annotation_array = np.array([-1, -1, -1, -1], dtype=np.short)
+            # annotation_array = np.random.randint(-1, 30, int(1e5), dtype=np.short)
+            label2int = {None: -1, "negative": 0, "positive": 1}
+            # label2int = {k: v for k, v in zip(["None"]+list(range(30)), list(range(-1, 30)))}
+            return weak_label_matrix, annotation_array, label2int
 
-    weak_labels = WeakLabels(rules=rules, dataset="mock")
+        monkeypatch.setattr(WeakLabels, "_apply_rules", mock_apply)
 
-    assert weak_labels.show_records().id.tolist() == [0, 1, 2, 3, 4]
-    assert weak_labels.show_records(labels=["positive"]).id.tolist() == [0, 3]
-    assert weak_labels.show_records(labels=["negative", "neutral"]).id.tolist() == [
-        1,
-        4,
-    ]
-    assert weak_labels.show_records(rules=[0]).id.tolist() == [0, 1, 3]
-    assert weak_labels.show_records(rules=[0, "rule_1"]).id.tolist() == [0, 1, 3]
-    assert weak_labels.show_records(labels=["negative"], rules=[1]).id.tolist() == [
-        0,
-        1,
-        4,
-    ]
-    assert weak_labels.show_records(labels=["positive"], rules=["rubrix_rule"]).empty
+        weak_labels = WeakLabels(rules=rules, dataset="mock")
 
-
-def test_change_mapping(monkeypatch, rules):
-    def mock_load(*args, **kwargs):
-        return [TextClassificationRecord(inputs="test", id=i) for i in range(5)]
-
-    monkeypatch.setattr(
-        "rubrix.labeling.text_classification.weak_labels.load", mock_load
-    )
-
-    def mock_apply(self, *args, **kwargs):
-        weak_label_matrix = np.array(
-            [[0, 1, -1], [2, 0, -1], [-1, -1, -1], [1, 1, -1], [-1, 0, 2]],
-            dtype=np.short,
+        summary = weak_labels.summary()
+        expected = pd.DataFrame(
+            {
+                "label": [
+                    {"negative", "positive"},
+                    {"negative", "positive"},
+                    set(),
+                    {"negative", "positive"},
+                ],
+                "coverage": [2.0 / 4, 3.0 / 4, 0, 3.0 / 4],
+                "overlaps": [2.0 / 4, 2.0 / 4, 0, 2.0 / 4],
+                "conflicts": [1.0 / 4, 1.0 / 4, 0, 1.0 / 4],
+            },
+            index=["first_rule", "rule_1", "rubrix_rule", "total"],
         )
-        annotation_array = np.array([0, 1, -1, 2, 0], dtype=np.short)
-        label2int = {None: -1, "negative": 0, "positive": 1, "neutral": 2}
-        return weak_label_matrix, annotation_array, label2int
+        pd.testing.assert_frame_equal(summary, expected)
 
-    monkeypatch.setattr(WeakLabels, "_apply_rules", mock_apply)
-
-    weak_labels = WeakLabels(rules=rules, dataset="mock")
-
-    with pytest.raises(MissingLabelError):
-        weak_labels.change_mapping({"negative": 2})
-
-    new_mapping = {None: -10, "negative": 2, "positive": 10, "neutral": 1}
-
-    old_wlm = weak_labels.matrix().copy()
-    old_mapping = weak_labels.label2int.copy()
-
-    weak_labels.change_mapping(new_mapping)
-
-    assert (
-        weak_labels.matrix()
-        == np.array(
-            [[2, 10, -10], [1, 2, -10], [-10, -10, -10], [10, 10, -10], [-10, 2, 1]],
-            dtype=np.short,
+        summary = weak_labels.summary(normalize_by_coverage=True)
+        expected = pd.DataFrame(
+            {
+                "label": [
+                    {"negative", "positive"},
+                    {"negative", "positive"},
+                    set(),
+                    {"negative", "positive"},
+                ],
+                "coverage": [2.0 / 4, 3.0 / 4, 0, 3.0 / 4],
+                "overlaps": [2.0 / 2, 2.0 / 3, 0, 2.0 / 3],
+                "conflicts": [1.0 / 2, 1.0 / 3, 0, 1.0 / 3],
+            },
+            index=["first_rule", "rule_1", "rubrix_rule", "total"],
         )
-    ).all()
-    assert (
-        weak_labels.annotation(include_missing=True)
-        == np.array([2, 10, -10, 1, 2], dtype=np.short)
-    ).all()
-    assert weak_labels.label2int == new_mapping
-    assert weak_labels.int2label == {val: key for key, val in new_mapping.items()}
+        pd.testing.assert_frame_equal(summary, expected)
 
-    weak_labels.change_mapping(old_mapping)
+        summary = weak_labels.summary(annotation=np.array([1, -1, 0, 1]))
+        expected = pd.DataFrame(
+            {
+                "label": [
+                    {"negative", "positive"},
+                    {"negative", "positive"},
+                    set(),
+                    {"negative", "positive"},
+                ],
+                "coverage": [2.0 / 4, 3.0 / 4, 0, 3.0 / 4],
+                "annotated_coverage": [2.0 / 3, 2.0 / 3, 0, 2.0 / 3],
+                "overlaps": [2.0 / 4, 2.0 / 4, 0, 2.0 / 4],
+                "conflicts": [1.0 / 4, 1.0 / 4, 0, 1.0 / 4],
+                "correct": [1, 2, 0, 3],
+                "incorrect": [1, 0, 0, 1],
+                "precision": [1.0 / 2, 2 / 2, np.nan, 3.0 / 4],
+            },
+            index=["first_rule", "rule_1", "rubrix_rule", "total"],
+        )
+        pd.testing.assert_frame_equal(summary, expected)
 
-    assert (weak_labels.matrix() == old_wlm).all()
+    def test_show_records(self, monkeypatch, rules):
+        def mock_load(*args, **kwargs):
+            return [TextClassificationRecord(inputs="test", id=i) for i in range(5)]
+
+        monkeypatch.setattr(
+            "rubrix.labeling.text_classification.weak_labels.load", mock_load
+        )
+
+        def mock_apply(self, *args, **kwargs):
+            weak_label_matrix = np.array(
+                [[0, 1, -1], [2, 0, -1], [-1, -1, -1], [1, 1, -1], [-1, 0, 2]],
+                dtype=np.short,
+            )
+            annotation_array = np.array([0, 1, -1, 2, 0], dtype=np.short)
+            label2int = {None: -1, "negative": 0, "positive": 1, "neutral": 2}
+            return weak_label_matrix, annotation_array, label2int
+
+        monkeypatch.setattr(WeakLabels, "_apply_rules", mock_apply)
+
+        weak_labels = WeakLabels(rules=rules, dataset="mock")
+
+        assert weak_labels.show_records().id.tolist() == [0, 1, 2, 3, 4]
+        assert weak_labels.show_records(labels=["positive"]).id.tolist() == [0, 3]
+        assert weak_labels.show_records(labels=["negative", "neutral"]).id.tolist() == [
+            1,
+            4,
+        ]
+        assert weak_labels.show_records(rules=[0]).id.tolist() == [0, 1, 3]
+        assert weak_labels.show_records(rules=[0, "rule_1"]).id.tolist() == [0, 1, 3]
+        assert weak_labels.show_records(labels=["negative"], rules=[1]).id.tolist() == [
+            0,
+            1,
+            4,
+        ]
+        assert weak_labels.show_records(
+            labels=["positive"], rules=["rubrix_rule"]
+        ).empty
+
+    def test_change_mapping(self, monkeypatch, rules):
+        def mock_load(*args, **kwargs):
+            return [TextClassificationRecord(inputs="test", id=i) for i in range(5)]
+
+        monkeypatch.setattr(
+            "rubrix.labeling.text_classification.weak_labels.load", mock_load
+        )
+
+        def mock_apply(self, *args, **kwargs):
+            weak_label_matrix = np.array(
+                [[0, 1, -1], [2, 0, -1], [-1, -1, -1], [1, 1, -1], [-1, 0, 2]],
+                dtype=np.short,
+            )
+            annotation_array = np.array([0, 1, -1, 2, 0], dtype=np.short)
+            label2int = {None: -1, "negative": 0, "positive": 1, "neutral": 2}
+            return weak_label_matrix, annotation_array, label2int
+
+        monkeypatch.setattr(WeakLabels, "_apply_rules", mock_apply)
+
+        weak_labels = WeakLabels(rules=rules, dataset="mock")
+
+        with pytest.raises(MissingLabelError):
+            weak_labels.change_mapping({"negative": 2})
+
+        new_mapping = {None: -10, "negative": 2, "positive": 10, "neutral": 1}
+
+        old_wlm = weak_labels.matrix().copy()
+        old_mapping = weak_labels.label2int.copy()
+
+        weak_labels.change_mapping(new_mapping)
+
+        assert (
+            weak_labels.matrix()
+            == np.array(
+                [
+                    [2, 10, -10],
+                    [1, 2, -10],
+                    [-10, -10, -10],
+                    [10, 10, -10],
+                    [-10, 2, 1],
+                ],
+                dtype=np.short,
+            )
+        ).all()
+        assert (
+            weak_labels.annotation(include_missing=True)
+            == np.array([2, 10, -10, 1, 2], dtype=np.short)
+        ).all()
+        assert weak_labels.label2int == new_mapping
+        assert weak_labels.int2label == {val: key for key, val in new_mapping.items()}
+
+        weak_labels.change_mapping(old_mapping)
+
+        assert (weak_labels.matrix() == old_wlm).all()
 
 
-def test_dataset_type_error():
-    with pytest.raises(TypeError, match="must be a string, but you provided"):
-        WeakLabels([1, 2, 3])
+class TestWeakMultiLabels:
+    def test_single_label_error(self, monkeypatch):
+        def mock_load(*args, **kwargs):
+            return [TextClassificationRecord(inputs="test", multi_label=False)]
 
+        monkeypatch.setattr(
+            "rubrix.labeling.text_classification.weak_labels.load", mock_load
+        )
 
-def test_rules_from_dataset(monkeypatch, mocked_client, log_dataset):
-    monkeypatch.setattr(httpx, "get", mocked_client.get)
-    monkeypatch.setattr(httpx, "stream", mocked_client.stream)
+        with pytest.raises(SingleLabelError):
+            WeakMultiLabels(rules=[lambda x: None], dataset="mock")
 
-    mock_rules = [Rule(query="mock", label="mock")]
-    monkeypatch.setattr(
-        "rubrix.labeling.text_classification.weak_labels.load_rules",
-        lambda x: mock_rules,
-    )
+    def test_apply(
+        self,
+        log_multilabel_dataset,
+        multilabel_rules,
+    ):
+        weak_labels = WeakMultiLabels(
+            rules=multilabel_rules, dataset=log_multilabel_dataset
+        )
 
-    wl = WeakLabels(log_dataset)
-    assert wl.rules is mock_rules
+        assert weak_labels.labels == ["negative", "positive"]
 
+        # check that all `Rule.apply`s are called
+        assert weak_labels._rules[-1]._matching_ids == {1: None, 2: None}
 
-def test_norulesfounderror(monkeypatch):
-    monkeypatch.setattr(
-        "rubrix.labeling.text_classification.weak_labels.load_rules", lambda x: []
-    )
+        assert (
+            weak_labels.matrix()
+            == np.array(
+                [
+                    [[0, 0], [-1, -1], [0, 1]],
+                    [[0, 0], [1, 1], [0, 1]],
+                    [[-1, -1], [-1, -1], [-1, -1]],
+                ],
+                dtype=np.short,
+            )
+        ).all()
 
-    with pytest.raises(NoRulesFoundError, match="No rules were found"):
-        WeakLabels("mock")
+        assert (
+            weak_labels._annotation
+            == np.array([[1, 0], [1, 1], [-1, -1]], dtype=np.short)
+        ).all()
+
+    def test_matrix_annotation(self, monkeypatch):
+        expected_records = [
+            TextClassificationRecord(inputs="test without annot", multi_label=True),
+            TextClassificationRecord(
+                inputs="test with annot", annotation="positive", multi_label=True
+            ),
+        ]
+
+        def mock_load(*args, **kwargs):
+            return expected_records
+
+        monkeypatch.setattr(
+            "rubrix.labeling.text_classification.weak_labels.load", mock_load
+        )
+
+        def mock_apply(self, *args, **kwargs):
+            weak_label_matrix = np.array(
+                [[[1, 0], [0, 1]], [[-1, -1], [1, 0]]], dtype=np.short
+            )
+            annotation_array = np.array([[-1, -1], [1, 0]], dtype=np.short)
+            labels = ["negative", "positive"]
+            return weak_label_matrix, annotation_array, labels
+
+        monkeypatch.setattr(WeakMultiLabels, "_apply_rules", mock_apply)
+
+        weak_labels = WeakMultiLabels(rules=[lambda x: "mock"] * 2, dataset="mock")
+
+        assert (
+            weak_labels.matrix(has_annotation=False)
+            == np.array([[[1, 0], [0, 1]]], dtype=np.short)
+        ).all()
+        assert (
+            weak_labels.matrix(has_annotation=True)
+            == np.array([[[-1, -1], [1, 0]]], dtype=np.short)
+        ).all()
+        assert (weak_labels.annotation() == np.array([[1, 0]], dtype=np.short)).all()
+        assert (
+            weak_labels.annotation(include_missing=True)
+            == np.array([[[-1, -1], [1, 0]]], dtype=np.short)
+        ).all()
+
+    def test_summary(self, monkeypatch, multilabel_rules):
+        def mock_load(*args, **kwargs):
+            return [TextClassificationRecord(inputs="test", multi_label=True)] * 4
+
+        monkeypatch.setattr(
+            "rubrix.labeling.text_classification.weak_labels.load", mock_load
+        )
+
+        def mock_apply(self, *args, **kwargs):
+            weak_label_matrix = np.array(
+                [
+                    [[1, 0], [1, 0], [-1, -1]],
+                    [[-1, -1], [1, 0], [-1, -1]],
+                    [[-1, -1], [-1, -1], [-1, -1]],
+                    [[1, 1], [1, 0], [-1, -1]],
+                ],
+                dtype=np.short,
+            )
+            # weak_label_matrix = np.random.randint(-1, 30, (int(1e5), 50), dtype=np.short)
+            annotation_array = np.array(
+                [[-1, -1], [-1, -1], [-1, -1], [-1, -1]], dtype=np.short
+            )
+            # annotation_array = np.random.randint(-1, 30, int(1e5), dtype=np.short)
+            labels = ["negative", "positive"]
+            # label2int = {k: v for k, v in zip(["None"]+list(range(30)), list(range(-1, 30)))}
+            return weak_label_matrix, annotation_array, labels
+
+        monkeypatch.setattr(WeakMultiLabels, "_apply_rules", mock_apply)
+
+        weak_labels = WeakMultiLabels(rules=multilabel_rules, dataset="mock")
+
+        summary = weak_labels.summary()
+        expected = pd.DataFrame(
+            {
+                "label": [
+                    {"negative", "positive"},
+                    {"negative"},
+                    set(),
+                    {"negative", "positive"},
+                ],
+                "coverage": [2.0 / 4, 3.0 / 4, 0, 3.0 / 4],
+                "overlaps": [2.0 / 4, 2.0 / 4, 0, 2.0 / 4],
+            },
+            index=["first_rule", "rule_1", "rubrix_rule", "total"],
+        )
+        pd.testing.assert_frame_equal(summary, expected)
+
+        summary = weak_labels.summary(normalize_by_coverage=True)
+        expected = pd.DataFrame(
+            {
+                "label": [
+                    {"negative", "positive"},
+                    {"negative"},
+                    set(),
+                    {"negative", "positive"},
+                ],
+                "coverage": [2.0 / 4, 3.0 / 4, 0, 3.0 / 4],
+                "overlaps": [2.0 / 2, 2.0 / 3, 0, 2.0 / 3],
+            },
+            index=["first_rule", "rule_1", "rubrix_rule", "total"],
+        )
+        pd.testing.assert_frame_equal(summary, expected)
+
+        summary = weak_labels.summary(
+            annotation=np.array([[0, 1], [-1, -1], [0, 1], [1, 1]])
+        )
+        expected = pd.DataFrame(
+            {
+                "label": [
+                    {"negative", "positive"},
+                    {"negative"},
+                    set(),
+                    {"negative", "positive"},
+                ],
+                "coverage": [2.0 / 4, 3.0 / 4, 0, 3.0 / 4],
+                "annotated_coverage": [2.0 / 3, 2.0 / 3, 0, 2.0 / 3],
+                "overlaps": [2.0 / 4, 2.0 / 4, 0, 2.0 / 4],
+                "correct": [2, 1, 0, 3],
+                "incorrect": [1, 1, 0, 2],
+                "precision": [2.0 / 3, 1.0 / 2, np.nan, 3.0 / 5],
+            },
+            index=["first_rule", "rule_1", "rubrix_rule", "total"],
+        )
+        pd.testing.assert_frame_equal(summary, expected)
+
+    def test_show_records(self, monkeypatch, multilabel_rules):
+        def mock_load(*args, **kwargs):
+            return [
+                TextClassificationRecord(inputs="test", id=i, multi_label=True)
+                for i in range(5)
+            ]
+
+        monkeypatch.setattr(
+            "rubrix.labeling.text_classification.weak_labels.load", mock_load
+        )
+
+        def mock_apply(self, *args, **kwargs):
+            weak_label_matrix = np.array(
+                [
+                    [[1, 0], [0, 1], [-1, -1]],
+                    [[0, 1], [1, 0], [-1, -1]],
+                    [[-1, -1], [-1, -1], [-1, -1]],
+                    [[0, 1], [0, 1], [-1, -1]],
+                    [[-1, -1], [1, 0], [1, 0]],
+                ],
+                dtype=np.short,
+            )
+            labels = ["negative", "positive"]
+            return weak_label_matrix, None, labels
+
+        monkeypatch.setattr(WeakMultiLabels, "_apply_rules", mock_apply)
+
+        weak_labels = WeakMultiLabels(rules=multilabel_rules, dataset="mock")
+
+        assert weak_labels.show_records().id.tolist() == [0, 1, 2, 3, 4]
+        assert weak_labels.show_records(labels=["positive"]).id.tolist() == [0, 1, 3]
+        assert weak_labels.show_records(labels=["negative"]).id.tolist() == [0, 1, 4]
+        assert weak_labels.show_records(
+            labels=["negative", "positive"]
+        ).id.tolist() == [0, 1]
+
+        assert weak_labels.show_records(rules=[0]).id.tolist() == [0, 1, 3]
+        assert weak_labels.show_records(rules=[0, "rule_1"]).id.tolist() == [0, 1, 3]
+        assert weak_labels.show_records(labels=["negative"], rules=[1]).id.tolist() == [
+            0,
+            1,
+            4,
+        ]
+        assert weak_labels.show_records(
+            labels=["positive"], rules=["rubrix_rule"]
+        ).empty


### PR DESCRIPTION
This PR addresses part of #1144 and implements a weak label matrix for multi-label text classification datasets.
It introduces a new `WeakMultiLabels` class that stores the weak labels as a 3 dim matrix (nr of records x nr of rules x nr of labels) with values of -1 (abstentions), 0 (no vote), and 1 (vote). The annotations are stored in a 2 dim matrix (nr of records x nr of labels). @frascuchon let's have a meeting and check that the metrics of the `WeakMultiLabels.summary` method and the ones in the UI/Server are aligned.

The `WeakLabels` and `WeakMultiLabels` classes share a common base class that facilitates the specific implementations and avoids code duplication.

The next step would be to make the label models compatible with this new weak label class.
