### PR TITLE
feat(#1192): disable ssl verify for elasticsearch http client

### DIFF
--- a/src/rubrix/server/commons/es_wrapper.py
+++ b/src/rubrix/server/commons/es_wrapper.py
@@ -64,7 +64,10 @@ class ElasticsearchWrapper(LoggingMixin):
         """
 
         if cls._INSTANCE is None:
-            es_client = OpenSearch(hosts=settings.elasticsearch)
+            es_client = OpenSearch(
+                hosts=settings.elasticsearch,
+                verify_certs=settings.elasticsearch_ssl_verify,
+            )
             cls._INSTANCE = cls(es_client)
 
         return cls._INSTANCE

--- a/src/rubrix/server/commons/settings.py
+++ b/src/rubrix/server/commons/settings.py
@@ -59,6 +59,7 @@ class ApiSettings(BaseSettings):
     __DATASETS_RECORDS_INDEX_NAME__ = ".rubrix<NAMESPACE>.dataset.{}.records-v0"
 
     elasticsearch: str = "http://localhost:9200"
+    elasticsearch_ssl_verify: bool = True
     cors_origins: List[str] = ["*"]
 
     docs_enabled: bool = True
@@ -116,6 +117,9 @@ class ApiSettings(BaseSettings):
     class Config:
         # TODO: include a common prefix for all rubrix env vars.
         fields = {
+            "elasticsearch_ssl_verify": {
+                "env": "RUBRIX_ELASTICSEARCH_SSL_VERIFY",
+            },
             "metadata_fields_limit": {"env": "RUBRIX_METADATA_FIELDS_LIMIT"},
             "namespace": {
                 "env": "RUBRIX_NAMESPACE",


### PR DESCRIPTION
This PR just allows disable http ssl client verification (for elasticsearch/opensearch connection) by setting the environment variable:

```bash
RUBRIX_ELASTICSEARCH_SSL_VERIFY=False
```

This is strongly discouraged for production environments, but can be used for quick testing of non-secure environments.