### PR TITLE
feat(datasets): simplify load flow from hf datasets with no rb format

### DIFF
--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -318,7 +318,7 @@ class DatasetBase:
     def _parse_annotation_field(
         cls, dataset: "datasets.Dataset", field: str
     ) -> "datasets.Dataset":
-        return dataset
+        return dataset.rename_column(field, "annotation")
 
 
 def _prepend_docstring(record_type: Type[Record]):

--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -195,7 +195,6 @@ class DatasetBase:
                 f" model and are ignored: {not_supported_columns}"
             )
             dataset = dataset.remove_columns(not_supported_columns)
-
         return cls._from_datasets(dataset)
 
     @classmethod
@@ -206,7 +205,6 @@ class DatasetBase:
         text: Optional[str] = None,
         annotation: Optional[str] = None,
         metadata: Optional[Union[str, List[str]]] = None,
-        **kwargs,
     ) -> "dataclasses.Dataset":
         for field, parser in [
             (id, cls._parse_id_field),
@@ -825,8 +823,8 @@ class DatasetForTokenClassification(DatasetBase):
         **kwargs,
     ) -> "dataclasses.Dataset":
         dataset = super()._prepare_hf_dataset(dataset, **kwargs)
-
-        dataset = cls._parse_tokens_field(dataset, field=tokens or "tokens")
+        if tokens:
+            dataset = cls._parse_tokens_field(dataset, field=tokens)
         if tags:
             dataset = cls._parse_tags_field(dataset, field=tags)
         return dataset

--- a/src/rubrix/client/models.py
+++ b/src/rubrix/client/models.py
@@ -58,7 +58,8 @@ class _Validators(BaseModel):
         """Triggers a warning when ONLY prediction agent is provided"""
         if v and values["prediction"] is None:
             warnings.warn(
-                "You provided an `prediction_agent`, but no `prediction`. The `prediction_agent` will not be logged to the server."
+                "You provided an `prediction_agent`, but no `prediction`. "
+                "The `prediction_agent` will not be logged to the server."
             )
         return v
 
@@ -67,7 +68,8 @@ class _Validators(BaseModel):
         """Triggers a warning when ONLY annotation agent is provided"""
         if v and values["annotation"] is None:
             warnings.warn(
-                "You provided an `annotation_agent`, but no `annotation`. The `annotation_agent` will not be logged to the server."
+                "You provided an `annotation_agent`, but no `annotation`. "
+                "The `annotation_agent` will not be logged to the server."
             )
         return v
 

--- a/src/rubrix/client/models.py
+++ b/src/rubrix/client/models.py
@@ -267,7 +267,7 @@ class TokenClassificationRecord(_Validators):
                 "Missing fields: At least one of `text` or `tokens` argument must be provided!"
             )
 
