### PR TITLE
fix(#1375): Pin click version for the Black pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
     rev: 21.9b0
     hooks:
     -   id: black
+        additional_dependencies: ['click==8.0.4']
 
 -   repo: https://github.com/pycqa/isort
     rev: 5.9.3


### PR DESCRIPTION
Closes #1375 .  

Pins the click version to `8.0.4` for the Black pre-commit hook.    

This PR fixes the bug without having to change or upgrade any of the pre-commit hooks.