### PR TITLE
fix(#1339): Metrics and status not updated when the query is refreshed

### DIFF
--- a/frontend/components/text-classifier/labeling-rules/RuleDefinition.vue
+++ b/frontend/components/text-classifier/labeling-rules/RuleDefinition.vue
@@ -61,6 +61,7 @@ export default {
   },
   watch: {
     async query(newValue) {
+      this.saved = false;
       const rule = this.dataset.findRuleByQuery(newValue, undefined);
       await this.dataset.setCurrentLabelingRule(
         rule

--- a/frontend/components/text-classifier/labeling-rules/RuleDefinition.vue
+++ b/frontend/components/text-classifier/labeling-rules/RuleDefinition.vue
@@ -61,7 +61,12 @@ export default {
   },
   watch: {
     async query(newValue) {
-      await this.dataset.setCurrentLabelingRule({ query: newValue });
+      const rule = this.dataset.findRuleByQuery(newValue, undefined);
+      await this.dataset.setCurrentLabelingRule(
+        rule
+          ? rule
+          : { query: newValue, labels: (this.currentRule || {}).labels }
+      );
     },
   },
   computed: {


### PR DESCRIPTION
fix #1339

This PR fixes the update of metrics and rule status when searching for a new query