### PR TITLE
feat(#1432): new dataset creation API endpoint

### DIFF
--- a/src/rubrix/server/apis/v0/handlers/datasets.py
+++ b/src/rubrix/server/apis/v0/handlers/datasets.py
@@ -87,7 +87,6 @@ async def create_dataset(
     task_mappings = TaskFactory.get_task_mappings(request.task)
 
     dataset = dataset_class.parse_obj({**request.dict()})
-    dataset.created_by = user.username
     dataset.owner = owner
 
     response = datasets.create_dataset(

--- a/src/rubrix/server/apis/v0/models/datasets.py
+++ b/src/rubrix/server/apis/v0/models/datasets.py
@@ -43,14 +43,11 @@ class UpdateDatasetRequest(BaseModel):
 
 
 class CreationDatasetRequest(UpdateDatasetRequest):
-    """
-    Fields for dataset creation
+    name: str = Field(regex=DATASET_NAME_REGEX_PATTERN, description="The dataset name")
 
-    name: str
-        the  dataset name
-    """
 
-    name: str = Field(regex=DATASET_NAME_REGEX_PATTERN)
+class DatasetCreate(CreationDatasetRequest):
+    task: TaskType = Field(description="The dataset task")
 
 
 class CopyDatasetRequest(CreationDatasetRequest):
@@ -80,6 +77,9 @@ class BaseDatasetDB(CreationDatasetRequest):
     task: TaskType
     owner: Optional[str] = None
     created_at: datetime = None
+    created_by: str = Field(
+        None, description="The Rubrix user that created the dataset"
+    )
     last_updated: datetime = None
 
     @classmethod
@@ -95,6 +95,7 @@ class BaseDatasetDB(CreationDatasetRequest):
         return self.build_dataset_id(self.name, self.owner)
 
 
+# TODO: Move this class to the services layer
 class DatasetDB(BaseDatasetDB):
     pass
 

--- a/tests/client/sdk/datasets/test_models.py
+++ b/tests/client/sdk/datasets/test_models.py
@@ -20,7 +20,9 @@ from rubrix.server.apis.v0.models.datasets import Dataset as ServerDataset
 
 def test_dataset_schema(helpers):
     client_schema = Dataset.schema()
-    server_schema = ServerDataset.schema()
+    server_schema = helpers.remove_key(
+        ServerDataset.schema(), key="created_by"
+    )  # don't care about creator here
 
     assert helpers.remove_description(client_schema) == helpers.remove_description(
         server_schema

--- a/tests/server/datasets/test_api.py
+++ b/tests/server/datasets/test_api.py
@@ -12,7 +12,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+from rubrix.server.apis.v0.models.commons.model import TaskType
 from rubrix.server.apis.v0.models.datasets import Dataset
 from rubrix.server.apis.v0.models.text_classification import TextClassificationBulkData
 
@@ -31,6 +31,35 @@ def test_delete_dataset(mocked_client):
             "params": {"name": "test_delete_dataset", "type": "Dataset"},
         }
     }
+
+
+def test_create_dataset(mocked_client):
+    dataset_name = "test_create_dataset"
+    delete_dataset(mocked_client, dataset_name)
+    request = dict(
+        name=dataset_name,
+        task=TaskType.text_classification,
+        tags={"env": "test", "class": "text classification"},
+        metadata={"config": {"the": "config"}},
+    )
+    response = mocked_client.post(
+        "/api/datasets/",
+        json=request,
+    )
+    assert response.status_code == 200
+    dataset = Dataset.parse_obj(response.json())
+    assert dataset.created_by == "rubrix"
+    assert dataset.metadata == request["metadata"]
+    assert dataset.tags == request["tags"]
+    assert dataset.name == dataset_name
+    assert dataset.owner == "rubrix"
+    assert dataset.task == TaskType.text_classification
+
+    response = mocked_client.post(
+        "/api/datasets/",
+        json=request,
+    )
+    assert response.status_code == 409
 
 
 def test_dataset_naming_validation(mocked_client):


### PR DESCRIPTION
This is the first PR of a set of PRs resolving the issue #1432 

I will split the work into several PRs for the sake of the revision work. Finally, I will keep new API endpoints in the current API version, since otherwise, it will require extra work that we cannot tackle now.

The work included in this PR refers to a new API endpoint (server-side) for explicit dataset creation. Remember that the only way to create datasets in the current API is by using the **log records** endpoint.

## TODO

-  [ ] Add tests