### PR TITLE
fix(#1241, #1245): show new line char in metrics plot & increase mentions in entity consistency

### DIFF
--- a/src/rubrix/metrics/helpers.py
+++ b/src/rubrix/metrics/helpers.py
@@ -20,7 +20,10 @@ def bar(data: dict, title: str = "Bar", x_legend: str = "", y_legend: str = ""):
         return empty_visualization()
 
     keys, values = zip(*data.items())
-    keys = [key.encode("unicode-escape").decode() for key in keys]
+    keys = [
+        key.encode("unicode-escape").decode() if isinstance(key, str) else key
+        for key in keys
+    ]
     fig = go.Figure(data=go.Bar(y=values, x=keys))
     fig.update_layout(
         title=title,

--- a/src/rubrix/metrics/helpers.py
+++ b/src/rubrix/metrics/helpers.py
@@ -20,6 +20,7 @@ def bar(data: dict, title: str = "Bar", x_legend: str = "", y_legend: str = ""):
         return empty_visualization()
 
     keys, values = zip(*data.items())
+    keys = [key.encode("unicode-escape").decode() for key in keys]
     fig = go.Figure(data=go.Bar(y=values, x=keys))
     fig.update_layout(
         title=title,

--- a/src/rubrix/metrics/token_classification/metrics.py
+++ b/src/rubrix/metrics/token_classification/metrics.py
@@ -341,7 +341,7 @@ def entity_consistency(
     name: str,
     query: Optional[str] = None,
     compute_for: Union[str, ComputeFor] = Predictions,
-    mentions: int = 10,
+    mentions: int = 100,
     threshold: int = 2,
 ):
     """Computes the consistency for top entity mentions in the dataset.


### PR DESCRIPTION
This PR closes #1241 and #1245.

- New line characters are now shown explicitly in the x-axis of the metrics plots for bar plots.
- the default value for `mentions` in entity consistency is increased