### PR TITLE
refactor(labels): compute dataset labels from a records subset

### DIFF
--- a/src/rubrix/server/tasks/text_classification/metrics.py
+++ b/src/rubrix/server/tasks/text_classification/metrics.py
@@ -89,10 +89,17 @@ class F1Metric(PythonMetric):
 class DatasetLabels(PythonMetric):
     id: str = Field("dataset_labels", const=True)
     name: str = Field("The dataset labels", const=True)
+    max_processed_records: int = 10000
 
     def apply(self, records: Iterable[TextClassificationRecord]) -> Dict[str, Any]:
         ds_labels = set()
-        for record in records:
+        for _ in range(
+            0, self.max_processed_records
+        ):  # Only a few of records will be parsed
+            record = next(records, None)
+            if record is None:
+                break
+
             if record.annotation:
                 ds_labels.update(
                     [label.class_label for label in record.annotation.labels]


### PR DESCRIPTION
In this PR we include changes about how dataset labels are computed. Instead of parse the whole dataset, we compute a subset of records. This should work fine for the main of use cases, the edge case can ben resolved with the concept of dataset settings, where user can provide a set of fixed labels.