### PR TITLE
docs(#1430): Remove experimental and update query url link

### DIFF
--- a/docs/guides/task_examples.ipynb
+++ b/docs/guides/task_examples.ipynb
@@ -839,7 +839,7 @@
     }
    },
    "source": [
-    "## Text2Text (Experimental)\n",
+    "## Text2Text\n",
     "\n",
     "The expression *Text2Text* encompasses text generation tasks where the model receives and outputs a sequence of tokens.\n",
     "Examples of such tasks are machine translation, text summarization, paraphrase generation, etc."

--- a/docs/reference/python/python_labeling.rst
+++ b/docs/reference/python/python_labeling.rst
@@ -1,7 +1,7 @@
 .. _python_labeling:
 
-Labeling (Experimental)
-=======================
+Labeling
+========
 
 The ``rubrix.labeling`` module aims at providing tools to enhance your labeling workflow.
 

--- a/docs/reference/python/python_metrics.rst
+++ b/docs/reference/python/python_metrics.rst
@@ -1,7 +1,7 @@
 .. _python_metrics:
 
-Metrics (Experimental)
-======================
+Metrics
+=======
 
 Here we describe the available metrics in Rubrix:
 

--- a/src/rubrix/client/api.py
+++ b/src/rubrix/client/api.py
@@ -315,7 +315,7 @@ class Api:
         Args:
             name: The dataset name.
             query: An ElasticSearch query with the
-                `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_
+                `query string syntax <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
             ids: If provided, load dataset records with given ids.
             limit: The number of records to retrieve.
             as_pandas: If True, return a pandas DataFrame. If False, return a Dataset.

--- a/src/rubrix/client/rubrix_client.py
+++ b/src/rubrix/client/rubrix_client.py
@@ -259,7 +259,7 @@ class RubrixClient:
         Args:
             name: The dataset name.
             query: An ElasticSearch query with the
-                `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_
+                `query string syntax <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
             ids: If provided, load dataset records with given ids.
             limit: The number of records to retrieve.
             as_pandas: If True, return a pandas DataFrame. If False, return a Dataset.

--- a/src/rubrix/labeling/text_classification/rule.py
+++ b/src/rubrix/labeling/text_classification/rule.py
@@ -24,7 +24,7 @@ class Rule:
     """A rule (labeling function) in form of an ElasticSearch query.
 
     Args:
-        query: An ElasticSearch query with the `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_.
+        query: An ElasticSearch query with the `query string syntax <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_.
         label: The label associated to the query. Can also be a list of labels.
         name: An optional name for the rule to be used as identifier in the
             `rubrix.labeling.text_classification.WeakLabels` class. By default, we will use the ``query`` string.

--- a/src/rubrix/labeling/text_classification/weak_labels.py
+++ b/src/rubrix/labeling/text_classification/weak_labels.py
@@ -37,7 +37,7 @@ class WeakLabelsBase:
             If None, we will use the rules of the dataset (Default).
         ids: An optional list of record ids to filter the dataset before applying the rules.
         query: An optional ElasticSearch query with the
-            `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_
+            `query string syntax <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
             to filter the dataset before applying the rules.
 
     Raises:
@@ -244,7 +244,7 @@ class WeakLabels(WeakLabelsBase):
             If None, we will use the rules of the dataset (Default).
         ids: An optional list of record ids to filter the dataset before applying the rules.
         query: An optional ElasticSearch query with the
-            `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_
+            `query string syntax <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
             to filter the dataset before applying the rules.
         label2int: An optional dict, mapping the labels to integers. Remember that the return type ``None`` means
             abstention (e.g. ``{None: -1}``). By default, we will build a mapping on the fly when applying the rules.
@@ -652,11 +652,11 @@ class WeakMultiLabels(WeakLabelsBase):
 
     Args:
         dataset: Name of the dataset to which the rules will be applied.
-        rules: A list of rules (labeling functions). They must return a string, or ``None`` in case of abstention.
-            If None, we will use the rules of the dataset (Default).
+        rules: A list of rules (labeling functions). They must return a string, list of strings, or ``None`` in case of
+            abstention. If None, we will use the rules of the dataset (Default).
         ids: An optional list of record ids to filter the dataset before applying the rules.
         query: An optional ElasticSearch query with the
-            `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_
+            `query string syntax <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
             to filter the dataset before applying the rules.
 
     Raises:

--- a/src/rubrix/metrics/commons.py
+++ b/src/rubrix/metrics/commons.py
@@ -12,7 +12,7 @@ def text_length(name: str, query: Optional[str] = None) -> MetricSummary:
         name:
             The dataset name.
         query:
-            An ElasticSearch query with the [query string syntax](https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html)
+            An ElasticSearch query with the [query string syntax](https://rubrix.readthedocs.io/en/stable/guides/queries.html)
 
     Returns:
         The text length metric summary
@@ -40,7 +40,7 @@ def records_status(name: str, query: Optional[str] = None) -> MetricSummary:
         name:
             The dataset name.
         query:
-            An ElasticSearch query with the [query string syntax](https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html)
+            An ElasticSearch query with the [query string syntax](https://rubrix.readthedocs.io/en/stable/guides/queries.html)
 
     Returns:
         The status distribution  metric summary

--- a/src/rubrix/metrics/text_classification/metrics.py
+++ b/src/rubrix/metrics/text_classification/metrics.py
@@ -12,7 +12,7 @@ def f1(name: str, query: Optional[str] = None) -> MetricSummary:
         name:
             The dataset name.
         query:
-            An ElasticSearch query with the [query string syntax](https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html)
+            An ElasticSearch query with the [query string syntax](https://rubrix.readthedocs.io/en/stable/guides/queries.html)
 
     Returns:
         The f1 metric summary
@@ -38,7 +38,7 @@ def f1_multilabel(name: str, query: Optional[str] = None) -> MetricSummary:
         name:
             The dataset name.
         query:
-            An ElasticSearch query with the [query string syntax](https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html)
+            An ElasticSearch query with the [query string syntax](https://rubrix.readthedocs.io/en/stable/guides/queries.html)
 
     Returns:
         The f1 metric summary

--- a/src/rubrix/metrics/token_classification/metrics.py
+++ b/src/rubrix/metrics/token_classification/metrics.py
@@ -14,7 +14,7 @@ def tokens_length(
     Args:
         name: The dataset name.
         query: An ElasticSearch query with the
-            `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_
+            `query string syntax <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
         interval: The bins or bucket for result histogram
 
     Returns:
@@ -48,7 +48,7 @@ def token_frequency(
     Args:
         name: The dataset name.
         query: An ElasticSearch query with the
-            `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_
+            `query string syntax <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
         tokens: The top-k number of tokens to retrieve
 
     Returns:
@@ -79,7 +79,7 @@ def token_length(name: str, query: Optional[str] = None) -> MetricSummary:
     Args:
         name: The dataset name.
         query: An ElasticSearch query with the
-            `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_
+            `query string syntax <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
 
     Returns:
         The summary for token length distribution
@@ -116,7 +116,7 @@ def token_capitalness(name: str, query: Optional[str] = None) -> MetricSummary:
     Args:
         name: The dataset name.
         query: An ElasticSearch query with the
-            `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_
+            `query string syntax <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
 
     Returns:
         The summary for token length distribution
@@ -181,7 +181,7 @@ def mention_length(
     Args:
         name: The dataset name.
         query: An ElasticSearch query with the
-            `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_
+            `query string syntax <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
         level: The mention length level. Accepted values are "token" and "char"
         compute_for: Metric can be computed for annotations or predictions. Accepted values are
             ``Annotations`` and ``Predictions``. Defaults to ``Predictions``.
@@ -230,7 +230,7 @@ def entity_labels(
     Args:
         name: The dataset name.
         query: An ElasticSearch query with the
-            `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_
+            `query string syntax <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
         compute_for: Metric can be computed for annotations or predictions. Accepted values are
             ``Annotations`` and ``Predictions``. Default to ``Predictions``
         labels: The number of top entities to retrieve. Lower numbers will be better performants
@@ -272,7 +272,7 @@ def entity_density(
     Args:
         name: The dataset name.
         query: An ElasticSearch query with the
-            `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_
+            `query string syntax <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
         compute_for: Metric can be computed for annotations or predictions. Accepted values are
             ``Annotations`` and ``Predictions``. Default to ``Predictions``.
         interval: The interval for histogram. The entity density is defined in the range 0-1.
@@ -319,7 +319,7 @@ def entity_capitalness(
     Args:
         name: The dataset name.
         query: An ElasticSearch query with the
-            `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_
+            `query string syntax <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
         compute_for: Metric can be computed for annotations or predictions. Accepted values are
             ``Annotations`` and ``Predictions``. Default to ``Predictions``.
     Returns:
@@ -361,7 +361,7 @@ def entity_consistency(
     Args:
         name: The dataset name.
         query: An ElasticSearch query with the
-            `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_
+            `query string syntax <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
         compute_for: Metric can be computed for annotations or predictions. Accepted values are
             ``Annotations`` and ``Predictions``. Default to ``Predictions``
         mentions: The number of top mentions to retrieve.
@@ -409,7 +409,7 @@ def f1(name: str, query: Optional[str] = None) -> MetricSummary:
     Args:
         name: The dataset name.
         query: An ElasticSearch query with the
-            `query string syntax <https://rubrix.readthedocs.io/en/stable/reference/webapp/search_records.html>`_
+            `query string syntax <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
 
     Returns:
         The F1 metric summary containing precision, recall and the F1 score (averaged and per label).


### PR DESCRIPTION
Closes #1430 

Removes the experimental tag from the docs for Text2Text records, as well as for the labeling and metrics module.
This PR also updates the url to the query guide.