### PR TITLE
refactor(#945): unify query to elasticsearch generation

### DIFF
--- a/src/rubrix/server/tasks/commons/api/model.py
+++ b/src/rubrix/server/tasks/commons/api/model.py
@@ -348,7 +348,7 @@ class BaseSearchResults(GenericModel, Generic[Record, Aggregations]):
     aggregations: Aggregations = None
 
 
-class ScoreRange(BaseModel):
+class QueryRange(BaseModel):
     """Score range filter"""
 
     range_from: float = Field(default=0.0, alias="from")
@@ -356,3 +356,7 @@ class ScoreRange(BaseModel):
 
     class Config:
         allow_population_by_field_name = True
+
+
+class ScoreRange(QueryRange):
+    pass

--- a/src/rubrix/server/tasks/commons/metrics/commons.py
+++ b/src/rubrix/server/tasks/commons/metrics/commons.py
@@ -27,6 +27,7 @@ class CommonTasksMetrics(BaseTaskMetrics, Generic[GenericRecord]):
             description="Computes the input text length distribution",
             field="metrics.text_length",
             # TODO(@frascuchon): This won't work once words is excluded from _source
+            # TODO: Implement changes with backward compatibility
             script="params._source.words.length()",
             fixed_interval=1,
         ),
@@ -52,6 +53,7 @@ class CommonTasksMetrics(BaseTaskMetrics, Generic[GenericRecord]):
             name="Inputs words cloud",
             description="The words cloud for dataset inputs",
             # TODO(@frascuchon): This won't work once words is excluded from _source
+            # TODO: Implement changes with backward compatibility
             default_field=EsRecordDataFieldNames.words,
         ),
         MetadataAggregations(id="metadata", name="Metadata fields stats"),

--- a/src/rubrix/server/tasks/search/model.py
+++ b/src/rubrix/server/tasks/search/model.py
@@ -1,7 +1,6 @@
-from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
+from typing import Any, Dict, List, Optional, TypeVar, Union
 
 from pydantic import BaseModel, Field
-from pydantic.generics import GenericModel
 
 from rubrix.server.tasks.commons import BaseRecord, SortableField, TaskStatus
 
@@ -44,10 +43,6 @@ class BaseSearchQuery(BaseModel):
     status: List[TaskStatus] = Field(default_factory=list)
 
     metadata: Optional[Dict[str, Union[str, List[str]]]] = None
-
-    def as_elasticsearch(self) -> Dict[str, Any]:
-        # TODO: Hide transformations in DAO component
-        raise NotImplementedError()
 
 
 class SortConfig(BaseModel):

--- a/src/rubrix/server/tasks/text_classification/service/labeling_service.py
+++ b/src/rubrix/server/tasks/text_classification/service/labeling_service.py
@@ -69,7 +69,9 @@ class LabelingRulesMetric(ElasticsearchMetric):
 
         if labels is not None:
             for label in labels:
-                rule_label_annotated_filter = filters.annotated_as([label])
+                rule_label_annotated_filter = filters.term_filter(
+                    "annotated_as", value=label
+                )
                 encoded_label = self._encode_label_name(label)
                 aggr_filters.update(
                     {

--- a/src/rubrix/server/tasks/token_classification/api/model.py
+++ b/src/rubrix/server/tasks/token_classification/api/model.py
@@ -19,7 +19,6 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 from pydantic import BaseModel, Field, root_validator, validator
 
 from rubrix._constants import MAX_KEYWORD_LENGTH
-from rubrix.server.commons.es_helpers import filters
 from rubrix.server.datasets.model import DatasetDB, UpdateDatasetRequest
 from rubrix.server.tasks.commons import (
     BaseAnnotation,
@@ -387,35 +386,6 @@ class TokenClassificationQuery(BaseSearchQuery):
     annotated_as: List[str] = Field(default_factory=list)
     score: Optional[ScoreRange] = Field(default=None)
     predicted: Optional[PredictionStatus] = Field(default=None, nullable=True)
-
-    def as_elasticsearch(self) -> Dict[str, Any]:
-        """Build an elasticsearch query part from search query"""
-
-        if self.ids:
-            return {"ids": {"values": self.ids}}
-
-        all_filters = filters.metadata(self.metadata)
-        query_filters = [
-            query_filter
-            for query_filter in [
-                filters.predicted_as(self.predicted_as),
-                filters.predicted_by(self.predicted_by),
-                filters.annotated_as(self.annotated_as),
-                filters.annotated_by(self.annotated_by),
-                filters.status(self.status),
-                filters.predicted(self.predicted),
-                filters.score(self.score),
-            ]
-            if query_filter
-        ]
-        query_text = filters.text_query(self.query_text)
-        all_filters.extend(query_filters)
-
-        return filters.boolean_filter(
-            must_query=query_text,
-            should_filters=all_filters,
-            minimum_should_match=len(all_filters),
-        )
 
 
 class TokenClassificationSearchRequest(BaseModel):

--- a/tests/server/text2text/test_model.py
+++ b/tests/server/text2text/test_model.py
@@ -1,3 +1,4 @@
+from rubrix.server.tasks.search.query_builder import EsQueryBuilder
 from rubrix.server.tasks.text2text import (
     Text2TextAnnotation,
     Text2TextPrediction,
@@ -56,4 +57,4 @@ def test_model_dict():
 
 def test_query_as_elasticsearch():
     query = Text2TextQuery(ids=[1, 2, 3])
-    assert query.as_elasticsearch() == {"ids": {"values": query.ids}}
+    assert EsQueryBuilder.to_es_query(query) == {"ids": {"values": query.ids}}

--- a/tests/server/text_classification/test_model.py
+++ b/tests/server/text_classification/test_model.py
@@ -18,6 +18,7 @@ from pydantic import ValidationError
 from rubrix._constants import MAX_KEYWORD_LENGTH
 from rubrix.server.commons.settings import settings
 from rubrix.server.tasks.commons import TaskStatus
+from rubrix.server.tasks.search.query_builder import EsQueryBuilder
 from rubrix.server.tasks.text_classification import TextClassificationQuery
 from rubrix.server.tasks.text_classification.api import (
     ClassPrediction,
@@ -280,7 +281,8 @@ def test_validate_without_labels_for_single_label(annotation):
 def test_query_with_uncovered_by_rules():
 
     query = TextClassificationQuery(uncovered_by_rules=["query", "other*"])
-    assert query.as_elasticsearch() == {
+
+    assert EsQueryBuilder.to_es_query(query) == {
         "bool": {
             "must": {"match_all": {}},
             "must_not": {

--- a/tests/server/token_classification/test_model.py
+++ b/tests/server/token_classification/test_model.py
@@ -17,6 +17,7 @@ import pytest
 from pydantic import ValidationError
 
 from rubrix._constants import MAX_KEYWORD_LENGTH
+from rubrix.server.tasks.search.query_builder import EsQueryBuilder
 from rubrix.server.tasks.token_classification.api.model import (
     EntitySpan,
     TokenClassificationAnnotation,
@@ -138,9 +139,9 @@ def test_entity_label_too_long():
         )
 
 
-def test_query_as_elasticsearch():
+def test_to_es_query():
     query = TokenClassificationQuery(ids=[1, 2, 3])
-    assert query.as_elasticsearch() == {"ids": {"values": query.ids}}
+    assert EsQueryBuilder.to_es_query(query) == {"ids": {"values": query.ids}}
 
 
 def test_misaligned_entity_mentions_with_spaces_left():


### PR DESCRIPTION
This PR centralizes all elasticsearch query generation from query datamodel in query builder. This will simplify extension or migrations to new search data model. 