### PR TITLE
feat(#981): add majority voter with multi label support

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -198,6 +198,7 @@ You can join the conversation on our Github page and our Github forum.
    tutorials/08-error_analysis_using_loss
    tutorials/09-automatic_fastapi_log
    tutorials/skweak
+   tutorials/weak-supervision-multi-label
 
 .. toctree::
    :maxdepth: 4

--- a/docs/tutorials/weak-supervision-multi-label.ipynb
+++ b/docs/tutorials/weak-supervision-multi-label.ipynb
@@ -67,7 +67,7 @@
     "\n",
     "The original [GoEmotions](https://huggingface.co/datasets/go_emotions) is a challenging dataset intended for multi-label emotion classification.\n",
     "For this tutorial, we simplify it a bit by selecting only 6 out of the 28 emotions: *admiration, annoyance, approval, curiosity, gratitude, optimism*.\n",
-    "We also try to accentuate the multi-label part of the dataset by down-sampling the examples that are classified with one label only.\n",
+    "We also try to accentuate the multi-label part of the dataset by down-sampling the examples that are classified with only one label.\n",
     "See Appendix A for all the details of this preprocessing step."
    ]
   },
@@ -915,7 +915,8 @@
    "source": [
     "## Research topic dataset\n",
     "\n",
-    "See Appendix B for the data preprocessing."
+    "After covering a multi-label emotion classification task, we will try to do the same for a multi-label classification task related to topic modeling.\n",
+    "In this dataset, research papers were classified with 6 non-exclusive labels based on their title and abstract."
    ]
   },
   {
@@ -939,7 +940,7 @@
     "\n",
     "# Download preprocessed dataset\n",
     "ds_rb = rb.read_datasets(\n",
-    "    load_dataset(\"rubrix/go_emotions_multi_label\", split=\"train\", use_auth_token=True),\n",
+    "    load_dataset(\"rubrix/research_titles_multi-label\", split=\"train\", use_auth_token=True),\n",
     "    task=\"TextClassification\"\n",
     ")"
    ]

