### PR TITLE
fix(workspaces): superuser with empty workspace

### DIFF
--- a/src/rubrix/server/security/model.py
+++ b/src/rubrix/server/security/model.py
@@ -85,8 +85,10 @@ class User(BaseModel):
             The original workspace name if user belongs to it
 
         """
-        if not workspace or workspace == self.default_workspace:
+        if workspace is None or workspace == self.default_workspace:
             return self.default_workspace
+        if not workspace and self.is_superuser():
+            return workspace
         if workspace not in (self.workspaces or []):
             raise EntityNotFoundError(name=workspace, type="Workspace")
         return workspace

--- a/tests/server/security/test_model.py
+++ b/tests/server/security/test_model.py
@@ -72,6 +72,9 @@ def test_workspace_for_superuser():
     with pytest.raises(EntityNotFoundError):
         assert user.check_workspace("some") == "some"
 
+    assert user.check_workspace(None) == "admin"
+    assert user.check_workspace("") == ""
+
     user.workspaces = ["some"]
     assert user.check_workspaces(["some"]) == ["some"]
 


### PR DESCRIPTION
Super user cannot see non-workspaced datasets (error 404). This PR fixes that.