### PR TITLE
docs: define the basic search schema

### DIFF
--- a/docs/getting_started/advanced_setup_guides.rst
+++ b/docs/getting_started/advanced_setup_guides.rst
@@ -87,17 +87,13 @@ Server
 
 - ``ELASTICSEARCH``: URL of the connection endpoint of the Elasticsearch instance (Default: http://localhost:9200 ).
 
-- ``RUBRIX_ELASTICSEARCH_SSL_VERIFY``: If "False", disables SSL certificate verification when connection to the
-    Elasticsearch backend.
+- ``RUBRIX_ELASTICSEARCH_SSL_VERIFY``: If "False", disables SSL certificate verification when connection to the Elasticsearch backend.
 
-- ``RUBRIX_NAMESPACE``: A prefix used to manage Elasticsearch indices. You can use this namespace to use the same
-    Elasticsearch instance for several independent Rubrix instances.
+- ``RUBRIX_NAMESPACE``: A prefix used to manage Elasticsearch indices. You can use this namespace to use the same Elasticsearch instance for several independent Rubrix instances.
 
-- ``RUBRIX_DEFAULT_ES_SEARCH_ANALYZER``: Default analyzer for textual fields excluding the metadata
-    (Default: "standard")
+- ``RUBRIX_DEFAULT_ES_SEARCH_ANALYZER``: Default analyzer for textual fields excluding the metadata (Default: "standard").
 
-- ``RUBRIX_EXACT_ES_SEARCH_ANALYZER``: Default analyzer for ``*.exact`` fields in textual information
-    (Default: "whitespace").
+- ``RUBRIX_EXACT_ES_SEARCH_ANALYZER``: Default analyzer for ``*.exact`` fields in textual information (Default: "whitespace").
 
 - ``METADATA_FIELDS_LIMIT``: Max number of fields in the metadata (Default: 50, max: 100).
 
@@ -110,9 +106,9 @@ Client
 
 - ``RUBRIX_API_URL``: The default API URL when calling :meth:`rubrix.init`.
 
-- ``RUBRIX_API_KEY``: The default API key when calling :meth:`rubrix.init``.
+- ``RUBRIX_API_KEY``: The default API key when calling :meth:`rubrix.init`.
 
-- ``RUBRIX_WORKSPACE``: The default workspace when calling :meth:`rubrix.init``.
+- ``RUBRIX_WORKSPACE``: The default workspace when calling :meth:`rubrix.init`.
 
 
 

--- a/docs/reference/webapp/dataset.md
+++ b/docs/reference/webapp/dataset.md
@@ -16,7 +16,7 @@ The page is composed of 4 major components:
 ![Search bar](../../_static/reference/webapp/search_bar.png)
 
 Rubrix's _search bar_ is a powerful tool that allows you to thoroughly explore your dataset, and quickly navigate through the records.
-You can either fuzzy search the contents of your records, or use the more advanced [query string syntax](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax) of Elasticsearch to take full advantage of Rubrix's [data models](../python/python_client.rst#module-rubrix.client.models).
+You can either fuzzy search the contents of your records, or use the more advanced [query string syntax](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-query-string-query.html#query-string-syntax) of Elasticsearch to take full advantage of Rubrix's [data models](../python/python_client.rst#module-rubrix.client.models).
 You can find more information about how to use the search bar in our detailed [search guide](search_records.md).
 
 ## Filters

--- a/docs/reference/webapp/search_records.md
+++ b/docs/reference/webapp/search_records.md
@@ -33,23 +33,35 @@ Suppose we have 2 records with the following text:
 1. *The quick brown fox jumped over the lazy dog.*
 2. *THE LAZY DOG HATED THE QUICK BROWN FOX!*
 
-The queries `text:dog.` and `text.fox` would match both of the records, while the queries `text.exact:dog` and `text.exact:FOX` would match none.
-However, the queries `text.exact:dog.` and `text.exact:fox` would both yield only the first record, while the queries `text.exact:DOG` or `text.exact:FOX!` would return the second record.
+Now consider these queries:
+
+- `text:dog.` or `text:fox`: matches both of the records.
+- `text.exact:dog` or `text.exact:FOX`: matches none of the records.
+- `text.exact:dog.` or `text.exact:fox`: matches only the first record.
+- `text.exact:DOG` or `text.exact:FOX!`: matches only the second record.
+
 You can see how the `text.exact` field can be used to search in a more fine-grained manner.
 
 ### TextClassificationRecord's `inputs`
 
 For [text classification records](../python/python_client.rst#rubrix.client.models.TextClassificationRecord) you can take advantage of the multiple `inputs` when performing a search.
 For example, if we uploaded records with `inputs={"subject": ..., "body": ...}`, you can direct your searches to only one of those inputs by specifying the `inputs.subject` or `inputs.body` field in your query.
-So to look for records in which the *subject* contains the word *news*, you would search for `inputs.subject:news`.
-Again, as with the `text` field, you can also use the white space analyzer to perform more fine-grained searches by specifying the `exact` field: `inputs.subject.exact:NEWS`.
+So to look for records in which the *subject* contains the word *news*, you would search for
+
+- `inputs.subject:news`
+
+Again, as with the `text` field, you can also use the white space analyzer to perform more fine-grained searches by specifying the `exact` field:
+
+- `inputs.subject.exact:NEWS`
 
 ## Words and phrases
 
 Apart from single words you can also search for *phrases* by surrounding multiples words with double quotes.
 This searches for all the words in the phrase, in the same order.
 
-Taking the two examples from above, `text:"lazy dog hated"` will return only the second example.
+If we take the two examples from above, then following query will only return the second example:
+
+- `text:"lazy dog hated"`
 
 ## Metadata fields
 
@@ -57,7 +69,7 @@ You also have the metadata of your records available when performing a search.
 Imagine you provided the split to which the record belongs to as metadata, that is `metadata={"split": "train"}` or `metadata={"split": "test"}`.
 Then you could only search your training data by specifying the corresponding field in your query:
 
-- `metadata.split:train`.
+- `metadata.split:train`
 
 Metadata are indexed as keywords.
 This means you cannot search for single words in them, and capitalization and punctuations are taken into account.
@@ -80,7 +92,7 @@ You can, however, use wild cards.
 You can combine an arbitrary amount of terms and fields in your search using the familiar boolean operators `AND`, `OR` and `NOT`.
 Following examples showcase the power of these operators:
 
-- `text:(quick AND fox)`: Returns records that contain the word *quick* and *fox*. The `AND` operator is the default one, that is equivalent: `text:(quick fox)`.
+- `text:(quick AND fox)`: Returns records that contain the word *quick* and *fox*. The `AND` operator is the default operator, so `text:(quick fox)` is equivalent.
 - `text:(quick OR brown)`: Returns records that contain either the word *quick* or *brown*.
 - `text:(quick AND fox AND NOT news)`: Returns records that contain the words *quick* and *fox*, **and do not** contain *news*.
 - `metadata.split:train AND text:fox`: Returns records that contain the word *fox* and that have a metadata *"split: train"*.

--- a/docs/reference/webapp/search_records.md
+++ b/docs/reference/webapp/search_records.md
@@ -2,6 +2,61 @@
 
 <video width="100%" controls><source src="../../_static/reference/webapp/search_records.mp4" type="video/mp4"></video>
 
+The search bar in Rubrix is driven by Elasticsearch's powerful [query string syntax](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-query-string-query.html#query-string-syntax).
+It allows you to perform simple fuzzy searches of words and phrases, or complex queries taking full advantage of Rubrix's data model.
+
+## Search fields
+
+An important concept when searching with Elasticsearch is the *field* concept.
+Every search in Rubrix is directed to a specific field of the record's underlying data model.
+For example, writing `text:fox` in the search bar will search for records with the word `fox` in the field `text`.
+
+If you do not provide any fields in your query string, by default Rubrix will search in the fields `word` and `word.extended`.
+For a complete list of available fields, their content and their type, have a look at the field glossary below.
+
+```{note}
+The default behavior when not specifying any fields in the search, will likely change in the near future.
+We recommend emulating the future behavior by using the `text` field for your default searches, that is change `brown fox` to `text:(brown fox)`, for example.
+```
+
+## `text` and `text.exact`
+
+The (arguably) most important fields are the `text` and `text.exact` fields.
+They both contain the text of the records, however in two different forms:
+
+- the `text` field uses Elasticsearch's [standard analyzer](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/analysis-standard-analyzer.html) that ignores capitalization and removes most of the punctuatio;
+- the `text.exact` field uses the [whitespace analyzer](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/analysis-whitespace-analyzer.html) that differentiates between lower and upper case, and does take into account punctuation;
+
+Let's have a look at a few examples.
+Suppose we have 2 records with the following text:
+
+1. *The quick brown fox jumped over the lazy dog.*
+2. *THE DOG HATED THE FOX!*
+
+The queries `text:dog.` and `text.fox` would match both of the records, while the queries `text.exact:dog` and `text.exact:fox` would match none.
+However, the queries `text.exact:dog.` and `text.exact:fox` would both yield only the first record, while the queries `text.exact:DOG` or `text.exact:FOX!` would return the second record.
+You can see how the `text.exact field can be used to search in a more fine-grained manner.
+
+## Words and phrases
+
+## Field types
+
+### metadata fields
+
+### filters as query string
+
+## Combine fields
+
+## Query string features
+
+### Escaping special characters
+
+## Field glossary
+
+
+
+
+
 You can search records by using full-text queries (a normal search), or by Elasticsearch with its [query string syntax](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax).
 
 - Using the `text` and `text.exact` fields

--- a/docs/reference/webapp/search_records.md
+++ b/docs/reference/webapp/search_records.md
@@ -4,7 +4,46 @@
 
 You can search records by using full-text queries (a normal search), or by Elasticsearch with its [query string syntax](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax).
 
-This component enables:
+- Using the `text` and `text.exact` fields
+  + standard and whitespace analyzers
+  + Examples: `text:The phrase` `text.exact:THE PHRASE`
+
+- Default search by `words` and `words.extended`
+  + Search are based on both fields. The default search use both fields.
+  + `words` and `words.extended` deprecation disclaims
+  + ->  promote to prefixed `text:` searches instead default
+
+- Using other fields in search:
+  + Selective inputs search for text classification (`inputs.*` and `inputs.*.exact`)
+  + Metadata values: `metadata.split: train` *ONLY AS KEYWORD
+
+- Filters as query text search
+  + You can use filters in search
+  + `predicted_as: POSITIVE`
+  + `status:Validated`
+  + `annotated_by: john`
+
+- Combining fields (AND OR NOT....)
+  + You can use boolean operator to compose fields or terms in search
+  + Default operator for keywords is the AND operator
+  + `text:(Mike OR Anna)`
+  + `annotated_as: john OR status:Default`
+  + `NOT(_exists_:predicted_as)`
+
+- Some interesting query dsl features:
+  + Regular patterns
+    + `text:/joh?n(ath[oa]n)/`
+  + Ranges
+    + `score:[0.7 TO 0.8]`
+  + Phrase search
+    + `text:"the phrase your're looking for"`
+  + fuzziness
+    + `rubri~`
+  + boosting
+    + `inputs.subject:Rubrix^2 AND inputs.body:better`
+
+- Fields glossary (and kind)
+  - TODO
 
 1. **Full-text queries** over all record `inputs`.
 

--- a/docs/reference/webapp/search_records.md
+++ b/docs/reference/webapp/search_records.md
@@ -146,21 +146,44 @@ For instance, to search for *"(1+1)=2"* you need to write:
 
 This is a table with available fields that you can use in your query string:
 
-| Field name      | Description               | TextClass.                                  | TokenClass.                                 | Text2Text                                   |
-|-----------------|---------------------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|
-| annotated_as    | annotation                | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
-| annotated_by    | annotation agent          | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
-| event_timestamp | timestamp                 | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
-| id              | id                        | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
-| inputs.\*       | inputs                    | <p style="text-align: center;">&#10004;</p> |                                             |                                             |
-| metadata.\*     | metadata                  | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
-| last_updated    |                           | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
-| predicted       |                           | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
-| predicted_as    |                           | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
-| predicted_by    | prediction agent          | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
-| score           | prediction score          | <p style="text-align: center;">&#10004;</p> |                                             |                                             |
-| status          |                           | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
-| text            | text, standard analyzer   | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
-| text.exact      | text, whitespace analyzer | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
-| tokens          | tokens                    |                                             | <p style="text-align: center;">&#10004;</p> |                                             |
+| Field name                               | Description                           | TextClass.                                 | TokenClass.                                 | Text2Text                                   |
+|------------------------------------------|---------------------------------------|--------------------------------------------|---------------------------------------------|---------------------------------------------|
+| annotated_as                             | annotation                            | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| annotated_by                             | annotation agent                      | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| event_timestamp                          | timestamp                             | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| id                                       | id                                    | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| inputs.\*                                | inputs                                | <p style="text-align: center;">&#10004;</p> |                                             |                                             |
+| metadata.\*                              | metadata                              | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| last_updated                             | date of the last update               | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| predicted_as                             | prediction                            | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| predicted_by                             | prediction agent                      | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| score                                    | prediction score                      | <p style="text-align: center;">&#10004;</p> |                                             |                                             |
+| status                                   | status                                | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| text                                     | text, standard analyzer               | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| text.exact                               | text, whitespace analyzer             | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| tokens                                   | tokens                                |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| -                                        | -                                     | -                                          | -                                           | -                                           |
+| metrics.text_lengt                       | Input text length                     | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| metrics.tokens.idx                       | Token idx in record                   |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.tokens.value                     | Text of the token                     |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.tokens.char_start                | Start char idx of token               |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.tokens.char_end                  | End char idx of token                 |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.annotated.mentions.value         | Text of the mention (annotation)      |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.annotated.mentions.label         | Label of the mention (annotation)     |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.annotated.mentions.score         | Score of the mention (annotation)     |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.annotated.mentions.capitalness   | Mention capitalness (annotation)      |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.annotated.mentions.density       | Local mention density (annotation)    |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.annotated.mentions.tokens_length | Mention length in tokens (annotation) |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.annotated.mentions.chars_length  | Mention length in chars (annotation)  |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.annotated.tags.value             | Text of the token (annotation)        |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.annotated.tags.tag               | IOB tag (annotation)                  |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.predicted.mentions.value         | Text of the mention (prediction)      |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.predicted.mentions.label         | Label of the mention (prediction)     |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.predicted.mentions.score         | Score of the mention (prediction)     |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.predicted.mentions.capitalness   | Mention capitalness (prediction)      |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.predicted.mentions.density       | Local mention density (prediction)    |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.predicted.mentions.tokens_length | Mention length in tokens (prediction) |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.predicted.mentions.chars_length  | Mention length in chars (prediction)  |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.predicted.tags.value             | Text of the token (prediction)        |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
+| metrics.predicted.tags.tag               | IOB tag (prediction)                  |                                            | <p style="text-align: center;">&#10004;</p> |                                             |
 

--- a/docs/reference/webapp/search_records.md
+++ b/docs/reference/webapp/search_records.md
@@ -8,11 +8,11 @@ It allows you to perform simple fuzzy searches of words and phrases, or complex 
 ## Search fields
 
 An important concept when searching with Elasticsearch is the *field* concept.
-Every search in Rubrix is directed to a specific field of the record's underlying data model.
+Every search term in Rubrix is directed to a specific field of the record's underlying data model.
 For example, writing `text:fox` in the search bar will search for records with the word `fox` in the field `text`.
 
 If you do not provide any fields in your query string, by default Rubrix will search in the fields `word` and `word.extended`.
-For a complete list of available fields, their content and their type, have a look at the field glossary below.
+For a complete list of available fields and their content, have a look at the field glossary below.
 
 ```{note}
 The default behavior when not specifying any fields in the search, will likely change in the near future.
@@ -31,119 +31,124 @@ Let's have a look at a few examples.
 Suppose we have 2 records with the following text:
 
 1. *The quick brown fox jumped over the lazy dog.*
-2. *THE DOG HATED THE FOX!*
+2. *THE LAZY DOG HATED THE QUICK BROWN FOX!*
 
-The queries `text:dog.` and `text.fox` would match both of the records, while the queries `text.exact:dog` and `text.exact:fox` would match none.
+The queries `text:dog.` and `text.fox` would match both of the records, while the queries `text.exact:dog` and `text.exact:FOX` would match none.
 However, the queries `text.exact:dog.` and `text.exact:fox` would both yield only the first record, while the queries `text.exact:DOG` or `text.exact:FOX!` would return the second record.
-You can see how the `text.exact field can be used to search in a more fine-grained manner.
+You can see how the `text.exact` field can be used to search in a more fine-grained manner.
+
+### TextClassificationRecord's `inputs`
+
+For [text classification records](../python/python_client.rst#rubrix.client.models.TextClassificationRecord) you can take advantage of the multiple `inputs` when performing a search.
+For example, if we uploaded records with `inputs={"subject": ..., "body": ...}`, you can direct your searches to only one of those inputs by specifying the `inputs.subject` or `inputs.body` field in your query.
+So to look for records in which the *subject* contains the word *news*, you would search for `inputs.subject:news`.
+Again, as with the `text` field, you can also use the white space analyzer to perform more fine-grained searches by specifying the `exact` field: `inputs.subject.exact:NEWS`.
 
 ## Words and phrases
 
-## Field types
+Apart from single words you can also search for *phrases* by surrounding multiples words with double quotes.
+This searches for all the words in the phrase, in the same order.
 
-### metadata fields
+Taking the two examples from above, `text:"lazy dog hated"` will return only the second example.
 
-### filters as query string
+## Metadata fields
 
-## Combine fields
+You also have the metadata of your records available when performing a search.
+Imagine you provided the split to which the record belongs to as metadata, that is `metadata={"split": "train"}` or `metadata={"split": "test"}`.
+Then you could only search your training data by specifying the corresponding field in your query:
+
+- `metadata.split:train`.
+
+Metadata are indexed as keywords.
+This means you cannot search for single words in them, and capitalization and punctuations are taken into account.
+You can, however, use wild cards.
+
+## Filters as query string
+
+Just like the metadata, you can also use the filter fields in you query.
+A few examples to emulate the filters in the query string are:
+
+- `status:Validated`
+- `annotated_as:HAM`
+- `predicted_by:Model A`
+
+The field values are treated as keywords, that is you cannot search for single words in them, and capitalization and punctuations are taken into account.
+You can, however, use wild cards.
+
+## Combine terms and fields
+
+You can combine an arbitrary amount of terms and fields in your search using the familiar boolean operators `AND`, `OR` and `NOT`.
+Following examples showcase the power of these operators:
+
+- `text:(quick AND fox)`: Returns records that contain the word *quick* and *fox*. The `AND` operator is the default one, that is equivalent: `text:(quick fox)`.
+- `text:(quick OR brown)`: Returns records that contain either the word *quick* or *brown*.
+- `text:(quick AND fox AND NOT news)`: Returns records that contain the words *quick* and *fox*, **and do not** contain *news*.
+- `metadata.split:train AND text:fox`: Returns records that contain the word *fox* and that have a metadata *"split: train"*.
+- `NOT _exists_:metadata.split` : Returns records that don't have a metadata *split*.
 
 ## Query string features
 
+The query string syntax has many powerful features that you can use to create complex searches.
+Following is just a hand selected subset of the many features you can look up on the official [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-query-string-query.html).
+
+### Wildcards
+
+Wildcard searches can be run on individual search terms, using `?` to replace a single character, and `*` to replace zero or more characters:
+
+- `text:(qu?ck bro*)`
+- `text.exact:"Lazy Dog*"`: Matches, for example, *"Lazy Dog"*, *"Lazy Dog."*, or *"Lazy Dogs"*.
+- `inputs.\*:news`: Searches all input fields for the word *news*.
+
+### Regular expressions
+
+Regular expression patterns can be embedded in the query string by wrapping them in forward slashes "/":
+
+- `text:/joh?n(ath[oa]n)/`: Matches *jonathon*, *jonathan*, *johnathon*, and *johnathan*.
+
+The supported regular expression syntax is explained on the official [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/regexp-syntax.html).
+
+### Fuzziness
+
+You can search for terms that are similar to, but not exactly like the search terms, using the *fuzzy* operator.
+This is useful to cover human misspellings:
+
+- `text:quikc~`: Matches quick and quikc.
+
+### Ranges
+
+Ranges can be specified for date, numeric or string fields.
+Inclusive ranges are specified with square brackets and exclusive ranges with curly brackets:
+
+- `score:[0.5 TO 0.6]`
+- `score:{0.9 TO *}`
+
 ### Escaping special characters
+
+The query string syntax has some reserved characters that you need to escape if you want to search for them.
+The reserved characters are: `+ - = && || > < ! ( ) { } [ ] ^ " ~ * ? : \ /`
+For instance, to search for *"(1+1)=2"* you need to write:
+
+- `text:\(1\+1\)\=2`
 
 ## Field glossary
 
+This is a table with available fields that you can use in your query string:
 
+| Field name      | Description               | TextClass.                                  | TokenClass.                                 | Text2Text                                   |
+|-----------------|---------------------------|---------------------------------------------|---------------------------------------------|---------------------------------------------|
+| annotated_as    | annotation                | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| annotated_by    | annotation agent          | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| event_timestamp | timestamp                 | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| id              | id                        | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| inputs.\*       | inputs                    | <p style="text-align: center;">&#10004;</p> |                                             |                                             |
+| metadata.\*     | metadata                  | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| last_updated    |                           | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| predicted       |                           | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| predicted_as    |                           | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| predicted_by    | prediction agent          | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| score           | prediction score          | <p style="text-align: center;">&#10004;</p> |                                             |                                             |
+| status          |                           | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| text            | text, standard analyzer   | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| text.exact      | text, whitespace analyzer | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> | <p style="text-align: center;">&#10004;</p> |
+| tokens          | tokens                    |                                             | <p style="text-align: center;">&#10004;</p> |                                             |
 
-
-
-You can search records by using full-text queries (a normal search), or by Elasticsearch with its [query string syntax](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax).
-
-- Using the `text` and `text.exact` fields
-  + standard and whitespace analyzers
-  + Examples: `text:The phrase` `text.exact:THE PHRASE`
-
-- Default search by `words` and `words.extended`
-  + Search are based on both fields. The default search use both fields.
-  + `words` and `words.extended` deprecation disclaims
-  + ->  promote to prefixed `text:` searches instead default
-
-- Using other fields in search:
-  + Selective inputs search for text classification (`inputs.*` and `inputs.*.exact`)
-  + Metadata values: `metadata.split: train` *ONLY AS KEYWORD
-
-- Filters as query text search
-  + You can use filters in search
-  + `predicted_as: POSITIVE`
-  + `status:Validated`
-  + `annotated_by: john`
-
-- Combining fields (AND OR NOT....)
-  + You can use boolean operator to compose fields or terms in search
-  + Default operator for keywords is the AND operator
-  + `text:(Mike OR Anna)`
-  + `annotated_as: john OR status:Default`
-  + `NOT(_exists_:predicted_as)`
-
-- Some interesting query dsl features:
-  + Regular patterns
-    + `text:/joh?n(ath[oa]n)/`
-  + Ranges
-    + `score:[0.7 TO 0.8]`
-  + Phrase search
-    + `text:"the phrase your're looking for"`
-  + fuzziness
-    + `rubri~`
-  + boosting
-    + `inputs.subject:Rubrix^2 AND inputs.body:better`
-
-- Fields glossary (and kind)
-  - TODO
-
-1. **Full-text queries** over all record `inputs`.
-
-2. Queries using **Elasticsearch's query DSL** with the [query string syntax](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax). Some examples are: -`inputs.text:(women AND feminists)` : records containing the words "women" AND "feminist" in the inputs.text field.
-
-   -`inputs.text:(NOT women)` : records NOT containing women in the inputs.text field.
-
-   -`inputs.hypothesis:(not OR don't)` : records containing the word "not" or the phrase "don't" in the inputs.hypothesis field.
-
-   -`metadata.format:pdf AND metadata.page_number>1` : records with metadata.format equals pdf and with metadata.page_number greater than 1.
-
-   -`NOT(_exists_:metadata.format)` : records that don't have a value for metadata.format.
-
-   -`predicted_as:(NOT Sports)` : records which are not predicted with the label `Sports`, this is useful when you have many target labels and want to exclude only some of them.
-
-![Search input with Elasticsearch DSL query string](../../_static/reference/webapp/active_query_params.png)
-
-**NOTE**: Elasticsearch's query DSL supports **escaping special characters** that are part of the query syntax. The current list special characters are:
-
-`+ - && || ! ( ) { } [ ] ^ " ~ * ? : \`
-
-To escape these character use the \\ before the character. For example to search for (1+1):2 use the query `\(1\+1\)\:2`.
-
-In both **Annotation** and **Exploration** modes, the search bar is placed in the upper left-hand corner. To search something, users must type one or several words (or a query) and click the **Intro** button.
-
-Note that this feature also works as a kind of filter. If users search something, it is possible to explore and/or annotate the results obtained. [Filters](filter_records.md) can be applied.
-
-## Elasticsearch fields
-
-Shown below is a summary of available fields that can be used for the query DSL, as well as for building **Kibana Dashboards**— common fields to all record types, and those specific to certain record types:
-
-| Common fields   | Text classification fields | Token classification fields |
-| --------------- | -------------------------- | --------------------------- |
-| Annotated_as    | inputs.\*                  | tokens                      |
-| Annotated_by    | score                      |                             |
-| event_timestamp |                            |                             |
-| id              |                            |                             |
-| last_updated    |                            |                             |
-| metadata.\*     |                            |                             |
-| multi_label     |                            |                             |
-| predicted       |                            |                             |
-| predicted_as    |                            |                             |
-| predicted_by    |                            |                             |
-| status          |                            |                             |
-| words           |                            |                             |
-| words.extended  |                            |                             |
-
-With this component, users are able to search specific information on the dataset, either by **full-text queries** or by queries using **Elasticsearch**.


### PR DESCRIPTION
I've include a bullet list for text searches in webapp.

@dcfidalgo Could you please apply the Paulo Coelho translator to generate the documentation? (i mean, could you please redact the docs from that?

We can talk next week for that, but it could be nice update the guide for weak supervision release.