### PR TITLE
docs(1272): Add instructions on how to import "generic" datasets to Rubrix

### DIFF
--- a/docs/guides/datasets.ipynb
+++ b/docs/guides/datasets.ipynb
@@ -89,9 +89,71 @@
     "\n",
     "# import data from a pandas DataFrame\n",
     "dataset_rb = rb.read_pandas(my_dataframe, task=\"TextClassification\")\n",
+    "# or\n",
+    "dataset_rb = rb.DatasetForTextClassification.from_pandas(my_dataframe)\n",
     "\n",
     "# import data from a datasets Dataset\n",
-    "dataset_rb = rb.read_datasets(my_dataset, task=\"TextClassification\")"
+    "dataset_rb = rb.read_datasets(my_dataset, task=\"TextClassification\")\n",
+    "# or\n",
+    "dataset_rb = rb.DatasetForTextClassification.from_datasets(my_dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be0a0e4d-f05b-4635-af54-885933f3bc9a",
+   "metadata": {},
+   "source": [
+    "We also provide helper arguments you can use to read almost arbitrary datasets for a given task from the [Hugging Face Hub](https://huggingface.co/datasets).\n",
+    "They map certain input arguments of the Rubrix records to columns of the given dataset.\n",
+    "Let's have a look at a few examples:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41209b56-0dce-4045-8a4f-ffc00f962a48",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import rubrix as rb\n",
+    "from datasets import load_dataset\n",
+    "\n",
+    "# the \"poem_sentiment\" dataset has columns \"verse_text\" and \"label\"\n",
+    "dataset_rb = rb.DatasetForTextClassification.from_datasets(\n",
+    "    dataset=load_dataset(\"poem_sentiment\", split=\"test\"),\n",
+    "    text=\"verse_text\",\n",
+    "    annotation=\"label\",\n",
+    ")\n",
+    "\n",
+    "# the \"snli\" dataset has the columns \"premise\", \"hypothesis\" and \"label\"\n",
+    "dataset_rb = rb.DatasetForTextClassification.from_datasets(\n",
+    "    dataset=load_dataset(\"snli\", split=\"test\"),\n",
+    "    inputs=[\"premise\", \"hypothesis\"],\n",
+    "    annotation=\"label\",\n",
+    ")\n",
+    "\n",
+    "# the \"conll2003\" dataset has the columns \"id\", \"tokens\", \"pos_tags\", \"chunk_tags\" and \"ner_tags\"\n",
+    "rb.DatasetForTokenClassification.from_datasets(\n",
+    "    dataset=load_dataset(\"conll2003\", split=\"test\"),\n",
+    "    tags=\"ner_tags\",\n",
+    ")\n",
+    "\n",
+    "# the \"xsum\" dataset has the columns \"id\", \"document\" and \"summary\"\n",
+    "rb.DatasetForText2Text.from_datasets(\n",
+    "    dataset=load_dataset(\"xsum\", split=\"test\"),\n",
+    "    text=\"document\",\n",
+    "    annotation=\"summary\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de341ab4-6be4-499b-9f4e-0eb4546fa753",
+   "metadata": {},
+   "source": [
+    "You can also use the shortcut `rb.read_datasets(dataset=..., task=..., **kwargs)` where the keyword arguments are passed on to the corresponding `from_datasets()` method."
    ]
   },
   {
@@ -149,6 +211,65 @@
     "\n",
     "# log the dataset to the Rubrix web app\n",
     "rb.log(dataset_rb, \"dataset_by_user\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2d5b02c-a24c-40d0-80ce-6332fba15318",
+   "metadata": {},
+   "source": [
+    "## Prepare dataset for training\n",
+    "\n",
+    "If you want to train a Hugging Face transformer with your dataset, we provide a handy method to prepare your dataset: `DatasetFor*.prepare_for_training()`.\n",
+    "It will return a Hugging Face dataset, optimized for the training process with the Hugging Face Trainer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4b1d63a-7940-46ff-85e9-062ab785b828",
+   "metadata": {},
+   "source": [
+    "For text classification tasks, it flattens the inputs into separate columns of the returned dataset and converts the annotations of your records into integers and writes them in a label column:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f3bcc58-fdc9-427a-8ffd-ef37e67e03a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_rb = rb.DatasetForTextClassification([\n",
+    "    rb.TextClassificationRecord(inputs={\"title\": \"My title\", \"content\": \"My content\"}, annotation=\"news\")\n",
+    "])\n",
+    "\n",
+    "dataset_rb.prepare_for_training()[0]\n",
+    "# Output:\n",
+    "# {'title': 'My title', 'content': 'My content', 'label': 0}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "907714da-5496-4a49-bc6d-2d9008d0082f",
+   "metadata": {},
+   "source": [
+    "For token classification tasks, it converts the annotations of a record into integers representing BIO tags and writes them in a `ner_tags` column: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c28c72cb-599a-4073-a018-6f9746e17e3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_rb = rb.DatasetForTokenClassification([\n",
+    "    rb.TokenClassificationRecord(text=\"I live in Madrid\", tokens=[\"I\", \"live\", \"in\", \"Madrid\"], annotation=[(\"LOC\", 10, 15)])\n",
+    "])\n",
+    "\n",
+    "dataset_rb.prepare_for_training()[0]\n",
+    "# Output:\n",
+    "# {..., 'tokens': ['I', 'live', 'in', 'Madrid'], 'ner_tags': [0, 0, 0, 1], ...}"
    ]
   }
  ],

--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -385,6 +385,7 @@ class DatasetForTextClassification(DatasetBase):
         # we implement this to have more specific type hints
         cls,
         dataset: "datasets.Dataset",
+        text: Optional[str] = None,
         id: Optional[str] = None,
         inputs: Optional[Union[str, List[str]]] = None,
         annotation: Optional[str] = None,
@@ -396,6 +397,7 @@ class DatasetForTextClassification(DatasetBase):
 
         Args:
             dataset: A datasets Dataset from which to import the records.
+            text: The field name used as record text. Default: `None`
             id: The field name used as record id. Default: `None`
             inputs: A list of field names used for record inputs. Default: `None`
             annotation: The field name used as record annotation. Default: `None`
@@ -416,7 +418,12 @@ class DatasetForTextClassification(DatasetBase):
         """
 
         return super().from_datasets(
-            dataset, id=id, annotation=annotation, metadata=metadata, inputs=inputs
+            dataset,
+            text=text,
+            id=id,
+            annotation=annotation,
+            metadata=metadata,
+            inputs=inputs,
         )
 
     @classmethod
@@ -1048,12 +1055,15 @@ Dataset = Union[
 ]
 
 
-def read_datasets(dataset: "datasets.Dataset", task: Union[str, TaskType]) -> Dataset:
+def read_datasets(
+    dataset: "datasets.Dataset", task: Union[str, TaskType], **kwargs
+) -> Dataset:
     """Reads a datasets Dataset and returns a Rubrix Dataset
 
     Args:
         dataset: Dataset to be read in.
-        task: Task for the dataset, one of: ["TextClassification", "TokenClassification", "Text2Text"]
+        task: Task for the dataset, one of: ["TextClassification", "TokenClassification", "Text2Text"].
+        **kwargs: Passed on to the task-specific ``DatasetFor*.from_datasets()`` method.
 
     Returns:
         A Rubrix dataset for the given task.
@@ -1095,11 +1105,11 @@ def read_datasets(dataset: "datasets.Dataset", task: Union[str, TaskType]) -> Da
         task = TaskType(task)
 
     if task is TaskType.text_classification:
-        return DatasetForTextClassification.from_datasets(dataset)
+        return DatasetForTextClassification.from_datasets(dataset, **kwargs)
     if task is TaskType.token_classification:
-        return DatasetForTokenClassification.from_datasets(dataset)
+        return DatasetForTokenClassification.from_datasets(dataset, **kwargs)
     if task is TaskType.text2text:
-        return DatasetForText2Text.from_datasets(dataset)
+        return DatasetForText2Text.from_datasets(dataset, **kwargs)
     raise NotImplementedError(
         "Reading a datasets Dataset is not implemented for the given task!"
     )

--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -485,9 +485,9 @@ class DatasetForTextClassification(DatasetBase):
             try:
                 return {"annotation": labels.int2str(example["annotation"])}
             # integers don't have to map to the names ...
-            # it seems that sometimes -1 is used to denote ... something ...
+            # it seems that sometimes -1 is used to denote "no label"
             except ValueError:
-                return {"annotation": example["annotation"]}
+                return {"annotation": None}
 
         return dataset.map(int2str_for_annotation)
 

--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -317,7 +317,9 @@ class DatasetBase:
         def parse_metadata_from_dataset(example):
             return {"metadata": {k: example[k] for k in fields}}
 
-        return dataset.map(parse_metadata_from_dataset).remove_columns(fields)
+        return dataset.map(
+            parse_metadata_from_dataset, desc="Parsing metadata"
+        ).remove_columns(fields)
 
     @classmethod
     def _parse_annotation_field(
@@ -489,7 +491,7 @@ class DatasetForTextClassification(DatasetBase):
             except ValueError:
                 return {"annotation": None}
 
-        return dataset.map(int2str_for_annotation)
+        return dataset.map(int2str_for_annotation, desc="Parsing annotation")
 
     @classmethod
     def _prepare_hf_dataset(
@@ -549,7 +551,10 @@ class DatasetForTextClassification(DatasetBase):
         if isinstance(fields, str):
             fields = [fields]
 
-        return dataset.map(lambda example: {"inputs": {k: example[k] for k in fields}})
+        return dataset.map(
+            lambda example: {"inputs": {k: example[k] for k in fields}},
+            desc="Parsing inputs",
+        )
 
     @classmethod
     def _from_pandas(cls, dataframe: pd.DataFrame) -> "DatasetForTextClassification":
@@ -890,7 +895,7 @@ class DatasetForTokenClassification(DatasetBase):
                 data["text"] = " ".join(tokens)
             return data
 
-        return dataset.map(parse_tokens_from_example)
+        return dataset.map(parse_tokens_from_example, desc="Parsing tokens")
 
     @classmethod
     def _parse_tags_field(
@@ -908,7 +913,7 @@ class DatasetForTokenClassification(DatasetBase):
         def parse_tags_from_example(example):
             return {"tags": [int2str(t) for t in example[field] or []]}
 
-        return dataset.map(parse_tags_from_example)
+        return dataset.map(parse_tags_from_example, desc="Parsing tags")
 
     @classmethod
     def _from_pandas(cls, dataframe: pd.DataFrame) -> "DatasetForTokenClassification":

--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -880,6 +880,9 @@ class DatasetForTokenClassification(DatasetBase):
                 row["prediction"] = cls.__entities_to_tuple__(row["prediction"])
             if row.get("annotation"):
                 row["annotation"] = cls.__entities_to_tuple__(row["annotation"])
+            if not row["tokens"]:
+                _LOGGER.warning(f"Ignoring row with no tokens.")
+                continue
             records.append(TokenClassificationRecord.parse_obj(row))
         return cls(records)
 

--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -542,14 +542,7 @@ class DatasetForTextClassification(DatasetBase):
         if isinstance(fields, str):
             fields = [fields]
 
-        def parse_inputs_from_dataset(example):
-            return {
-                "inputs": example[fields[0]]
-                if len(fields) == 1
-                else {k: example[k] for k in fields}
-            }
-
-        return dataset.map(parse_inputs_from_dataset)
+        return dataset.map(lambda example: {k: example[k] for k in fields})
 
     @classmethod
     def _from_pandas(cls, dataframe: pd.DataFrame) -> "DatasetForTextClassification":

--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -298,13 +298,13 @@ class DatasetBase:
     def _parse_id_field(
         cls, dataset: "datasets.Dataset", field: str
     ) -> "datasets.Dataset":
-        return dataset.rename_column(field, "id").remove_columns(field)
+        return dataset.rename_column(field, "id")
 
     @classmethod
     def _parse_text_field(
         cls, dataset: "datasets.Dataset", field: str
     ) -> "datasets.Dataset":
-        return dataset.rename_column(field, "text").remove_columns(field)
+        return dataset.rename_column(field, "text")
 
     @classmethod
     def _parse_metadata_field(
@@ -325,7 +325,7 @@ class DatasetBase:
     def _parse_annotation_field(
         cls, dataset: "datasets.Dataset", field: str
     ) -> "datasets.Dataset":
-        return dataset.rename_column(field, "annotation").remove_columns(field)
+        return dataset.rename_column(field, "annotation")
 
 
 def _prepend_docstring(record_type: Type[Record]):
@@ -478,7 +478,7 @@ class DatasetForTextClassification(DatasetBase):
         if isinstance(labels, datasets.Sequence):
             labels = labels.feature
 
-        dataset = dataset.rename_column(field, "annotation").remove_columns(field)
+        dataset = dataset.rename_column(field, "annotation")
 
         if not isinstance(labels, datasets.ClassLabel):
             return dataset
@@ -554,7 +554,7 @@ class DatasetForTextClassification(DatasetBase):
         return dataset.map(
             lambda example: {"inputs": {k: example[k] for k in fields}},
             desc="Parsing inputs",
-        ).remove_columns(fields)
+        )
 
     @classmethod
     def _from_pandas(cls, dataframe: pd.DataFrame) -> "DatasetForTextClassification":
@@ -898,9 +898,7 @@ class DatasetForTokenClassification(DatasetBase):
                 data["text"] = " ".join(tokens)
             return data
 
-        return dataset.map(
-            parse_tokens_from_example, desc="Parsing tokens"
-        ).remove_columns(field)
+        return dataset.map(parse_tokens_from_example, desc="Parsing tokens")
 
     @classmethod
     def _parse_tags_field(
@@ -918,9 +916,7 @@ class DatasetForTokenClassification(DatasetBase):
         def parse_tags_from_example(example):
             return {"tags": [int2str(t) for t in example[field] or []]}
 
-        return dataset.map(parse_tags_from_example, desc="Parsing tags").remove_columns(
-            field
-        )
+        return dataset.map(parse_tags_from_example, desc="Parsing tags")
 
     @classmethod
     def _from_pandas(cls, dataframe: pd.DataFrame) -> "DatasetForTokenClassification":

--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -298,13 +298,13 @@ class DatasetBase:
     def _parse_id_field(
         cls, dataset: "datasets.Dataset", field: str
     ) -> "datasets.Dataset":
-        return dataset.rename_column(field, "id")
+        return dataset.rename_column(field, "id").remove_columns(field)
 
     @classmethod
     def _parse_text_field(
         cls, dataset: "datasets.Dataset", field: str
     ) -> "datasets.Dataset":
-        return dataset.rename_column(field, "text")
+        return dataset.rename_column(field, "text").remove_columns(field)
 
     @classmethod
     def _parse_metadata_field(
@@ -325,7 +325,7 @@ class DatasetBase:
     def _parse_annotation_field(
         cls, dataset: "datasets.Dataset", field: str
     ) -> "datasets.Dataset":
-        return dataset.rename_column(field, "annotation")
+        return dataset.rename_column(field, "annotation").remove_columns(field)
 
 
 def _prepend_docstring(record_type: Type[Record]):
@@ -478,7 +478,7 @@ class DatasetForTextClassification(DatasetBase):
         if isinstance(labels, datasets.Sequence):
             labels = labels.feature
 
-        dataset = dataset.rename_column(field, "annotation")
+        dataset = dataset.rename_column(field, "annotation").remove_columns(field)
 
         if not isinstance(labels, datasets.ClassLabel):
             return dataset
@@ -554,7 +554,7 @@ class DatasetForTextClassification(DatasetBase):
         return dataset.map(
             lambda example: {"inputs": {k: example[k] for k in fields}},
             desc="Parsing inputs",
-        )
+        ).remove_columns(fields)
 
     @classmethod
     def _from_pandas(cls, dataframe: pd.DataFrame) -> "DatasetForTextClassification":
@@ -898,7 +898,9 @@ class DatasetForTokenClassification(DatasetBase):
                 data["text"] = " ".join(tokens)
             return data
 
-        return dataset.map(parse_tokens_from_example, desc="Parsing tokens")
+        return dataset.map(
+            parse_tokens_from_example, desc="Parsing tokens"
+        ).remove_columns(field)
 
     @classmethod
     def _parse_tags_field(
@@ -916,7 +918,9 @@ class DatasetForTokenClassification(DatasetBase):
         def parse_tags_from_example(example):
             return {"tags": [int2str(t) for t in example[field] or []]}
 
-        return dataset.map(parse_tags_from_example, desc="Parsing tags")
+        return dataset.map(parse_tags_from_example, desc="Parsing tags").remove_columns(
+            field
+        )
 
     @classmethod
     def _from_pandas(cls, dataframe: pd.DataFrame) -> "DatasetForTokenClassification":

--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -542,7 +542,7 @@ class DatasetForTextClassification(DatasetBase):
         if isinstance(fields, str):
             fields = [fields]
 
-        return dataset.map(lambda example: {k: example[k] for k in fields})
+        return dataset.map(lambda example: {"inputs": {k: example[k] for k in fields}})
 
     @classmethod
     def _from_pandas(cls, dataframe: pd.DataFrame) -> "DatasetForTextClassification":

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -619,9 +619,8 @@ class TestDatasetForTokenClassification:
             dataset_ds, tokens="empty_tokens"
         )
 
-        assert len(caplog.record_tuples) == 1
-        assert caplog.record_tuples[0][1] == 30
-        assert caplog.record_tuples[0][2] == "Ignoring row with no tokens."
+        assert caplog.record_tuples[1][1] == 30
+        assert caplog.record_tuples[1][2] == "Ignoring row with no tokens."
 
         assert len(dataset_rb) == 1
         assert dataset_rb[0].tokens == ["mock"]

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -335,8 +335,6 @@ class TestDatasetForTextClassification:
         reason="You need a HF Hub access token to test the push_to_hub feature",
     )
     def test_from_dataset_with_non_rubrix_format_multilabel(self):
-        import datasets
-
         ds = datasets.load_dataset(
             "rubrix/go_emotions_test_100",
             split="test",
@@ -370,8 +368,6 @@ class TestDatasetForTextClassification:
         reason="You need a HF Hub access token to test the push_to_hub feature",
     )
     def test_from_dataset_with_non_rubrix_format(self):
-        import datasets
-
         ds = datasets.load_dataset(
             "rubrix/app_reviews_train_100",
             split="train",
@@ -576,8 +572,6 @@ class TestDatasetForTokenClassification:
         reason="You need a HF Hub access token to test the push_to_hub feature",
     )
     def test_from_dataset_with_non_rubrix_format(self):
-        import datasets
-
         ds = datasets.load_dataset(
             "rubrix/wikiann_es_test_100",
             split="test",
@@ -602,6 +596,23 @@ class TestDatasetForTokenClassification:
             "event_timestamp",
             "metrics",
         ]
+
+
+def test_from_datasets_with_annotation_arg():
+    dataset_ds = datasets.Dataset.from_dict(
+        {"text": ["mock", "mock2"], "label": [0, -1]},
+        features=datasets.Features(
+            {
+                "text": datasets.Value("string"),
+                "label": datasets.ClassLabel(names=["HAM"]),
+            }
+        ),
+    )
+    dataset_rb = rb.DatasetForTextClassification.from_datasets(
+        dataset_ds, annotation="label"
+    )
+
+    assert [rec.annotation for rec in dataset_rb] == ["HAM", None]
 
 
 class TestDatasetForText2Text:
@@ -702,8 +713,6 @@ class TestDatasetForText2Text:
         reason="You need a HF Hub access token to test the push_to_hub feature",
     )
     def test_from_dataset_with_non_rubrix_format(self):
-        import datasets
-
         ds = datasets.load_dataset(
             "rubrix/big_patent_a_test_100",
             split="test",


### PR DESCRIPTION
Closes #1272

See the new guide here: https://rubrix.readthedocs.io/en/docs-improve_datasets_guide/guides/datasets.html

Apart from improving the dataset guide, this PR also includes 2 fixes I encountered in the examples:
- label being `-1` in the original HF dataset. apparently, this is sometimes used to denote "no label"
- empty list of tokens in a NER HF datasets