### PR TITLE
ci: include es 8.0 in build process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elasticsearch: [ 7.4, 7.10.2, 7.14, 7.16, 7.17 ]
+        elasticsearch: [ 7.4, 7.10.2, 7.14, 7.16, 7.17, 8.0 ]
     defaults:
       run:
         shell: bash -l {0}

--- a/src/rubrix/server/tasks/commons/dao/dao.py
+++ b/src/rubrix/server/tasks/commons/dao/dao.py
@@ -207,7 +207,7 @@ class DatasetRecordsDAO:
             "_source": {"excludes": exclude_fields or []},
             "from": record_from,
             "query": search.query or {"match_all": {}},
-            "sort": search.sort or [{"_id": {"order": "asc"}}],
+            "sort": search.sort or [{"id": {"order": "asc"}}],
             "aggs": aggregation_requests,
             "highlight": self.__configure_query_highlight__(),
         }

--- a/src/rubrix/server/tasks/commons/dao/es_config.py
+++ b/src/rubrix/server/tasks/commons/dao/es_config.py
@@ -20,7 +20,9 @@ class mappings:
             "ignore_above": MAX_KEYWORD_LENGTH,
         }
         if enable_text_search:
-            mapping["fields"] = {"text": mappings.text_field()}
+            text_field = mappings.text_field()
+            text_field_fields = text_field.pop("fields", {})
+            mapping["fields"] = {"text": text_field, **text_field_fields}
         return mapping
 
     @staticmethod

--- a/src/rubrix/server/tasks/commons/dao/es_config.py
+++ b/src/rubrix/server/tasks/commons/dao/es_config.py
@@ -137,7 +137,11 @@ def tasks_common_settings():
 
 
 def dynamic_metrics_text():
-    return {"metrics.*": mappings.path_match_keyword_template(path="metrics.*")}
+    return {
+        "metrics.*": mappings.path_match_keyword_template(
+            path="metrics.*", enable_text_search_in_keywords=False
+        )
+    }
 
 
 def dynamic_metadata_text():


### PR DESCRIPTION
This PR includes required changes to make rubrix compatible with the new elasticsearch 8.x version.

The main changes are:

- Use `id` field as default sort key, instead of the `_id` field, which is disabled as default for this es version
- Avoid to define nested fields in mappings. This configuration was deprecated in previos versions and is not allowed in last version. This changes affect to `metadata.*` fields and how the text searches can be used over them. String metadata fields are defined as keywords, and extends the 2 subfields `text` and `exact` for textual queries. You should use them in query string as follows:
```
metadata.my_field.text:total effort
# or
metadata.my_field.exact:Total Effor~
```