### PR TITLE
fix: make starlette an optional dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ install_requires =
   pandas >=1.0.0,<2.0.0
   # Aligned pydantic version with server fastAPI
   pydantic >= 1.7.1
-  starlette >=0.13.0,<1.0.0
   # monitoring
   wrapt ~= 1.13.0
   # weaksupervision

--- a/src/rubrix/monitoring/asgi.py
+++ b/src/rubrix/monitoring/asgi.py
@@ -21,10 +21,18 @@ import threading
 from queue import Queue
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
-from starlette.requests import Request
-from starlette.responses import JSONResponse, Response, StreamingResponse
-from starlette.types import Message, Receive
+try:
+    import starlette
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(
+        "'starlette' must be installed to use the middleware feature! "
+        "You can install 'starlette' with the command: `pip install starlette>=0.13.0`"
+    )
+else:
+    from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse, Response, StreamingResponse
+    from starlette.types import Message, Receive
 
 import rubrix
 from rubrix.client.models import (


### PR DESCRIPTION
Closes #1271 

This PR makes starlette an optional dependency for the client. This solves version issues when installing client+server with an older version of pip.