### PR TITLE
feat(#1247): label models predict method returns DatasetForTextClassification

### DIFF
--- a/docs/tutorials/weak-supervision-multi-label.ipynb
+++ b/docs/tutorials/weak-supervision-multi-label.ipynb
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "c90591ef-bedb-4069-b491-bd9d7f58edde",
    "metadata": {},
    "outputs": [],
@@ -592,7 +592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "6985e6b7-7c28-4efc-84d2-08b7fff02ef8",
    "metadata": {},
    "outputs": [],
@@ -614,15 +614,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "152abc10-1538-4660-aa3a-0e210887c0f1",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Get records with the predictions from the label model to train a down-stream model\n",
-    "train_rb = rb.DatasetForTextClassification(label_model.predict())\n",
+    "train_rb = label_model.predict()\n",
     "\n",
-    "# Copy label model predictions to annotation\n",
+    "# Copy label model predictions to annotation with a threshold of 0.5\n",
     "for rec in train_rb:\n",
     "    rec.annotation = [pred[0] for pred in rec.prediction if pred[1] > 0.5]"
    ]
@@ -637,7 +637,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "fce0c5a0-bfa5-4649-a59a-f0114f7891a5",
    "metadata": {},
    "outputs": [],
@@ -656,7 +656,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "232a2d46-1516-4c7d-8d39-d55fe0d8130d",
    "metadata": {},
    "outputs": [],
@@ -666,7 +666,7 @@
     "# Create dataset dictionary and shuffle training set\n",
     "ds = DatasetDict(\n",
     "    train=train_rb.prepare_for_training().shuffle(seed=42),\n",
-    "    test=test_rb.prepare_for_training()\n",
+    "    test=test_rb.prepare_for_training(),\n",
     ")"
    ]
   },
@@ -718,7 +718,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "id": "88365498-15df-4aff-ae3a-48c22e4e1a66",
    "metadata": {},
    "outputs": [],
@@ -789,7 +789,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 285,
+   "execution_count": null,
    "id": "d50f9ae8-2b1a-4905-b19f-62bcfa8c64d9",
    "metadata": {},
    "outputs": [],
@@ -853,7 +853,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 283,
+   "execution_count": null,
    "id": "2dd0c0bd-b7d9-4e1c-a734-8c2a8e9d57d6",
    "metadata": {},
    "outputs": [],
@@ -872,7 +872,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 286,
+   "execution_count": null,
    "id": "61e0896c-dc7b-4844-95b6-a258aa8f8d1c",
    "metadata": {},
    "outputs": [],
@@ -978,7 +978,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "id": "8f85fd20-7086-4581-9078-2a28c9155997",
    "metadata": {},
    "outputs": [],
@@ -1055,7 +1055,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 5,
    "id": "a5bfc002-0845-4d36-b2c5-8133995561ce",
    "metadata": {},
    "outputs": [
@@ -1412,7 +1412,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>total</th>\n",
-       "      <td>{Quantitative Biology, Mathematics, Physics, S...</td>\n",
+       "      <td>{Physics, Quantitative Biology, Mathematics, C...</td>\n",
        "      <td>0.176616</td>\n",
        "      <td>0.185936</td>\n",
        "      <td>0.017833</td>\n",
@@ -1458,7 +1458,7 @@
        "mixture                                                                    {Statistics}   \n",
        "gaussian                                                                   {Statistics}   \n",
        "gene                                                             {Quantitative Biology}   \n",
-       "total                                 {Quantitative Biology, Mathematics, Physics, S...   \n",
+       "total                                 {Physics, Quantitative Biology, Mathematics, C...   \n",
        "\n",
        "                                      coverage  annotated_coverage  overlaps  \\\n",
        "stock*                                0.000954            0.000715  0.000334   \n",
@@ -1531,7 +1531,7 @@
        "total                                     720        135   0.842105  "
       ]
      },
-     "execution_count": 56,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1556,7 +1556,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "id": "8152fabd-969d-40b1-a4fc-956f8783ce29",
    "metadata": {},
    "outputs": [],
