### PR TITLE
feat: Implement 'prepare_for_training' for text classification datasets

### DIFF
--- a/docs/tutorials/01-labeling-finetuning.ipynb
+++ b/docs/tutorials/01-labeling-finetuning.ipynb
@@ -216,7 +216,7 @@
     "\n",
     "Note\n",
     "\n",
-    "If you don't want to run the predictions yourself, you can also load the records with the predictions directly from the Hugging Face Hub: `load_dataset(\"Recognai/sentiment-banking\", split=\"train\")`, see below for more details.\n",
+    "If you don't want to run the predictions yourself, you can also load the records with the predictions directly from the Hugging Face Hub: `load_dataset(\"rubrix/sentiment-banking\", split=\"train\")`, see below for more details.\n",
     "    \n",
     "</div>"
    ]

--- a/docs/tutorials/01-labeling-finetuning.ipynb
+++ b/docs/tutorials/01-labeling-finetuning.ipynb
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "498b7a66-8554-43fb-9ae1-c6bed273158d",
    "metadata": {},
    "outputs": [
@@ -128,10 +128,10 @@
       "text/plain": [
        "('Hi, Last week I have contacted the seller for a refund as directed by you, but i have not received the money yet. Please look into this issue with seller and help me in getting the refund.',\n",
        " [[{'label': 'NEGATIVE', 'score': 0.9934700727462769},\n",
-       "   {'label': 'POSITIVE', 'score': 0.006529912818223238}]])"
+       "   {'label': 'POSITIVE', 'score': 0.0065299225971102715}]])"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -198,22 +198,7 @@
    "execution_count": null,
    "id": "dfdbab73-3316-47d5-8545-2cacbe076b05",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f160a9b5e3b5409781a3c38d1c02065a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/3 [00:00<?, ?ba/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "def predict(examples):\n",
     "    return {\"predictions\": sentiment_classifier(examples['text'], truncation=True)}\n",
@@ -410,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 47,
    "id": "b1b331bd-e4e0-41b5-9370-28f8aac01aab",
    "metadata": {},
    "outputs": [
@@ -437,8 +422,8 @@
        "      <th></th>\n",
        "      <th>inputs</th>\n",
        "      <th>prediction</th>\n",
-       "      <th>annotation</th>\n",
        "      <th>prediction_agent</th>\n",
+       "      <th>annotation</th>\n",
        "      <th>annotation_agent</th>\n",
        "      <th>multi_label</th>\n",
        "      <th>explanation</th>\n",
@@ -447,53 +432,57 @@
        "      <th>status</th>\n",
        "      <th>event_timestamp</th>\n",
        "      <th>metrics</th>\n",
+       "      <th>search_keywords</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>{'text': 'Why couldn't I make a withdrawal fro...</td>\n",
-       "      <td>[(NEGATIVE, 0.9984630346298218), (POSITIVE, 0....</td>\n",
-       "      <td>NEGATIVE</td>\n",
+       "      <td>{'text': 'I would like to cancel a purchase.'}</td>\n",
+       "      <td>[(NEGATIVE, 0.9997695088386536), (POSITIVE, 0....</td>\n",
        "      <td>distilbert-base-uncased-finetuned-sst-2-english</td>\n",
+       "      <td>POSITIVE</td>\n",
        "      <td>rubrix</td>\n",
        "      <td>False</td>\n",
        "      <td>None</td>\n",
-       "      <td>012e8ec1-2b3a-4efd-b593-4cbfc3fa4ec9</td>\n",
-       "      <td>{'category': 26}</td>\n",
+       "      <td>0002cbd9-b687-462a-bbd2-3130f4c88d8d</td>\n",
+       "      <td>{'category': 52}</td>\n",
        "      <td>Validated</td>\n",
        "      <td>None</td>\n",
-       "      <td>{}</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>{'text': 'Hi, Last week I have contacted the s...</td>\n",
-       "      <td>[(NEGATIVE, 0.9934700727462769), (POSITIVE, 0....</td>\n",
-       "      <td>NEGATIVE</td>\n",
+       "      <td>{'text': 'What's up with the extra fee I got?'}</td>\n",
+       "      <td>[(NEGATIVE, 0.9968097805976868), (POSITIVE, 0....</td>\n",
        "      <td>distilbert-base-uncased-finetuned-sst-2-english</td>\n",
+       "      <td>NEGATIVE</td>\n",
        "      <td>rubrix</td>\n",
        "      <td>False</td>\n",
        "      <td>None</td>\n",
-       "      <td>102f02fa-1474-42b6-8025-5d0ae67d1d8c</td>\n",
-       "      <td>{'category': 51}</td>\n",
+       "      <td>0009f445-4844-4ccd-9ea8-207a1fb0e239</td>\n",
+       "      <td>{'category': 19}</td>\n",
        "      <td>Validated</td>\n",
        "      <td>None</td>\n",
-       "      <td>{}</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>{'text': 'Why have I not received my PIN'}</td>\n",
-       "      <td>[(NEGATIVE, 0.9959989786148071), (POSITIVE, 0....</td>\n",
-       "      <td>NEGATIVE</td>\n",
+       "      <td>{'text': 'Do you have an age requirement when ...</td>\n",
+       "      <td>[(NEGATIVE, 0.9825802445411682), (POSITIVE, 0....</td>\n",
        "      <td>distilbert-base-uncased-finetuned-sst-2-english</td>\n",
+       "      <td>POSITIVE</td>\n",
        "      <td>rubrix</td>\n",
        "      <td>False</td>\n",
        "      <td>None</td>\n",
-       "      <td>40db49db-92e7-46b0-b23d-6888e0149f14</td>\n",
-       "      <td>{'category': 38}</td>\n",
+       "      <td>0012e385-643c-4660-ad66-5b4339bb3999</td>\n",
+       "      <td>{'category': 1}</td>\n",
        "      <td>Validated</td>\n",
        "      <td>None</td>\n",
-       "      <td>{}</td>\n",
+       "      <td>None</td>\n",
+       "      <td>None</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -501,39 +490,44 @@
       ],
       "text/plain": [
        "                                              inputs  \\\n",
-       "0  {'text': 'Why couldn't I make a withdrawal fro...   \n",
-       "1  {'text': 'Hi, Last week I have contacted the s...   \n",
-       "2         {'text': 'Why have I not received my PIN'}   \n",
+       "0     {'text': 'I would like to cancel a purchase.'}   \n",
+       "1    {'text': 'What's up with the extra fee I got?'}   \n",
+       "2  {'text': 'Do you have an age requirement when ...   \n",
        "\n",
-       "                                          prediction annotation  \\\n",
-       "0  [(NEGATIVE, 0.9984630346298218), (POSITIVE, 0....   NEGATIVE   \n",
-       "1  [(NEGATIVE, 0.9934700727462769), (POSITIVE, 0....   NEGATIVE   \n",
-       "2  [(NEGATIVE, 0.9959989786148071), (POSITIVE, 0....   NEGATIVE   \n",
+       "                                          prediction  \\\n",
+       "0  [(NEGATIVE, 0.9997695088386536), (POSITIVE, 0....   \n",
+       "1  [(NEGATIVE, 0.9968097805976868), (POSITIVE, 0....   \n",
+       "2  [(NEGATIVE, 0.9825802445411682), (POSITIVE, 0....   \n",
        "\n",
-       "                                  prediction_agent annotation_agent  \\\n",
-       "0  distilbert-base-uncased-finetuned-sst-2-english           rubrix   \n",
-       "1  distilbert-base-uncased-finetuned-sst-2-english           rubrix   \n",
-       "2  distilbert-base-uncased-finetuned-sst-2-english           rubrix   \n",
+       "                                  prediction_agent annotation  \\\n",
+       "0  distilbert-base-uncased-finetuned-sst-2-english   POSITIVE   \n",
+       "1  distilbert-base-uncased-finetuned-sst-2-english   NEGATIVE   \n",
+       "2  distilbert-base-uncased-finetuned-sst-2-english   POSITIVE   \n",
        "\n",
-       "   multi_label explanation                                    id  \\\n",
-       "0        False        None  012e8ec1-2b3a-4efd-b593-4cbfc3fa4ec9   \n",
-       "1        False        None  102f02fa-1474-42b6-8025-5d0ae67d1d8c   \n",
-       "2        False        None  40db49db-92e7-46b0-b23d-6888e0149f14   \n",
+       "  annotation_agent  multi_label explanation  \\\n",
+       "0           rubrix        False        None   \n",
+       "1           rubrix        False        None   \n",
+       "2           rubrix        False        None   \n",
        "\n",
-       "           metadata     status event_timestamp metrics  \n",
-       "0  {'category': 26}  Validated            None      {}  \n",
-       "1  {'category': 51}  Validated            None      {}  \n",
-       "2  {'category': 38}  Validated            None      {}  "
+       "                                     id          metadata     status  \\\n",
+       "0  0002cbd9-b687-462a-bbd2-3130f4c88d8d  {'category': 52}  Validated   \n",
+       "1  0009f445-4844-4ccd-9ea8-207a1fb0e239  {'category': 19}  Validated   \n",
+       "2  0012e385-643c-4660-ad66-5b4339bb3999   {'category': 1}  Validated   \n",
+       "\n",
+       "  event_timestamp metrics search_keywords  \n",
+       "0            None    None            None  \n",
+       "1            None    None            None  \n",
+       "2            None    None            None  "
       ]
      },
-     "execution_count": 11,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "rb_df = rb.load(name='labeling_with_pretrained', query=\"status:Validated\")\n",
-    "rb_df.head()"
+    "rb_dataset = rb.load(name='labeling_with_pretrained', query=\"status:Validated\", as_pandas=False)\n",
+    "rb_dataset.to_pandas().head(3)"
    ]
   },
   {
@@ -555,45 +549,41 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fdc7dab5-164b-4013-ba06-41c94cccc926",
+   "id": "433cea34-a0cd-4e58-917f-0fa08caa43dd",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from datasets import Dataset, Features, Value, ClassLabel\n",
-    "from transformers import AutoTokenizer\n",
-    "\n",
-    "# select text input and the annotated label\n",
-    "rb_df['text'] = rb_df.inputs.transform(lambda r: r['text'])\n",
-    "rb_df['labels'] = rb_df.annotation\n",
-    "\n",
-    "ds = rb_df[['text', 'labels']].to_dict(orient='list')\n",
-    "\n",
-    "# create 🤗 dataset from pandas with labels as numeric ids\n",
-    "train_ds = Dataset.from_dict(\n",
-    "    ds, \n",
-    "    features=Features({\n",
-    "        \"text\": Value(\"string\"),\n",
-    "        \"labels\": ClassLabel(names=list(rb_df.labels.unique()))\n",
-    "    })\n",
-    ")\n",
-    "train_ds = train_ds.train_test_split(test_size=0.2) ; train_ds"
+    "# create 🤗 dataset with labels as numeric ids\n",
+    "train_ds = rb_dataset.prepare_for_training()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61f26f9a-f653-4418-8cec-c7081ecabfb3",
+   "id": "83c3a9af-0a7c-4d06-a774-b72f9ce310e7",
    "metadata": {},
    "outputs": [],
    "source": [
+    "from transformers import AutoTokenizer\n",
+    "\n",
     "# tokenize our datasets\n",
     "tokenizer = AutoTokenizer.from_pretrained(\"distilbert-base-uncased-finetuned-sst-2-english\")\n",
     "\n",
     "def tokenize_function(examples):\n",
     "    return tokenizer(examples[\"text\"], padding=\"max_length\", truncation=True)\n",
     "\n",
-    "train_dataset = train_ds['train'].map(tokenize_function, batched=True).shuffle(seed=42)\n",
-    "eval_dataset = train_ds['test'].map(tokenize_function, batched=True).shuffle(seed=42)"
+    "tokenized_train_ds = train_ds.map(tokenize_function, batched=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d202796-e056-4875-bb3a-bcd65b01e9e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# split the data into a training and evalutaion set\n",
+    "train_dataset, eval_dataset = tokenized_train_ds.train_test_split(test_size=0.2, seed=42).values()"
    ]
   },
   {
@@ -643,7 +633,7 @@
     "training_args = TrainingArguments(\n",
     "    \"distilbert-base-uncased-sentiment-banking\", \n",
     "    evaluation_strategy=\"epoch\",\n",
-    "    logging_steps=30\n",
+    "    logging_steps=30,\n",
     ")\n",
     "\n",
     "metric = load_metric(\"accuracy\")\n",
@@ -768,14 +758,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "62066df5-4900-4df0-b504-499bcea85955",
    "metadata": {},
    "outputs": [],
    "source": [
-    "rb_df = rb.load(name='labeling_with_pretrained', query=\"status:Default\")\n",
-    "rb_df['text'] = rb_df.inputs.transform(lambda r: r['text'])\n",
-    "ds = Dataset.from_pandas(rb_df[['text']])"
+    "rb_dataset = rb.load(name='labeling_with_pretrained', query=\"status:Default\", as_pandas=False)"
    ]
   },
   {
@@ -789,35 +777,48 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "b387ffb2-35b0-42f5-b23a-c09074722838",
+   "cell_type": "markdown",
+   "id": "545a2a5e-bc60-4bc0-9c68-ac6b963c2684",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "def predict(examples):\n",
-    "    return {\"predictions\": finetuned_sentiment_classifier(examples['text'])}\n",
-    "\n",
-    "ds = ds.map(predict, batched=True, batch_size=8) "
+    "Let's take advantage of the datasets `map` feature, to make batched predictions."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55a373c8-fc54-4c78-8198-4163dd352dec",
+   "id": "b387ffb2-35b0-42f5-b23a-c09074722838",
    "metadata": {},
    "outputs": [],
    "source": [
-    "records = []\n",
-    "for example in ds.shuffle():\n",
-    "    record = rb.TextClassificationRecord(\n",
-    "        inputs=example[\"text\"],\n",
-    "        prediction=[(pred['label'], pred['score']) for pred in example['predictions']],\n",
-    "        prediction_agent=\"distilbert-base-uncased-banking77-sentiment\"\n",
-    "    )\n",
-    "    records.append(record)\n",
-    "    \n",
-    "rb.log(name='labeling_with_finetuned', records=records)"
+    "def predict(examples):\n",
+    "    texts = [example[\"text\"] for example in examples[\"inputs\"]]\n",
+    "    return {\n",
+    "        \"prediction\": finetuned_sentiment_classifier(texts), \n",
+    "        \"prediction_agent\": [\"distilbert-base-uncased-banking77-sentiment\"]*len(texts)\n",
+    "    }\n",
+    "\n",
+    "ds_dataset = rb_dataset.to_datasets().map(predict, batched=True, batch_size=8) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1683b401-3ffd-4f2e-bef0-be0e667452b8",
+   "metadata": {},
+   "source": [
+    "Afterward, we can convert the dataset directly to Rubrix records again and log them to the web app."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a62ce3bc-8c55-410d-8aae-e250b98d5c09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "records = rb.read_datasets(ds_dataset, task=\"TextClassification\")\n",
+    "\n",
+    "rb.log(records=records, name='labeling_with_finetuned')"
    ]
   },
   {
@@ -863,44 +864,26 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fafcf0ca-d86e-436e-9670-3680a9746531",
+   "id": "07f1ae06-e420-4a1f-8251-bf40aa3bb946",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def prepare_train_df(dataset_name):\n",
-    "    rb_df = rb.load(name=dataset_name)\n",
-    "    rb_df = rb_df[rb_df.status == \"Validated\"] ; len(rb_df)\n",
-    "    rb_df['text'] = rb_df.inputs.transform(lambda r: r['text'])\n",
-    "    rb_df['labels'] = rb_df.annotation.transform(lambda r: r[0])\n",
-    "    return rb_df\n",
+    "rb_dataset = rb.load(\"labeling_with_finetuned\", as_pandas=False)\n",
     "\n",
-    "df = prepare_train_df('labeling_with_finetuned')\n",
-    "train_dataset = train_dataset.remove_columns('__index_level_0__')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "039c6a0d-2aaf-478e-a576-a1c5a0ee1d19",
-   "metadata": {},
-   "source": [
-    "We'll use the [.add_item](https://huggingface.co/docs/datasets/package_reference/main_classes.html#datasets.Dataset.add_item) method from the `datasets` library to add our examples:"
+    "train_ds = rb_dataset.prepare_for_training()\n",
+    "tokenized_train_ds = train_ds.map(tokenize_function, batched=True)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce9e243a-61e6-46b4-99e9-9c8617d55161",
+   "id": "33dd4a29-5e00-4b3d-ad0d-b652eaf9b68e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "for i,r in df.iterrows():\n",
-    "    tokenization = tokenizer(r[\"text\"], padding=\"max_length\", truncation=True)\n",
-    "    train_dataset = train_dataset.add_item({\n",
-    "        \"attention_mask\": tokenization[\"attention_mask\"],\n",
-    "        \"input_ids\": tokenization[\"input_ids\"],\n",
-    "        \"labels\": label2id[r['labels']],\n",
-    "        \"text\": r['text'],\n",
-    "    })"
+    "from datasets import concatenate_datasets\n",
+    "\n",
+    "train_dataset = concatenate_datasets([train_dataset, tokenized_train_ds])"
    ]
   },
   {
@@ -991,7 +974,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1005,7 +988,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -302,9 +302,10 @@ class TestDatasetForTextClassification:
         train = ds.prepare_for_training()
 
         assert isinstance(train, datasets.Dataset)
-        assert train.column_names == ["text", "label"]
+        assert train.column_names == ["text", "context", "label"]
         assert len(train) == 2
-        assert train[1]["text"] == "mock3 mock3"
+        assert train[1]["text"] == "mock3"
+        assert train[1]["context"] == "mock3"
         assert train.features["text"] == datasets.Value("string")
         if records[0].multi_label:
             assert train.features["label"] == [datasets.ClassLabel(names=["a", "b"])]


### PR DESCRIPTION
This PR implements the `prepare_for_training` method for the `DatasetForTextClassification`. I modified the first tutorial to show the usage: https://rubrix.readthedocs.io/en/feat-prepare_for_training/tutorials/01-labeling-finetuning.html
I don't think I will manage to implement the `prepare_for_training` for all tasks before the release.

@dvsrepo @frascuchon For the TokenClassification task, should we rely on spacy utilities to make the conversion from spans to ner tags, or should we provide our own utilities? To me it would seem a bit strange if we required spacy to be installed, to prepare the dataset for training with transformers ... @dvsrepo Do you know of any other library that provides some utilities for converting spans to ner tags?