--- a/docs/tutorials/weak-supervision-multi-label.ipynb
+++ b/docs/tutorials/weak-supervision-multi-label.ipynb
@@ -5,7 +5,7 @@
    "id": "7641399c-d8bc-411b-952b-32a9f2100776",
    "metadata": {},
    "source": [
-    "# Weak supervision in multi-label text classification tasks\n",
+    "# 🗂 Weak supervision in multi-label text classification tasks\n",
     "\n",
     "WORK IN PROGRESS: This tutorial is a work in progress and you can expect some changes within the next few releases.\n",
     "We will showcase new features here as soon as they are available."
@@ -1749,10 +1749,18 @@
   {
    "cell_type": "markdown",
    "id": "dd4b7565-f21a-48c8-99ce-278450a2705b",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Next steps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fda0f2f-683f-4820-8516-dd12e58bd321",
    "metadata": {},
    "source": [
-    "## Next steps\n",
-    "\n",
     "**⭐ Star Rubrix [Github repo](https://github.com/recognai/rubrix) to stay updated.**\n",
     "\n",
     "**📚 [Rubrix documentation](https://docs.rubrix.ml) for more guides and tutorials.**\n",
@@ -1767,7 +1775,7 @@
     "tags": []
    },
    "source": [
-    "## APPENDIX A\n",
+    "## Appendix A\n",
     "\n",
     "This appendix summarizes the preprocessing steps for our curated *GoEmotions* dataset.\n",
     "The goal was to limit the labels, and down-sample single-label annotations to move the focus to multi-label outputs."
@@ -1854,7 +1862,7 @@
    "id": "ef1de2b1-97be-4372-8919-2dfc422a86b1",
    "metadata": {},
    "source": [
-    "## APPENDIX B\n",
+    "## Appendix B\n",
     "\n",
     "This appendix summarizes the minimal preprocessing done to [this multi-label classification dataset](https://www.kaggle.com/shivanandmn/multilabel-classification-dataset) from Kaggle.\n",
     "You can download the original data (`train.csv`) following the Kaggle link.\n",

--- a/docs/tutorials/weak-supervision-multi-label.ipynb
+++ b/docs/tutorials/weak-supervision-multi-label.ipynb
@@ -55,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install datasets transformers[torch] sklearn ipywidgets -qqq"
+    "%pip install datasets transformers[torch] scikit-multilearn ipywidgets -qqq"
    ]
   },
   {
@@ -916,81 +916,62 @@
     "## Research topic dataset\n",
     "\n",
     "After covering a multi-label emotion classification task, we will try to do the same for a multi-label classification task related to topic modeling.\n",
-    "In this dataset, research papers were classified with 6 non-exclusive labels based on their title and abstract."
+    "In this dataset, research papers were classified with 6 non-exclusive labels based on their title and abstract.\n",
+    "\n",
+    "We will try to classify the papers only based on the title, which is considerably harder, but allows us to quickly scan through the data and come up with heuristics.\n",
+    "See Appendix B for all the details of the minimal data preprocessing."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ba65805-bfb2-4027-9231-28538a7873e8",
+   "metadata": {},
+   "source": [
+    "### Define rules\n",
+    "\n",
+    "Let us start by downloading our preprocessed dataset from the Hugging Face Hub, and log it to Rubrix:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "dd4cdd38-604c-4fe6-8104-fc6b136d331a",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2022-03-16 00:17:22.386 | WARNING  | datasets.builder:_create_builder_config:378 - Using custom data configuration rubrix--go_emotions_multi_label-c52a16149c24284f\n",
-      "2022-03-16 00:17:22.392 | WARNING  | datasets.builder:download_and_prepare:531 - Reusing dataset parquet (/home/david/.cache/huggingface/datasets/parquet/rubrix--go_emotions_multi_label-c52a16149c24284f/0.0.0/0b6d5799bb726b24ad7fc7be720c170d8e497f575d02d47537de9a5bac074901)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import rubrix as rb\n",
     "from datasets import load_dataset\n",
     "\n",
     "# Download preprocessed dataset\n",
     "ds_rb = rb.read_datasets(\n",
-    "    load_dataset(\"rubrix/research_titles_multi-label\", split=\"train\", use_auth_token=True),\n",
+    "    load_dataset(\"rubrix/research_titles_multi-label\", split=\"train\"),\n",
     "    task=\"TextClassification\"\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": null,
    "id": "34899478-62ae-4864-8196-36348aa568c3",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4626453ea0af4a2cb96b91add2bfcbf6",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/20972 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "20972 records logged to http://localhost:6900/ws/rubrix/research_titles\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "BulkResponse(dataset='research_titles', processed=20972, failed=0)"
-      ]
-     },
-     "execution_count": 95,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Log dataset to Rubrix to find good heuristics\n",
-    "rb.log(records, \"research_titles\")"
+    "rb.log(ds_rb, \"research_titles\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a95ac66-480b-4bf2-b35c-e548df16a084",
+   "metadata": {},
+   "source": [
+    "Now we can inspect the research titles and try to come up with good heuristic rules.\n",
+    "Here we came up with the following ones that surely can be improved:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 54,
    "id": "8f85fd20-7086-4581-9078-2a28c9155997",
    "metadata": {},
    "outputs": [],
@@ -1011,6 +992,7 @@
     "    Rule(\"system* AND design*\", \"Computer Science\"),\n",
     "    Rule(\"allocat* AND *net*\", \"Computer Science\"),\n",
     "    Rule(\"program\", \"Computer Science\"),\n",
+    "    Rule(\"classification* AND (label* OR deep)\", \"Computer Science\"),\n",
     "    Rule(\"scattering\", \"Physics\"),\n",
     "    Rule(\"astro*\", \"Physics\"),\n",
     "    Rule(\"material*\", \"Physics\"),\n",
@@ -1034,61 +1016,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "93311e7a-4522-4036-9151-10edc1101d3d",
+   "metadata": {},
+   "source": [
+    "We go on and apply these heuristic rules to our dataset creating our weak label matrix.\n",
+    "As mentioned in the [GoEmotions](#goemotions) section, the weak label matrix will have 3 dimensions and values of -1, 0 and 1."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "c41d2c90-e550-4d44-9935-b5eeea415c67",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2022-03-16 00:17:31.646 | WARNING  | rubrix.client.api:load:366 - The argument 'as_pandas' in `rb.load` will be deprecated in the future, and we will always return a `Dataset`. To emulate the future behavior set `as_pandas=False`. To get a pandas DataFrame, call `Dataset.to_pandas()`\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "65ae298816df4df3b8700a32b8135265",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Preparing rules:   0%|          | 0/31 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6e5356b5e04645a89c180c89ec0e61ea",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Applying rules:   0%|          | 0/20972 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "830b4f9c1c0747dfbe2e9ec021267267",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Filling weak label matrix:   0%|          | 0/20972 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from rubrix.labeling.text_classification import WeakMultiLabels\n",
     "\n",
@@ -1097,8 +1038,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "fa6a2585-58cc-4eae-b5da-e31e29fd188d",
+   "metadata": {},
+   "source": [
+    "Let us get an overview of the our heuristics and how they perform:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 56,
    "id": "a5bfc002-0845-4d36-b2c5-8133995561ce",
    "metadata": {},
    "outputs": [
@@ -1198,7 +1147,7 @@
        "      <td>{Computer Science}</td>\n",
        "      <td>0.009155</td>\n",
        "      <td>0.010250</td>\n",
-       "      <td>0.002098</td>\n",
+       "      <td>0.002909</td>\n",
        "      <td>32</td>\n",
        "      <td>11</td>\n",
        "      <td>0.744186</td>\n",
@@ -1208,7 +1157,7 @@
        "      <td>{Computer Science}</td>\n",
        "      <td>0.010109</td>\n",
        "      <td>0.009297</td>\n",
-       "      <td>0.002146</td>\n",
+       "      <td>0.002241</td>\n",
        "      <td>32</td>\n",
        "      <td>7</td>\n",
        "      <td>0.820513</td>\n",
@@ -1252,6 +1201,16 @@
        "      <td>11</td>\n",
        "      <td>2</td>\n",
        "      <td>0.846154</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>classification* AND (label* OR deep)</th>\n",
+       "      <td>{Computer Science}</td>\n",
+       "      <td>0.003338</td>\n",
+       "      <td>0.004052</td>\n",
+       "      <td>0.001335</td>\n",
+       "      <td>14</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.823529</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>scattering</th>\n",
@@ -1338,7 +1297,7 @@
        "      <td>{Mathematics}</td>\n",
        "      <td>0.014829</td>\n",
        "      <td>0.018355</td>\n",
-       "      <td>0.000572</td>\n",
+       "      <td>0.000620</td>\n",
        "      <td>70</td>\n",
        "      <td>7</td>\n",
        "      <td>0.909091</td>\n",
@@ -1368,7 +1327,7 @@
        "      <td>{Mathematics}</td>\n",
        "      <td>0.010586</td>\n",
        "      <td>0.009774</td>\n",
-       "      <td>0.001812</td>\n",
+       "      <td>0.001860</td>\n",
        "      <td>38</td>\n",
        "      <td>3</td>\n",
        "      <td>0.926829</td>\n",
@@ -1388,7 +1347,7 @@
        "      <td>{Statistics}</td>\n",
        "      <td>0.009393</td>\n",
        "      <td>0.009058</td>\n",
-       "      <td>0.002527</td>\n",
+       "      <td>0.002575</td>\n",
        "      <td>33</td>\n",
        "      <td>5</td>\n",
        "      <td>0.868421</td>\n",
@@ -1408,7 +1367,7 @@
        "      <td>{Statistics}</td>\n",
        "      <td>0.021266</td>\n",
        "      <td>0.021216</td>\n",
-       "      <td>0.003338</td>\n",
+       "      <td>0.003385</td>\n",
        "      <td>65</td>\n",
        "      <td>24</td>\n",
        "      <td>0.730337</td>\n",
@@ -1445,123 +1404,126 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>total</th>\n",
-       "      <td>{Quantitative Biology, Computer Science, Stati...</td>\n",
-       "      <td>0.174614</td>\n",
-       "      <td>0.183075</td>\n",
-       "      <td>0.016737</td>\n",
-       "      <td>706</td>\n",
-       "      <td>132</td>\n",
-       "      <td>0.842482</td>\n",
+       "      <td>{Quantitative Biology, Mathematics, Physics, S...</td>\n",
+       "      <td>0.176616</td>\n",
+       "      <td>0.185936</td>\n",
+       "      <td>0.017833</td>\n",
+       "      <td>720</td>\n",
+       "      <td>135</td>\n",
+       "      <td>0.842105</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                                                              label  \\\n",
-       "stock*                                                       {Quantitative Finance}   \n",
-       "*asset*                                                      {Quantitative Finance}   \n",
-       "trading                                                      {Quantitative Finance}   \n",
-       "finance                                                      {Quantitative Finance}   \n",
-       "pric*                                                        {Quantitative Finance}   \n",
-       "economy                                                      {Quantitative Finance}   \n",
-       "deep AND neural AND network*                                     {Computer Science}   \n",
-       "convolutional                                                    {Computer Science}   \n",
-       "memor* AND (design* OR network*)                                 {Computer Science}   \n",
-       "system* AND design*                                              {Computer Science}   \n",
-       "allocat* AND *net*                                               {Computer Science}   \n",
-       "program                                                          {Computer Science}   \n",
-       "scattering                                                                {Physics}   \n",
-       "astro*                                                                    {Physics}   \n",
-       "material*                                                                 {Physics}   \n",
-       "spin                                                                      {Physics}   \n",
-       "magnetic                                                                  {Physics}   \n",
-       "optical                                                                   {Physics}   \n",
-       "ray                                                                       {Physics}   \n",
-       "entangle*                                                                 {Physics}   \n",
-       "*algebra*                                                             {Mathematics}   \n",
-       "manifold* AND (NOT learn*)                                            {Mathematics}   \n",
-       "equation                                                              {Mathematics}   \n",
-       "spaces                                                                {Mathematics}   \n",
-       "operators                                                             {Mathematics}   \n",
-       "regression                                                             {Statistics}   \n",
-       "bayes*                                                                 {Statistics}   \n",
-       "estimation                                                             {Statistics}   \n",
-       "mixture                                                                {Statistics}   \n",
-       "gaussian                                                               {Statistics}   \n",
-       "gene                                                         {Quantitative Biology}   \n",
-       "total                             {Quantitative Biology, Computer Science, Stati...   \n",
+       "                                                                                  label  \\\n",
+       "stock*                                                           {Quantitative Finance}   \n",
+       "*asset*                                                          {Quantitative Finance}   \n",
+       "trading                                                          {Quantitative Finance}   \n",
+       "finance                                                          {Quantitative Finance}   \n",
+       "pric*                                                            {Quantitative Finance}   \n",
+       "economy                                                          {Quantitative Finance}   \n",
+       "deep AND neural AND network*                                         {Computer Science}   \n",
+       "convolutional                                                        {Computer Science}   \n",
+       "memor* AND (design* OR network*)                                     {Computer Science}   \n",
+       "system* AND design*                                                  {Computer Science}   \n",
+       "allocat* AND *net*                                                   {Computer Science}   \n",
+       "program                                                              {Computer Science}   \n",
+       "classification* AND (label* OR deep)                                 {Computer Science}   \n",
+       "scattering                                                                    {Physics}   \n",
+       "astro*                                                                        {Physics}   \n",
+       "material*                                                                     {Physics}   \n",
+       "spin                                                                          {Physics}   \n",
+       "magnetic                                                                      {Physics}   \n",
+       "optical                                                                       {Physics}   \n",
+       "ray                                                                           {Physics}   \n",
+       "entangle*                                                                     {Physics}   \n",
+       "*algebra*                                                                 {Mathematics}   \n",
+       "manifold* AND (NOT learn*)                                                {Mathematics}   \n",
+       "equation                                                                  {Mathematics}   \n",
+       "spaces                                                                    {Mathematics}   \n",
+       "operators                                                                 {Mathematics}   \n",
+       "regression                                                                 {Statistics}   \n",
+       "bayes*                                                                     {Statistics}   \n",
+       "estimation                                                                 {Statistics}   \n",
+       "mixture                                                                    {Statistics}   \n",
+       "gaussian                                                                   {Statistics}   \n",
+       "gene                                                             {Quantitative Biology}   \n",
+       "total                                 {Quantitative Biology, Mathematics, Physics, S...   \n",
        "\n",
-       "                                  coverage  annotated_coverage  overlaps  \\\n",
-       "stock*                            0.000954            0.000715  0.000334   \n",
-       "*asset*                           0.000477            0.000715  0.000286   \n",
-       "trading                           0.000954            0.000238  0.000191   \n",
-       "finance                           0.000048            0.000238  0.000000   \n",
-       "pric*                             0.003433            0.003337  0.000715   \n",
-       "economy                           0.000238            0.000238  0.000000   \n",
-       "deep AND neural AND network*      0.009155            0.010250  0.002098   \n",
-       "convolutional                     0.010109            0.009297  0.002146   \n",
-       "memor* AND (design* OR network*)  0.001383            0.002145  0.000286   \n",
-       "system* AND design*               0.001144            0.002384  0.000238   \n",
-       "allocat* AND *net*                0.000763            0.000715  0.000000   \n",
-       "program                           0.002623            0.003099  0.000143   \n",
-       "scattering                        0.004053            0.002861  0.001001   \n",
-       "astro*                            0.003099            0.004052  0.000620   \n",
-       "material*                         0.004148            0.003099  0.000238   \n",
-       "spin                              0.013542            0.015018  0.002146   \n",
-       "magnetic                          0.011301            0.012872  0.002432   \n",
-       "optical                           0.007105            0.006913  0.001097   \n",
-       "ray                               0.005865            0.007390  0.001192   \n",
-       "entangle*                         0.002623            0.002861  0.000095   \n",
-       "*algebra*                         0.014829            0.018355  0.000572   \n",
-       "manifold* AND (NOT learn*)        0.007057            0.008343  0.000858   \n",
-       "equation                          0.010681            0.007867  0.000954   \n",
-       "spaces                            0.010586            0.009774  0.001812   \n",
-       "operators                         0.006151            0.005959  0.001526   \n",
-       "regression                        0.009393            0.009058  0.002527   \n",
-       "bayes*                            0.015306            0.014779  0.003147   \n",
-       "estimation                        0.021266            0.021216  0.003338   \n",
-       "mixture                           0.003290            0.003099  0.001287   \n",
-       "gaussian                          0.009250            0.011204  0.002766   \n",
-       "gene                              0.001287            0.001669  0.000191   \n",
-       "total                             0.174614            0.183075  0.016737   \n",
+       "                                      coverage  annotated_coverage  overlaps  \\\n",
+       "stock*                                0.000954            0.000715  0.000334   \n",
+       "*asset*                               0.000477            0.000715  0.000286   \n",
+       "trading                               0.000954            0.000238  0.000191   \n",
+       "finance                               0.000048            0.000238  0.000000   \n",
+       "pric*                                 0.003433            0.003337  0.000715   \n",
+       "economy                               0.000238            0.000238  0.000000   \n",
+       "deep AND neural AND network*          0.009155            0.010250  0.002909   \n",
+       "convolutional                         0.010109            0.009297  0.002241   \n",
+       "memor* AND (design* OR network*)      0.001383            0.002145  0.000286   \n",
+       "system* AND design*                   0.001144            0.002384  0.000238   \n",
+       "allocat* AND *net*                    0.000763            0.000715  0.000000   \n",
+       "program                               0.002623            0.003099  0.000143   \n",
+       "classification* AND (label* OR deep)  0.003338            0.004052  0.001335   \n",
+       "scattering                            0.004053            0.002861  0.001001   \n",
+       "astro*                                0.003099            0.004052  0.000620   \n",
+       "material*                             0.004148            0.003099  0.000238   \n",
+       "spin                                  0.013542            0.015018  0.002146   \n",
+       "magnetic                              0.011301            0.012872  0.002432   \n",
+       "optical                               0.007105            0.006913  0.001097   \n",
+       "ray                                   0.005865            0.007390  0.001192   \n",
+       "entangle*                             0.002623            0.002861  0.000095   \n",
+       "*algebra*                             0.014829            0.018355  0.000620   \n",
+       "manifold* AND (NOT learn*)            0.007057            0.008343  0.000858   \n",
+       "equation                              0.010681            0.007867  0.000954   \n",
+       "spaces                                0.010586            0.009774  0.001860   \n",
+       "operators                             0.006151            0.005959  0.001526   \n",
+       "regression                            0.009393            0.009058  0.002575   \n",
+       "bayes*                                0.015306            0.014779  0.003147   \n",
+       "estimation                            0.021266            0.021216  0.003385   \n",
+       "mixture                               0.003290            0.003099  0.001287   \n",
+       "gaussian                              0.009250            0.011204  0.002766   \n",
+       "gene                                  0.001287            0.001669  0.000191   \n",
+       "total                                 0.176616            0.185936  0.017833   \n",
        "\n",
-       "                                  correct  incorrect  precision  \n",
-       "stock*                                  3          0   1.000000  \n",
-       "*asset*                                 3          0   1.000000  \n",
-       "trading                                 1          0   1.000000  \n",
-       "finance                                 1          0   1.000000  \n",
-       "pric*                                   9          5   0.642857  \n",
-       "economy                                 1          0   1.000000  \n",
-       "deep AND neural AND network*           32         11   0.744186  \n",
-       "convolutional                          32          7   0.820513  \n",
-       "memor* AND (design* OR network*)        9          0   1.000000  \n",
-       "system* AND design*                     9          1   0.900000  \n",
-       "allocat* AND *net*                      3          0   1.000000  \n",
-       "program                                11          2   0.846154  \n",
-       "scattering                             10          2   0.833333  \n",
-       "astro*                                 17          0   1.000000  \n",
-       "material*                              10          3   0.769231  \n",
-       "spin                                   60          3   0.952381  \n",
-       "magnetic                               49          5   0.907407  \n",
-       "optical                                27          2   0.931034  \n",
-       "ray                                    27          4   0.870968  \n",
-       "entangle*                              11          1   0.916667  \n",
-       "*algebra*                              70          7   0.909091  \n",
-       "manifold* AND (NOT learn*)             28          7   0.800000  \n",
-       "equation                               24          9   0.727273  \n",
-       "spaces                                 38          3   0.926829  \n",
-       "operators                              22          3   0.880000  \n",
-       "regression                             33          5   0.868421  \n",
-       "bayes*                                 49         13   0.790323  \n",
-       "estimation                             65         24   0.730337  \n",
-       "mixture                                10          3   0.769231  \n",
-       "gaussian                               36         11   0.765957  \n",
-       "gene                                    6          1   0.857143  \n",
-       "total                                 706        132   0.842482  "
+       "                                      correct  incorrect  precision  \n",
+       "stock*                                      3          0   1.000000  \n",
+       "*asset*                                     3          0   1.000000  \n",
+       "trading                                     1          0   1.000000  \n",
+       "finance                                     1          0   1.000000  \n",
+       "pric*                                       9          5   0.642857  \n",
+       "economy                                     1          0   1.000000  \n",
+       "deep AND neural AND network*               32         11   0.744186  \n",
+       "convolutional                              32          7   0.820513  \n",
+       "memor* AND (design* OR network*)            9          0   1.000000  \n",
+       "system* AND design*                         9          1   0.900000  \n",
+       "allocat* AND *net*                          3          0   1.000000  \n",
+       "program                                    11          2   0.846154  \n",
+       "classification* AND (label* OR deep)       14          3   0.823529  \n",
+       "scattering                                 10          2   0.833333  \n",
+       "astro*                                     17          0   1.000000  \n",
+       "material*                                  10          3   0.769231  \n",
+       "spin                                       60          3   0.952381  \n",
+       "magnetic                                   49          5   0.907407  \n",
+       "optical                                    27          2   0.931034  \n",
+       "ray                                        27          4   0.870968  \n",
+       "entangle*                                  11          1   0.916667  \n",
+       "*algebra*                                  70          7   0.909091  \n",
+       "manifold* AND (NOT learn*)                 28          7   0.800000  \n",
+       "equation                                   24          9   0.727273  \n",
+       "spaces                                     38          3   0.926829  \n",
+       "operators                                  22          3   0.880000  \n",
+       "regression                                 33          5   0.868421  \n",
+       "bayes*                                     49         13   0.790323  \n",
+       "estimation                                 65         24   0.730337  \n",
+       "mixture                                    10          3   0.769231  \n",
+       "gaussian                                   36         11   0.765957  \n",
+       "gene                                        6          1   0.857143  \n",
+       "total                                     720        135   0.842105  "
       ]
      },
-     "execution_count": 4,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1572,8 +1534,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "49fd5c07-7e51-4c3f-bd7d-c6bbec5194c4",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Create training set\n",
+    "\n",
+    "When we are happy with our heuristics, it is time to combine them and compute weak labels for the training of our downstream model.\n",
+    "As for the \"GoEmotions\" dataset, we will use the simple `MajorityVoter`."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 57,
    "id": "8152fabd-969d-40b1-a4fc-956f8783ce29",
    "metadata": {},
    "outputs": [],
@@ -1585,8 +1560,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "9cda9587-7531-4780-9bc9-489f7e6d7523",
+   "metadata": {},
+   "source": [
+    "From our label model we get the training records together with its weak labels and probabilities.\n",
+    "Since we are going to train an sklearn model, we will put the records in a pandas DataFrame that generally has a good integration with the sklearn ecosystem."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 58,
    "id": "f7edc676-5c9a-4b21-82d6-1a820b466483",
    "metadata": {},
    "outputs": [],
@@ -1595,8 +1579,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e01f7528-a499-49aa-a851-f41779b099df",
+   "metadata": {},
+   "source": [
+    "Before training our model, we need to extract the training labels from the label model predictions and transform them into a multi-label compatible format."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 59,
    "id": "f45f92a3-b9a8-482a-9f37-52e4802790b4",
    "metadata": {},
    "outputs": [],
@@ -1604,6 +1596,7 @@
     "# Create labels in multi-label format\n",
     "train_df[\"label\"] = train_df.prediction.map(\n",
     "    lambda x: [\n",
+    "        # we will use a threshold of 0.5 for the probability\n",
     "        {p[0]: int(p[1] > 0.5) for p in x}[label] \n",
     "        for label in weak_labels.labels\n",
     "    ]\n",
@@ -1611,13 +1604,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b976259c-15b6-4d61-b4e3-640f5a4282b2",
+   "metadata": {},
+   "source": [
+    "Now, let us define our downstream model and train it.\n",
+    "\n",
+    "We will use the [scikit-multilearn library](http://scikit.ml/) to wrap a multinomial **Naive Bayes classifier** that is suitable for classification with discrete features (e.g., word counts for text classification).\n",
+    "The `BinaryRelevance` class transforms the multi-label problem with L labels into L single-label binary classification problems, so in the end we will automatically fit L naive bayes classifiers to our data.\n",
+    "\n",
+    "The features for our classifier will be the counts of different word [n-grams](https://en.wikipedia.org/wiki/N-gram): that is, for each example we count the number of contiguous sequences of *n* words, where n goes from 1 to 5.\n",
+    "We extract these features with the `CountVectorizer`.\n",
+    "\n",
+    "Finally, we will put our feature extractor and multi-label classifier in a sklearn pipeline that makes fitting and scoring the model a breeze."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 147,
    "id": "7f2a5d4b-4d6a-4dc0-8533-287f92c745f4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from skmultilearn.problem_transform import ClassifierChain, BinaryRelevance\n",
+    "from skmultilearn.problem_transform import BinaryRelevance\n",
     "from sklearn.feature_extraction.text import CountVectorizer\n",
     "from sklearn.naive_bayes import MultinomialNB\n",
     "from sklearn.pipeline import Pipeline\n",
@@ -1630,25 +1639,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "cb281796-cce4-40b8-b583-ae2574fde3e7",
+   "metadata": {},
+   "source": [
+    "Training the model is as easy as calling the `fit` method on the our pipeline, and provide our training text and training labels."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "019aae12-aab3-4d9c-9695-80018541c3ca",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Pipeline(steps=[('vect', CountVectorizer()),\n",
-       "                ('clf',\n",
-       "                 BinaryRelevance(classifier=MultinomialNB(),\n",
-       "                                 require_dense=[True, True]))])"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -1660,8 +1663,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "7cb69af9-8edc-46f8-80c9-b842d99986d2",
+   "metadata": {},
+   "source": [
+    "To score our trained model, we retrieve its predictions of the test set and use sklearn's `classification_report` to get all important classification metrics in a nicely formatted string."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 86,
    "id": "858f1c6e-99df-4918-803c-18647e2edd68",
    "metadata": {},
    "outputs": [],
@@ -1674,7 +1685,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 77,
    "id": "8b12a128-a184-494d-a926-6100a9d252da",
    "metadata": {},
    "outputs": [
@@ -1682,28 +1693,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "              precision    recall  f1-score   support\n",
+      "                      precision    recall  f1-score   support\n",
       "\n",
-      "           0       0.81      0.23      0.36      1740\n",
-      "           1       0.77      0.59      0.67      1141\n",
-      "           2       0.88      0.66      0.75      1186\n",
-      "           3       0.50      0.01      0.02       109\n",
-      "           4       0.45      0.11      0.18        45\n",
-      "           5       0.55      0.67      0.60      1069\n",
+      "    Computer Science       0.82      0.26      0.40      1740\n",
+      "         Mathematics       0.71      0.64      0.67      1141\n",
+      "             Physics       0.81      0.70      0.75      1186\n",
+      "Quantitative Biology       1.00      0.01      0.02       109\n",
+      "Quantitative Finance       0.44      0.09      0.15        45\n",
+      "          Statistics       0.48      0.71      0.57      1069\n",
       "\n",
-      "   micro avg       0.72      0.49      0.58      5290\n",
-      "   macro avg       0.66      0.38      0.43      5290\n",
-      "weighted avg       0.75      0.49      0.56      5290\n",
-      " samples avg       0.58      0.52      0.53      5290\n",
+      "           micro avg       0.66      0.53      0.59      5290\n",
+      "           macro avg       0.71      0.40      0.43      5290\n",
+      "        weighted avg       0.73      0.53      0.56      5290\n",
+      "         samples avg       0.66      0.56      0.59      5290\n",
       "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/david/miniconda3/envs/rubrix/lib/python3.8/site-packages/sklearn/metrics/_classification.py:1248: UndefinedMetricWarning: Precision and F-score are ill-defined and being set to 0.0 in samples with no predicted labels. Use `zero_division` parameter to control this behavior.\n",
-      "  _warn_prf(average, modifier, msg_start, len(result))\n"
      ]
     }
    ],
@@ -1711,7 +1714,50 @@
     "from sklearn.metrics import classification_report\n",
     "\n",
     "# Compute metrics\n",
-    "print(classification_report(weak_labels.annotation(), predictions))"
+    "print(classification_report(\n",
+    "    weak_labels.annotation(), \n",
+    "    predictions, \n",
+    "    target_names=weak_labels.labels\n",
+    "))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dbe8a43e-0405-4d45-b117-aff8865ed305",
+   "metadata": {},
+   "source": [
+    "We obtain a micro averaged F1 score of around 0.59, which again is not perfect but can serve as a decent baseline for future improvements.\n",
+    "Looking at the F1 per label, we see that the main problem is the recall of our heuristics and we should either define more of them, or try to find more general ones. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d66e81db-da5d-49ff-ab1a-dc8749b8783d",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this tutorial we saw how you can use *Rubrix* to tackle multi-label text classification problems with weak supervision.\n",
+    "We showed you how to train two downstream models on two different multi-label datasets using the discovered heuristics.\n",
+    "\n",
+    "For the emotion classification task, we trained a full-blown transformer model with Hugging Face, while for the topic classification task, we relied on a more lightweight Bayes classifier from sklearn.\n",
+    "Although the results are not perfect, they can serve as a good baseline for future improvements.\n",
+    "\n",
+    "So the next time you encounter a multi-label classification problem, maybe try out weak supervision with *Rubrix* and save some time for your annotation team 😀."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd4b7565-f21a-48c8-99ce-278450a2705b",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "**⭐ Star Rubrix [Github repo](https://github.com/recognai/rubrix) to stay updated.**\n",
+    "\n",
+    "**📚 [Rubrix documentation](https://docs.rubrix.ml) for more guides and tutorials.**\n",
+    "\n",
+    "**🙋‍♀️ Join the Rubrix community! A good place to start is the [discussion forum](https://github.com/recognai/rubrix/discussions).**"
    ]
   },
   {
@@ -1723,7 +1769,8 @@
    "source": [
     "## APPENDIX A\n",
     "\n",
-    "We want to limit the labels, and down-sample single-label annotations to move the focus to multi-label outputs."
+    "This appendix summarizes the preprocessing steps for our curated *GoEmotions* dataset.\n",
+    "The goal was to limit the labels, and down-sample single-label annotations to move the focus to multi-label outputs."
    ]
   },
   {
@@ -1733,117 +1780,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# load original dataset and check label frequencies\n",
+    "\n",
     "import pandas as pd\n",
-    "import datasets"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "cf227957-7eb6-4ac5-b9d5-f3c671865377",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "No config specified, defaulting to: go_emotions/simplified\n",
-      "Reusing dataset go_emotions (/home/david/.cache/huggingface/datasets/go_emotions/simplified/0.0.0/2637cfdd4e64d30249c3ed2150fa2b9d279766bfcd6a809b9f085c61a90d776d)\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2cecb0f3b98f45f2bdcfbdab50ff9c00",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/3 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "go_emotions = datasets.load_dataset(\"go_emotions\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "814047aa-d1df-4da4-9f68-2562f08bf9fa",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df = go_emotions[\"test\"].to_pandas()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "6444063b-2bb7-4653-9dfe-eb57306bc296",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "import datasets\n",
+    "\n",
+    "go_emotions = datasets.load_dataset(\"go_emotions\")\n",
+    "df = go_emotions[\"test\"].to_pandas()\n",
+    "\n",
     "def int2str(i):\n",
     "    #return int(i)\n",
-    "    return go_emotions[\"train\"].features[\"labels\"].feature.int2str(int(i))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "a75bfea6-cc9e-4d29-b091-b8cd9459069a",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "27    181\n",
-       "0     156\n",
-       "3     126\n",
-       "4     115\n",
-       "7     108\n",
-       "15     92\n",
-       "20     79\n",
-       "1      78\n",
-       "18     78\n",
-       "10     72\n",
-       "17     68\n",
-       "2      67\n",
-       "9      63\n",
-       "22     56\n",
-       "6      56\n",
-       "26     54\n",
-       "25     54\n",
-       "5      49\n",
-       "11     47\n",
-       "13     46\n",
-       "8      27\n",
-       "12     14\n",
-       "14     13\n",
-       "24     12\n",
-       "19     11\n",
-       "21      9\n",
-       "23      4\n",
-       "16      4\n",
-       "dtype: int64"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "label_freq = []\n",
+    "    return go_emotions[\"train\"].features[\"labels\"].feature.int2str(int(i))\n",
     "\n",
+    "label_freq = []\n",
     "idx_multi = df.labels.map(lambda x: len(x) > 1)\n",
     "df[\"is_single\"] = df.labels.map(lambda x: 0 if len(x) > 1 else 1) \n",
     "df[idx_multi].labels.map(lambda x: [label_freq.append(int(l)) for l in x])\n",
-    "pd.Series(label_freq).value_counts()"
+    "pd.Series(label_freq).value_counts();"
    ]
   },
   {
@@ -1853,6 +1806,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# limit labels, down-sample single-label annotations and create Rubrix records\n",
+    "\n",
+    "import rubrix as rb\n",
+    "\n",
     "def create(split: str) -> pd.DataFrame:\n",
     "    df = go_emotions[split].to_pandas()\n",
     "    df[\"is_single\"] = df.labels.map(lambda x: 0 if len(x) > 1 else 1)\n",
@@ -1861,17 +1818,7 @@
     "    idx_most_common = df.labels.map(lambda x: all([int(label) in [0, 4, 3, 15, 7, 15, 20] for label in x]))\n",
     "    df_multi = df[(df.is_single == 0) & idx_most_common]\n",
     "    df_single = df[idx_most_common].sample(3*len(df_multi), weights=\"is_single\", axis=0, random_state=42)\n",
-    "    return pd.concat([df_multi, df_single]).sample(frac=1, random_state=42)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "id": "c784365d-4830-481d-a771-57a0d9623cf7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import rubrix as rb\n",
+    "    return pd.concat([df_multi, df_single]).sample(frac=1, random_state=42)\n",
     "\n",
     "def make_records(row, is_train: bool) -> rb.TextClassificationRecord:\n",
     "    annotation = [int2str(i) for i in row.labels] if not is_train else None\n",
@@ -1880,36 +1827,11 @@
     "        annotation=annotation,\n",
     "        multi_label=True,\n",
     "        id=row.id,\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "id": "fa658986-026e-4936-9c78-25b8c65516bc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "train_recs = create(\"train\").apply(make_records, axis=1, is_train=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "id": "a4ce778d-83b1-4799-9a67-f304f027cb5f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "test_recs = create(\"test\").apply(make_records, axis=1, is_train=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "id": "b1e552bc-df6f-4368-8d30-7d8e35238fc4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "    )\n",
+    "\n",
+    "train_recs = create(\"train\").apply(make_records, axis=1, is_train=True)\n",
+    "test_recs = create(\"test\").apply(make_records, axis=1, is_train=False)\n",
+    "\n",
     "records = train_recs.to_list() + test_recs.tolist()"
    ]
   },
@@ -1920,31 +1842,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds_rb = rb.DatasetForTextClassification(records).to_datasets()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "id": "f61ddb4d-1387-47b4-b01c-3072e835e4ed",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "97ff3efe852046beb60232c09e4c04b2",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Pushing dataset shards to the dataset hub:   0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
+    "# publish dataset in the Hub\n",
+    "\n",
+    "ds_rb = rb.DatasetForTextClassification(records).to_datasets()\n",
+    "\n",
     "ds_rb.push_to_hub(\"rubrix/go_emotions_multi-label\", private=True)"
    ]
   },
@@ -1955,138 +1856,56 @@
    "source": [
     "## APPENDIX B\n",
     "\n",
-    "https://www.kaggle.com/shivanandmn/multilabel-classification-dataset"
+    "This appendix summarizes the minimal preprocessing done to [this multi-label classification dataset](https://www.kaggle.com/shivanandmn/multilabel-classification-dataset) from Kaggle.\n",
+    "You can download the original data (`train.csv`) following the Kaggle link.\n",
+    "\n",
+    "The preprocessing consists of extracting only the title from the research paper, and split the data into a train and validation set."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 16,
    "id": "708ac8e3-b809-430a-941a-ac0d5fb36446",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "55420944-3786-4dab-9b35-7cbcc47a9cad",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df = pd.read_csv(\"/home/david/Downloads/topic_modeling_researc_articles/train.csv\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "87774d1a-b14a-41ff-9080-0eb34c008db0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.model_selection import train_test_split"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "d16639d4-1e3a-4c71-b629-3090c8223830",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "_, test_id = train_test_split(df.ID, test_size=0.2, random_state=42)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "771f9ebf-4f12-4533-b3f9-f2a820ea0074",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "labels = [\"Computer Science\", \"Physics\", \"Mathematics\", \"Statistics\", \"Quantitative Biology\", \"Quantitative Finance\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "2b539077-6dec-459b-ab48-0684410d78dd",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "# Extact the title and split the data\n",
+    "\n",
+    "import pandas as pd\n",
+    "import rubrix as rb\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "df = pd.read_csv(\"train.csv\")\n",
+    "\n",
+    "_, test_id = train_test_split(df.ID, test_size=0.2, random_state=42)\n",
+    "\n",
+    "labels = [\"Computer Science\", \"Physics\", \"Mathematics\", \"Statistics\", \"Quantitative Biology\", \"Quantitative Finance\"]\n",
     "def make_record(row):\n",
     "    annotation = [label for label in labels if row[label] == 1]\n",
     "    return rb.TextClassificationRecord(\n",
     "        inputs=row.TITLE,\n",
+    "        # inputs={\"title\": row.TITLE, \"abstract\": row.ABSTRACT},\n",
     "        annotation=annotation if row.ID in test_id else None,\n",
     "        multi_label=True,\n",
     "        id=row.ID,\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "cb7e6338-d3e8-41c5-a130-7b0b20a068e4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "    )\n",
+    "\n",
     "records = df.apply(make_record, axis=1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "a2de5c5a-8eb4-49a7-b0f5-d6f2283323fa",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import rubrix as rb"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "8d68ba77-89ec-4856-87b1-603be88ae1da",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dataset_rb = rb.DatasetForTextClassification(records.tolist())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "b47a6b98-d0a1-459e-b5bd-3514d5692d42",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9eeb3777625a4bb8849460ba43ff6ab4",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Pushing dataset shards to the dataset hub:   0%|          | 0/1 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "dataset_rb.to_datasets().push_to_hub(\"rubrix/research_titles_multi-label\", private=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3987ecd4-1d4c-475b-be38-b94381ae9d4d",
-   "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# publish the dataset in the Hub\n",
+    "\n",
+    "dataset_rb = rb.DatasetForTextClassification(records.tolist())\n",
+    "\n",
+    "dataset_rb.to_datasets().push_to_hub(\"rubrix/research_titles_multi-label\")"
+   ]
   }
  ],
  "metadata": {

--- a/docs/tutorials/weak-supervision-multi-label.ipynb
+++ b/docs/tutorials/weak-supervision-multi-label.ipynb
@@ -115,7 +115,9 @@
    "metadata": {},
    "source": [
     "After uploading the dataset, we can explore and inspect it to find good heuristic rules.\n",
-    "Here we came up with the following ones that surely can be improved:"
+    "For this we highly recommend the dedicated [*Define rules* mode](../reference/webapp/define_rules.md) of the Rubrix web app, that allows you to quickly iterate over heuristic rules, compute their metrics and save them.\n",
+    "\n",
+    "Here we copy our rules found via the web app to the notebook for you to easily follow along the tutorial."
    ]
   },
   {
@@ -127,7 +129,7 @@
    "source": [
     "from rubrix.labeling.text_classification import Rule\n",
     "\n",
-    "# Define our heuristic rules (can probably be improved)\n",
+    "# Define our heuristic rules, they can surely be improved\n",
     "rules = [\n",
     "    Rule(\"thank*\", \"gratitude\"),\n",
     "    Rule(\"appreciate\", \"gratitude\"),\n",
@@ -177,7 +179,8 @@
    "source": [
     "from rubrix.labeling.text_classification import WeakMultiLabels\n",
     "\n",
-    "# Compute the weak labels for our dataset given the rules\n",
+    "# Compute the weak labels for our dataset given the rules.\n",
+    "# If your dataset already contains rules you can omit the rules argument.\n",
     "weak_labels = WeakMultiLabels(\"go_emotions\", rules=rules)"
    ]
   },
@@ -965,8 +968,10 @@
    "id": "1a95ac66-480b-4bf2-b35c-e548df16a084",
    "metadata": {},
    "source": [
-    "Now we can inspect the research titles and try to come up with good heuristic rules.\n",
-    "Here we came up with the following ones that surely can be improved:"
+    "After uploading the dataset, we can explore and inspect it to find good heuristic rules.\n",
+    "For this we highly recommend the dedicated [*Define rules* mode](../reference/webapp/define_rules.md) of the Rubrix web app, that allows you to quickly iterate over heuristic rules, compute their metrics and save them.\n",
+    "\n",
+    "Here we copy our rules found via the web app to the notebook for you to easily follow along the tutorial."
    ]
   },
   {
@@ -1034,6 +1039,7 @@
     "from rubrix.labeling.text_classification import WeakMultiLabels\n",
     "\n",
     "# Compute the weak labels for our dataset given the rules\n",
+    "# If your dataset already contains rules you can omit the rules argument.\n",
     "weak_labels = WeakMultiLabels(\"research_titles\", rules=rules)"
    ]
   },

--- a/docs/tutorials/weak-supervision-multi-label.ipynb
+++ b/docs/tutorials/weak-supervision-multi-label.ipynb
@@ -1,0 +1,1916 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7641399c-d8bc-411b-952b-32a9f2100776",
+   "metadata": {},
+   "source": [
+    "# Weak supervision in multi-label text classification tasks\n",
+    "\n",
+    "WORK IN PROGRESS: This tutorial is a work in progress and you can expect some changes within the next few releases.\n",
+    "We will showcase new features here as soon as they are available."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ea2fec7-ded9-4752-be5d-d365ebe6c039",
+   "metadata": {},
+   "source": [
+    "In this tutorial we will tackle two text classification tasks that deal with multi-labels."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f37c0bbe-904a-49de-9443-234252f0acb0",
+   "metadata": {},
+   "source": [
+    "## go emotions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83559db4-9bc1-4080-bccb-cc154ed753ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import rubrix as rb\n",
+    "from datasets import load_dataset\n",
+    "\n",
+    "# Download preprocessed dataset\n",
+    "ds_rb = rb.read_datasets(\n",
+    "    load_dataset(\"rubrix/go_emotions_multi-label\", split=\"train\", use_auth_token=True),\n",
+    "    task=\"TextClassification\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91c11e9e-9dec-424e-a582-795803e0a682",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Log dataset to Rubrix to find good heuristics\n",
+    "rb.log(ds_rb, name=\"go_emotions\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 264,
+   "id": "c90591ef-bedb-4069-b491-bd9d7f58edde",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rubrix.labeling.text_classification import Rule\n",
+    "\n",
+    "# Define our heuristic rules (can probably be improved)\n",
+    "rules = [\n",
+    "    Rule(\"thank*\", \"gratitude\"),\n",
+    "    Rule(\"appreciate\", \"gratitude\"),\n",
+    "    Rule(\"text:(thanks AND good)\", [\"admiration\", \"gratitude\"]),\n",
+    "    Rule(\"advice\", \"admiration\"),\n",
+    "    Rule(\"amazing\", \"admiration\"),\n",
+    "    Rule(\"awesome\", \"admiration\"),\n",
+    "    Rule(\"impressed\", \"admiration\"),\n",
+    "    Rule(\"text:(good AND (point OR call OR idea OR job))\", \"admiration\"),\n",
+    "    Rule(\"legend\", \"admiration\"),\n",
+    "    Rule(\"exactly\", \"approval\"),\n",
+    "    Rule(\"agree\", \"approval\"),\n",
+    "    Rule(\"yeah\", \"approval\"),\n",
+    "    Rule(\"suck\", \"annoyance\"),\n",
+    "    Rule(\"pissed\", \"annoyance\"),\n",
+    "    Rule(\"annoying\", \"annoyance\"),\n",
+    "    Rule(\"ruined\", \"annoyance\"),\n",
+    "    Rule(\"hoping\", \"optimism\"),\n",
+    "    Rule(\"text:(\\\"good luck\\\")\", \"optimism\"),\n",
+    "    Rule(\"\\\"nice day\\\"\", \"optimism\"),\n",
+    "    Rule(\"\\\"what is\\\"\", \"curiosity\"),\n",
+    "    Rule(\"\\\"can you\\\"\", \"curiosity\"),\n",
+    "    Rule(\"\\\"would you\\\"\", \"curiosity\"),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de1f67bb-8666-4fd9-a293-f0e6a1168f0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rubrix.labeling.text_classification import WeakMultiLabels\n",
+    "\n",
+    "# Compute the weak labels for our dataset given the rules\n",
+    "weak_labels = WeakMultiLabels(\"go_emotions\", rules=rules)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 266,
+   "id": "cdc6fea9-f248-4f55-a542-a0296f2873f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>label</th>\n",
+       "      <th>coverage</th>\n",
+       "      <th>annotated_coverage</th>\n",
+       "      <th>overlaps</th>\n",
+       "      <th>correct</th>\n",
+       "      <th>incorrect</th>\n",
+       "      <th>precision</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>thank*</th>\n",
+       "      <td>{gratitude}</td>\n",
+       "      <td>0.196768</td>\n",
+       "      <td>0.196237</td>\n",
+       "      <td>0.037785</td>\n",
+       "      <td>73</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>appreciate</th>\n",
+       "      <td>{gratitude}</td>\n",
+       "      <td>0.016160</td>\n",
+       "      <td>0.021505</td>\n",
+       "      <td>0.009506</td>\n",
+       "      <td>7</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.875000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>text:(thanks AND good)</th>\n",
+       "      <td>{gratitude, admiration}</td>\n",
+       "      <td>0.007842</td>\n",
+       "      <td>0.010753</td>\n",
+       "      <td>0.007605</td>\n",
+       "      <td>8</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>advice</th>\n",
+       "      <td>{admiration}</td>\n",
+       "      <td>0.008317</td>\n",
+       "      <td>0.008065</td>\n",
+       "      <td>0.006654</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>amazing</th>\n",
+       "      <td>{admiration}</td>\n",
+       "      <td>0.025428</td>\n",
+       "      <td>0.021505</td>\n",
+       "      <td>0.003565</td>\n",
+       "      <td>8</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>awesome</th>\n",
+       "      <td>{admiration}</td>\n",
+       "      <td>0.025190</td>\n",
+       "      <td>0.034946</td>\n",
+       "      <td>0.006179</td>\n",
+       "      <td>12</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.923077</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>impressed</th>\n",
+       "      <td>{admiration}</td>\n",
+       "      <td>0.002139</td>\n",
+       "      <td>0.005376</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>text:(good AND (point OR call OR idea OR job))</th>\n",
+       "      <td>{admiration}</td>\n",
+       "      <td>0.008555</td>\n",
+       "      <td>0.018817</td>\n",
+       "      <td>0.002376</td>\n",
+       "      <td>7</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>legend</th>\n",
+       "      <td>{admiration}</td>\n",
+       "      <td>0.001901</td>\n",
+       "      <td>0.002688</td>\n",
+       "      <td>0.000475</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>exactly</th>\n",
+       "      <td>{approval}</td>\n",
+       "      <td>0.004278</td>\n",
+       "      <td>0.002688</td>\n",
+       "      <td>0.001188</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>agree</th>\n",
+       "      <td>{approval}</td>\n",
+       "      <td>0.016873</td>\n",
+       "      <td>0.021505</td>\n",
+       "      <td>0.003089</td>\n",
+       "      <td>6</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.750000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>yeah</th>\n",
+       "      <td>{approval}</td>\n",
+       "      <td>0.024952</td>\n",
+       "      <td>0.021505</td>\n",
+       "      <td>0.004990</td>\n",
+       "      <td>5</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.625000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>suck</th>\n",
+       "      <td>{annoyance}</td>\n",
+       "      <td>0.002139</td>\n",
+       "      <td>0.008065</td>\n",
+       "      <td>0.000475</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>pissed</th>\n",
+       "      <td>{annoyance}</td>\n",
+       "      <td>0.002139</td>\n",
+       "      <td>0.008065</td>\n",
+       "      <td>0.000475</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.666667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>annoying</th>\n",
+       "      <td>{annoyance}</td>\n",
+       "      <td>0.003327</td>\n",
+       "      <td>0.018817</td>\n",
+       "      <td>0.000951</td>\n",
+       "      <td>7</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ruined</th>\n",
+       "      <td>{annoyance}</td>\n",
+       "      <td>0.000713</td>\n",
+       "      <td>0.002688</td>\n",
+       "      <td>0.000238</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>hoping</th>\n",
+       "      <td>{optimism}</td>\n",
+       "      <td>0.003565</td>\n",
+       "      <td>0.005376</td>\n",
+       "      <td>0.000713</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>text:(\"good luck\")</th>\n",
+       "      <td>{optimism}</td>\n",
+       "      <td>0.015209</td>\n",
+       "      <td>0.018817</td>\n",
+       "      <td>0.002139</td>\n",
+       "      <td>4</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.571429</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>\"nice day\"</th>\n",
+       "      <td>{optimism}</td>\n",
+       "      <td>0.000713</td>\n",
+       "      <td>0.005376</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>\"what is\"</th>\n",
+       "      <td>{curiosity}</td>\n",
+       "      <td>0.004040</td>\n",
+       "      <td>0.005376</td>\n",
+       "      <td>0.000951</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>\"can you\"</th>\n",
+       "      <td>{curiosity}</td>\n",
+       "      <td>0.004278</td>\n",
+       "      <td>0.008065</td>\n",
+       "      <td>0.000713</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>\"would you\"</th>\n",
+       "      <td>{curiosity}</td>\n",
+       "      <td>0.000951</td>\n",
+       "      <td>0.005376</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>total</th>\n",
+       "      <td>{gratitude, optimism, curiosity, approval, ann...</td>\n",
+       "      <td>0.327234</td>\n",
+       "      <td>0.384409</td>\n",
+       "      <td>0.041825</td>\n",
+       "      <td>161</td>\n",
+       "      <td>11</td>\n",
+       "      <td>0.936047</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                                            label  \\\n",
+       "thank*                                                                                {gratitude}   \n",
+       "appreciate                                                                            {gratitude}   \n",
+       "text:(thanks AND good)                                                    {gratitude, admiration}   \n",
+       "advice                                                                               {admiration}   \n",
+       "amazing                                                                              {admiration}   \n",
+       "awesome                                                                              {admiration}   \n",
+       "impressed                                                                            {admiration}   \n",
+       "text:(good AND (point OR call OR idea OR job))                                       {admiration}   \n",
+       "legend                                                                               {admiration}   \n",
+       "exactly                                                                                {approval}   \n",
+       "agree                                                                                  {approval}   \n",
+       "yeah                                                                                   {approval}   \n",
+       "suck                                                                                  {annoyance}   \n",
+       "pissed                                                                                {annoyance}   \n",
+       "annoying                                                                              {annoyance}   \n",
+       "ruined                                                                                {annoyance}   \n",
+       "hoping                                                                                 {optimism}   \n",
+       "text:(\"good luck\")                                                                     {optimism}   \n",
+       "\"nice day\"                                                                             {optimism}   \n",
+       "\"what is\"                                                                             {curiosity}   \n",
+       "\"can you\"                                                                             {curiosity}   \n",
+       "\"would you\"                                                                           {curiosity}   \n",
+       "total                                           {gratitude, optimism, curiosity, approval, ann...   \n",
+       "\n",
+       "                                                coverage  annotated_coverage  \\\n",
+       "thank*                                          0.196768            0.196237   \n",
+       "appreciate                                      0.016160            0.021505   \n",
+       "text:(thanks AND good)                          0.007842            0.010753   \n",
+       "advice                                          0.008317            0.008065   \n",
+       "amazing                                         0.025428            0.021505   \n",
+       "awesome                                         0.025190            0.034946   \n",
+       "impressed                                       0.002139            0.005376   \n",
+       "text:(good AND (point OR call OR idea OR job))  0.008555            0.018817   \n",
+       "legend                                          0.001901            0.002688   \n",
+       "exactly                                         0.004278            0.002688   \n",
+       "agree                                           0.016873            0.021505   \n",
+       "yeah                                            0.024952            0.021505   \n",
+       "suck                                            0.002139            0.008065   \n",
+       "pissed                                          0.002139            0.008065   \n",
+       "annoying                                        0.003327            0.018817   \n",
+       "ruined                                          0.000713            0.002688   \n",
+       "hoping                                          0.003565            0.005376   \n",
+       "text:(\"good luck\")                              0.015209            0.018817   \n",
+       "\"nice day\"                                      0.000713            0.005376   \n",
+       "\"what is\"                                       0.004040            0.005376   \n",
+       "\"can you\"                                       0.004278            0.008065   \n",
+       "\"would you\"                                     0.000951            0.005376   \n",
+       "total                                           0.327234            0.384409   \n",
+       "\n",
+       "                                                overlaps  correct  incorrect  \\\n",
+       "thank*                                          0.037785       73          0   \n",
+       "appreciate                                      0.009506        7          1   \n",
+       "text:(thanks AND good)                          0.007605        8          0   \n",
+       "advice                                          0.006654        3          0   \n",
+       "amazing                                         0.003565        8          0   \n",
+       "awesome                                         0.006179       12          1   \n",
+       "impressed                                       0.000000        2          0   \n",
+       "text:(good AND (point OR call OR idea OR job))  0.002376        7          0   \n",
+       "legend                                          0.000475        1          0   \n",
+       "exactly                                         0.001188        1          0   \n",
+       "agree                                           0.003089        6          2   \n",
+       "yeah                                            0.004990        5          3   \n",
+       "suck                                            0.000475        3          0   \n",
+       "pissed                                          0.000475        2          1   \n",
+       "annoying                                        0.000951        7          0   \n",
+       "ruined                                          0.000238        1          0   \n",
+       "hoping                                          0.000713        2          0   \n",
+       "text:(\"good luck\")                              0.002139        4          3   \n",
+       "\"nice day\"                                      0.000000        2          0   \n",
+       "\"what is\"                                       0.000951        2          0   \n",
+       "\"can you\"                                       0.000713        3          0   \n",
+       "\"would you\"                                     0.000000        2          0   \n",
+       "total                                           0.041825      161         11   \n",
+       "\n",
+       "                                                precision  \n",
+       "thank*                                           1.000000  \n",
+       "appreciate                                       0.875000  \n",
+       "text:(thanks AND good)                           1.000000  \n",
+       "advice                                           1.000000  \n",
+       "amazing                                          1.000000  \n",
+       "awesome                                          0.923077  \n",
+       "impressed                                        1.000000  \n",
+       "text:(good AND (point OR call OR idea OR job))   1.000000  \n",
+       "legend                                           1.000000  \n",
+       "exactly                                          1.000000  \n",
+       "agree                                            0.750000  \n",
+       "yeah                                             0.625000  \n",
+       "suck                                             1.000000  \n",
+       "pissed                                           0.666667  \n",
+       "annoying                                         1.000000  \n",
+       "ruined                                           1.000000  \n",
+       "hoping                                           1.000000  \n",
+       "text:(\"good luck\")                               0.571429  \n",
+       "\"nice day\"                                       1.000000  \n",
+       "\"what is\"                                        1.000000  \n",
+       "\"can you\"                                        1.000000  \n",
+       "\"would you\"                                      1.000000  \n",
+       "total                                            0.936047  "
+      ]
+     },
+     "execution_count": 266,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Check coverage/precision of our rules\n",
+    "weak_labels.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 268,
+   "id": "6985e6b7-7c28-4efc-84d2-08b7fff02ef8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rubrix.labeling.text_classification import MajorityVoter\n",
+    "\n",
+    "# Use the majority voter as the label model\n",
+    "label_model = MajorityVoter(weak_labels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 269,
+   "id": "152abc10-1538-4660-aa3a-0e210887c0f1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1234"
+      ]
+     },
+     "execution_count": 269,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Get records with the predictions from the label model to train a down-stream model\n",
+    "train_rb = rb.DatasetForTextClassification(label_model.predict())\n",
+    "\n",
+    "# Copy label model predictions to annotation\n",
+    "for rec in train_rb:\n",
+    "    rec.annotation = [pred[0] for pred in rec.prediction if pred[1] > 0.5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 270,
+   "id": "fce0c5a0-bfa5-4649-a59a-f0114f7891a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get records with manual annotations to use as test set for the down-stream model\n",
+    "test_rb = rb.DatasetForTextClassification(weak_labels.records(has_annotation=True))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 271,
+   "id": "232a2d46-1516-4c7d-8d39-d55fe0d8130d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datasets import DatasetDict\n",
+    "\n",
+    "# Create dataset dictionary and shuffle training set\n",
+    "ds = DatasetDict(\n",
+    "    train=train_rb.prepare_for_training().shuffle(seed=42),\n",
+    "    test=test_rb.prepare_for_training()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "072218ae-2167-48d8-8b93-243daff497b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Push dataset for training our down-stream model to the HF hub\n",
+    "ds.push_to_hub(\"rubrix/go_emotions_training\", private=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0957ad2-f05d-4ea4-b303-d77495a449e9",
+   "metadata": {},
+   "source": [
+    "### Train transformers down-stream model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 273,
+   "id": "88365498-15df-4aff-ae3a-48c22e4e1a66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import AutoTokenizer\n",
+    "\n",
+    "# Initialize tokenizer\n",
+    "tokenizer = AutoTokenizer.from_pretrained(\"distilbert-base-uncased\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 274,
+   "id": "6635d069-e242-4d89-92be-ecce502b92db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def tokenize_func(examples):\n",
+    "    return tokenizer(examples[\"text\"], padding=\"max_length\", truncation=True)\n",
+    "\n",
+    "# Tokenize the data\n",
+    "tokenized_ds = ds.map(tokenize_func, batched=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4043767f-9adc-4724-938e-45fdf500d2b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.preprocessing import MultiLabelBinarizer\n",
+    "\n",
+    "# Init and fit a binarizer to help with the label format\n",
+    "mb = MultiLabelBinarizer()\n",
+    "mb.fit(ds[\"test\"][\"label\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 278,
+   "id": "a5d04aa2-560d-450d-8242-db5ea4a44844",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def binarize_labels(examples):\n",
+    "    return {\"label\": mb.transform(examples[\"label\"])}\n",
+    "\n",
+    "# Turn labels into multi-label format\n",
+    "binarized_tokenized_ds = tokenized_ds.map(binarize_labels, batched=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1fa9ee91-82f0-4cb1-a1b6-10369804e22a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from transformers import AutoModelForSequenceClassification\n",
+    "\n",
+    "# Init our down-stream model\n",
+    "model = AutoModelForSequenceClassification.from_pretrained(\n",
+    "    \"distilbert-base-uncased\", \n",
+    "    problem_type=\"multi_label_classification\", \n",
+    "    num_labels=6\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 283,
+   "id": "2dd0c0bd-b7d9-4e1c-a734-8c2a8e9d57d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import TrainingArguments\n",
+    "\n",
+    "# Set our training arguments\n",
+    "training_args = TrainingArguments(\n",
+    "    output_dir=\"test_trainer\", \n",
+    "    evaluation_strategy=\"epoch\", \n",
+    "    num_train_epochs=2,\n",
+    "    per_device_train_batch_size=16,   \n",
+    "    per_device_eval_batch_size=16, \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 285,
+   "id": "d50f9ae8-2b1a-4905-b19f-62bcfa8c64d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datasets import load_metric\n",
+    "import numpy as np\n",
+    "\n",
+    "# Define our metrics\n",
+    "metric = load_metric(\"f1\", config_name=\"multilabel\")\n",
+    "def compute_metrics(eval_pred):\n",
+    "    logits, labels = eval_pred\n",
+    "    predictions = ( 1. / (1 + np.exp(-logits)) ) > 0.5\n",
+    "    \n",
+    "    metrics = metric.compute(predictions=predictions, references=labels, average=\"micro\")\n",
+    "    per_label_metric = metric.compute(predictions=predictions, references=labels, average=None)\n",
+    "    for label, f1 in zip(ds[\"train\"].features[\"label\"][0].names, per_label_metric[\"f1\"]):\n",
+    "        metrics[f\"f1_{label}\"] = f1\n",
+    "\n",
+    "    return metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 286,
+   "id": "61e0896c-dc7b-4844-95b6-a258aa8f8d1c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import Trainer\n",
+    "\n",
+    "# Init the trainer\n",
+    "trainer = Trainer(\n",
+    "    model=model,\n",
+    "    args=training_args,\n",
+    "    train_dataset=binarized_tokenized_ds[\"train\"],\n",
+    "    eval_dataset=binarized_tokenized_ds[\"test\"],\n",
+    "    compute_metrics=compute_metrics,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ddd25cb-1cf8-4721-a8e8-c16eb0c7aaf7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Train the down-stream model\n",
+    "trainer.train()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee0dfbaa-90f3-4803-8e93-b86e1440bd51",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Research topic dataset\n",
+    "\n",
+    "See Appendix B for the data preprocessing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd4cdd38-604c-4fe6-8104-fc6b136d331a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-03-16 00:17:22.386 | WARNING  | datasets.builder:_create_builder_config:378 - Using custom data configuration rubrix--go_emotions_multi_label-c52a16149c24284f\n",
+      "2022-03-16 00:17:22.392 | WARNING  | datasets.builder:download_and_prepare:531 - Reusing dataset parquet (/home/david/.cache/huggingface/datasets/parquet/rubrix--go_emotions_multi_label-c52a16149c24284f/0.0.0/0b6d5799bb726b24ad7fc7be720c170d8e497f575d02d47537de9a5bac074901)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import rubrix as rb\n",
+    "from datasets import load_dataset\n",
+    "\n",
+    "# Download preprocessed dataset\n",
+    "ds_rb = rb.read_datasets(\n",
+    "    load_dataset(\"rubrix/go_emotions_multi_label\", split=\"train\", use_auth_token=True),\n",
+    "    task=\"TextClassification\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "id": "34899478-62ae-4864-8196-36348aa568c3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4626453ea0af4a2cb96b91add2bfcbf6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/20972 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "20972 records logged to http://localhost:6900/ws/rubrix/research_titles\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "BulkResponse(dataset='research_titles', processed=20972, failed=0)"
+      ]
+     },
+     "execution_count": 95,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Log dataset to Rubrix to find good heuristics\n",
+    "rb.log(records, \"research_titles\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8f85fd20-7086-4581-9078-2a28c9155997",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rubrix.labeling.text_classification import Rule\n",
+    "\n",
+    "# Define our heuristic rules (can probably be improved)\n",
+    "rules = [\n",
+    "    Rule(\"stock*\", \"Quantitative Finance\"),\n",
+    "    Rule(\"*asset*\", \"Quantitative Finance\"),\n",
+    "    Rule(\"trading\", \"Quantitative Finance\"),\n",
+    "    Rule(\"finance\", \"Quantitative Finance\"),\n",
+    "    Rule(\"pric*\", \"Quantitative Finance\"),\n",
+    "    Rule(\"economy\", \"Quantitative Finance\"),\n",
+    "    Rule(\"deep AND neural AND network*\", \"Computer Science\"),\n",
+    "    Rule(\"convolutional\", \"Computer Science\"),\n",
+    "    Rule(\"memor* AND (design* OR network*)\", \"Computer Science\"),\n",
+    "    Rule(\"system* AND design*\", \"Computer Science\"),\n",
+    "    Rule(\"allocat* AND *net*\", \"Computer Science\"),\n",
+    "    Rule(\"program\", \"Computer Science\"),\n",
+    "    Rule(\"scattering\", \"Physics\"),\n",
+    "    Rule(\"astro*\", \"Physics\"),\n",
+    "    Rule(\"material*\", \"Physics\"),\n",
+    "    Rule(\"spin\", \"Physics\"),\n",
+    "    Rule(\"magnetic\", \"Physics\"),\n",
+    "    Rule(\"optical\", \"Physics\"),\n",
+    "    Rule(\"ray\", \"Physics\"),\n",
+    "    Rule(\"entangle*\", \"Physics\"),\n",
+    "    Rule(\"*algebra*\", \"Mathematics\"),\n",
+    "    Rule(\"manifold* AND (NOT learn*)\", \"Mathematics\"),\n",
+    "    Rule(\"equation\", \"Mathematics\"),\n",
+    "    Rule(\"spaces\", \"Mathematics\"), \n",
+    "    Rule(\"operators\", \"Mathematics\"), \n",
+    "    Rule(\"regression\", \"Statistics\"),\n",
+    "    Rule(\"bayes*\", \"Statistics\"),\n",
+    "    Rule(\"estimation\", \"Statistics\"),\n",
+    "    Rule(\"mixture\", \"Statistics\"),\n",
+    "    Rule(\"gaussian\", \"Statistics\"),\n",
+    "    Rule(\"gene\", \"Quantitative Biology\"),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c41d2c90-e550-4d44-9935-b5eeea415c67",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-03-16 00:17:31.646 | WARNING  | rubrix.client.api:load:366 - The argument 'as_pandas' in `rb.load` will be deprecated in the future, and we will always return a `Dataset`. To emulate the future behavior set `as_pandas=False`. To get a pandas DataFrame, call `Dataset.to_pandas()`\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "65ae298816df4df3b8700a32b8135265",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Preparing rules:   0%|          | 0/31 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6e5356b5e04645a89c180c89ec0e61ea",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Applying rules:   0%|          | 0/20972 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "830b4f9c1c0747dfbe2e9ec021267267",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Filling weak label matrix:   0%|          | 0/20972 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from rubrix.labeling.text_classification import WeakMultiLabels\n",
+    "\n",
+    "# Compute the weak labels for our dataset given the rules\n",
+    "weak_labels = WeakMultiLabels(\"research_titles\", rules=rules)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a5bfc002-0845-4d36-b2c5-8133995561ce",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>label</th>\n",
+       "      <th>coverage</th>\n",
+       "      <th>annotated_coverage</th>\n",
+       "      <th>overlaps</th>\n",
+       "      <th>correct</th>\n",
+       "      <th>incorrect</th>\n",
+       "      <th>precision</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>stock*</th>\n",
+       "      <td>{Quantitative Finance}</td>\n",
+       "      <td>0.000954</td>\n",
+       "      <td>0.000715</td>\n",
+       "      <td>0.000334</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>*asset*</th>\n",
+       "      <td>{Quantitative Finance}</td>\n",
+       "      <td>0.000477</td>\n",
+       "      <td>0.000715</td>\n",
+       "      <td>0.000286</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>trading</th>\n",
+       "      <td>{Quantitative Finance}</td>\n",
+       "      <td>0.000954</td>\n",
+       "      <td>0.000238</td>\n",
+       "      <td>0.000191</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>finance</th>\n",
+       "      <td>{Quantitative Finance}</td>\n",
+       "      <td>0.000048</td>\n",
+       "      <td>0.000238</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>pric*</th>\n",
+       "      <td>{Quantitative Finance}</td>\n",
+       "      <td>0.003433</td>\n",
+       "      <td>0.003337</td>\n",
+       "      <td>0.000715</td>\n",
+       "      <td>9</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.642857</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>economy</th>\n",
+       "      <td>{Quantitative Finance}</td>\n",
+       "      <td>0.000238</td>\n",
+       "      <td>0.000238</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>deep AND neural AND network*</th>\n",
+       "      <td>{Computer Science}</td>\n",
+       "      <td>0.009155</td>\n",
+       "      <td>0.010250</td>\n",
+       "      <td>0.002098</td>\n",
+       "      <td>32</td>\n",
+       "      <td>11</td>\n",
+       "      <td>0.744186</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>convolutional</th>\n",
+       "      <td>{Computer Science}</td>\n",
+       "      <td>0.010109</td>\n",
+       "      <td>0.009297</td>\n",
+       "      <td>0.002146</td>\n",
+       "      <td>32</td>\n",
+       "      <td>7</td>\n",
+       "      <td>0.820513</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>memor* AND (design* OR network*)</th>\n",
+       "      <td>{Computer Science}</td>\n",
+       "      <td>0.001383</td>\n",
+       "      <td>0.002145</td>\n",
+       "      <td>0.000286</td>\n",
+       "      <td>9</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>system* AND design*</th>\n",
+       "      <td>{Computer Science}</td>\n",
+       "      <td>0.001144</td>\n",
+       "      <td>0.002384</td>\n",
+       "      <td>0.000238</td>\n",
+       "      <td>9</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.900000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>allocat* AND *net*</th>\n",
+       "      <td>{Computer Science}</td>\n",
+       "      <td>0.000763</td>\n",
+       "      <td>0.000715</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>program</th>\n",
+       "      <td>{Computer Science}</td>\n",
+       "      <td>0.002623</td>\n",
+       "      <td>0.003099</td>\n",
+       "      <td>0.000143</td>\n",
+       "      <td>11</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.846154</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>scattering</th>\n",
+       "      <td>{Physics}</td>\n",
+       "      <td>0.004053</td>\n",
+       "      <td>0.002861</td>\n",
+       "      <td>0.001001</td>\n",
+       "      <td>10</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.833333</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>astro*</th>\n",
+       "      <td>{Physics}</td>\n",
+       "      <td>0.003099</td>\n",
+       "      <td>0.004052</td>\n",
+       "      <td>0.000620</td>\n",
+       "      <td>17</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>material*</th>\n",
+       "      <td>{Physics}</td>\n",
+       "      <td>0.004148</td>\n",
+       "      <td>0.003099</td>\n",
+       "      <td>0.000238</td>\n",
+       "      <td>10</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.769231</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>spin</th>\n",
+       "      <td>{Physics}</td>\n",
+       "      <td>0.013542</td>\n",
+       "      <td>0.015018</td>\n",
+       "      <td>0.002146</td>\n",
+       "      <td>60</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.952381</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>magnetic</th>\n",
+       "      <td>{Physics}</td>\n",
+       "      <td>0.011301</td>\n",
+       "      <td>0.012872</td>\n",
+       "      <td>0.002432</td>\n",
+       "      <td>49</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.907407</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>optical</th>\n",
+       "      <td>{Physics}</td>\n",
+       "      <td>0.007105</td>\n",
+       "      <td>0.006913</td>\n",
+       "      <td>0.001097</td>\n",
+       "      <td>27</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.931034</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>ray</th>\n",
+       "      <td>{Physics}</td>\n",
+       "      <td>0.005865</td>\n",
+       "      <td>0.007390</td>\n",
+       "      <td>0.001192</td>\n",
+       "      <td>27</td>\n",
+       "      <td>4</td>\n",
+       "      <td>0.870968</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>entangle*</th>\n",
+       "      <td>{Physics}</td>\n",
+       "      <td>0.002623</td>\n",
+       "      <td>0.002861</td>\n",
+       "      <td>0.000095</td>\n",
+       "      <td>11</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.916667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>*algebra*</th>\n",
+       "      <td>{Mathematics}</td>\n",
+       "      <td>0.014829</td>\n",
+       "      <td>0.018355</td>\n",
+       "      <td>0.000572</td>\n",
+       "      <td>70</td>\n",
+       "      <td>7</td>\n",
+       "      <td>0.909091</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>manifold* AND (NOT learn*)</th>\n",
+       "      <td>{Mathematics}</td>\n",
+       "      <td>0.007057</td>\n",
+       "      <td>0.008343</td>\n",
+       "      <td>0.000858</td>\n",
+       "      <td>28</td>\n",
+       "      <td>7</td>\n",
+       "      <td>0.800000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>equation</th>\n",
+       "      <td>{Mathematics}</td>\n",
+       "      <td>0.010681</td>\n",
+       "      <td>0.007867</td>\n",
+       "      <td>0.000954</td>\n",
+       "      <td>24</td>\n",
+       "      <td>9</td>\n",
+       "      <td>0.727273</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>spaces</th>\n",
+       "      <td>{Mathematics}</td>\n",
+       "      <td>0.010586</td>\n",
+       "      <td>0.009774</td>\n",
+       "      <td>0.001812</td>\n",
+       "      <td>38</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.926829</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>operators</th>\n",
+       "      <td>{Mathematics}</td>\n",
+       "      <td>0.006151</td>\n",
+       "      <td>0.005959</td>\n",
+       "      <td>0.001526</td>\n",
+       "      <td>22</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.880000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>regression</th>\n",
+       "      <td>{Statistics}</td>\n",
+       "      <td>0.009393</td>\n",
+       "      <td>0.009058</td>\n",
+       "      <td>0.002527</td>\n",
+       "      <td>33</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0.868421</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>bayes*</th>\n",
+       "      <td>{Statistics}</td>\n",
+       "      <td>0.015306</td>\n",
+       "      <td>0.014779</td>\n",
+       "      <td>0.003147</td>\n",
+       "      <td>49</td>\n",
+       "      <td>13</td>\n",
+       "      <td>0.790323</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>estimation</th>\n",
+       "      <td>{Statistics}</td>\n",
+       "      <td>0.021266</td>\n",
+       "      <td>0.021216</td>\n",
+       "      <td>0.003338</td>\n",
+       "      <td>65</td>\n",
+       "      <td>24</td>\n",
+       "      <td>0.730337</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mixture</th>\n",
+       "      <td>{Statistics}</td>\n",
+       "      <td>0.003290</td>\n",
+       "      <td>0.003099</td>\n",
+       "      <td>0.001287</td>\n",
+       "      <td>10</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0.769231</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>gaussian</th>\n",
+       "      <td>{Statistics}</td>\n",
+       "      <td>0.009250</td>\n",
+       "      <td>0.011204</td>\n",
+       "      <td>0.002766</td>\n",
+       "      <td>36</td>\n",
+       "      <td>11</td>\n",
+       "      <td>0.765957</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>gene</th>\n",
+       "      <td>{Quantitative Biology}</td>\n",
+       "      <td>0.001287</td>\n",
+       "      <td>0.001669</td>\n",
+       "      <td>0.000191</td>\n",
+       "      <td>6</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.857143</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>total</th>\n",
+       "      <td>{Quantitative Biology, Computer Science, Stati...</td>\n",
+       "      <td>0.174614</td>\n",
+       "      <td>0.183075</td>\n",
+       "      <td>0.016737</td>\n",
+       "      <td>706</td>\n",
+       "      <td>132</td>\n",
+       "      <td>0.842482</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                              label  \\\n",
+       "stock*                                                       {Quantitative Finance}   \n",
+       "*asset*                                                      {Quantitative Finance}   \n",
+       "trading                                                      {Quantitative Finance}   \n",
+       "finance                                                      {Quantitative Finance}   \n",
+       "pric*                                                        {Quantitative Finance}   \n",
+       "economy                                                      {Quantitative Finance}   \n",
+       "deep AND neural AND network*                                     {Computer Science}   \n",
+       "convolutional                                                    {Computer Science}   \n",
+       "memor* AND (design* OR network*)                                 {Computer Science}   \n",
+       "system* AND design*                                              {Computer Science}   \n",
+       "allocat* AND *net*                                               {Computer Science}   \n",
+       "program                                                          {Computer Science}   \n",
+       "scattering                                                                {Physics}   \n",
+       "astro*                                                                    {Physics}   \n",
+       "material*                                                                 {Physics}   \n",
+       "spin                                                                      {Physics}   \n",
+       "magnetic                                                                  {Physics}   \n",
+       "optical                                                                   {Physics}   \n",
+       "ray                                                                       {Physics}   \n",
+       "entangle*                                                                 {Physics}   \n",
+       "*algebra*                                                             {Mathematics}   \n",
+       "manifold* AND (NOT learn*)                                            {Mathematics}   \n",
+       "equation                                                              {Mathematics}   \n",
+       "spaces                                                                {Mathematics}   \n",
+       "operators                                                             {Mathematics}   \n",
+       "regression                                                             {Statistics}   \n",
+       "bayes*                                                                 {Statistics}   \n",
+       "estimation                                                             {Statistics}   \n",
+       "mixture                                                                {Statistics}   \n",
+       "gaussian                                                               {Statistics}   \n",
+       "gene                                                         {Quantitative Biology}   \n",
+       "total                             {Quantitative Biology, Computer Science, Stati...   \n",
+       "\n",
+       "                                  coverage  annotated_coverage  overlaps  \\\n",
+       "stock*                            0.000954            0.000715  0.000334   \n",
+       "*asset*                           0.000477            0.000715  0.000286   \n",
+       "trading                           0.000954            0.000238  0.000191   \n",
+       "finance                           0.000048            0.000238  0.000000   \n",
+       "pric*                             0.003433            0.003337  0.000715   \n",
+       "economy                           0.000238            0.000238  0.000000   \n",
+       "deep AND neural AND network*      0.009155            0.010250  0.002098   \n",
+       "convolutional                     0.010109            0.009297  0.002146   \n",
+       "memor* AND (design* OR network*)  0.001383            0.002145  0.000286   \n",
+       "system* AND design*               0.001144            0.002384  0.000238   \n",
+       "allocat* AND *net*                0.000763            0.000715  0.000000   \n",
+       "program                           0.002623            0.003099  0.000143   \n",
+       "scattering                        0.004053            0.002861  0.001001   \n",
+       "astro*                            0.003099            0.004052  0.000620   \n",
+       "material*                         0.004148            0.003099  0.000238   \n",
+       "spin                              0.013542            0.015018  0.002146   \n",
+       "magnetic                          0.011301            0.012872  0.002432   \n",
+       "optical                           0.007105            0.006913  0.001097   \n",
+       "ray                               0.005865            0.007390  0.001192   \n",
+       "entangle*                         0.002623            0.002861  0.000095   \n",
+       "*algebra*                         0.014829            0.018355  0.000572   \n",
+       "manifold* AND (NOT learn*)        0.007057            0.008343  0.000858   \n",
+       "equation                          0.010681            0.007867  0.000954   \n",
+       "spaces                            0.010586            0.009774  0.001812   \n",
+       "operators                         0.006151            0.005959  0.001526   \n",
+       "regression                        0.009393            0.009058  0.002527   \n",
+       "bayes*                            0.015306            0.014779  0.003147   \n",
+       "estimation                        0.021266            0.021216  0.003338   \n",
+       "mixture                           0.003290            0.003099  0.001287   \n",
+       "gaussian                          0.009250            0.011204  0.002766   \n",
+       "gene                              0.001287            0.001669  0.000191   \n",
+       "total                             0.174614            0.183075  0.016737   \n",
+       "\n",
+       "                                  correct  incorrect  precision  \n",
+       "stock*                                  3          0   1.000000  \n",
+       "*asset*                                 3          0   1.000000  \n",
+       "trading                                 1          0   1.000000  \n",
+       "finance                                 1          0   1.000000  \n",
+       "pric*                                   9          5   0.642857  \n",
+       "economy                                 1          0   1.000000  \n",
+       "deep AND neural AND network*           32         11   0.744186  \n",
+       "convolutional                          32          7   0.820513  \n",
+       "memor* AND (design* OR network*)        9          0   1.000000  \n",
+       "system* AND design*                     9          1   0.900000  \n",
+       "allocat* AND *net*                      3          0   1.000000  \n",
+       "program                                11          2   0.846154  \n",
+       "scattering                             10          2   0.833333  \n",
+       "astro*                                 17          0   1.000000  \n",
+       "material*                              10          3   0.769231  \n",
+       "spin                                   60          3   0.952381  \n",
+       "magnetic                               49          5   0.907407  \n",
+       "optical                                27          2   0.931034  \n",
+       "ray                                    27          4   0.870968  \n",
+       "entangle*                              11          1   0.916667  \n",
+       "*algebra*                              70          7   0.909091  \n",
+       "manifold* AND (NOT learn*)             28          7   0.800000  \n",
+       "equation                               24          9   0.727273  \n",
+       "spaces                                 38          3   0.926829  \n",
+       "operators                              22          3   0.880000  \n",
+       "regression                             33          5   0.868421  \n",
+       "bayes*                                 49         13   0.790323  \n",
+       "estimation                             65         24   0.730337  \n",
+       "mixture                                10          3   0.769231  \n",
+       "gaussian                               36         11   0.765957  \n",
+       "gene                                    6          1   0.857143  \n",
+       "total                                 706        132   0.842482  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Check coverage/precision of our rules\n",
+    "weak_labels.summary()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8152fabd-969d-40b1-a4fc-956f8783ce29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rubrix.labeling.text_classification import MajorityVoter\n",
+    "\n",
+    "# Use the majority voter as the label model\n",
+    "label_model = MajorityVoter(weak_labels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f7edc676-5c9a-4b21-82d6-1a820b466483",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_df = rb.DatasetForTextClassification(label_model.predict()).to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "f45f92a3-b9a8-482a-9f37-52e4802790b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create labels in multi-label format\n",
+    "train_df[\"label\"] = train_df.prediction.map(\n",
+    "    lambda x: [\n",
+    "        {p[0]: int(p[1] > 0.5) for p in x}[label] \n",
+    "        for label in weak_labels.labels\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "7f2a5d4b-4d6a-4dc0-8533-287f92c745f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from skmultilearn.problem_transform import ClassifierChain, BinaryRelevance\n",
+    "from sklearn.feature_extraction.text import CountVectorizer\n",
+    "from sklearn.naive_bayes import MultinomialNB\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "\n",
+    "# Define our down-stream model\n",
+    "classifier = Pipeline([\n",
+    "    ('vect', CountVectorizer()),\n",
+    "    ('clf', BinaryRelevance(MultinomialNB()))\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "019aae12-aab3-4d9c-9695-80018541c3ca",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Pipeline(steps=[('vect', CountVectorizer()),\n",
+       "                ('clf',\n",
+       "                 BinaryRelevance(classifier=MultinomialNB(),\n",
+       "                                 require_dense=[True, True]))])"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "# Fit the down-stream classifier\n",
+    "classifier.fit(\n",
+    "    X=train_df.text,\n",
+    "    y=np.array(train_df.label.tolist()),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "858f1c6e-99df-4918-803c-18647e2edd68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get predictions for test set\n",
+    "predictions = classifier.predict(\n",
+    "    X=[rec.text for rec in weak_labels.records(has_annotation=True)]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "8b12a128-a184-494d-a926-6100a9d252da",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "              precision    recall  f1-score   support\n",
+      "\n",
+      "           0       0.81      0.23      0.36      1740\n",
+      "           1       0.77      0.59      0.67      1141\n",
+      "           2       0.88      0.66      0.75      1186\n",
+      "           3       0.50      0.01      0.02       109\n",
+      "           4       0.45      0.11      0.18        45\n",
+      "           5       0.55      0.67      0.60      1069\n",
+      "\n",
+      "   micro avg       0.72      0.49      0.58      5290\n",
+      "   macro avg       0.66      0.38      0.43      5290\n",
+      "weighted avg       0.75      0.49      0.56      5290\n",
+      " samples avg       0.58      0.52      0.53      5290\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/david/miniconda3/envs/rubrix/lib/python3.8/site-packages/sklearn/metrics/_classification.py:1248: UndefinedMetricWarning: Precision and F-score are ill-defined and being set to 0.0 in samples with no predicted labels. Use `zero_division` parameter to control this behavior.\n",
+      "  _warn_prf(average, modifier, msg_start, len(result))\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sklearn.metrics import classification_report\n",
+    "\n",
+    "# Compute metrics\n",
+    "print(classification_report(weak_labels.annotation(), predictions))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "303c082b-38c7-4f3a-94a7-ab0cdbc5acbe",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## APPENDIX A\n",
+    "\n",
+    "We want to limit the labels, and down-sample single-label annotations to move the focus to multi-label outputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "16336e27-c99c-4a51-b81b-bc63fb26daa2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "cf227957-7eb6-4ac5-b9d5-f3c671865377",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "70f48b2d858e46189ff8510524a2b71c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading:   0%|          | 0.00/2.02k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "436b97fc180a428fbc53cb24ab91943a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading:   0%|          | 0.00/1.67k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-03-15 23:59:34.112 | WARNING  | datasets.builder:_create_builder_config:333 - No config specified, defaulting to: go_emotions/simplified\n",
+      "2022-03-15 23:59:34.120 | WARNING  | datasets.builder:download_and_prepare:531 - Reusing dataset go_emotions (/home/david/.cache/huggingface/datasets/go_emotions/simplified/0.0.0/2637cfdd4e64d30249c3ed2150fa2b9d279766bfcd6a809b9f085c61a90d776d)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b3b8c2fb279545aa8f904ef054361fa1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/3 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "go_emotions = datasets.load_dataset(\"go_emotions\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "814047aa-d1df-4da4-9f68-2562f08bf9fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = go_emotions[\"test\"].to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "6444063b-2bb7-4653-9dfe-eb57306bc296",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def int2str(i):\n",
+    "    #return int(i)\n",
+    "    return go_emotions[\"train\"].features[\"labels\"].feature.int2str(int(i))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "a75bfea6-cc9e-4d29-b091-b8cd9459069a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "label_freq = []\n",
+    "\n",
+    "idx_multi = df.labels.map(lambda x: len(x) > 1)\n",
+    "df[\"is_single\"] = df.labels.map(lambda x: 0 if len(x) > 1 else 1) \n",
+    "df[idx_multi].labels.map(lambda x: [label_freq.append(int(l)) for l in x])\n",
+    "pd.Series(label_freq).value_counts();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "31b129f2-b92c-4ac7-a2aa-e6601dc9404c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create(split: str) -> pd.DataFrame:\n",
+    "    df = go_emotions[split].to_pandas()\n",
+    "    df[\"is_single\"] = df.labels.map(lambda x: 0 if len(x) > 1 else 1)\n",
+    "    \n",
+    "    #['admiration', 'approval', 'annoyance', 'gratitude', 'curiosity', 'optimism', 'amusement']\n",
+    "    idx_most_common = df.labels.map(lambda x: all([int(label) in [0, 4, 3, 15, 7, 15, 20] for label in x]))\n",
+    "    df_multi = df[(df.is_single == 0) & idx_most_common]\n",
+    "    df_single = df[idx_most_common].sample(3*len(df_multi), weights=\"is_single\", axis=0, random_state=42)\n",
+    "    return pd.concat([df_multi, df_single]).sample(frac=1, random_state=42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "c784365d-4830-481d-a771-57a0d9623cf7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import rubrix as rb\n",
+    "\n",
+    "def make_records(row, is_train: bool) -> rb.TextClassificationRecord:\n",
+    "    annotation = [int2str(i) for i in row.labels] if not is_train else None\n",
+    "    return rb.TextClassificationRecord(\n",
+    "        inputs=row.text,\n",
+    "        annotation=annotation,\n",
+    "        multi_label=True,\n",
+    "        id=row.id,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "fa658986-026e-4936-9c78-25b8c65516bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_recs = create(\"train\").apply(make_records, axis=1, is_train=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "a4ce778d-83b1-4799-9a67-f304f027cb5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_recs = create(\"test\").apply(make_records, axis=1, is_train=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "b1e552bc-df6f-4368-8d30-7d8e35238fc4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "records = train_recs.to_list() + test_recs.tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "1f854543-63ea-4b52-bf17-cf33ec604e53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_rb = rb.DatasetForTextClassification(records).to_datasets()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "f61ddb4d-1387-47b4-b01c-3072e835e4ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "97ff3efe852046beb60232c09e4c04b2",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Pushing dataset shards to the dataset hub:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ds_rb.push_to_hub(\"rubrix/go_emotions_multi-label\", private=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef1de2b1-97be-4372-8919-2dfc422a86b1",
+   "metadata": {},
+   "source": [
+    "## APPENDIX B\n",
+    "\n",
+    "https://www.kaggle.com/shivanandmn/multilabel-classification-dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "708ac8e3-b809-430a-941a-ac0d5fb36446",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "55420944-3786-4dab-9b35-7cbcc47a9cad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(\"/home/david/Downloads/topic_modeling_researc_articles/train.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "87774d1a-b14a-41ff-9080-0eb34c008db0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.model_selection import train_test_split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d16639d4-1e3a-4c71-b629-3090c8223830",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_, test_id = train_test_split(df.ID, test_size=0.2, random_state=42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "771f9ebf-4f12-4533-b3f9-f2a820ea0074",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "labels = [\"Computer Science\", \"Physics\", \"Mathematics\", \"Statistics\", \"Quantitative Biology\", \"Quantitative Finance\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "2b539077-6dec-459b-ab48-0684410d78dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_record(row):\n",
+    "    annotation = [label for label in labels if row[label] == 1]\n",
+    "    return rb.TextClassificationRecord(\n",
+    "        inputs=row.TITLE,\n",
+    "        annotation=annotation if row.ID in test_id else None,\n",
+    "        multi_label=True,\n",
+    "        id=row.ID,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cb7e6338-d3e8-41c5-a130-7b0b20a068e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "records = df.apply(make_record, axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "a2de5c5a-8eb4-49a7-b0f5-d6f2283323fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import rubrix as rb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "8d68ba77-89ec-4856-87b1-603be88ae1da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_rb = rb.DatasetForTextClassification(records.tolist())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "b47a6b98-d0a1-459e-b5bd-3514d5692d42",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9eeb3777625a4bb8849460ba43ff6ab4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Pushing dataset shards to the dataset hub:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "dataset_rb.to_datasets().push_to_hub(\"rubrix/research_titles_multi-label\", private=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3987ecd4-1d4c-475b-be38-b94381ae9d4d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/tutorials/weak-supervision-multi-label.ipynb
+++ b/docs/tutorials/weak-supervision-multi-label.ipynb
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 264,
+   "execution_count": 13,
    "id": "c90591ef-bedb-4069-b491-bd9d7f58edde",
    "metadata": {},
    "outputs": [],
@@ -93,10 +93,53 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "de1f67bb-8666-4fd9-a293-f0e6a1168f0a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "95b9b3058a434f9793065bf1059f607d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Preparing rules:   0%|          | 0/22 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "42c99a7d89304768b241ff6f20ee39f8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Applying rules:   0%|          | 0/4208 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6fbc69a9302f42da9f45c6d84dcd2af5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Filling weak label matrix:   0%|          | 0/4208 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "from rubrix.labeling.text_classification import WeakMultiLabels\n",
     "\n",
@@ -106,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 266,
+   "execution_count": 15,
    "id": "cdc6fea9-f248-4f55-a542-a0296f2873f0",
    "metadata": {},
    "outputs": [
@@ -163,7 +206,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>text:(thanks AND good)</th>\n",
-       "      <td>{gratitude, admiration}</td>\n",
+       "      <td>{admiration, gratitude}</td>\n",
        "      <td>0.007842</td>\n",
        "      <td>0.010753</td>\n",
        "      <td>0.007605</td>\n",
@@ -363,7 +406,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>total</th>\n",
-       "      <td>{gratitude, optimism, curiosity, approval, ann...</td>\n",
+       "      <td>{curiosity, annoyance, admiration, approval, o...</td>\n",
        "      <td>0.327234</td>\n",
        "      <td>0.384409</td>\n",
        "      <td>0.041825</td>\n",
@@ -379,7 +422,7 @@
        "                                                                                            label  \\\n",
        "thank*                                                                                {gratitude}   \n",
        "appreciate                                                                            {gratitude}   \n",
-       "text:(thanks AND good)                                                    {gratitude, admiration}   \n",
+       "text:(thanks AND good)                                                    {admiration, gratitude}   \n",
        "advice                                                                               {admiration}   \n",
        "amazing                                                                              {admiration}   \n",
        "awesome                                                                              {admiration}   \n",
@@ -399,7 +442,7 @@
        "\"what is\"                                                                             {curiosity}   \n",
        "\"can you\"                                                                             {curiosity}   \n",
        "\"would you\"                                                                           {curiosity}   \n",
-       "total                                           {gratitude, optimism, curiosity, approval, ann...   \n",
+       "total                                           {curiosity, annoyance, admiration, approval, o...   \n",
        "\n",
        "                                                coverage  annotated_coverage  \\\n",
        "thank*                                          0.196768            0.196237   \n",
@@ -477,7 +520,7 @@
        "total                                            0.936047  "
       ]
      },
-     "execution_count": 266,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -489,7 +532,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 268,
+   "execution_count": 16,
    "id": "6985e6b7-7c28-4efc-84d2-08b7fff02ef8",
    "metadata": {},
    "outputs": [],
@@ -502,21 +545,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 269,
+   "execution_count": 17,
    "id": "152abc10-1538-4660-aa3a-0e210887c0f1",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1234"
-      ]
-     },
-     "execution_count": 269,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Get records with the predictions from the label model to train a down-stream model\n",
     "train_rb = rb.DatasetForTextClassification(label_model.predict())\n",
@@ -528,7 +560,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 270,
+   "execution_count": 18,
    "id": "fce0c5a0-bfa5-4649-a59a-f0114f7891a5",
    "metadata": {},
    "outputs": [],
@@ -539,7 +571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 271,
+   "execution_count": 19,
    "id": "232a2d46-1516-4c7d-8d39-d55fe0d8130d",
    "metadata": {},
    "outputs": [],
@@ -574,7 +606,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 273,
+   "execution_count": 20,
    "id": "88365498-15df-4aff-ae3a-48c22e4e1a66",
    "metadata": {},
    "outputs": [],
@@ -587,10 +619,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 274,
+   "execution_count": 21,
    "id": "6635d069-e242-4d89-92be-ecce502b92db",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a23f052f685c4c7b88ae627b30e3c3a8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/2 [00:00<?, ?ba/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "48552906ee5e499f8d9fc330c13eb6a0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1 [00:00<?, ?ba/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "def tokenize_func(examples):\n",
     "    return tokenizer(examples[\"text\"], padding=\"max_length\", truncation=True)\n",
@@ -601,27 +662,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "4043767f-9adc-4724-938e-45fdf500d2b7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.preprocessing import MultiLabelBinarizer\n",
-    "\n",
-    "# Init and fit a binarizer to help with the label format\n",
-    "mb = MultiLabelBinarizer()\n",
-    "mb.fit(ds[\"test\"][\"label\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 278,
+   "execution_count": 39,
    "id": "a5d04aa2-560d-450d-8242-db5ea4a44844",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "25301609aa924a49bbe92ed8cb481315",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/2 [00:00<?, ?ba/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5022b7f93285445ba0aaf90cd696a6fa",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1 [00:00<?, ?ba/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "def binarize_labels(examples):\n",
-    "    return {\"label\": mb.transform(examples[\"label\"])}\n",
+    "    return {\"label\": [\n",
+    "        [int(i in labels) for i in range(len(ds[\"test\"].features[\"label\"][0].names))] \n",
+    "        for labels in examples[\"label\"]\n",
+    "    ]}\n",
     "\n",
     "# Turn labels into multi-label format\n",
     "binarized_tokenized_ds = tokenized_ds.map(binarize_labels, batched=True)"

--- a/docs/tutorials/weak-supervision-multi-label.ipynb
+++ b/docs/tutorials/weak-supervision-multi-label.ipynb
@@ -16,7 +16,46 @@
    "id": "8ea2fec7-ded9-4752-be5d-d365ebe6c039",
    "metadata": {},
    "source": [
-    "In this tutorial we will tackle two text classification tasks that deal with multi-labels."
+    "In this tutorial we use Rubrix and weak supervision to tackle two multi-label classification datasets:\n",
+    "\n",
+    "- The first dataset is a curated version of [**GoEmotions**](https://huggingface.co/datasets/go_emotions), a dataset intended for **multi-label emotion classification**.\n",
+    "- We inspect the dataset in Rubrix, come up with good heuristics, and combine them with a label model to train a **weakly supervised Hugging Face transformer**.\n",
+    "- In the second dataset, we [**categorize research papers**](https://www.kaggle.com/shivanandmn/multilabel-classification-dataset) by topic based on their titles, which is a **multi-label topic classification** problem.\n",
+    "- We repeat the process of finding good heuristics, combine them with a label model and train a **lightweight downstream model using sklearn** in the end.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Note\n",
+    "\n",
+    "If you are new to weak supervision, check out our [weak supervision guide](../guides/weak-supervision.ipynb) and our first [weak supervision tutorial](weak-supervision-with-rubrix.ipynb).\n",
+    "    \n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a742259-2a99-4f2b-ac62-074bf2d6892a",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Rubrix, is a free and open-source tool to explore, annotate, and monitor data for NLP projects.\n",
+    "\n",
+    "If you are new to Rubrix, check out the [Github repository](https://github.com/recognai/rubrix) ⭐.\n",
+    "\n",
+    "If you have not installed and launched Rubrix yet, check the [Setup and Installation guide](../getting_started/setup&installation.rst).\n",
+    "\n",
+    "For this tutorial we also need some third party libraries that can be installed via pip:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55c31a41-b80d-44e9-97a3-0d9a71cd658e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install datasets transformers[torch] sklearn ipywidgets -qqq"
    ]
   },
   {
@@ -24,7 +63,22 @@
    "id": "f37c0bbe-904a-49de-9443-234252f0acb0",
    "metadata": {},
    "source": [
-    "## go emotions"
+    "## GoEmotions\n",
+    "\n",
+    "The original [GoEmotions](https://huggingface.co/datasets/go_emotions) is a challenging dataset intended for multi-label emotion classification.\n",
+    "For this tutorial, we simplify it a bit by selecting only 6 out of the 28 emotions: *admiration, annoyance, approval, curiosity, gratitude, optimism*.\n",
+    "We also try to accentuate the multi-label part of the dataset by down-sampling the examples that are classified with one label only.\n",
+    "See Appendix A for all the details of this preprocessing step."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2336f09-21a0-47a1-a5f7-4d930ddc1355",
+   "metadata": {},
+   "source": [
+    "### Define rules\n",
+    "\n",
+    "Let us start by downloading our curated version of the dataset from the Hugging Face Hub, and log it to Rubrix:"
    ]
   },
   {
@@ -39,7 +93,7 @@
     "\n",
     "# Download preprocessed dataset\n",
     "ds_rb = rb.read_datasets(\n",
-    "    load_dataset(\"rubrix/go_emotions_multi-label\", split=\"train\", use_auth_token=True),\n",
+    "    load_dataset(\"rubrix/go_emotions_multi-label\", split=\"train\"),\n",
     "    task=\"TextClassification\"\n",
     ")"
    ]
@@ -53,6 +107,15 @@
    "source": [
     "# Log dataset to Rubrix to find good heuristics\n",
     "rb.log(ds_rb, name=\"go_emotions\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0531d9c-b7df-4128-8b93-f8661558d603",
+   "metadata": {},
+   "source": [
+    "After uploading the dataset, we can explore and inspect it to find good heuristic rules.\n",
+    "Here we came up with the following ones that surely can be improved:"
    ]
   },
   {
@@ -92,59 +155,38 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "43da2cd0-58b3-4bf6-af48-88852959bd48",
+   "metadata": {},
+   "source": [
+    "We go on and apply these heuristic rules to our dataset creating our weak label matrix.\n",
+    "Since we are dealing with a multi-label classification task, the weak label matrix will have 3 dimensions.\n",
+    "\n",
+    "> Dimensions of the weak multi label matrix: *number of records* x *number of rules* x *number of labels* \n",
+    "\n",
+    "It will be filled with 0 and 1, depending on if the rule voted for the respective label or not.\n",
+    "If the rule abstained for a given record, the matrix will be filled with -1. "
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "de1f67bb-8666-4fd9-a293-f0e6a1168f0a",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "95b9b3058a434f9793065bf1059f607d",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Preparing rules:   0%|          | 0/22 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "42c99a7d89304768b241ff6f20ee39f8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Applying rules:   0%|          | 0/4208 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6fbc69a9302f42da9f45c6d84dcd2af5",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Filling weak label matrix:   0%|          | 0/4208 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from rubrix.labeling.text_classification import WeakMultiLabels\n",
     "\n",
     "# Compute the weak labels for our dataset given the rules\n",
     "weak_labels = WeakMultiLabels(\"go_emotions\", rules=rules)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2021a90-9e5b-4d5a-996d-71d8c19679d9",
+   "metadata": {},
+   "source": [
+    "We can call the `weak_labels.summary()` method to check the precision of each rule as well as our total coverage of the dataset."
    ]
   },
   {
@@ -531,6 +573,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "ba19f6b8-520a-4caa-87a4-307f52749b92",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Create training set\n",
+    "\n",
+    "When we are happy with our heuristics, it is time to combine them and compute weak labels for the training of our downstream model.\n",
+    "Here we will use the simple `MajorityVoter`, that in the multi-label case, sets the probability of a label to 0 or 1 depending on whether at least one non-abstaining rule voted for the respective label or not."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 16,
    "id": "6985e6b7-7c28-4efc-84d2-08b7fff02ef8",
@@ -541,6 +596,15 @@
     "\n",
     "# Use the majority voter as the label model\n",
     "label_model = MajorityVoter(weak_labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f82fe715-e703-457a-a158-78709f442bbd",
+   "metadata": {},
+   "source": [
+    "From our label model we get the training records together with its weak labels and probabilities.\n",
+    "We will use the weak labels with a probability greater than 0.5 as labels for our training, and hence copy them to the `annotation` property of our records."
    ]
   },
   {
@@ -559,6 +623,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "24414843-70c2-4dc2-902d-e6e8bcc2a449",
+   "metadata": {},
+   "source": [
+    "We extract the test set with manual annotations from our `WeakMultiLabels` object:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 18,
    "id": "fce0c5a0-bfa5-4649-a59a-f0114f7891a5",
@@ -567,6 +639,14 @@
    "source": [
     "# Get records with manual annotations to use as test set for the down-stream model\n",
     "test_rb = rb.DatasetForTextClassification(weak_labels.records(has_annotation=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7738210-4273-49c2-a70c-634b18fa008e",
+   "metadata": {},
+   "source": [
+    "We will use the convenient `DatasetForTextClassification.prepare_for_training()` method to create datasets optimized for training with the Hugging Face transformers library:"
    ]
   },
   {
@@ -586,6 +666,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b0be5d9c-1532-4265-8f7a-18e346e9caaf",
+   "metadata": {},
+   "source": [
+    "Let us push the dataset to the Hub to share it with our colleagues.\n",
+    "It is also an easy way to outsource the training of the model to an environment with an accelerator, like Google Colab for example."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "072218ae-2167-48d8-8b93-243daff497b3",
@@ -593,7 +682,7 @@
    "outputs": [],
    "source": [
     "# Push dataset for training our down-stream model to the HF hub\n",
-    "ds.push_to_hub(\"rubrix/go_emotions_training\", private=True)"
+    "ds.push_to_hub(\"rubrix/go_emotions_training\")"
    ]
   },
   {
@@ -601,7 +690,25 @@
    "id": "c0957ad2-f05d-4ea4-b303-d77495a449e9",
    "metadata": {},
    "source": [
-    "### Train transformers down-stream model"
+    "### Train a transformer downstream model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec8cea7b-cd6f-408d-9667-249e3d66eac0",
+   "metadata": {},
+   "source": [
+    "The following steps are basically a copy&paste from the amazing documentation of the [Hugging Face transformers](https://huggingface.co/docs/transformers) library.\n",
+    "\n",
+    "First, we will load the tokenizer corresponding to our model, which we choose to be the [distilled version](https://huggingface.co/distilbert-base-uncased) of the infamous BERT.\n",
+    "\n",
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Note\n",
+    "\n",
+    "Since we will use a full-blown transformer as a downstream model (albeit a distilled one), we recommend executing the following code on a machine with a GPU, or in a Google Colab with a GPU backend enabled.\n",
+    "    \n",
+    "</div>"
    ]
   },
   {
@@ -618,40 +725,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "fd0cb66a-c31e-4811-abc3-453179ee567f",
+   "metadata": {},
+   "source": [
+    "Afterward, we tokenize our data:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "6635d069-e242-4d89-92be-ecce502b92db",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a23f052f685c4c7b88ae627b30e3c3a8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/2 [00:00<?, ?ba/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "48552906ee5e499f8d9fc330c13eb6a0",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/1 [00:00<?, ?ba/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "def tokenize_func(examples):\n",
     "    return tokenizer(examples[\"text\"], padding=\"max_length\", truncation=True)\n",
@@ -661,49 +747,74 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 39,
-   "id": "a5d04aa2-560d-450d-8242-db5ea4a44844",
+   "cell_type": "markdown",
+   "id": "28d70c03-9602-472f-aa79-28777fe3b0e2",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "25301609aa924a49bbe92ed8cb481315",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/2 [00:00<?, ?ba/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5022b7f93285445ba0aaf90cd696a6fa",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "  0%|          | 0/1 [00:00<?, ?ba/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
    "source": [
-    "def binarize_labels(examples):\n",
-    "    return {\"label\": [\n",
-    "        [int(i in labels) for i in range(len(ds[\"test\"].features[\"label\"][0].names))] \n",
-    "        for labels in examples[\"label\"]\n",
-    "    ]}\n",
+    "The transformer model expects our labels to follow a common multi-label format of binaries, so let us use [sklearn](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MultiLabelBinarizer.html) for this transformation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7efcbc6-938c-4341-9e83-e8761974deda",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.preprocessing import MultiLabelBinarizer\n",
     "\n",
     "# Turn labels into multi-label format\n",
+    "mb = MultiLabelBinarizer()\n",
+    "mb.fit(ds[\"test\"][\"label\"])\n",
+    "\n",
+    "def binarize_labels(examples):\n",
+    "    return {\"label\": mb.transform(examples[\"label\"])}\n",
+    "\n",
     "binarized_tokenized_ds = tokenized_ds.map(binarize_labels, batched=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e71e2cd7-50e4-4dd1-883f-f2e31d1ec051",
+   "metadata": {},
+   "source": [
+    "Before we start the training, it is important to define our metric for the evaluation.\n",
+    "Here we settle on the commonly used micro averaged *F1* metric, but we will also keep track of the *F1 per label*, for a more in-depth error analysis afterward."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 285,
+   "id": "d50f9ae8-2b1a-4905-b19f-62bcfa8c64d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datasets import load_metric\n",
+    "import numpy as np\n",
+    "\n",
+    "# Define our metrics\n",
+    "metric = load_metric(\"f1\", config_name=\"multilabel\")\n",
+    "def compute_metrics(eval_pred):\n",
+    "    logits, labels = eval_pred\n",
+    "    # apply sigmoid\n",
+    "    predictions = ( 1. / (1 + np.exp(-logits)) ) > 0.5\n",
+    "    \n",
+    "    # f1 micro averaged\n",
+    "    metrics = metric.compute(predictions=predictions, references=labels, average=\"micro\")\n",
+    "    # f1 per label\n",
+    "    per_label_metric = metric.compute(predictions=predictions, references=labels, average=None)\n",
+    "    for label, f1 in zip(ds[\"train\"].features[\"label\"][0].names, per_label_metric[\"f1\"]):\n",
+    "        metrics[f\"f1_{label}\"] = f1\n",
+    "\n",
+    "    return metrics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5cf20aa-0117-438d-a960-59a85adb4d37",
+   "metadata": {},
+   "source": [
+    "Now we are ready to load our pretrained transformer model and prepare it for our task: multi-label text classification with 6 labels."
    ]
   },
   {
@@ -726,6 +837,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "29498e65-8edc-4086-8ab7-f2db90f8a113",
+   "metadata": {},
+   "source": [
+    "The only thing missing for the training is the `Trainer` and its `TrainingArguments`.\n",
+    "To keep it simple, we mostly rely on the default arguments, that often work out of the box, but tweak a bit the batch size to train faster. \n",
+    "We also checked that 2 epochs are enough for our rather small dataset."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 283,
    "id": "2dd0c0bd-b7d9-4e1c-a734-8c2a8e9d57d6",
@@ -742,30 +863,6 @@
     "    per_device_train_batch_size=16,   \n",
     "    per_device_eval_batch_size=16, \n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 285,
-   "id": "d50f9ae8-2b1a-4905-b19f-62bcfa8c64d9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from datasets import load_metric\n",
-    "import numpy as np\n",
-    "\n",
-    "# Define our metrics\n",
-    "metric = load_metric(\"f1\", config_name=\"multilabel\")\n",
-    "def compute_metrics(eval_pred):\n",
-    "    logits, labels = eval_pred\n",
-    "    predictions = ( 1. / (1 + np.exp(-logits)) ) > 0.5\n",
-    "    \n",
-    "    metrics = metric.compute(predictions=predictions, references=labels, average=\"micro\")\n",
-    "    per_label_metric = metric.compute(predictions=predictions, references=labels, average=None)\n",
-    "    for label, f1 in zip(ds[\"train\"].features[\"label\"][0].names, per_label_metric[\"f1\"]):\n",
-    "        metrics[f\"f1_{label}\"] = f1\n",
-    "\n",
-    "    return metrics"
    ]
   },
   {
@@ -798,6 +895,15 @@
    "source": [
     "# Train the down-stream model\n",
     "trainer.train()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b77e8d7e-1463-42c8-96e2-13dfe98cc318",
+   "metadata": {},
+   "source": [
+    "We achieved an micro averaged *F1* of abut 0.54, which is not perfect, but a good baseline for this challenging dataset.\n",
+    "When inspecting the *F1s per label*, we clearly see that the worst performing labels are the ones with the poorest heuristics in terms of accuracy and coverage, which comes to no surprise."
    ]
   },
   {
@@ -1621,7 +1727,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 1,
    "id": "16336e27-c99c-4a51-b81b-bc63fb26daa2",
    "metadata": {},
    "outputs": [],
@@ -1632,50 +1738,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 2,
    "id": "cf227957-7eb6-4ac5-b9d5-f3c671865377",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "70f48b2d858e46189ff8510524a2b71c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          | 0.00/2.02k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "436b97fc180a428fbc53cb24ab91943a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          | 0.00/1.67k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2022-03-15 23:59:34.112 | WARNING  | datasets.builder:_create_builder_config:333 - No config specified, defaulting to: go_emotions/simplified\n",
-      "2022-03-15 23:59:34.120 | WARNING  | datasets.builder:download_and_prepare:531 - Reusing dataset go_emotions (/home/david/.cache/huggingface/datasets/go_emotions/simplified/0.0.0/2637cfdd4e64d30249c3ed2150fa2b9d279766bfcd6a809b9f085c61a90d776d)\n"
+      "No config specified, defaulting to: go_emotions/simplified\n",
+      "Reusing dataset go_emotions (/home/david/.cache/huggingface/datasets/go_emotions/simplified/0.0.0/2637cfdd4e64d30249c3ed2150fa2b9d279766bfcd6a809b9f085c61a90d776d)\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b3b8c2fb279545aa8f904ef054361fa1",
+       "model_id": "2cecb0f3b98f45f2bdcfbdab50ff9c00",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1693,7 +1771,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 5,
    "id": "814047aa-d1df-4da4-9f68-2562f08bf9fa",
    "metadata": {},
    "outputs": [],
@@ -1703,7 +1781,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 6,
    "id": "6444063b-2bb7-4653-9dfe-eb57306bc296",
    "metadata": {},
    "outputs": [],
@@ -1715,17 +1793,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 8,
    "id": "a75bfea6-cc9e-4d29-b091-b8cd9459069a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "27    181\n",
+       "0     156\n",
+       "3     126\n",
+       "4     115\n",
+       "7     108\n",
+       "15     92\n",
+       "20     79\n",
+       "1      78\n",
+       "18     78\n",
+       "10     72\n",
+       "17     68\n",
+       "2      67\n",
+       "9      63\n",
+       "22     56\n",
+       "6      56\n",
+       "26     54\n",
+       "25     54\n",
+       "5      49\n",
+       "11     47\n",
+       "13     46\n",
+       "8      27\n",
+       "12     14\n",
+       "14     13\n",
+       "24     12\n",
+       "19     11\n",
+       "21      9\n",
+       "23      4\n",
+       "16      4\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "label_freq = []\n",
     "\n",
     "idx_multi = df.labels.map(lambda x: len(x) > 1)\n",
     "df[\"is_single\"] = df.labels.map(lambda x: 0 if len(x) > 1 else 1) \n",
     "df[idx_multi].labels.map(lambda x: [label_freq.append(int(l)) for l in x])\n",
-    "pd.Series(label_freq).value_counts();"
+    "pd.Series(label_freq).value_counts()"
    ]
   },
   {

--- a/src/rubrix/labeling/text_classification/__init__.py
+++ b/src/rubrix/labeling/text_classification/__init__.py
@@ -14,6 +14,6 @@
 #  limitations under the License.
 
 from .label_errors import find_label_errors
-from .label_models import FlyingSquid, Snorkel
+from .label_models import FlyingSquid, MajorityVoter, Snorkel
 from .rule import Rule, load_rules
 from .weak_labels import WeakLabels, WeakMultiLabels

--- a/src/rubrix/labeling/text_classification/label_models.py
+++ b/src/rubrix/labeling/text_classification/label_models.py
@@ -15,7 +15,7 @@
 import hashlib
 import logging
 from enum import Enum
-from typing import Dict, List, Union
+from typing import Dict, List, Tuple, Union
 
 import numpy as np
 
@@ -117,7 +117,7 @@ class MajorityVoter(LabelModel):
             include_annotated_records: Whether to include annotated records.
             include_abstentions: Whether to include records in the output, for which the label model abstained.
             prediction_agent: String used for the ``prediction_agent`` in the returned records.
-            tie_break_policy: Policy to break ties (IGNORED FOR MULTI LABEL!). You can choose among two policies:
+            tie_break_policy: Policy to break ties (IGNORED FOR MULTI-LABEL!). You can choose among two policies:
 
                 - `abstain`: Do not provide any prediction
                 - `random`: randomly choose among tied option using deterministic hash
@@ -128,48 +128,46 @@ class MajorityVoter(LabelModel):
         Returns:
             A list of records that include the predictions of the label model.
         """
-        if isinstance(self._weak_labels, WeakMultiLabels):
-            return self._multi_label_predict(
-                include_annotated_records, include_abstentions, prediction_agent
-            )
-        return self._single_label_predict(
-            include_annotated_records,
-            include_abstentions,
-            prediction_agent,
-            tie_break_policy,
-        )
-
-    def _single_label_predict(
-        self,
-        include_annotated_records: bool = False,
-        include_abstentions: bool = False,
-        prediction_agent: str = "MajorityVoter",
-        tie_break_policy: Union[TieBreakPolicy, str] = "abstain",
-    ) -> List[TextClassificationRecord]:
-        """Applies the label model.
-
-        Args:
-            include_annotated_records: Whether to include annotated records.
-            include_abstentions: Whether to include records in the output, for which the label model abstained.
-            prediction_agent: String used for the ``prediction_agent`` in the returned records.
-            tie_break_policy: Policy to break ties. You can choose among three policies:
-
-                - `abstain`: Do not provide any prediction
-                - `random`: randomly choose among tied option using deterministic hash
-
-                The last policy can introduce quite a bit of noise, especially when the tie is among many labels,
-                as is the case when all the labeling functions (rules) abstained.
-
-        Returns:
-            A list of records that include the predictions of the label model.
-        """
-        if isinstance(tie_break_policy, str):
-            tie_break_policy = TieBreakPolicy(tie_break_policy)
-
         wl_matrix = self._weak_labels.matrix(
             has_annotation=None if include_annotated_records else False
         )
+        records = self._weak_labels.records(
+            has_annotation=None if include_annotated_records else False
+        )
 
+        if isinstance(self._weak_labels, WeakMultiLabels):
+            probabilities = self._compute_multi_label_probs(wl_matrix)
+
+            return self._make_multi_label_records(
+                probabilities=probabilities,
+                records=records,
+                include_abstentions=include_abstentions,
+                prediction_agent=prediction_agent,
+            )
+
+        if isinstance(tie_break_policy, str):
+            tie_break_policy = TieBreakPolicy(tie_break_policy)
+
+        probabilities = self._compute_single_label_probs(wl_matrix)
+
+        return self._make_single_label_records(
+            probabilities=probabilities,
+            records=records,
+            include_abstentions=include_abstentions,
+            prediction_agent=prediction_agent,
+            tie_break_policy=tie_break_policy,
+        )
+
+    def _compute_single_label_probs(self, wl_matrix: np.ndarray) -> np.ndarray:
+        """Helper methods that computes the probabilities.
+
+        Args:
+            wl_matrix: The weak label matrix.
+
+        Returns:
+            A matrix of "probabilities" with nr or records x nr of labels.
+            The label order matches the one from `self.weak_labels.labels`.
+        """
         counts = np.column_stack(
             [
                 np.count_nonzero(
@@ -179,19 +177,38 @@ class MajorityVoter(LabelModel):
             ]
         )
         with np.errstate(invalid="ignore"):
-            probabilities = np.nan_to_num(
-                counts / counts.sum(axis=1).reshape(len(counts), -1)
-            )
+            probabilities = counts / counts.sum(axis=1).reshape(len(counts), -1)
 
-        # add predictions to records
+        return np.nan_to_num(probabilities)
+
+    def _make_single_label_records(
+        self,
+        probabilities: np.ndarray,
+        records: List[TextClassificationRecord],
+        include_abstentions: bool,
+        prediction_agent: str,
+        tie_break_policy: TieBreakPolicy,
+    ):
+        """Helper method to create records given predicted probabilities.
+
+        Args:
+            probabilities: The predicted probabilities.
+            records: The records associated with the probabilities.
+            include_abstentions: Whether to include records in the output, for which the label model abstained.
+            prediction_agent: String used for the ``prediction_agent`` in the returned records.
+            tie_break_policy: Policy to break ties. You can choose among two policies:
+
+                - `abstain`: Do not provide any prediction
+                - `random`: randomly choose among tied option using deterministic hash
+
+                The last policy can introduce quite a bit of noise, especially when the tie is among many labels,
+                as is the case when all the labeling functions (rules) abstained.
+
+        Returns:
+            A list of records that include the predictions of the label model.
+        """
         records_with_prediction = []
-        for i, prob, rec in zip(
-            range(len(probabilities)),
-            probabilities,
-            self._weak_labels.records(
-                has_annotation=None if include_annotated_records else False
-            ),
-        ):
+        for i, prob, rec in zip(range(len(records)), probabilities, records):
             # Check if model abstains, that is if the highest probability is assigned to more than one label
             # 1.e-8 is taken from the abs tolerance of np.isclose
             equal_prob_idx = np.nonzero(np.abs(prob.max() - prob) < 1.0e-8)[0]
@@ -207,8 +224,8 @@ class MajorityVoter(LabelModel):
 
             if not tie:
                 pred_for_rec = [
-                    (self._weak_labels.labels[i], prob[i])
-                    for i in np.argsort(prob)[::-1]
+                    (self._weak_labels.labels[idx], prob[idx])
+                    for idx in np.argsort(prob)[::-1]
                 ]
             # resolve ties following the tie break policy
             elif tie_break_policy is TieBreakPolicy.ABSTAIN:
@@ -225,8 +242,8 @@ class MajorityVoter(LabelModel):
                             len(prob) - 1
                         )
                 pred_for_rec = [
-                    (self._weak_labels.labels[i], prob[i])
-                    for i in np.argsort(prob)[::-1]
+                    (self._weak_labels.labels[idx], prob[idx])
+                    for idx in np.argsort(prob)[::-1]
                 ]
             else:
                 raise NotImplementedError(
@@ -239,48 +256,53 @@ class MajorityVoter(LabelModel):
 
         return records_with_prediction
 
-    def _multi_label_predict(
-        self,
-        include_annotated_records: bool = False,
-        include_abstentions: bool = False,
-        prediction_agent: str = "MajorityVoter",
-    ) -> List[TextClassificationRecord]:
-        """Applies the label model.
+    def _compute_multi_label_probs(self, wl_matrix: np.ndarray) -> np.ndarray:
+        """Helper methods that computes the probabilities.
 
         Args:
-            include_annotated_records: Whether to include annotated records.
+            wl_matrix: The weak label matrix.
+
+        Returns:
+            A matrix of "probabilities" with nr or records x nr of labels.
+            The label order matches the one from `self.weak_labels.labels`.
+        """
+        # turn abstentions (-1) into 0
+        counts = np.where(wl_matrix == -1, 0, wl_matrix).sum(axis=1)
+        # binary probability, predict all labels with at least one vote
+        probabilities = np.where(counts > 0, 1, 0).astype(np.float16)
+
+        all_rules_abstained = wl_matrix.sum(axis=1).sum(axis=1) == (
+            -1 * self._weak_labels.cardinality * len(self._weak_labels.rules)
+        )
+        probabilities[all_rules_abstained] = [np.nan] * len(self._weak_labels.labels)
+
+        # more "nuanced probability", not sure if useful though
+        # with np.errstate(invalid="ignore"):
+        #     probabilities = counts / counts.sum(axis=1).reshape(len(counts), -1)
+
+        return probabilities
+
+    def _make_multi_label_records(
+        self,
+        probabilities: np.ndarray,
+        records: List[TextClassificationRecord],
+        include_abstentions: bool,
+        prediction_agent: str,
+    ) -> List[TextClassificationRecord]:
+        """Helper method to create records given predicted probabilities.
+
+        Args:
+            probabilities: The predicted probabilities.
+            records: The records associated with the probabilities.
             include_abstentions: Whether to include records in the output, for which the label model abstained.
             prediction_agent: String used for the ``prediction_agent`` in the returned records.
 
         Returns:
             A list of records that include the predictions of the label model.
         """
-        wl_matrix = self._weak_labels.matrix(
-            has_annotation=None if include_annotated_records else False
-        )
-
-        all_rules_abstained = wl_matrix.sum(axis=1).sum(axis=1) == (
-            -1 * self._weak_labels.cardinality * len(self._weak_labels.rules)
-        )
-
-        # turn abstentions (-1) into 0
-        counts = np.where(wl_matrix == -1, 0, wl_matrix).sum(axis=1)
-        probabilities = np.where(counts > 0, 1, 0)
-        # more nuanced "probability", not sure if useful though
-        # with np.errstate(invalid="ignore"):
-        #     probabilities = np.nan_to_num(
-        #         counts / counts.sum(axis=1).reshape(len(counts), -1)
-        #     )
-
-        # add predictions to records
         records_with_prediction = []
-        for all_abstained, prob, rec in zip(
-            all_rules_abstained,
-            probabilities,
-            self._weak_labels.records(
-                has_annotation=None if include_annotated_records else False
-            ),
-        ):
+        for prob, rec in zip(probabilities, records):
+            all_abstained = np.isnan(prob).all()
             # maybe skip record
             if not include_abstentions and all_abstained:
                 continue
@@ -297,6 +319,149 @@ class MajorityVoter(LabelModel):
             records_with_prediction[-1].prediction_agent = prediction_agent
 
         return records_with_prediction
+
+    def score(
+        self,
+        tie_break_policy: Union[TieBreakPolicy, str] = "abstain",
+        output_str: bool = False,
+    ) -> Union[Dict[str, float], str]:
+        """Returns some scores/metrics of the label model with respect to the annotated records.
+
+        The metrics are:
+
+        - accuracy
+        - micro/macro averages for precision, recall and f1
+        - precision, recall, f1 and support for each label
+
+        For more details about the metrics, check out the
+        `sklearn docs <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_recall_fscore_support.html#sklearn-metrics-precision-recall-fscore-support>`__.
+
+        Args:
+            tie_break_policy: Policy to break ties (IGNORED FOR MULTI-LABEL). You can choose among two policies:
+
+                - `abstain`: Do not provide any prediction
+                - `random`: randomly choose among tied option using deterministic hash
+
+                The last policy can introduce quite a bit of noise, especially when the tie is among many labels,
+                as is the case when all the labeling functions (rules) abstained.
+            output_str: If True, return output as nicely formatted string.
+
+        Returns:
+            The scores/metrics in a dictionary or as a nicely formatted str.
+
+        .. note:: Metrics are only calculated over non-abstained predictions!
+
+        Raises:
+            MissingAnnotationError: If the ``weak_labels`` do not contain annotated records.
+        """
+        try:
+            import sklearn
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                "'sklearn' must be installed to compute the metrics! "
+                "You can install 'sklearn' with the command: `pip install scikit-learn`"
+            )
+        from sklearn.metrics import classification_report
+
+        wl_matrix = self._weak_labels.matrix(has_annotation=True)
+
+        if isinstance(self._weak_labels, WeakMultiLabels):
+            probabilities = self._compute_multi_label_probs(wl_matrix)
+
+            annotation, prediction = self._score_multi_label(probabilities)
+        else:
+            if isinstance(tie_break_policy, str):
+                tie_break_policy = TieBreakPolicy(tie_break_policy)
+
+            probabilities = self._compute_single_label_probs(wl_matrix)
+
+            annotation, prediction = self._score_single_label(probabilities)
+
+        return classification_report(
+            annotation,
+            prediction,
+            target_names=self._weak_labels.labels[: annotation.max() + 1],
+            output_dict=not output_str,
+        )
+
+    def _score_single_label(
+        self, probabilities: np.ndarray, tie_break_policy: TieBreakPolicy
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Helper method to compute scores for single-label classifications.
+
+        Args:
+            probabilities: The probabilities.
+            tie_break_policy: Policy to break ties. You can choose among two policies:
+
+                - `abstain`: Exclude from scores.
+                - `random`: randomly choose among tied option using deterministic hash.
+
+                The last policy can introduce quite a bit of noise, especially when the tie is among many labels,
+                as is the case when all the labeling functions (rules) abstained.
+
+        Returns:
+            A tuple of the annotation and prediction array.
+        """
+        # 1.e-8 is taken from the abs tolerance of np.isclose
+        is_max = (
+            np.abs(probabilities.max(axis=1, keepdims=True) - probabilities) < 1.0e-8
+        )
+        is_tie = is_max.sum(axis=1) > 1
+
+        prediction = np.argmax(is_max, axis=1)
+        # we need to transform the indexes!
+        annotation = np.array(
+            [
+                self._weak_labels.labels.index(self._weak_labels.int2label[i])
+                for i in self._weak_labels.annotation()
+            ],
+            dtype=np.short,
+        )
+
+        if not is_tie.any():
+            pass
+        # resolve ties
+        elif tie_break_policy is TieBreakPolicy.ABSTAIN:
+            prediction, annotation = prediction[~is_tie], annotation[~is_tie]
+        elif tie_break_policy is TieBreakPolicy.RANDOM:
+            for i in np.nonzero(is_tie)[0]:
+                equal_prob_idx = np.nonzero(is_max[i])[0]
+                random_idx = int(hashlib.sha1(f"{i}".encode()).hexdigest(), 16) % len(
+                    equal_prob_idx
+                )
+                prediction[i] = equal_prob_idx[random_idx]
+        else:
+            raise NotImplementedError(
+                f"The tie break policy '{tie_break_policy.value}' is not implemented for FlyingSquid!"
+            )
+
+        return annotation, prediction
+
+    def _score_multi_label(
+        self, probabilities: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Helper method to compute scores for multi-label classifications.
+
+        Args:
+            probabilities: The probabilities.
+
+        Returns:
+            A tuple of the annotation and prediction array.
+        """
+        prediction = np.where(probabilities > 0.5, 1, 0)
+        annotation = np.array(
+            [
+                self._weak_labels.labels.index(self._weak_labels.int2label[i])
+                for i in self._weak_labels.annotation()
+            ],
+            dtype=np.short,
+        )
+
+        is_abstain = np.isnan(probabilities).all(axis=1)
+
+        prediction, annotation = prediction[~is_abstain], annotation[~is_abstain]
+
+        return annotation, prediction
 
 
 class Snorkel(LabelModel):

--- a/src/rubrix/labeling/text_classification/label_models.py
+++ b/src/rubrix/labeling/text_classification/label_models.py
@@ -259,16 +259,18 @@ class MajorityVoter(LabelModel):
             has_annotation=None if include_annotated_records else False
         )
 
-        # turn abstentions (-1) into 0
-        counts = np.where(wl_matrix == -1, 0, wl_matrix).sum(axis=1)
-        with np.errstate(invalid="ignore"):
-            probabilities = np.nan_to_num(
-                counts / counts.sum(axis=1).reshape(len(counts), -1)
-            )
-
         all_rules_abstained = wl_matrix.sum(axis=1).sum(axis=1) == (
             -1 * self._weak_labels.cardinality * len(self._weak_labels.rules)
         )
+
+        # turn abstentions (-1) into 0
+        counts = np.where(wl_matrix == -1, 0, wl_matrix).sum(axis=1)
+        probabilities = np.where(counts > 0, 1, 0)
+        # more nuanced "probability", not sure if useful though
+        # with np.errstate(invalid="ignore"):
+        #     probabilities = np.nan_to_num(
+        #         counts / counts.sum(axis=1).reshape(len(counts), -1)
+        #     )
 
         # add predictions to records
         records_with_prediction = []

--- a/src/rubrix/labeling/text_classification/label_models.py
+++ b/src/rubrix/labeling/text_classification/label_models.py
@@ -437,7 +437,7 @@ class MajorityVoter(LabelModel):
                 prediction[i] = equal_prob_idx[random_idx]
         else:
             raise NotImplementedError(
-                f"The tie break policy '{tie_break_policy.value}' is not implemented for FlyingSquid!"
+                f"The tie break policy '{tie_break_policy.value}' is not implemented for MajorityVoter!"
             )
 
         return annotation, prediction
@@ -454,17 +454,13 @@ class MajorityVoter(LabelModel):
             A tuple of the annotation and prediction array.
         """
         prediction = np.where(probabilities > 0.5, 1, 0)
-        annotation = np.array(
-            [
-                self._weak_labels.labels.index(self._weak_labels.int2label[i])
-                for i in self._weak_labels.annotation()
-            ],
-            dtype=np.short,
-        )
 
         is_abstain = np.isnan(probabilities).all(axis=1)
 
-        prediction, annotation = prediction[~is_abstain], annotation[~is_abstain]
+        prediction, annotation = (
+            prediction[~is_abstain],
+            self._weak_labels.annotation()[~is_abstain],
+        )
 
         return annotation, prediction
 

--- a/src/rubrix/labeling/text_classification/weak_labels.py
+++ b/src/rubrix/labeling/text_classification/weak_labels.py
@@ -718,9 +718,9 @@ class WeakMultiLabels(WeakLabelsBase):
 
         # create weak label matrix (3D), annotation matrix
         weak_label_matrix = np.empty(
-            (len(self._records), len(self._rules), len(labels)), dtype=np.short
+            (len(self._records), len(self._rules), len(labels)), dtype=np.byte
         )
-        annotation_matrix = np.empty((len(self._records), len(labels)), dtype=np.short)
+        annotation_matrix = np.empty((len(self._records), len(labels)), dtype=np.byte)
 
         # SECOND: Fill arrays with weak labels
         for n, annotation_n, weak_label_n in tqdm(
@@ -730,11 +730,11 @@ class WeakMultiLabels(WeakLabelsBase):
             # first: fill annotation matrix
             if annotation_n == [None]:
                 # "abstain" is an array with -1
-                annotation_matrix[n] = -1 * np.ones(len(labels), dtype=np.short)
+                annotation_matrix[n] = -1 * np.ones(len(labels), dtype=np.byte)
             else:
                 annotation_matrix[n] = np.array(
                     [1 if label in annotation_n else 0 for label in labels],
-                    dtype=np.short,
+                    dtype=np.byte,
                 )
 
             # second: fill weak label matrix (3D)
@@ -744,7 +744,7 @@ class WeakMultiLabels(WeakLabelsBase):
                 else:
                     weak_label_matrix[n, m] = np.array(
                         [1 if label in weak_labels_m else 0 for label in labels],
-                        dtype=np.short,
+                        dtype=np.byte,
                     )
 
         return weak_label_matrix, annotation_matrix, labels

--- a/src/rubrix/labeling/text_classification/weak_labels.py
+++ b/src/rubrix/labeling/text_classification/weak_labels.py
@@ -726,6 +726,7 @@ class WeakMultiLabels(WeakLabelsBase):
         for n, annotation_n, weak_label_n in tqdm(
             zip(range(len(annotations)), annotations, weak_labels),
             desc="Filling weak label matrix",
+            total=len(annotations),
         ):
             # first: fill annotation matrix
             if annotation_n == [None]:

--- a/src/rubrix/labeling/text_classification/weak_labels.py
+++ b/src/rubrix/labeling/text_classification/weak_labels.py
@@ -107,6 +107,11 @@ class WeakLabelsBase:
         """The rules (labeling functions) that were used to produce the weak labels."""
         return self._rules
 
+    @property
+    def cardinality(self) -> int:
+        """The number of labels."""
+        raise NotImplementedError
+
     def records(
         self, has_annotation: Optional[bool] = None
     ) -> List[TextClassificationRecord]:
@@ -363,6 +368,10 @@ class WeakLabels(WeakLabelsBase):
                 weak_label_matrix[n, m] = weak_label
 
         return weak_label_matrix, annotation_array, _label2int
+
+    @property
+    def cardinality(self) -> int:
+        return len(self._label2int) - 1
 
     @property
     def label2int(self) -> Dict[Optional[str], int]:
@@ -735,6 +744,10 @@ class WeakMultiLabels(WeakLabelsBase):
     def labels(self) -> List[str]:
         """The labels of the multi-label text classification dataset."""
         return self._labels
+
+    @property
+    def cardinality(self) -> int:
+        return len(self._labels)
 
     def matrix(self, has_annotation: Optional[bool] = None) -> np.ndarray:
         """Returns the 3 dimensional weak label matrix, or optionally just a part of it.

--- a/src/rubrix/labeling/text_classification/weak_labels.py
+++ b/src/rubrix/labeling/text_classification/weak_labels.py
@@ -108,6 +108,11 @@ class WeakLabelsBase:
         return self._rules
 
     @property
+    def labels(self) -> List[str]:
+        """The list of labels."""
+        raise NotImplementedError
+
+    @property
     def cardinality(self) -> int:
         """The number of labels."""
         raise NotImplementedError
@@ -372,6 +377,10 @@ class WeakLabels(WeakLabelsBase):
     @property
     def cardinality(self) -> int:
         return len(self._label2int) - 1
+
+    @property
+    def labels(self) -> List[str]:
+        return [key for key in self._label2int.keys() if key is not None]
 
     @property
     def label2int(self) -> Dict[Optional[str], int]:

--- a/tests/labeling/text_classification/test_weak_labels.py
+++ b/tests/labeling/text_classification/test_weak_labels.py
@@ -246,6 +246,10 @@ class TestWeakLabelsBase:
             weak_labels.summary()
         with pytest.raises(NotImplementedError):
             weak_labels.show_records()
+        with pytest.raises(NotImplementedError):
+            _ = weak_labels.labels
+        with pytest.raises(NotImplementedError):
+            _ = weak_labels.cardinality
 
 
 class TestWeakLabels:

--- a/tests/monitoring/test_spacy_monitoring.py
+++ b/tests/monitoring/test_spacy_monitoring.py
@@ -12,7 +12,7 @@ def test_spacy_ner_monitor(monkeypatch, mocked_client):
     nlp = rb.monitor(nlp, dataset=dataset, sample_rate=0.1)
     mock_monitor(nlp, monkeypatch)
 
-    for _ in range(0, 100):
+    for _ in range(0, 20):
         nlp("Paris is my favourite city")
 
     df = rb.load(dataset)
@@ -20,14 +20,14 @@ def test_spacy_ner_monitor(monkeypatch, mocked_client):
     assert df.text.unique().tolist() == ["Paris is my favourite city"]
 
     rb.delete(dataset)
-    list(nlp.pipe(["This is a text"] * 100))
+    list(nlp.pipe(["This is a text"] * 20))
 
     df = rb.load(dataset)
     assert 1 < len(df) <= 20
     assert df.text.unique().tolist() == ["This is a text"]
 
     rb.delete(dataset)
-    list(nlp.pipe([("This is a text", {"meta": "data"})] * 100, as_tuples=True))
+    list(nlp.pipe([("This is a text", {"meta": "data"})] * 20, as_tuples=True))
 
     df = rb.load(dataset)
     assert 1 < len(df) <= 20

--- a/tests/monitoring/test_spacy_monitoring.py
+++ b/tests/monitoring/test_spacy_monitoring.py
@@ -1,3 +1,5 @@
+import random
+
 import rubrix as rb
 from tests.monitoring.helpers import mock_monitor
 
@@ -9,27 +11,30 @@ def test_spacy_ner_monitor(monkeypatch, mocked_client):
     import spacy
 
     nlp = spacy.load("en_core_web_sm")
-    nlp = rb.monitor(nlp, dataset=dataset, sample_rate=0.1)
+    nlp = rb.monitor(nlp, dataset=dataset, sample_rate=0.5)
     mock_monitor(nlp, monkeypatch)
+
+    random.seed(42)
 
     for _ in range(0, 20):
         nlp("Paris is my favourite city")
 
     df = rb.load(dataset)
-    assert 1 < len(df) <= 20
+    assert len(df) == 11
+    # assert 10 - std < len(df) < 10 + std
     assert df.text.unique().tolist() == ["Paris is my favourite city"]
 
     rb.delete(dataset)
     list(nlp.pipe(["This is a text"] * 20))
 
     df = rb.load(dataset)
-    assert 1 < len(df) <= 20
+    assert len(df) == 6
     assert df.text.unique().tolist() == ["This is a text"]
 
     rb.delete(dataset)
     list(nlp.pipe([("This is a text", {"meta": "data"})] * 20, as_tuples=True))
 
     df = rb.load(dataset)
-    assert 1 < len(df) <= 20
+    assert len(df) == 14
     for metadata in df.metadata.values.tolist():
         assert metadata == {"meta": "data"}


### PR DESCRIPTION
Closes #981 

This PR adds a `MajorityVoter` to our label models and supports a `WeakMultiLabels` object. In the multi-label case, this label model simply sets the probability to 1, if at least one rule voted for the respective label. Otherwise, the probability is zero.

I think a lot of the logic can be shared with the FlyingSquid label model, but I would like to do the refactoring in a separate PR. Also, Ruan is working heavily on this label model, so I would like to wait for his PR to go in. 

You can find the tutorial here: https://rubrix.readthedocs.io/en/feat-majority_vote_model/tutorials/weak-supervision-multi-label.html
I'm not super thrilled about the tutorial, mainly because of the bad results. Either the datasets are really challenging, or I'm simply bad at finding good heuristics. I doubt that a more sophisticated label model will bring much improvement, but we can use those results as a baseline. @dvsrepo feedback would be much appreciated!