### PR TITLE
fix(search): prevent exceed search.max buckets for metadata fields

### DIFF
--- a/src/rubrix/server/commons/es_helpers.py
+++ b/src/rubrix/server/commons/es_helpers.py
@@ -274,6 +274,7 @@ class aggregations:
     """Group of functions related to elasticsearch aggregations requests"""
 
     DEFAULT_AGGREGATION_SIZE = 1000  # TODO: Improve this logic
+    MAX_AGGREGATION_SIZE = 5000  # TODO: improve by setting env var
 
     @staticmethod
     def nested_aggregation(nested_path: str, inner_aggregation: Dict[str, Any]):
@@ -319,7 +320,10 @@ class aggregations:
             "meta": {"kind": "terms"},
             "terms": {
                 **query_part,
-                "size": size or aggregations.DEFAULT_AGGREGATION_SIZE,
+                "size": min(
+                    size or aggregations.DEFAULT_AGGREGATION_SIZE,
+                    aggregations.MAX_AGGREGATION_SIZE,
+                ),
                 "order": {"_count": "desc"},
                 **dynamic_args,
             },

--- a/src/rubrix/server/tasks/commons/metrics/model/base.py
+++ b/src/rubrix/server/tasks/commons/metrics/model/base.py
@@ -58,7 +58,9 @@ class ElasticsearchMetric(BaseMetric):
     A metric summarized by using one or several elasticsearch aggregations
     """
 
-    def aggregation_request(self, *args, **kwargs) -> Dict[str, Any]:
+    def aggregation_request(
+        self, *args, **kwargs
+    ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
         """
         Configures the summary es aggregation definition
         """
@@ -291,11 +293,12 @@ class MetadataAggregations(ElasticsearchMetric):
         dataset: Dataset,
         dao: DatasetRecordsDAO,
         size: int = None,
-    ) -> Dict[str, Any]:
+    ) -> List[Dict[str, Any]]:
 
-        return aggregations.custom_fields(
+        metadata_aggs = aggregations.custom_fields(
             fields_definitions=dao.get_metadata_schema(dataset), size=size
         )
+        return [{key: value} for key, value in metadata_aggs.items()]
 
     def aggregation_result(self, aggregation_result: Dict[str, Any]) -> Dict[str, Any]:
         data = unflatten_dict(aggregation_result, stop_keys=["metadata"])


### PR DESCRIPTION
After the changes included in #1396, we could find errors related to `search.max_buckets`  configuration.  This PR includes some checks and reactors to avoid that, especially for metadata fields.

