### PR TITLE
refactor: allow launch server without statics folder

### DIFF
--- a/src/rubrix/server/server.py
+++ b/src/rubrix/server/server.py
@@ -69,14 +69,14 @@ def configure_api_router(app: FastAPI):
 def configure_app_statics(app: FastAPI):
     """Configure static folder for app"""
     parent_path = Path(__file__).parent.absolute()
+    statics_folder = Path(os.path.join(parent_path, "static"))
+    if not (statics_folder.exists() and statics_folder.is_dir()):
+        return
 
     app.mount(
         "/",
         RewriteStaticFiles(
-            directory=os.path.join(
-                parent_path,
-                "static",
-            ),
+            directory=statics_folder,
             html=True,
             check_dir=False,
         ),


### PR DESCRIPTION
Just launch the server with API routes if the statics folder is not found. The current behavior is to stop the server with an error.