### PR TITLE
fix( #1347): allow tooltip record overlapping in Token Classifier

### DIFF
--- a/frontend/assets/scss/base/base.scss
+++ b/frontend/assets/scss/base/base.scss
@@ -220,7 +220,6 @@ a {
     flex: 1;
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
-    overflow: hidden;
     position: relative
 }
 

--- a/frontend/components/token-classifier/results/RecordTokenClassification.vue
+++ b/frontend/components/token-classifier/results/RecordTokenClassification.vue
@@ -106,7 +106,7 @@ export default {
 
 <style lang="scss" scoped>
 .record {
-  padding: 50px 20px 50px 50px;
+  padding: 56px 20px 50px 50px;
   display: block;
   margin-bottom: 0;
   @include font-size(18px);


### PR DESCRIPTION
fix  #1347

This PR allows Token Classifier tooltip to overlap record container