### PR TITLE
docs(#1267): move docker command to one line

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Check the [tutorial](https://rubrix.readthedocs.io/en/master/tutorials/weak-supe
 Getting started with Rubrix is as easy as:
 
 ```bash
-pip install rubrix[server]
+pip install "rubrix[server]"
 ```
 
 If you don't have [Elasticsearch (ES)](https://www.elastic.co/elasticsearch) running, make sure you have `Docker` installed and run:
@@ -111,12 +111,7 @@ If you don't have [Elasticsearch (ES)](https://www.elastic.co/elasticsearch) run
 > :information_source: **Check [our documentation](https://rubrix.readthedocs.io/en/stable/getting_started/setup%26installation.html) for further options and configurations regarding Elasticsearch.**
 
 ```bash
-docker run -d \
- --name elasticsearch-for-rubrix \
- -p 9200:9200 -p 9300:9300 \
- -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
- -e "discovery.type=single-node" \
- docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+docker run -d --name elasticsearch-for-rubrix -p 9200:9200 -p 9300:9300 -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
 ```
 
 Then simply run:

--- a/docs/getting_started/advanced_setup_guides.rst
+++ b/docs/getting_started/advanced_setup_guides.rst
@@ -22,12 +22,7 @@ Simply run the following command:
 
 .. code-block:: bash
 
-   docker run -d \
-     --name elasticsearch-for-rubrix \
-     -p 9200:9200 -p 9300:9300 \
-     -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
-     -e "discovery.type=single-node" \
-     docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+   docker run -d --name elasticsearch-for-rubrix -p 9200:9200 -p 9300:9300 -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
 
 This will create an ES docker container named *"elasticsearch-for-rubrix"* that will run in the background.
 

--- a/docs/getting_started/supported_tasks.rst
+++ b/docs/getting_started/supported_tasks.rst
@@ -50,7 +50,7 @@ Rubrix is flexible with input and output shapes, which means you can model relat
 Text2Text
 ^^^^^^^^^
 
-The most typical and oldest task in this category is probably `Machine Translation<http://nlpprogress.com/english/machine_translation.html>`_:
+The most typical and oldest task in this category is probably `Machine Translation <http://nlpprogress.com/english/machine_translation.html>`__:
 
 ..
 

--- a/docs/guides/task_examples.ipynb
+++ b/docs/guides/task_examples.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Tasks Templates\n",
     "\n",
-    "Hi there! In this article we wanted to share some examples of our supported tasks, so you can go from zero to hero as fast as possible. We are going to cover those tasks present in our [supported tasks list](https://docs.rubrix.ml/en/stable/getting_started/supported_tasks.html), so don't forget to stop by and take a look.\n",
+    "Hi there! In this article we wanted to share some examples of our supported tasks, so you can go from zero to hero as fast as possible. We are going to cover those tasks present in our [supported tasks list](../getting_started/supported_tasks.rst), so don't forget to stop by and take a look.\n",
     "\n",
     "The tasks are divided into their different category, from text classification to token classification. We will update this article, as well as the supported task list when a new task gets added to Rubrix."
    ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,12 +46,7 @@ If you don't have `Elasticsearch (ES) <https://www.elastic.co/elasticsearch>`__ 
 
 .. code-block:: bash
 
-   docker run -d \
-     --name elasticsearch-for-rubrix \
-     -p 9200:9200 -p 9300:9300 \
-     -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
-     -e "discovery.type=single-node" \
-     docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
+   docker run -d --name elasticsearch-for-rubrix -p 9200:9200 -p 9300:9300 -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
 
 
 Then simply run:


### PR DESCRIPTION
Closes #1267 

I simply moved the docker command to one line, since this works for linux/macos, too. 
This PR also contains a few minor fixes.