### PR TITLE
fix(metrics): extends metrics from common class

### DIFF
--- a/src/rubrix/server/tasks/commons/metrics/commons.py
+++ b/src/rubrix/server/tasks/commons/metrics/commons.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, Generic, List
 
 from rubrix.server.tasks.commons import EsRecordDataFieldNames, TaskStatus
 from rubrix.server.tasks.commons.metrics.model.base import (
@@ -12,7 +12,7 @@ from rubrix.server.tasks.commons.metrics.model.base import (
 )
 
 
-class CommonTasksMetrics(BaseTaskMetrics[GenericRecord]):
+class CommonTasksMetrics(BaseTaskMetrics, Generic[GenericRecord]):
     """Common task metrics"""
 
     @classmethod

--- a/src/rubrix/server/tasks/commons/metrics/model/base.py
+++ b/src/rubrix/server/tasks/commons/metrics/model/base.py
@@ -110,7 +110,7 @@ class NestedPathElasticsearchMetric(ElasticsearchMetric):
         return f"{self.nested_path}.{inner_field}"
 
 
-class BaseTaskMetrics(GenericModel, Generic[GenericRecord]):
+class BaseTaskMetrics(BaseModel):
     """
     Base class encapsulating related task metrics
 

--- a/src/rubrix/server/tasks/text2text/metrics.py
+++ b/src/rubrix/server/tasks/text2text/metrics.py
@@ -5,9 +5,9 @@ from rubrix.server.tasks.commons.metrics.model.base import BaseMetric, BaseTaskM
 from rubrix.server.tasks.text2text import Text2TextRecord
 
 
-class Text2TextMetrics(BaseTaskMetrics[Text2TextRecord]):
+class Text2TextMetrics(CommonTasksMetrics[Text2TextRecord]):
     """
     Configured metrics for text2text task
     """
 
-    metrics: ClassVar[List[BaseMetric]] = CommonTasksMetrics.metrics
+    pass

--- a/src/rubrix/server/tasks/text_classification/metrics.py
+++ b/src/rubrix/server/tasks/text_classification/metrics.py
@@ -122,7 +122,7 @@ class DatasetLabels(TermsAggregation):
         return {"labels": [k for k in (aggregation_result or {}).keys()]}
 
 
-class TextClassificationMetrics(BaseTaskMetrics[TextClassificationRecord]):
+class TextClassificationMetrics(CommonTasksMetrics[TextClassificationRecord]):
     """Configured metrics for text classification task"""
 
     metrics: ClassVar[List[BaseMetric]] = CommonTasksMetrics.metrics + [

--- a/src/rubrix/server/tasks/token_classification/metrics.py
+++ b/src/rubrix/server/tasks/token_classification/metrics.py
@@ -307,7 +307,7 @@ class TokenMetrics(BaseModel):
     custom: Dict[str, Any] = None
 
 
-class TokenClassificationMetrics(BaseTaskMetrics[TokenClassificationRecord]):
+class TokenClassificationMetrics(CommonTasksMetrics[TokenClassificationRecord]):
     """Configured metrics for token classification"""
 
     _PREDICTED_MENTIONS_NAMESPACE = "metrics.predicted.mentions"
@@ -420,8 +420,10 @@ class TokenClassificationMetrics(BaseTaskMetrics[TokenClassificationRecord]):
     @classmethod
     def record_metrics(cls, record: TokenClassificationRecord) -> Dict[str, Any]:
         """Compute metrics at record level"""
+        base_metrics = super(TokenClassificationMetrics, cls).record_metrics(record)
 
         return {
+            **base_metrics,
             "tokens": cls.build_tokens_metrics(record),
             "tokens_length": len(record.tokens),
             **cls.build_mentions_metrics(record),

--- a/tests/functional_tests/test_log_for_token_classification.py
+++ b/tests/functional_tests/test_log_for_token_classification.py
@@ -34,7 +34,8 @@ def test_log_with_empty_tokens_list(mocked_client):
 def test_log_record_that_makes_me_cry(mocked_client):
     dataset = "test_log_record_that_makes_me_cry"
     record = TokenClassificationRecord(
-        text="'Secret Story : Última hora' debuta con un pobre 8.7% en el access de Telecinco.. . PROGRAMAS CON MEJOR CUOTA DEL LUNES (POR CADENAS). . ",
+        text="'Secret Story : Última hora' debuta con un pobre 8.7% en el access de Telecinco.. . "
+        "PROGRAMAS CON MEJOR CUOTA DEL LUNES (POR CADENAS). . ",
         tokens=[
             "'",
             "Secret",
@@ -429,6 +430,7 @@ def test_log_record_that_makes_me_cry(mocked_client):
             },
         ],
         "tokens_length": 31,
+        "text_length": 137,
         "predicted": {
             "mentions": [
                 {


### PR DESCRIPTION
This PR add the missing work developed in #1162, by extending metric classes from `CommonMetrics`