### PR TITLE
fix(init): using api sdk wrapper is better

### DIFF
--- a/src/rubrix/client/rubrix_client.py
+++ b/src/rubrix/client/rubrix_client.py
@@ -19,7 +19,6 @@ import logging
 import socket
 from typing import Any, Dict, Iterable, List, Optional, Union
 
-import httpx
 import pandas
 from tqdm.auto import tqdm
 
@@ -104,34 +103,14 @@ class RubrixClient:
             api_url: Address from which the API is serving.
             api_key: Authentication token.
             workspace: Active workspace for this client session.
-            timeout: Seconds to considered a connection timeout.
+            timeout: Seconds to consider a connection timeout.
         """
 
-        self._client = None  # Variable to store the client after the init
-
-        try:
-            response = httpx.get(url=f"{api_url}/api/docs/spec.json")
-        except ConnectionRefusedError:
-            raise Exception("Connection Refused: cannot connect to the API.")
-
-        if response.status_code != 200:
-            raise Exception(
-                "Connection error: Undetermined error connecting to the Rubrix Server. "
-                "The API answered with a {} code: {}".format(
-                    response.status_code, response.content
-                )
-            )
         self._client = AuthenticatedClient(
             base_url=api_url, token=api_key, timeout=timeout
         )
 
-        response = whoami(client=self._client)
-
-        whoami_response_status = response.status_code
-        if whoami_response_status == 401:
-            raise Exception("Authentication error: invalid credentials.")
-
-        self.__current_user__: User = response.parsed
+        self.__current_user__: User = whoami(client=self._client)
         if workspace:
             self.set_workspace(workspace)
 

--- a/src/rubrix/client/rubrix_client.py
+++ b/src/rubrix/client/rubrix_client.py
@@ -103,7 +103,7 @@ class RubrixClient:
             api_url: Address from which the API is serving.
             api_key: Authentication token.
             workspace: Active workspace for this client session.
-            timeout: Seconds to consider a connection timeout.
+            timeout: Seconds to wait before raising a connection timeout.
         """
 
         self._client = AuthenticatedClient(

--- a/src/rubrix/client/sdk/users/api.py
+++ b/src/rubrix/client/sdk/users/api.py
@@ -2,11 +2,10 @@ import httpx
 
 from rubrix.client.sdk.client import AuthenticatedClient
 from rubrix.client.sdk.commons.errors_handler import handle_response_error
-from rubrix.client.sdk.commons.models import Response
 from rubrix.client.sdk.users.models import User
 
 
-def whoami(client: AuthenticatedClient):
+def whoami(client: AuthenticatedClient) -> User:
     url = "{}/api/me".format(client.base_url)
 
     response = httpx.get(
@@ -17,11 +16,6 @@ def whoami(client: AuthenticatedClient):
     )
 
     if response.status_code == 200:
-        return Response(
-            status_code=response.status_code,
-            content=response.content,
-            headers=response.headers,
-            parsed=User(**response.json()),
-        )
+        return User(**response.json())
 
-    return handle_response_error(response, msg="Invalid credentials")
+    handle_response_error(response, msg="Invalid credentials")

--- a/tests/client/sdk/users/test_api.py
+++ b/tests/client/sdk/users/test_api.py
@@ -3,19 +3,28 @@ import pytest
 
 from rubrix import DEFAULT_API_KEY
 from rubrix.client.sdk.client import AuthenticatedClient
+from rubrix.client.sdk.commons.errors import UnauthorizedApiError
 from rubrix.client.sdk.users.api import whoami
 from rubrix.client.sdk.users.models import User
 
 
-@pytest.fixture
-def sdk_client():
-    return AuthenticatedClient(base_url="http://localhost:6900", token=DEFAULT_API_KEY)
+def test_whoami(mocked_client):
+    sdk_client = AuthenticatedClient(
+        base_url="http://localhost:6900", token=DEFAULT_API_KEY
+    )
+    user = whoami(client=sdk_client)
+    assert isinstance(user, User)
 
 
-def test_whoami(mocked_client, sdk_client, monkeypatch):
-    monkeypatch.setattr(httpx, "get", mocked_client.get)
+def test_whoami_with_auth_error(mocked_client):
+    with pytest.raises(UnauthorizedApiError):
+        whoami(
+            AuthenticatedClient(base_url="http://localhost:6900", token="wrong-apikey")
+        )
 
-    response = whoami(client=sdk_client)
 
-    assert response.status_code == 200
-    assert isinstance(response.parsed, User)
+def test_whoami_with_connection_error():
+    with pytest.raises(httpx.ConnectError):
+        whoami(
+            AuthenticatedClient(base_url="http://localhost:6900", token="wrong-apikey")
+        )

--- a/tests/functional_tests/test_log_for_token_classification.py
+++ b/tests/functional_tests/test_log_for_token_classification.py
@@ -450,7 +450,7 @@ def test_search_keywords(mocked_client):
     dataset = "test_search_keywords"
     from datasets import load_dataset
 
-    dataset_ds = load_dataset("rubrix/gutenberg_spacy-ner_sm", split="train")
+    dataset_ds = load_dataset("rubrix/gutenberg_spacy-ner", split="train")
     dataset_rb = rubrix.read_datasets(dataset_ds, task="TokenClassification")
 
     rubrix.delete(dataset)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -23,7 +23,7 @@ import pytest
 import rubrix
 from rubrix.client import RubrixClient
 from rubrix.client.sdk.client import AuthenticatedClient
-from rubrix.client.sdk.commons.errors import UnauthorizedApiError
+from rubrix.client.sdk.commons.errors import GenericApiError, UnauthorizedApiError
 
 
 @pytest.fixture
@@ -145,10 +145,7 @@ def test_init_incorrect(mock_response_500):
     """
 
     rubrix._client = None  # assert empty client
-    with pytest.raises(
-        Exception,
-        match="Connection error: Undetermined error connecting to the Rubrix Server. The API answered with a 500 code: b",
-    ):
+    with pytest.raises(GenericApiError):
         rubrix.init()
 
 
@@ -179,10 +176,7 @@ def test_init_token_incorrect(mock_response_500):
         Mocked correct http response
     """
     rubrix._client = None  # assert empty client
-    with pytest.raises(
-        Exception,
-        match="Connection error: Undetermined error connecting to the Rubrix Server. The API answered with a 500 code: b",
-    ):
+    with pytest.raises(GenericApiError):
         rubrix.init(api_key="422")
 
 


### PR DESCRIPTION
This PR changes the client initialization and use the sdk api wrapper. This normalizes the use of timeout in requests and the error handler in responses.

Closes #1207 