### PR TITLE
fix(#1335): force line break in rules summary

### DIFF
--- a/frontend/components/core/table/ReTableInfo.vue
+++ b/frontend/components/core/table/ReTableInfo.vue
@@ -512,11 +512,6 @@ export default {
       &:first-child {
         flex-shrink: 0;
         min-width: 240px;
-        a {
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
-        }
       }
     }
     .svg-icon {


### PR DESCRIPTION
Closes #1335

This PR prevents text overlapping by forcing line breaks in the first column