### PR TITLE
docs(#1242, #1240, #1221): Add env var section + other minor fixes

### DIFF
--- a/docs/getting_started/advanced_setup_guides.rst
+++ b/docs/getting_started/advanced_setup_guides.rst
@@ -76,6 +76,29 @@ For more details about fastapi and uvicorn, see `here <https://fastapi.tiangolo.
 
 Fastapi also provides beautiful REST API docs that you can check at `http://localhost:6900/api/docs <http://localhost:6900/api/docs>`__.
 
+Environment variables
+---------------------
+
+Here we will give you a list of useful environment variables that you can set to configure your client or server.
+
+Client
+^^^^^^
+
+- ``RUBRIX_API_URL``: The default API URL when calling :meth:`rubrix.init`.
+
+- ``RUBRIX_API_KEY``: The default API key when calling :meth:`rubrix.init``.
+
+- ``RUBRIX_WORKSPACE``: The default workspace when calling :meth:`rubrix.init``.
+
+Server
+^^^^^^
+
+- ``ELASTICSEARCH``: URL of the endpoint of the Elasticsearch instance.
+
+- ``CORS_ORIGINS``: List of host patterns for CORS origin access.
+
+- ``DOCS_ENABLED``: If False, disables openapi docs endpoint at */api/docs*.
+
 
 .. _launching-the-web-app-via-docker:
 

--- a/docs/getting_started/advanced_setup_guides.rst
+++ b/docs/getting_started/advanced_setup_guides.rst
@@ -59,6 +59,7 @@ Server configurations
 
 By default, the Rubrix server will look for your ES endpoint at ``http://localhost:9200``.
 But you can customize this by setting the ``ELASTICSEARCH`` environment variable.
+Have a look at the list of available `environment variables`_ to further configure the Rubrix server.
 
 Since the Rubrix server is built on fastapi, you can launch it using **uvicorn** directly:
 
@@ -77,12 +78,35 @@ For more details about fastapi and uvicorn, see `here <https://fastapi.tiangolo.
 Fastapi also provides beautiful REST API docs that you can check at `http://localhost:6900/api/docs <http://localhost:6900/api/docs>`__.
 
 Environment variables
----------------------
+^^^^^^^^^^^^^^^^^^^^^
 
-Here we will give you a list of useful environment variables that you can set to configure your client or server.
+You can set following environment variables to further configure your server and client.
+
+Server
+""""""
+
+- ``ELASTICSEARCH``: URL of the connection endpoint of the Elasticsearch instance (Default: http://localhost:9200 ).
+
+- ``RUBRIX_ELASTICSEARCH_SSL_VERIFY``: If "False", disables SSL certificate verification when connection to the
+    Elasticsearch backend.
+
+- ``RUBRIX_NAMESPACE``: A prefix used to manage Elasticsearch indices. You can use this namespace to use the same
+    Elasticsearch instance for several independent Rubrix instances.
+
+- ``RUBRIX_DEFAULT_ES_SEARCH_ANALYZER``: Default analyzer for textual fields excluding the metadata
+    (Default: "standard")
+
+- ``RUBRIX_EXACT_ES_SEARCH_ANALYZER``: Default analyzer for ``*.exact`` fields in textual information
+    (Default: "whitespace").
+
+- ``METADATA_FIELDS_LIMIT``: Max number of fields in the metadata (Default: 50, max: 100).
+
+- ``CORS_ORIGINS``: List of host patterns for CORS origin access.
+
+- ``DOCS_ENABLED``: If False, disables openapi docs endpoint at */api/docs*.
 
 Client
-^^^^^^
+""""""
 
 - ``RUBRIX_API_URL``: The default API URL when calling :meth:`rubrix.init`.
 
@@ -90,14 +114,6 @@ Client
 
 - ``RUBRIX_WORKSPACE``: The default workspace when calling :meth:`rubrix.init``.
 
-Server
-^^^^^^
-
-- ``ELASTICSEARCH``: URL of the endpoint of the Elasticsearch instance.
-
-- ``CORS_ORIGINS``: List of host patterns for CORS origin access.
-
-- ``DOCS_ENABLED``: If False, disables openapi docs endpoint at */api/docs*.
 
 
 .. _launching-the-web-app-via-docker:

--- a/docs/getting_started/setup&installation.rst
+++ b/docs/getting_started/setup&installation.rst
@@ -21,7 +21,7 @@ Then you can install Rubrix with ``pip`` or ``conda``\.
 
 .. code-block:: bash
 
-   pip install rubrix[server]
+   pip install "rubrix[server]"
 
 **with conda**
 

--- a/docs/getting_started/supported_tasks.rst
+++ b/docs/getting_started/supported_tasks.rst
@@ -21,7 +21,7 @@ According to the amazing `NLP Progress resource by Seb Ruder <http://nlpprogress
 
 Rubrix is flexible with input and output shapes, which means you can model many related tasks like for example:
 
-* `Sentiment analysis <http://nlpprogress.com/english/sentiment_analysis.html>`_ 
+* `Sentiment analysis <http://nlpprogress.com/english/sentiment_analysis.html>`_
 * `Natural Language Inference <http://nlpprogress.com/english/natural_language_inference.html>`_
 * `Semantic Textual Similarity <https://paperswithcode.com/task/semantic-textual-similarity>`_
 * `Stance detection <http://nlpprogress.com/english/stance_detection.html>`_
@@ -42,10 +42,28 @@ The most well-known task in this category is probably `Named Entity Recognition 
 
 Rubrix is flexible with input and output shapes, which means you can model related tasks like for example:
 
-
 * Named entity recognition
 * Part of speech tagging
 * Slot filling
+
+
+Text2Text
+^^^^^^^^^
+
+The most typical and oldest task in this category is probably `Machine Translation<http://nlpprogress.com/english/machine_translation.html>`_:
+
+..
+
+   Machine translation is the task of translating a sentence in a source language to a different target language.
+
+The common frame of this category is that the modal receives and outputs a sequence of tokens.
+It encompasses a variety of tasks such as
+
+* text summarization
+* machine translation
+* natural language generation
+* paraphrase generation, etc.
+
 
 Tasks on the roadmap
 --------------------
@@ -53,8 +71,6 @@ Tasks on the roadmap
 Natural language processing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-
-* Text2Text, covering summarization, machine translation, natural language generation, etc.
 * Question answering
 * `Keyphrase extraction <https://paperswithcode.com/task/keyword-extraction>`_
 * `Relationship Extraction <http://nlpprogress.com/english/relationship_extraction.html>`_
@@ -62,12 +78,10 @@ Natural language processing
 Computer vision
 ^^^^^^^^^^^^^^^
 
-
 * Image classification
 * Image captioning
 
 Speech
 ^^^^^^
-
 
 * Speech2Text

--- a/docs/guides/weak-supervision.ipynb
+++ b/docs/guides/weak-supervision.ipynb
@@ -100,7 +100,7 @@
     "\n",
     "To make things even easier for you, we provide wrapper classes around the most common label models, that directly consume a `WeakLabels` object.\n",
     "This makes working with those models a breeze.\n",
-    "Take a look at the list of built-in models in the [labeling module docs](../reference/python/python_labeling.rst#rubrix.labeling.text_classification.label_models.LabelModel).\n",
+    "Take a look at the list of built-in models in the [labeling module docs](../reference/python/python_labeling.rst).\n",
     "\n",
     "\n",
     "## Detailed Workflow\n",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ Getting started with Rubrix is easy, let's see a quick example using the 🤗 ``
 
 .. code-block:: bash
 
-   pip install rubrix[server] transformers[torch] datasets
+   pip install "rubrix[server]" "transformers[torch]" datasets
 
 If you don't have `Elasticsearch (ES) <https://www.elastic.co/elasticsearch>`__ running, make sure you have `Docker` installed and run:
 

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -25,6 +25,7 @@ dependencies:
       - sphinx_rtd_theme==0.5.2
       - myst-parser==0.16.1
       - nbsphinx==0.8.7
+      - nbformat<5.2.0 # Installs ipython-genutils, with a new version (>0.8.8) of nbsphinx this can probably go away.
       - sphinxext.opengraph==0.4.2
       # code formatting
       - pre-commit==2.15.0

--- a/environment_docs.yml
+++ b/environment_docs.yml
@@ -17,6 +17,6 @@ dependencies:
       - sphinx_rtd_theme==0.5.2
       - myst-parser==0.16.1
       - nbsphinx==0.8.7
-      - nbformat<5.2.0 # This will install ipython-genutils
+      - nbformat<5.2.0 # Installs ipython-genutils, with a new version (>0.8.8) of nbsphinx this can probably go away.
       - sphinxext.opengraph==0.4.2
       - -e .

--- a/src/rubrix/client/api.py
+++ b/src/rubrix/client/api.py
@@ -84,8 +84,8 @@ class Api:
     ):
         """Init the Python client.
 
-        Passing an api_url disables environment variable reading, which will provide
-        default values.
+        We will automatically init a default client for you when calling other client methods.
+        The arguments provided here will overwrite your corresponding environment variables.
 
         Args:
             api_url: Address of the REST API. If `None` (default) and the env variable ``RUBRIX_API_URL`` is not set,


### PR DESCRIPTION
Closes #1242 #1240 #1221

This PR updates the task list of the documentation, introduces a new `Environment variables` section in the docs, and adds quotation marks to `pip install "rubrix[server]"`.
@frascuchon Could you have a look at the env var list for the server, I'm sure I missed some variables.