### PR TITLE
fix(#1428): support cleanlab v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,8 @@ jobs:
           pytest --cov=rubrix --cov-report=xml
           pip install "spacy<3.0" && python -m spacy download en_core_web_sm
           pytest tests/monitoring/test_spacy_monitoring.py
-
+          pip install "cleanlab<2.0"
+          pytest tests/labeling/text_classification/test_label_errors.py
       - name: Upload Coverage to Codecov 📦
         uses: codecov/codecov-action@v1
         if: steps.filter.outputs.python_code == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
           pytest tests/monitoring/test_spacy_monitoring.py
           pip install "cleanlab<2.0"
           pytest tests/labeling/text_classification/test_label_errors.py
+
       - name: Upload Coverage to Codecov 📦
         uses: codecov/codecov-action@v1
         if: steps.filter.outputs.python_code == 'true'

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -30,7 +30,7 @@ dependencies:
       # code formatting
       - pre-commit==2.15.0
       # extra test dependencies
-      - cleanlab<2.0.0
+      - cleanlab
       - datasets>1.17.0
       - huggingface_hub != 0.5.0 # some backward comp. problems introduced in 0.5.0
       - https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.1.0/en_core_web_sm-3.1.0.tar.gz

--- a/src/rubrix/labeling/text_classification/label_errors.py
+++ b/src/rubrix/labeling/text_classification/label_errors.py
@@ -158,6 +158,13 @@ def _check_and_update_kwargs(
             kwargs["return_indices_ranked_by"] = "self_confidence"
         elif sort_by is SortBy.NONE:
             kwargs["return_indices_ranked_by"] = None
+        # TODO: Remove this once https://github.com/cleanlab/cleanlab/issues/243 is solved
+        elif kwargs["multi_label"]:
+            _LOGGER.warning(
+                "With cleanlab v2 and multi-label records there is an issue sorting records by 'likelihood' "
+                "(https://github.com/cleanlab/cleanlab/issues/243). We will sort by 'prediction' instead."
+            )
+            kwargs["return_indices_ranked_by"] = "self_confidence"
 
 
 def _construct_s_and_psx(

--- a/tests/labeling/text_classification/test_label_errors.py
+++ b/tests/labeling/text_classification/test_label_errors.py
@@ -241,11 +241,5 @@ def dataset(mocked_client, records):
 
 def test_find_label_errors_integration(dataset):
     records = rb.load(dataset, as_pandas=False)
-    # Remove this once https://github.com/cleanlab/cleanlab/issues/243 is addressed
-    if (
-        parse_version(cleanlab.__version__) == parse_version("2.0.0")
-        and records[0].multi_label
-    ):
-        return
     recs = find_label_errors(records)
     assert [rec.id for rec in recs] == list(range(0, 11, 2)) + list(range(1, 12, 2))

--- a/tests/labeling/text_classification/test_label_errors.py
+++ b/tests/labeling/text_classification/test_label_errors.py
@@ -14,7 +14,9 @@
 #  limitations under the License.
 import sys
 
+import cleanlab
 import pytest
+from pkg_resources import parse_version
 
 import rubrix as rb
 from rubrix.labeling.text_classification import find_label_errors
@@ -77,7 +79,10 @@ def test_no_records():
 
 def test_multi_label_warning(caplog):
     record = rb.TextClassificationRecord(
-        text="test", prediction=[("mock", 0.0)], annotation="mock"
+        text="test",
+        prediction=[("mock", 0.0), ("mock2", 0.0)],
+        annotation=["mock", "mock2"],
+        multi_label=True,
     )
     find_label_errors([record], multi_label="True")
     assert (
@@ -89,20 +94,32 @@ def test_multi_label_warning(caplog):
 @pytest.mark.parametrize(
     "sort_by,expected",
     [
-        ("likelihood", "normalized_margin"),
-        ("prediction", "prob_given_label"),
-        ("none", None),
+        ("likelihood", ("normalized_margin", "normalized_margin")),
+        ("prediction", ("prob_given_label", "self_confidence")),
+        ("none", (None, None)),
     ],
 )
 def test_sort_by(monkeypatch, sort_by, expected):
-    def mock_get_noise_indices(*args, **kwargs):
-        assert kwargs["sorted_index_method"] == expected
-        return []
+    if parse_version(cleanlab.__version__) < parse_version("2.0"):
 
-    monkeypatch.setattr(
-        "cleanlab.pruning.get_noise_indices",
-        mock_get_noise_indices,
-    )
+        def mock_get_noise_indices(*args, **kwargs):
+            assert kwargs["sorted_index_method"] == expected[0]
+            return []
+
+        monkeypatch.setattr(
+            "cleanlab.pruning.get_noise_indices",
+            mock_get_noise_indices,
+        )
+    else:
+
+        def mock_find_label_issues(*args, **kwargs):
+            assert kwargs["return_indices_ranked_by"] == expected[1]
+            return []
+
+        monkeypatch.setattr(
+            "cleanlab.filter.find_label_issues",
+            mock_find_label_issues,
+        )
 
     record = rb.TextClassificationRecord(
         inputs="mock", prediction=[("mock", 0.1)], annotation="mock"
@@ -113,25 +130,48 @@ def test_sort_by(monkeypatch, sort_by, expected):
 def test_kwargs(monkeypatch, records):
     is_multi_label = records[0].multi_label
 
-    def mock_get_noise_indices(s, psx, n_jobs, **kwargs):
-        assert kwargs == {
-            "multi_label": is_multi_label,
-            "sorted_index_method": "normalized_margin",
-            "mock": "mock",
-        }
-        return []
+    if parse_version(cleanlab.__version__) < parse_version("2.0"):
 
-    monkeypatch.setattr(
-        "cleanlab.pruning.get_noise_indices",
-        mock_get_noise_indices,
-    )
+        def mock_get_noise_indices(s, psx, n_jobs, **kwargs):
+            assert kwargs == {
+                "mock": "mock",
+                "multi_label": is_multi_label,
+                "sorted_index_method": "normalized_margin",
+            }
+            return []
 
-    with pytest.raises(
-        ValueError, match="'sorted_index_method' kwarg is not supported"
-    ):
-        find_label_errors(records=records, sorted_index_method="mock")
+        monkeypatch.setattr(
+            "cleanlab.pruning.get_noise_indices",
+            mock_get_noise_indices,
+        )
 
-    find_label_errors(records=records, mock="mock")
+        with pytest.raises(
+            ValueError, match="'sorted_index_method' kwarg is not supported"
+        ):
+            find_label_errors(records=records, sorted_index_method="mock")
+
+        find_label_errors(records=records, mock="mock")
+    else:
+
+        def mock_find_label_issues(s, psx, n_jobs, **kwargs):
+            assert kwargs == {
+                "mock": "mock",
+                "multi_label": is_multi_label,
+                "return_indices_ranked_by": "normalized_margin",
+            }
+            return []
+
+        monkeypatch.setattr(
+            "cleanlab.filter.find_label_issues",
+            mock_find_label_issues,
+        )
+
+        with pytest.raises(
+            ValueError, match="'return_indices_ranked_by' kwarg is not supported"
+        ):
+            find_label_errors(records=records, return_indices_ranked_by="mock")
+
+        find_label_errors(records=records, mock="mock")
 
 
 def test_construct_s_and_psx(records):
@@ -201,5 +241,11 @@ def dataset(mocked_client, records):
 
 def test_find_label_errors_integration(dataset):
     records = rb.load(dataset, as_pandas=False)
+    # Remove this once https://github.com/cleanlab/cleanlab/issues/243 is addressed
+    if (
+        parse_version(cleanlab.__version__) == parse_version("2.0.0")
+        and records[0].multi_label
+    ):
+        return
     recs = find_label_errors(records)
     assert [rec.id for rec in recs] == list(range(0, 11, 2)) + list(range(1, 12, 2))

--- a/tests/labeling/text_classification/test_label_errors.py
+++ b/tests/labeling/text_classification/test_label_errors.py
@@ -157,7 +157,9 @@ def test_kwargs(monkeypatch, records):
             assert kwargs == {
                 "mock": "mock",
                 "multi_label": is_multi_label,
-                "return_indices_ranked_by": "normalized_margin",
+                "return_indices_ranked_by": "normalized_margin"
+                if not is_multi_label
+                else "self_confidence",
             }
             return []
 


### PR DESCRIPTION
Fixes #1428 

With this PR we support cleanlab v1 and v2. There is an issue with our default sorting method and multi-label records (https://github.com/cleanlab/cleanlab/issues/243), so for now we choose a different method when using cleanlab v2 + multi-label records.