### PR TITLE
chore: configure huggingface-hub dep

### DIFF
--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -32,7 +32,7 @@ dependencies:
       # extra test dependencies
       - cleanlab
       - datasets>1.17.0
-      - huggingface_hub==0.4.0 # resolve problems with 0.5.0
+      - huggingface_hub != 0.5.0 # some backward comp. problems introduced in 0.5.0
       - https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.1.0/en_core_web_sm-3.1.0.tar.gz
       - flair==0.10
       - flyingsquid


### PR DESCRIPTION
Since [this issue](https://github.com/huggingface/huggingface_hub/issues/821) is fixed, we can upgrade the latest hugginface-hub version