### PR TITLE
fix(#1458): token classifier visualization in Safari

### DIFF
--- a/frontend/components/token-classifier/results/EntityHighlight.vue
+++ b/frontend/components/token-classifier/results/EntityHighlight.vue
@@ -75,7 +75,7 @@ export default {
       return this.dataset.viewSettings.viewMode === "annotate";
     },
     charsBetweenTokens() {
-      return this.span.tokens.at(-1).charsBetweenTokens;
+      return this.span.tokens[this.span.tokens.length - 1].charsBetweenTokens;
     },
   },
   methods: {


### PR DESCRIPTION
Closes #1458