### PR TITLE
fix(#1379): Remove wrong annotations in Token Classifier

### DIFF
--- a/frontend/components/token-classifier/results/RecordTokenClassification.vue
+++ b/frontend/components/token-classifier/results/RecordTokenClassification.vue
@@ -20,6 +20,7 @@
     <div class="content">
       <div class="origins">
         <text-spans-static
+          v-if="record.prediction"
           :v-once="dataset.query.score ? false : true"
           key="prediction"
           origin="prediction"
@@ -123,9 +124,18 @@ export default {
       updateRecords: "entities/datasets/updateDatasetRecords",
     }),
     getEntitiesByOrigin(origin) {
-      return origin === "annotation"
-        ? this.record.annotatedEntities
-        : (this.record.prediction && this.record.prediction.entities) || [];
+      if (this.annotationEnabled) {
+        return origin === "annotation"
+          ? this.record.annotatedEntities
+          : (this.record.prediction && this.record.prediction.entities) || [];
+      } else {
+        return this.record[origin]
+          ? this.record[origin].entities.map((obj) => ({
+              ...obj,
+              origin: origin,
+            }))
+          : [];
+      }
     },
     async onValidate(record) {
       await this.validate({


### PR DESCRIPTION
closes (#1379)

Tis PR removes wrong annotations in the explore view of Token Classifier