### PR TITLE
docs(setup): the current section format is a bit weird

### DIFF
--- a/docs/getting_started/advanced_setup_guides.rst
+++ b/docs/getting_started/advanced_setup_guides.rst
@@ -168,9 +168,10 @@ Below you can see a screenshot for setting up a new *rubrix* Role and its permis
 Change elasticsearch index analyzers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default, for indexing text fields, Rubrix uses the `standard` analyzer for general search and the `whitespace` analyzer for more exact queries (required by certain rules in the weak supervision module).
- If those analyzers don't fit your use case, you can change them using the following environment variables:
-`RUBRIX_DEFAULT_ES_SEARCH_ANALYZER` and `RUBRIX_EXACT_ES_SEARCH_ANALYZER`.
+By default, for indexing text fields, Rubrix uses the `standard` analyzer for general search and the `whitespace`
+analyzer for more exact queries (required by certain rules in the weak supervision module). If those analyzers
+don't fit your use case, you can change them using the following environment variables:
+``RUBRIX_DEFAULT_ES_SEARCH_ANALYZER`` and ``RUBRIX_EXACT_ES_SEARCH_ANALYZER``.
 
 Note that provided analyzers names should be defined as built-in ones. If you want to use a
 customized analyzer, you should create it inside an index_template matching Rubrix index names (`.rubrix*.records-v0),


### PR DESCRIPTION
See [current docs](https://rubrix.readthedocs.io/en/stable/getting_started/advanced_setup_guides.html#change-elasticsearch-index-analyzers)