### PR TITLE
fix(#1248): allow multiple label attributions in UI

### DIFF
--- a/frontend/components/text-classifier/header/ExplainHelpInfo.vue
+++ b/frontend/components/text-classifier/header/ExplainHelpInfo.vue
@@ -47,7 +47,7 @@
         model predicting a specific label.
       </p>
       <p>
-        [1-, 0] <strong>Negative attributions</strong> will always be blue and
+        [-1, 0] <strong>Negative attributions</strong> will always be blue and
         highlight those tokens that diverge the model from its final prediction.
       </p>
     </div>

--- a/frontend/components/text-classifier/header/ExplainHelpInfo.vue
+++ b/frontend/components/text-classifier/header/ExplainHelpInfo.vue
@@ -29,26 +29,24 @@
       <div class="help__panel__button" @click="showHelpPanel = false">
         Close
       </div>
-      <p class="help__panel__title">What do highlight colours mean?</p>
-      <p>
-        We use model interpretability methods such as Integrated Gradients to
-        compute the attribution of tokens to the model prediction with the goal
-        of providing hints about the model interpretation of data.
+      <p class="help__panel__title">
+        This dataset contains token attributions. What do highlight colors mean?
       </p>
       <p>
-        Model predictions can be correct or incorrect, as indicated by the green
-        or red labels assigned to the predictions together with their score.
-        Given this attributions work as follows:
+        Rubrix enables you to register token attributions as part of the dataset
+        records. For getting token attributions, you can use methods such as
+        Integrated Gradients or SHAP. These methods try to provide a mechanism
+        to interpret model predictions.
+      </p>
+      <p>The attributions work as follows:</p>
+      <p>
+        [0,1] <strong>Positive attributions</strong> (in blue) reflect those
+        tokens that are making the model predict the specific predicted label.
       </p>
       <p>
-        [0,+1] <strong>Positive attributions</strong> will have the same colour
-        as the label assigned to the prediction (red for wrong, green for
-        correct). Tokens with positive attributions have the most impacto on the
-        model predicting a specific label.
-      </p>
-      <p>
-        [-1, 0] <strong>Negative attributions</strong> will always be blue and
-        highlight those tokens that diverge the model from its final prediction.
+        [-1, 0] <strong>Negative attributions</strong> (in red) reflect those
+        tokens that can influence the model to predict a label other than the
+        specific predicted label.
       </p>
     </div>
   </div>

--- a/frontend/components/text-classifier/results/RecordExplain.vue
+++ b/frontend/components/text-classifier/results/RecordExplain.vue
@@ -76,19 +76,9 @@ export default {
   },
   methods: {
     customClass(tokenItem) {
-      if (this.predicted !== undefined) {
-        if (Math.sign(tokenItem.grad) !== 1) {
-          return `grad-neg-${tokenItem.percent}`;
-        } else {
-          return this.predicted === "ko"
-            ? `grad-rest-${tokenItem.percent}`
-            : `grad-plus-${tokenItem.percent}`;
-        }
-      } else {
-        return Math.sign(tokenItem.grad) !== 1
-          ? `grad-rest-${tokenItem.percent}`
-          : `grad-neg-${tokenItem.percent}`;
-      }
+      return Math.sign(tokenItem.grad) !== 1
+        ? `grad-rest-${tokenItem.percent}`
+        : `grad-neg-${tokenItem.percent}`;
     },
   },
 };

--- a/frontend/components/text-classifier/results/RecordExplain.vue
+++ b/frontend/components/text-classifier/results/RecordExplain.vue
@@ -16,7 +16,7 @@
   -->
 
 <template>
-  <div>
+  <div class="explain__content">
     <div
       v-for="tokenItem in explainFormatted"
       :key="tokenItem.index"
@@ -45,10 +45,18 @@ export default {
     predicted() {
       return this.record.predicted;
     },
+    prediction() {
+      const predictedLabel =
+        this.record.prediction &&
+        this.record.prediction.labels.reduce((max, obj) =>
+          max.score > obj.score ? max : obj
+        );
+      return predictedLabel.class;
+    },
     explainFormatted() {
       // TODO ALLOW FOR MULTI LABEL
       return this.explain.map((token) => {
-        const grad = Number(Object.values(token.attributions)).toFixed(3);
+        const grad = Number(token.attributions[this.prediction]).toFixed(3);
         let percent = Math.round(Math.abs(grad) * 100);
         if (percent !== 0) {
           /* eslint-disable no-mixed-operators */
@@ -193,5 +201,8 @@ export default {
 }
 .word {
   margin: 0 0.13em 0 0.12em;
+}
+.explain__content {
+  padding-top: 0.9em;
 }
 </style>

--- a/frontend/components/text-classifier/results/RecordExplain.vue
+++ b/frontend/components/text-classifier/results/RecordExplain.vue
@@ -16,7 +16,7 @@
   -->
 
 <template>
-  <div class="explain__content">
+  <div>
     <div
       v-for="tokenItem in explainFormatted"
       :key="tokenItem.index"
@@ -87,7 +87,7 @@ export default {
       } else {
         return Math.sign(tokenItem.grad) !== 1
           ? `grad-rest-${tokenItem.percent}`
-          : `grad-plus-${tokenItem.percent}`;
+          : `grad-neg-${tokenItem.percent}`;
       }
     },
   },
@@ -201,8 +201,5 @@ export default {
 }
 .word {
   margin: 0 0.13em 0 0.12em;
-}
-.explain__content {
-  padding-top: 0.9em;
 }
 </style>

--- a/frontend/components/text-classifier/results/RecordInputs.vue
+++ b/frontend/components/text-classifier/results/RecordInputs.vue
@@ -20,7 +20,7 @@
     ref="list"
     :class="showFullRecord ? 'record__expanded' : 'record__collapsed'"
   >
-    <div class="record__content">
+    <div :class="!explanation ? 'record__content' : ''">
       <span v-for="(text, index) in data" :key="index" class="record">
         <span :class="['record__item', isHtml(text) ? 'record--email' : '']">
           <span class="record__key">{{ index }}:</span>
@@ -35,7 +35,7 @@
     </div>
     <a
       href="#"
-      v-if="scrollHeight >= visibleRecordHeight"
+      v-if="scrollHeight >= visibleRecordHeight && !explanation"
       class="record__button"
       @click.prevent="showFullRecord = !showFullRecord"
       >{{ !showFullRecord ? "Show full record" : "Show less" }}


### PR DESCRIPTION
fix #1248

This PR gets prediction from label attribution list to display the explain