### PR TITLE
fix(#1265): persist pagination size after query

### DIFF
--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -291,7 +291,7 @@ async function _refreshDatasetAggregations({ dataset }) {
 async function _search({ dataset, query, sort, size }) {
   query = _normalizeSearchQuery({ query: query || {}, dataset });
   sort = sort || dataset.sort || [];
-  size = size || new Pagination().size;
+  size = size || Pagination.find(dataset.name).size;
   try {
     await _updateViewSettings({ id: dataset.name, data: { loading: true } });
     await _querySearch({ dataset, query, sort, size });


### PR DESCRIPTION
fix #1265
This PR prevents the pagination size from changing to the default size after each query