-        if data.get("annotation") or data.get("prediction") and text is None:
+        if (data.get("annotation") or data.get("prediction")) and text is None:
             raise AssertionError(
                 "Missing field `text`: "
                 "char level spans must be provided with a raw text sentence"

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -695,8 +695,9 @@ def _compare_datasets(dataset, expected_dataset):
             # TODO: have to think about how we deal with `None`s
             if col in ["metadata", "metrics"]:
                 continue
-            if getattr(rec, col) != getattr(expected, col):
-                raise AssertionError(f"Wrong column value {col}")
+            assert getattr(rec, col) == getattr(
+                expected, col
+            ), f"Wrong column value '{col}'"
 
 
 @pytest.mark.parametrize(

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -403,6 +403,9 @@ class TestDatasetForTokenClassification:
         assert ds._RECORD_TYPE == rb.TokenClassificationRecord
         assert ds._records == tokenclassification_records
 
+    @pytest.mark.skip(
+        reason="This test is failing. See this issue https://github.com/huggingface/datasets/issues/3676"
+    )
     def test_to_from_datasets(self, tokenclassification_records):
         expected_dataset = rb.DatasetForTokenClassification(tokenclassification_records)
 

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -688,6 +688,37 @@ class TestDatasetForText2Text:
 
         assert isinstance(dataset_ds, datasets.Dataset)
 
+    @pytest.mark.skipif(
+        _HF_HUB_ACCESS_TOKEN is None,
+        reason="You need a HF Hub access token to test the push_to_hub feature",
+    )
+    def test_from_dataset_with_non_rubrix_format(self):
+        import datasets
+
+        ds = datasets.load_dataset(
+            "rubrix/big_patent_a_test_100",
+            split="test",
+            use_auth_token=_HF_HUB_ACCESS_TOKEN,
+        )
+
+        rb_ds = rb.DatasetForText2Text.from_datasets(
+            ds, text="description", annotation="abstract"
+        )
+
+        again_the_ds = rb_ds.to_datasets()
+        assert again_the_ds.column_names == [
+            "text",
+            "prediction",
+            "prediction_agent",
+            "annotation",
+            "annotation_agent",
+            "id",
+            "metadata",
+            "status",
+            "event_timestamp",
+            "metrics",
+        ]
+
 
 def _compare_datasets(dataset, expected_dataset):
     for rec, expected in zip(dataset, expected_dataset):

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -403,9 +403,6 @@ class TestDatasetForTokenClassification:
         assert ds._RECORD_TYPE == rb.TokenClassificationRecord
         assert ds._records == tokenclassification_records
 
-    @pytest.mark.skip(
-        reason="This test is failing. See this issue https://github.com/huggingface/datasets/issues/3676"
-    )
     def test_to_from_datasets(self, tokenclassification_records):
         expected_dataset = rb.DatasetForTokenClassification(tokenclassification_records)
 

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -329,6 +329,73 @@ class TestDatasetForTextClassification:
         else:
             assert train.features["label"] == datasets.ClassLabel(names=["a"])
 
+    @pytest.mark.skipif(
+        _HF_HUB_ACCESS_TOKEN is None,
+        reason="You need a HF Hub access token to test the push_to_hub feature",
+    )
+    def test_from_dataset_with_non_rubrix_format_multilabel(self):
+        import datasets
+
+        ds = datasets.load_dataset(
+            "rubrix/go_emotions_test_100",
+            split="test",
+            use_auth_token=_HF_HUB_ACCESS_TOKEN,
+        )
+
+        rb_ds = rb.DatasetForTextClassification.from_datasets(
+            ds,
+            inputs="text",
+            annotation="labels",
+        )
+        again_the_ds = rb_ds.to_datasets()
+        assert again_the_ds.column_names == [
+            "inputs",
+            "prediction",
+            "prediction_agent",
+            "annotation",
+            "annotation_agent",
+            "multi_label",
+            "explanation",
+            "id",
+            "metadata",
+            "status",
+            "event_timestamp",
+            "metrics",
+        ]
+
+    @pytest.mark.skipif(
+        _HF_HUB_ACCESS_TOKEN is None,
+        reason="You need a HF Hub access token to test the push_to_hub feature",
+    )
+    def test_from_dataset_with_non_rubrix_format(self):
+        import datasets
+
+        ds = datasets.load_dataset(
+            "rubrix/app_reviews_train_100",
+            split="train",
+            use_auth_token=_HF_HUB_ACCESS_TOKEN,
+        )
+
+        rb_ds = rb.DatasetForTextClassification.from_datasets(
+            ds, inputs="review", annotation="star", metadata=["package_name", "date"]
+        )
+
+        again_the_ds = rb_ds.to_datasets()
+        assert again_the_ds.column_names == [
+            "inputs",
+            "prediction",
+            "prediction_agent",
+            "annotation",
+            "annotation_agent",
+            "multi_label",
+            "explanation",
+            "id",
+            "metadata",
+            "status",
+            "event_timestamp",
+            "metrics",
+        ]
+
 
 class TestDatasetForTokenClassification:
     def test_init(self, tokenclassification_records):
@@ -495,6 +562,38 @@ class TestDatasetForTokenClassification:
             private=True,
         )
 
+    @pytest.mark.skipif(
+        _HF_HUB_ACCESS_TOKEN is None,
+        reason="You need a HF Hub access token to test the push_to_hub feature",
+    )
+    def test_from_dataset_with_non_rubrix_format(self):
+        import datasets
+
+        ds = datasets.load_dataset(
+            "rubrix/wikiann_es_test_100",
+            split="test",
+            use_auth_token=_HF_HUB_ACCESS_TOKEN,
+        )
+
+        rb_ds = rb.DatasetForTokenClassification.from_datasets(
+            ds, tags="ner_tags", metadata=["spans"]
+        )
+
+        again_the_ds = rb_ds.to_datasets()
+        assert again_the_ds.column_names == [
+            "text",
+            "tokens",
+            "prediction",
+            "prediction_agent",
+            "annotation",
+            "annotation_agent",
+            "id",
+            "metadata",
+            "status",
+            "event_timestamp",
+            "metrics",
+        ]
+
 
 class TestDatasetForText2Text:
     def test_init(self, text2text_records):
@@ -596,7 +695,8 @@ def _compare_datasets(dataset, expected_dataset):
             # TODO: have to think about how we deal with `None`s
             if col in ["metadata", "metrics"]:
                 continue
-            assert getattr(rec, col) == getattr(expected, col)
+            if getattr(rec, col) != getattr(expected, col):
+                raise AssertionError(f"Wrong column value {col}")
 
 
 @pytest.mark.parametrize(

--- a/tests/client/test_models.py
+++ b/tests/client/test_models.py
@@ -80,6 +80,38 @@ def test_token_classification_record(annotation, status, expected_status, expect
     assert record.spans2iob(record.annotation) == expected_iob
 
 
+def test_token_classification_validations():
+    with pytest.raises(
+        AssertionError,
+        match="Missing fields: "
+        "At least one of `text` or `tokens` argument must be provided!",
+    ):
+        TokenClassificationRecord()
+
+    tokens = ["test", "text"]
+    annotation = [("test", 0, 4)]
+    with pytest.raises(
+        AssertionError,
+        match="Missing field `text`: "
+        "char level spans must be provided with a raw text sentence",
+    ):
+        TokenClassificationRecord(tokens=tokens, annotation=annotation)
+
+    with pytest.raises(
+        AssertionError,
+        match="Missing field `text`: "
+        "char level spans must be provided with a raw text sentence",
+    ):
+        TokenClassificationRecord(tokens=tokens, prediction=annotation)
+
+    TokenClassificationRecord(
+        text=" ".join(tokens), tokens=tokens, prediction=annotation
+    )
+
+    record = TokenClassificationRecord(tokens=tokens)
+    assert record.text == "test text"
+
+
 def test_token_classification_with_mutation():
     text_a = "The text"
     text_b = "Another text sample here !!!"


### PR DESCRIPTION
With this PR you can convert hf datasets to rubrix datasets as follow:

```python

import datasets
amazon_reviews = datasets.load_dataset("amazon_reviews_multi", "es", split="train")
rb_ds = rb.DatasetForTextClassification.from_datasets(
    amazon_reviews, 
    inputs=["review_title","review_body"], 
    annotation="stars"
)
# Here you can just log the dataset
rb.log(rb_ds, name="amazon-reviews")
```
We can define similar approach for `metadata` or `text` for the  other tasks, or `tags` for token classification

@dcfidalgo @dvsrepo any suggestion?


TODO:
- [x] Include tests for text2text
- [x] Fix failing tests once hf bug is fixed:

```python
import datasets
ds = datasets.Dataset.from_dict({ "a": [None, [1,2], None, [3,4]]})
ds.map(lambda x: { "b": "b"}).to_pandas() # None values in a becomes empty lists
```

See this PR https://github.com/huggingface/datasets/issues/3676