### PR TITLE
feat(#950): include search keywords as part of record results

### DIFF
--- a/src/rubrix/client/models.py
+++ b/src/rubrix/client/models.py
@@ -147,7 +147,9 @@ class TextClassificationRecord(_Validators):
         metrics:
             READ ONLY! Metrics at record level provided by the server when using `rb.load`.
             This attribute will be ignored when using `rb.log`.
-
+        search_keywords:
+            READ ONLY! Relevant record keywords/terms for provided query when using `rb.load`.
+            This attribute will be ignored when using `rb.log`.
     Examples:
         >>> import rubrix as rb
         >>> record = rb.TextClassificationRecord(
@@ -172,6 +174,7 @@ class TextClassificationRecord(_Validators):
     event_timestamp: Optional[datetime.datetime] = None
 
     metrics: Optional[Dict[str, Any]] = None
+    search_keywords: Optional[List[str]] = None
 
     @validator("inputs", pre=True)
     def input_as_dict(cls, inputs):
@@ -213,7 +216,9 @@ class TokenClassificationRecord(_Validators):
         metrics:
             READ ONLY! Metrics at record level provided by the server when using `rb.load`.
             This attribute will be ignored when using `rb.log`.
-
+        search_keywords:
+            READ ONLY! Relevant record keywords/terms for provided query when using `rb.load`.
+            This attribute will be ignored when using `rb.log`.
     Examples:
         >>> import rubrix as rb
         >>> record = rb.TokenClassificationRecord(
@@ -239,6 +244,7 @@ class TokenClassificationRecord(_Validators):
     event_timestamp: Optional[datetime.datetime] = None
 
     metrics: Optional[Dict[str, Any]] = None
+    search_keywords: Optional[List[str]] = None
 
     @validator("prediction")
     def add_default_score(
@@ -283,6 +289,9 @@ class Text2TextRecord(_Validators):
         metrics:
             READ ONLY! Metrics at record level provided by the server when using `rb.load`.
             This attribute will be ignored when using `rb.log`.
+        search_keywords:
+            READ ONLY! Relevant record keywords/terms for provided query when using `rb.load`.
+            This attribute will be ignored when using `rb.log`.
 
     Examples:
         >>> import rubrix as rb
@@ -305,6 +314,7 @@ class Text2TextRecord(_Validators):
     event_timestamp: Optional[datetime.datetime] = None
 
     metrics: Optional[Dict[str, Any]] = None
+    search_keywords: Optional[List[str]] = None
 
     @validator("prediction")
     def prediction_as_tuples(

--- a/src/rubrix/client/sdk/commons/models.py
+++ b/src/rubrix/client/sdk/commons/models.py
@@ -46,6 +46,7 @@ class BaseRecord(GenericModel, Generic[T]):
     prediction: Optional[T] = None
     annotation: Optional[T] = None
     metrics: Dict[str, Any] = Field(default_factory=dict)
+    search_keywords: Optional[List[str]] = None
 
     # this is a small hack to get a json-compatible serialization on cls.dict(), which we use for the httpx calls.
     # they want to build this feature into pydantic, see https://github.com/samuelcolvin/pydantic/issues/1409

--- a/src/rubrix/client/sdk/text2text/models.py
+++ b/src/rubrix/client/sdk/text2text/models.py
@@ -94,6 +94,7 @@ class Text2TextRecord(CreationText2TextRecord):
             id=self.id,
             event_timestamp=self.event_timestamp,
             metrics=self.metrics or None,
+            search_keywords=self.search_keywords or None,
         )
 
 

--- a/src/rubrix/client/sdk/text_classification/models.py
+++ b/src/rubrix/client/sdk/text_classification/models.py
@@ -129,6 +129,7 @@ class TextClassificationRecord(CreationTextClassificationRecord):
             if self.explanation
             else None,
             metrics=self.metrics or None,
+            search_keywords=self.search_keywords or None,
         )
 
 

--- a/src/rubrix/client/sdk/token_classification/models.py
+++ b/src/rubrix/client/sdk/token_classification/models.py
@@ -118,6 +118,7 @@ class TokenClassificationRecord(CreationTokenClassificationRecord):
             status=self.status,
             metadata=self.metadata or {},
             metrics=self.metrics or {},
+            search_keywords=self.search_keywords or None,
         )
 
 

--- a/src/rubrix/client/sdk/token_classification/models.py
+++ b/src/rubrix/client/sdk/token_classification/models.py
@@ -117,7 +117,7 @@ class TokenClassificationRecord(CreationTokenClassificationRecord):
             event_timestamp=self.event_timestamp,
             status=self.status,
             metadata=self.metadata or {},
-            metrics=self.metrics or {},
+            metrics=self.metrics or None,
             search_keywords=self.search_keywords or None,
         )
 

--- a/src/rubrix/server/tasks/commons/api/model.py
+++ b/src/rubrix/server/tasks/commons/api/model.py
@@ -179,6 +179,13 @@ class BaseRecord(GenericModel, Generic[Annotation]):
     prediction: Optional[Annotation] = None
     annotation: Optional[Annotation] = None
     metrics: Dict[str, Any] = Field(default_factory=dict)
+    search_keywords: Optional[List[str]] = None
+
+    @validator("search_keywords")
+    def remove_duplicated_keywords(cls, value) -> List[str]:
+        """Remove duplicated keywords"""
+        if value:
+            return list(set(value))
 
     @validator("id", always=True)
     def default_id_if_none_provided(cls, id: Optional[str]) -> str:

--- a/src/rubrix/server/tasks/commons/dao/dao.py
+++ b/src/rubrix/server/tasks/commons/dao/dao.py
@@ -282,7 +282,10 @@ class DatasetRecordsDAO:
             An iterable over found dataset records
         """
         search = search or RecordSearch()
-        es_query = {"query": search.query}
+        es_query = {
+            "query": search.query,
+            "highlight": self.__configure_query_highlight__(),
+        }
         docs = self._es.list_documents(
             dataset_records_index(dataset.id), query=es_query
         )

--- a/src/rubrix/server/tasks/storage/service.py
+++ b/src/rubrix/server/tasks/storage/service.py
@@ -37,7 +37,7 @@ class RecordsStorageService:
         self,
         dataset: BaseDatasetDB,
         records: List[Record],
-        record_type: Type[BaseRecord],
+        record_type: Type[Record],
     ) -> int:
         """Store a set of records"""
         self._compute_record_metrics(dataset, records)

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -263,23 +263,24 @@ class TestDatasetForTextClassification:
         reason="You need a HF Hub access token to test the push_to_hub feature",
     )
     @pytest.mark.parametrize(
-        "records",
+        "name",
         [
             "singlelabel_textclassification_records",
             "multilabel_textclassification_records",
         ],
     )
-    def test_push_to_hub(self, request, records):
-        records = request.getfixturevalue(records)
+    def test_push_to_hub(self, request, name: str):
+        records = request.getfixturevalue(name)
+        dataset_name = f"rubrix/_test_text_classification_records-{name}"
         dataset_rb = rb.DatasetForTextClassification(records)
         dataset_rb.to_datasets().push_to_hub(
-            "rubrix/_test_text_classification_records",
+            dataset_name,
             token=_HF_HUB_ACCESS_TOKEN,
             private=True,
         )
         sleep(1)
         dataset_ds = datasets.load_dataset(
-            "rubrix/_test_text_classification_records",
+            dataset_name,
             use_auth_token=_HF_HUB_ACCESS_TOKEN,
             split="train",
         )

--- a/tests/functional_tests/test_log_for_text_classification.py
+++ b/tests/functional_tests/test_log_for_text_classification.py
@@ -50,6 +50,31 @@ def test_delete_and_create_for_different_task(mocked_client):
     rubrix.load(dataset)
 
 
+def test_search_keywords(mocked_client):
+    dataset = "test_search_keywords"
+    from datasets import load_dataset
+
+    dataset_ds = load_dataset("Recognai/sentiment-banking", split="train")
+    dataset_rb = rubrix.read_datasets(dataset_ds, task="TextClassification")
+
+    rubrix.delete(dataset)
+    rubrix.log(name=dataset, records=dataset_rb)
+
+    df = rubrix.load(dataset, query="li*")
+    assert not df.empty
+    assert "search_keywords" in df.columns
+    top_keywords = set(
+        [
+            keyword
+            for keywords in df.search_keywords.value_counts(sort=True, ascending=False)
+            .index[:3]
+            .tolist()
+            for keyword in keywords
+        ]
+    )
+    assert {"link", "like", "limit"} == top_keywords, top_keywords
+
+
 def test_log_records_with_empty_metadata_list(mocked_client):
     dataset = "test_log_records_with_empty_metadata_list"
 

--- a/tests/functional_tests/test_log_for_text_classification.py
+++ b/tests/functional_tests/test_log_for_text_classification.py
@@ -60,7 +60,7 @@ def test_search_keywords(mocked_client):
     rubrix.delete(dataset)
     rubrix.log(name=dataset, records=dataset_rb)
 
-    df = rubrix.load(dataset, query="li*")
+    df = rubrix.load(dataset, query="lim*")
     assert not df.empty
     assert "search_keywords" in df.columns
     top_keywords = set(
@@ -72,7 +72,7 @@ def test_search_keywords(mocked_client):
             for keyword in keywords
         ]
     )
-    assert {"link", "like", "limit"} == top_keywords, top_keywords
+    assert {"limit", "limits", "limited"} == top_keywords, top_keywords
 
 
 def test_log_records_with_empty_metadata_list(mocked_client):

--- a/tests/functional_tests/test_log_for_token_classification.py
+++ b/tests/functional_tests/test_log_for_token_classification.py
@@ -456,7 +456,7 @@ def test_search_keywords(mocked_client):
     rubrix.delete(dataset)
     rubrix.log(name=dataset, records=dataset_rb)
 
-    df = rubrix.load(dataset, query="li*")
+    df = rubrix.load(dataset, query="lis*")
     assert not df.empty
     assert "search_keywords" in df.columns
     top_keywords = set(
@@ -468,10 +468,4 @@ def test_search_keywords(mocked_client):
             for keyword in keywords
         ]
     )
-    assert {
-        "listened",
-        "little",
-        "lived",
-        "listen",
-        "light",
-    } == top_keywords, top_keywords
+    assert {"listened", "listen"} == top_keywords, top_keywords

--- a/tests/functional_tests/test_log_for_token_classification.py
+++ b/tests/functional_tests/test_log_for_token_classification.py
@@ -444,3 +444,34 @@ def test_log_record_that_makes_me_cry(mocked_client):
         },
         "annotated": {"mentions": []},
     }
+
+
+def test_search_keywords(mocked_client):
+    dataset = "test_search_keywords"
+    from datasets import load_dataset
+
+    dataset_ds = load_dataset("rubrix/gutenberg_spacy-ner_sm", split="train")
+    dataset_rb = rubrix.read_datasets(dataset_ds, task="TokenClassification")
+
+    rubrix.delete(dataset)
+    rubrix.log(name=dataset, records=dataset_rb)
+
+    df = rubrix.load(dataset, query="li*")
+    assert not df.empty
+    assert "search_keywords" in df.columns
+    top_keywords = set(
+        [
+            keyword
+            for keywords in df.search_keywords.value_counts(sort=True, ascending=False)
+            .index[:3]
+            .tolist()
+            for keyword in keywords
+        ]
+    )
+    assert {
+        "listened",
+        "little",
+        "lived",
+        "listen",
+        "light",
+    } == top_keywords, top_keywords


### PR DESCRIPTION
This PR includes as part of search/scan dataset record response the record keywords relevant for provided query.

These keywords will be returned only for full text search queries and are computed in approximative fashion.

Can be used for search highlighting or automatic labelling function generation for Token classification .


See #950 