### PR TITLE
fix(#1349): Remove uppercase in Rubrix version

### DIFF
--- a/frontend/components/commons/header/user/user.vue
+++ b/frontend/components/commons/header/user/user.vue
@@ -134,7 +134,6 @@ $buttonSize: 34px;
 .copyright {
   display: block;
   @include font-size(11px);
-  text-transform: uppercase;
   font-weight: 400;
   color: palette(grey, dark);
   line-height: 1em;


### PR DESCRIPTION
fix #1349
This PR changes Rubrix version to lower case in the user's dropdown