### PR TITLE
feat(#1225): prepare tokenclass dataset for hf training

### DIFF
--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -539,6 +539,32 @@ class DatasetForTokenClassification(DatasetBase):
         return super().from_pandas(dataframe)
 
     def prepare_for_training(self) -> "datasets.Dataset":
+        """Prepares the dataset for training.
+
+        This will return a ``datasets.Dataset`` with all columns returned by ``to_datasets`` method
+        and an additional  *ner_tags* column:
+            - Records without an annotation are removed.
+            - The *ner_tags* column corresponds to the iob tags sequences for annotations of the records
+            - The iob tags are transformed to integers.
+
+        Returns:
+            A datasets Dataset with a *ner_tags* column and all columns returned by ``to_datasets``.
+
+        Examples:
+            >>> import rubrix as rb
+            >>> rb_dataset = rb.DatasetForTokenClassification([
+            ...     rb.DatasetForTokenClassification(
+            ...         text="The text",
+            ...         tokens=["the", "text"],
+            ...         annotation=[("TAG", 0, 2)],
+            ...     )
+            ... ])
+            >>> rb_dataset.prepare_for_training().features
+            {'text': Value(dtype='string'),
+             'tokens': Sequence(Value(dtype='string')),
+             'ner_tags': ClassLabel(num_classes=2, names=['O','B-TAG'])}
+
+        """
         import datasets
 
         class_tags = ["O"]

--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -538,6 +538,7 @@ class DatasetForTokenClassification(DatasetBase):
     ) -> "DatasetForTokenClassification":
         return super().from_pandas(dataframe)
 
+    @_requires_datasets
     def prepare_for_training(self) -> "datasets.Dataset":
         """Prepares the dataset for training.
 

--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -125,7 +125,8 @@ class DatasetBase:
 
         ds_dict = self._to_datasets_dict()
         # TODO: THIS FIELD IS ONLY AT CLIENT API LEVEL. NOT SENSE HERE FOR NOW
-        del ds_dict["search_keywords"]
+        if "search_keywords" in ds_dict:
+            del ds_dict["search_keywords"]
 
         try:
             dataset = datasets.Dataset.from_dict(ds_dict)

--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -554,16 +554,28 @@ class DatasetForTokenClassification(DatasetBase):
         Examples:
             >>> import rubrix as rb
             >>> rb_dataset = rb.DatasetForTokenClassification([
-            ...     rb.DatasetForTokenClassification(
+            ...     rb.TokenClassificationRecord(
             ...         text="The text",
-            ...         tokens=["the", "text"],
+            ...         tokens=["The", "text"],
             ...         annotation=[("TAG", 0, 2)],
             ...     )
             ... ])
             >>> rb_dataset.prepare_for_training().features
             {'text': Value(dtype='string'),
-             'tokens': Sequence(Value(dtype='string')),
-             'ner_tags': ClassLabel(num_classes=2, names=['O','B-TAG'])}
+             'tokens': Sequence(feature=Value(dtype='string'), length=-1),
+             'prediction': Value(dtype='null'),
+             'prediction_agent': Value(dtype='null'),
+             'annotation': [{'end': Value(dtype='int64'),
+               'label': Value(dtype='string'),
+               'start': Value(dtype='int64')}],
+             'annotation_agent': Value(dtype='null'),
+             'id': Value(dtype='null'),
+             'metadata': Value(dtype='null'),
+             'status': Value(dtype='string'),
+             'event_timestamp': Value(dtype='null'),
+             'metrics': Value(dtype='null'),
+             'ner_tags': [ClassLabel(num_classes=3, names=['O', 'B-TAG', 'I-TAG'])]}
+
 
         """
         import datasets

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -212,7 +212,20 @@ class TestDatasetForTextClassification:
         dataset_ds = expected_dataset.to_datasets()
 
         assert isinstance(dataset_ds, datasets.Dataset)
-        assert dataset_ds.column_names == list(expected_dataset[0].__fields__.keys())
+        assert dataset_ds.column_names == [
+            "inputs",
+            "prediction",
+            "prediction_agent",
+            "annotation",
+            "annotation_agent",
+            "multi_label",
+            "explanation",
+            "id",
+            "metadata",
+            "status",
+            "event_timestamp",
+            "metrics",
+        ]
         assert dataset_ds.features["prediction"] == [
             {"label": datasets.Value("string"), "score": datasets.Value("float64")}
         ]
@@ -329,7 +342,19 @@ class TestDatasetForTokenClassification:
         dataset_ds = expected_dataset.to_datasets()
 
         assert isinstance(dataset_ds, datasets.Dataset)
-        assert dataset_ds.column_names == list(expected_dataset[0].__fields__.keys())
+        assert dataset_ds.column_names == [
+            "text",
+            "tokens",
+            "prediction",
+            "prediction_agent",
+            "annotation",
+            "annotation_agent",
+            "id",
+            "metadata",
+            "status",
+            "event_timestamp",
+            "metrics",
+        ]
         assert dataset_ds.features["prediction"] == [
             {
                 "label": datasets.Value("string"),
@@ -483,7 +508,18 @@ class TestDatasetForText2Text:
         dataset_ds = expected_dataset.to_datasets()
 
         assert isinstance(dataset_ds, datasets.Dataset)
-        assert dataset_ds.column_names == list(expected_dataset[0].__fields__.keys())
+        assert dataset_ds.column_names == [
+            "text",
+            "prediction",
+            "prediction_agent",
+            "annotation",
+            "annotation_agent",
+            "id",
+            "metadata",
+            "status",
+            "event_timestamp",
+            "metrics",
+        ]
         assert dataset_ds.features["prediction"] == [
             {
                 "text": datasets.Value("string"),


### PR DESCRIPTION
This PR includes the `prepare_for_training` method implementation for token classification datasets.

This method extends generated dataset from `to_datasets` including the annotation `ner_tags` column. This allow use the same published dataset for training and/or for explore/annotate in rubrix

Closes #1225 