### PR TITLE
fix(datasets): prevent error when no annotated records found in dataset

### DIFF
--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -731,6 +731,15 @@ class DatasetForTokenClassification(DatasetBase):
         """
         import datasets
 
+        has_annotations = False
+        for rec in self._records:
+            if rec.annotation is not None:
+                has_annotations = True
+                break
+
+        if not has_annotations:
+            return datasets.Dataset.from_dict({})
+
         class_tags = ["O"]
         class_tags.extend(
             [
@@ -752,12 +761,11 @@ class DatasetForTokenClassification(DatasetBase):
         ds = (
             self.to_datasets()
             .filter(self.__only_annotations__)
-            .map(
-                lambda example: {"ner_tags": spans2iob(example)},
-            )
+            .map(lambda example: {"ner_tags": spans2iob(example)})
         )
         new_features = ds.features.copy()
         new_features["ner_tags"] = [class_tags]
+
         return ds.cast(new_features)
 
     def __all_labels__(self):

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -461,6 +461,12 @@ class TestDatasetForTokenClassification:
 
         assert rb.read_datasets(dataset_ds, task="TokenClassification")[0].id is None
 
+    def test_prepare_for_training_empty(self):
+        dataset = rb.DatasetForTokenClassification(
+            [rb.TokenClassificationRecord(text="mock", tokens=["mock"])]
+        )
+        assert len(dataset.prepare_for_training()) == 0
+
     def test_datasets_empty_metadata(self):
         dataset = rb.DatasetForTokenClassification(
             [rb.TokenClassificationRecord(text="mock", tokens=["mock"])]


### PR DESCRIPTION
This PR prevent error on `ner_ds.prepare_for_training` method with no annotations. Also prevent the dataset generation in those cases, what can improve performance. 