@@ -1578,12 +1578,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "id": "f7edc676-5c9a-4b21-82d6-1a820b466483",
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_df = rb.DatasetForTextClassification(label_model.predict()).to_pandas()"
+    "train_df = label_model.predict().to_pandas()"
    ]
   },
   {
@@ -1596,19 +1596,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "id": "f45f92a3-b9a8-482a-9f37-52e4802790b4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create labels in multi-label format\n",
-    "train_df[\"label\"] = train_df.prediction.map(\n",
-    "    lambda x: [\n",
-    "        # we will use a threshold of 0.5 for the probability\n",
-    "        {p[0]: int(p[1] > 0.5) for p in x}[label] \n",
-    "        for label in weak_labels.labels\n",
-    "    ]\n",
-    ")"
+    "# Create labels in multi-label format, we will use a threshold of 0.5 for the probability\n",
+    "def multi_label_binarizer(predictions, threshold=0.5):\n",
+    "    predicted_labels = [label for label, prob in predictions if prob > threshold]\n",
+    "    binary_labels = [1 if label in predicted_labels else 0 for label in weak_labels.labels]\n",
+    "    return binary_labels\n",
+    "    \n",
+    "train_df[\"label\"] = train_df.prediction.map(multi_label_binarizer)"
    ]
   },
   {
@@ -1629,7 +1628,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 147,
+   "execution_count": null,
    "id": "7f2a5d4b-4d6a-4dc0-8533-287f92c745f4",
    "metadata": {},
    "outputs": [],
@@ -1680,7 +1679,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": null,
    "id": "858f1c6e-99df-4918-803c-18647e2edd68",
    "metadata": {},
    "outputs": [],
@@ -1791,7 +1790,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "16336e27-c99c-4a51-b81b-bc63fb26daa2",
    "metadata": {},
    "outputs": [],
@@ -1817,7 +1816,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "31b129f2-b92c-4ac7-a2aa-e6601dc9404c",
    "metadata": {},
    "outputs": [],
@@ -1853,7 +1852,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "1f854543-63ea-4b52-bf17-cf33ec604e53",
    "metadata": {},
    "outputs": [],
@@ -1880,7 +1879,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "708ac8e3-b809-430a-941a-ac0d5fb36446",
    "metadata": {},
    "outputs": [],

--- a/docs/tutorials/weak-supervision-with-rubrix.ipynb
+++ b/docs/tutorials/weak-supervision-with-rubrix.ipynb
@@ -645,7 +645,9 @@
   {
    "cell_type": "markdown",
    "id": "f38c5862-903b-48c4-bf34-233a2430b2a7",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "## 4. Prepare our training set\n",
     "\n",
@@ -660,8 +662,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "id": "7c321871-3bfc-45b9-902b-4beb45f4ca13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "# get records with the predictions from the label model\n",
+    "records = label_model.predict()\n",
+    "# you can replace this line with\n",
+    "# records = rb.read_datasets(\n",
+    "#    load_dataset(\"rubrix/news\", split=\"train\"),\n",
+    "#    task=\"TextClassification\",\n",
+    "# )\n",
+    "\n",
+    "# we could also use the `weak_labels.label2int` dict\n",
+    "label2int = {'Sports': 0, 'Sci/Tech': 1, 'World': 2, 'Business': 3}\n",
+    "\n",
+    "# extract training data\n",
+    "X_train = [rec.text for rec in records]\n",
+    "y_train = [label2int[rec.prediction[0][0]] for rec in records]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "9c81c6c3-75fa-4534-9e27-e888d3f5257b",
    "metadata": {},
    "outputs": [
     {
@@ -751,31 +778,18 @@
        "</div>"
       ],
       "text/plain": [
-       "                                                                                                                                                                                                                                                                                                   text  \\\n",
-       "0                                                                                       FA Cup: Third round draw - joy for Yeading and Exeter The great big fat bullies from across the playground enter the FA Cup arena at the third round stage, for which the draw was made yesterday (December 5).   \n",
-       "1                                                                                          Rats May Help Unravel Human Drug Addiction Mysteries By LAURAN NEERGAARD    WASHINGTON (AP) -- Rats can become drug addicts. That's important to know, scientists say, and has taken a long time to prove...   \n",
-       "2                                                                                  Palmer Passes Test Bengals quarterback Carson Palmer enjoyed his breakthrough game at the expense of the Super Bowl champion Patriots, racking up 179 yards on 12-of-19 passing in a 31-3 triumph on Saturday night.   \n",
-       "3                                       Compromises urged amid deadlock in Darfur talks ABUJA, Nigeria -- Peace talks on Sudan's violence-torn Darfur region are deadlocked, a mediator said yesterday, as the chief of the African Union appealed to the Sudanese government and rebels to compromise.   \n",
-       "4                                                               CAPELLO FED UP WITH FEIGNING Juventus coach Fabio Capello has ordered his players not to kick the ball out of play when an opponent falls to the ground apparently hurt because he believes some players fake injury to stop the match.   \n",
-       "...                                                                                                                                                                                                                                                                                                 ...   \n",
-       "38080                                                                                                                              Apple ships Mac OS X update The 26MB upgrade to version 10.3.6 is available now via the OS #39; Software Update control panel and from Apple #39;s support web site.   \n",
-       "38081  Bob Evans, mainframe pioneer, dies at 77 Bob Evans, an IBM computer scientist who helped to develop the modern mainframe computer, died Thursday. He was 77. Evans died of heart failure at his at his home in the San Francisco suburb of Hillsborough, his son Evan told the Associated Press.   \n",
-       "38082                                                                                    For Brazil's Economy, the Doctor Is In Antonio Palocci, a doctor from Brazil's farm belt, has found himself presiding as the country's finance minister during the most robust economic expansion in a decade.   \n",
-       "38083                                                UbiSoft Get Ready With The Next Rainbox Six Installment Ubisoft today announced its plans to launch the next installment in the Tom Clancys Rainbow Six franchise in Spring 2005. The next Rainbow Six game follows Team Rainbow, the worlds most    \n",
-       "38084          PM #39;s visit to focus on reconstruction of Kashmir New Delhi: The two-day visit of Prime Minister Manmohan Singh to Jammu and Kashmir, starting on Wednesday will focus more on reconstruction and development of the state, Parliamentary Affairs Minister Ghulam Nabi Azad has said.   \n",
-       "\n",
-       "       label  \n",
-       "0          0  \n",
-       "1          1  \n",
-       "2          0  \n",
-       "3          2  \n",
-       "4          0  \n",
-       "...      ...  \n",
-       "38080      1  \n",
-       "38081      1  \n",
-       "38082      2  \n",
-       "38083      0  \n",
-       "38084      2  \n",
+       "                                                                                                                                                                                                                                                                                                   text  label\n",
+       "0                                                                                       FA Cup: Third round draw - joy for Yeading and Exeter The great big fat bullies from across the playground enter the FA Cup arena at the third round stage, for which the draw was made yesterday (December 5).      0\n",
+       "1                                                                                          Rats May Help Unravel Human Drug Addiction Mysteries By LAURAN NEERGAARD    WASHINGTON (AP) -- Rats can become drug addicts. That's important to know, scientists say, and has taken a long time to prove...      1\n",
+       "2                                                                                  Palmer Passes Test Bengals quarterback Carson Palmer enjoyed his breakthrough game at the expense of the Super Bowl champion Patriots, racking up 179 yards on 12-of-19 passing in a 31-3 triumph on Saturday night.      0\n",
+       "3                                       Compromises urged amid deadlock in Darfur talks ABUJA, Nigeria -- Peace talks on Sudan's violence-torn Darfur region are deadlocked, a mediator said yesterday, as the chief of the African Union appealed to the Sudanese government and rebels to compromise.      2\n",
+       "4                                                               CAPELLO FED UP WITH FEIGNING Juventus coach Fabio Capello has ordered his players not to kick the ball out of play when an opponent falls to the ground apparently hurt because he believes some players fake injury to stop the match.      0\n",
+       "...                                                                                                                                                                                                                                                                                                 ...    ...\n",
+       "38080                                                                                                                              Apple ships Mac OS X update The 26MB upgrade to version 10.3.6 is available now via the OS #39; Software Update control panel and from Apple #39;s support web site.      1\n",
+       "38081  Bob Evans, mainframe pioneer, dies at 77 Bob Evans, an IBM computer scientist who helped to develop the modern mainframe computer, died Thursday. He was 77. Evans died of heart failure at his at his home in the San Francisco suburb of Hillsborough, his son Evan told the Associated Press.      1\n",
+       "38082                                                                                    For Brazil's Economy, the Doctor Is In Antonio Palocci, a doctor from Brazil's farm belt, has found himself presiding as the country's finance minister during the most robust economic expansion in a decade.      2\n",
+       "38083                                                UbiSoft Get Ready With The Next Rainbox Six Installment Ubisoft today announced its plans to launch the next installment in the Tom Clancys Rainbow Six franchise in Spring 2005. The next Rainbow Six game follows Team Rainbow, the worlds most       0\n",
+       "38084          PM #39;s visit to focus on reconstruction of Kashmir New Delhi: The two-day visit of Prime Minister Manmohan Singh to Jammu and Kashmir, starting on Wednesday will focus more on reconstruction and development of the state, Parliamentary Affairs Minister Ghulam Nabi Azad has said.      2\n",
        "\n",
        "[38085 rows x 2 columns]"
       ]
@@ -785,28 +799,9 @@
     }
    ],
    "source": [
-    "import pandas as pd\n",
-    "\n",
-    "# get records with the predictions from the label model\n",
-    "records = label_model.predict()\n",
-    "# you can replace this line with\n",
-    "# records = rb.read_datasets(\n",
-    "#    load_dataset(\"rubrix/news\", split=\"train\"),\n",
-    "#    task=\"TextClassification\",\n",
-    "# )\n",
-    "\n",
-    "# we could also use the `weak_labels.label2int` dict\n",
-    "label2int = {'Sports': 0, 'Sci/Tech': 1, 'World': 2, 'Business': 3}\n",
-    "\n",
-    "# build a simple dataframe with text and the prediction with the highest score\n",
-    "df_train = pd.DataFrame([\n",
-    "    {\"text\": record.text, \"label\": label2int[record.prediction[0][0]]}\n",
-    "    for record in records\n",
-    "])\n",
-    "\n",
-    "# quick look at our training data with the weak labels from our label model \n",
+    "# quick look at our training data with the weak labels from our label model\n",
     "with pd.option_context('display.max_colwidth', None):\n",
-    "    display(df_train)"
+    "    display(pd.DataFrame({\"text\": X_train, \"label\": y_train}))"
    ]
   },
   {
@@ -838,8 +833,8 @@
     "\n",
     "# fit the classifier\n",
     "classifier.fit(\n",
-    "    X=df_train.text.tolist(), \n",
-    "    y=df_train.label.values\n",
+    "    X=X_train, \n",
+    "    y=y_train,\n",
     ")"
    ]
   },
@@ -858,15 +853,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Retrieve records with annotations\n",
+    "# retrieve records with annotations\n",
     "test_ds = weak_labels.records(has_annotation=True)\n",
-    "# # you can replace this line with\n",
+    "# you can replace this line with\n",
     "# test_ds = rb.read_datasets(\n",
     "#    load_dataset(\"rubrix/news_test\", split=\"train\"),\n",
     "#    task=\"TextClassification\",\n",
     "# )\n",
     "\n",
-    "# Extract text and labels\n",
+    "# extract text and labels\n",
     "X_test = [rec.text for rec in test_ds]\n",
     "y_test = [label2int[rec.annotation] for rec in test_ds]"
    ]


### PR DESCRIPTION
Closes #1247

With this PR the label model predict method returns now a `DatasetForTextClassification` instead of a list of records.
It also updates the documentation (tutorials) accordingly improving it a bit.