### PR TITLE
fix(search): compute dataset schema properly

### DIFF
--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -32,6 +32,7 @@ dependencies:
       # extra test dependencies
       - cleanlab
       - datasets>1.17.0
+      - huggingface_hub==0.4.0 # resolve problems with 0.5.0
       - https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.1.0/en_core_web_sm-3.1.0.tar.gz
       - flair==0.10
       - flyingsquid

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -40,5 +40,6 @@ dependencies:
       - snorkel>=0.9.7
       - spacy==3.1.0
       - transformers[torch]
+      - loguru
       # install Rubrix in editable mode
       - -e .[server]

--- a/src/rubrix/server/tasks/commons/dao/dao.py
+++ b/src/rubrix/server/tasks/commons/dao/dao.py
@@ -33,7 +33,8 @@ from rubrix.server.commons.es_wrapper import (
 from rubrix.server.commons.helpers import unflatten_dict
 from rubrix.server.commons.settings import settings
 from rubrix.server.datasets.model import BaseDatasetDB
-from rubrix.server.tasks.commons import BaseRecord, MetadataLimitExceededError, TaskType
+from rubrix.server.tasks.commons import BaseRecord, TaskType
+from rubrix.server.tasks.commons.api.errors import MetadataLimitExceededError
 from rubrix.server.tasks.commons.dao.es_config import (
     mappings,
     tasks_common_mappings,
@@ -426,7 +427,12 @@ class DatasetRecordsDAO:
     def get_dataset_schema(self, dataset: BaseDatasetDB) -> Dict[str, Any]:
         """Return inner elasticsearch index configuration"""
         index_name = dataset_records_index(dataset.id)
-        return self._es.__client__.indices.get_mapping(index=index_name)
+        response = self._es.__client__.indices.get_mapping(index=index_name)
+
+        if index_name in response:
+            response = response.get(index_name)
+
+        return response
 
     @classmethod
     def __configure_query_highlight__(cls, task: TaskType):


### PR DESCRIPTION
A wrong dataset schema computation makes es query won't be built properly with nested fields.