### PR TITLE
feat(#1432): dataset settings api

### DIFF
--- a/src/rubrix/server/apis/v0/handlers/text_classification.py
+++ b/src/rubrix/server/apis/v0/handlers/text_classification.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, Depends, Query, Security
 from fastapi.responses import StreamingResponse
 
 from rubrix.server.apis.v0.config.tasks_factory import TaskFactory
+from rubrix.server.apis.v0.handlers import text_classification_dataset_settings
 from rubrix.server.apis.v0.helpers import takeuntil
 from rubrix.server.apis.v0.models.commons.model import (
     BulkResponse,
@@ -515,3 +516,6 @@ async def update_rule(
         description=update.description,
     )
     return rule
+
+
+text_classification_dataset_settings.configure_router(router)

--- a/src/rubrix/server/apis/v0/handlers/text_classification_dataset_settings.py
+++ b/src/rubrix/server/apis/v0/handlers/text_classification_dataset_settings.py
@@ -1,0 +1,104 @@
+from typing import Type
+
+from fastapi import APIRouter, Body, Depends, Security
+
+from rubrix.server.apis.v0.models.commons.model import TaskType
+from rubrix.server.apis.v0.models.commons.params import DATASET_NAME_PATH_PARAM
+from rubrix.server.apis.v0.models.commons.workspace import CommonTaskQueryParams
+from rubrix.server.apis.v0.models.dataset_settings import TextClassificationSettings
+from rubrix.server.security import auth
+from rubrix.server.security.model import User
+from rubrix.server.services.datasets import DatasetsService, SVCDatasetSettings
+
+
+def configure_router(router: APIRouter):
+
+    task = TaskType.text_classification
+    base_endpoint = f"/{{name}}/{task}/settings"
+    svc_settings_class: Type[SVCDatasetSettings] = type(
+        f"{task}_DatasetSettings", (SVCDatasetSettings, TextClassificationSettings), {}
+    )
+
+    @router.get(
+        path=base_endpoint,
+        name=f"get_dataset_settings_for_{task}",
+        operation_id=f"get_dataset_settings_for_{task}",
+        description=f"Get the {task} dataset settings",
+        response_model_exclude_none=True,
+        response_model=TextClassificationSettings,
+    )
+    async def get_dataset_settings(
+        name: str = DATASET_NAME_PATH_PARAM,
+        ws_params: CommonTaskQueryParams = Depends(),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        user: User = Security(auth.get_user, scopes=["read:dataset.settings"]),
+    ) -> TextClassificationSettings:
+
+        found_ds = datasets.find_by_name(
+            user=user,
+            name=name,
+            workspace=ws_params.workspace,
+            task=task,
+        )
+
+        settings = await datasets.get_settings(
+            user=user, dataset=found_ds, class_type=svc_settings_class
+        )
+        return TextClassificationSettings.parse_obj(settings)
+
+    @router.put(
+        path=base_endpoint,
+        name=f"save_dataset_settings_for_{task}",
+        operation_id=f"save_dataset_settings_for_{task}",
+        description=f"Save the {task} dataset settings",
+        response_model_exclude_none=True,
+        response_model=TextClassificationSettings,
+    )
+    async def save_settings(
+        request: TextClassificationSettings = Body(
+            ..., description=f"The {task} dataset settings"
+        ),
+        name: str = DATASET_NAME_PATH_PARAM,
+        ws_params: CommonTaskQueryParams = Depends(),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        user: User = Security(auth.get_user, scopes=["write:dataset.settings"]),
+    ) -> TextClassificationSettings:
+
+        found_ds = datasets.find_by_name(
+            user=user,
+            name=name,
+            task=task,
+            workspace=ws_params.workspace,
+        )
+        # TODO(frascuchon): validate settings...
+        settings = await datasets.save_settings(
+            user=user,
+            dataset=found_ds,
+            settings=svc_settings_class.parse_obj(request.dict()),
+        )
+        return TextClassificationSettings.parse_obj(settings)
+
+    @router.delete(
+        path=base_endpoint,
+        operation_id=f"delete_{task}_settings",
+        name=f"delete_{task}_settings",
+        description=f"Delete {task} dataset settings",
+    )
+    async def delete_settings(
+        name: str = DATASET_NAME_PATH_PARAM,
+        ws_params: CommonTaskQueryParams = Depends(),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        user: User = Security(auth.get_user, scopes=["delete:dataset.settings"]),
+    ) -> None:
+        found_ds = datasets.find_by_name(
+            user=user,
+            name=name,
+            task=task,
+            workspace=ws_params.workspace,
+        )
+        await datasets.delete_settings(
+            user=user,
+            dataset=found_ds,
+        )
+
+    return router

--- a/src/rubrix/server/apis/v0/handlers/text_classification_dataset_settings.py
+++ b/src/rubrix/server/apis/v0/handlers/text_classification_dataset_settings.py
@@ -14,7 +14,7 @@ from rubrix.server.services.datasets import DatasetsService, SVCDatasetSettings
 def configure_router(router: APIRouter):
 
     task = TaskType.text_classification
-    base_endpoint = f"/{{name}}/{task}/settings"
+    base_endpoint = f"/{task}/{{name}}/settings"
     svc_settings_class: Type[SVCDatasetSettings] = type(
         f"{task}_DatasetSettings", (SVCDatasetSettings, TextClassificationSettings), {}
     )

--- a/src/rubrix/server/apis/v0/handlers/token_classification.py
+++ b/src/rubrix/server/apis/v0/handlers/token_classification.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, Depends, Query, Security
 from fastapi.responses import StreamingResponse
 
 from rubrix.server.apis.v0.config.tasks_factory import TaskFactory
+from rubrix.server.apis.v0.handlers import token_classification_dataset_settings
 from rubrix.server.apis.v0.helpers import takeuntil
 from rubrix.server.apis.v0.models.commons.model import (
     BulkResponse,
@@ -289,3 +290,6 @@ async def stream_data(
         data_stream=data_stream,
         limit=limit,
     )
+
+
+token_classification_dataset_settings.configure_router(router)

--- a/src/rubrix/server/apis/v0/handlers/token_classification_dataset_settings.py
+++ b/src/rubrix/server/apis/v0/handlers/token_classification_dataset_settings.py
@@ -14,7 +14,7 @@ from rubrix.server.services.datasets import DatasetsService, SVCDatasetSettings
 def configure_router(router: APIRouter):
 
     task = TaskType.token_classification
-    base_endpoint = f"/{{name}}/{task}/settings"
+    base_endpoint = f"/{task}/{{name}}/settings"
     svc_settings_class: Type[SVCDatasetSettings] = type(
         f"{task}_DatasetSettings", (SVCDatasetSettings, TokenClassificationSettings), {}
     )

--- a/src/rubrix/server/apis/v0/handlers/token_classification_dataset_settings.py
+++ b/src/rubrix/server/apis/v0/handlers/token_classification_dataset_settings.py
@@ -1,0 +1,104 @@
+from typing import Type
+
+from fastapi import APIRouter, Body, Depends, Security
+
+from rubrix.server.apis.v0.models.commons.model import TaskType
+from rubrix.server.apis.v0.models.commons.params import DATASET_NAME_PATH_PARAM
+from rubrix.server.apis.v0.models.commons.workspace import CommonTaskQueryParams
+from rubrix.server.apis.v0.models.dataset_settings import TokenClassificationSettings
+from rubrix.server.security import auth
+from rubrix.server.security.model import User
+from rubrix.server.services.datasets import DatasetsService, SVCDatasetSettings
+
+
+def configure_router(router: APIRouter):
+
+    task = TaskType.token_classification
+    base_endpoint = f"/{{name}}/{task}/settings"
+    svc_settings_class: Type[SVCDatasetSettings] = type(
+        f"{task}_DatasetSettings", (SVCDatasetSettings, TokenClassificationSettings), {}
+    )
+
+    @router.get(
+        path=base_endpoint,
+        name=f"get_dataset_settings_for_{task}",
+        operation_id=f"get_dataset_settings_for_{task}",
+        description=f"Get the {task} dataset settings",
+        response_model_exclude_none=True,
+        response_model=TokenClassificationSettings,
+    )
+    async def get_dataset_settings(
+        name: str = DATASET_NAME_PATH_PARAM,
+        ws_params: CommonTaskQueryParams = Depends(),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        user: User = Security(auth.get_user, scopes=["read:dataset.settings"]),
+    ) -> TokenClassificationSettings:
+
+        found_ds = datasets.find_by_name(
+            user=user,
+            name=name,
+            workspace=ws_params.workspace,
+            task=task,
+        )
+
+        settings = await datasets.get_settings(
+            user=user, dataset=found_ds, class_type=svc_settings_class
+        )
+        return TokenClassificationSettings.parse_obj(settings)
+
+    @router.put(
+        path=base_endpoint,
+        name=f"save_dataset_settings_for_{task}",
+        operation_id=f"save_dataset_settings_for_{task}",
+        description=f"Save the {task} dataset settings",
+        response_model_exclude_none=True,
+        response_model=TokenClassificationSettings,
+    )
+    async def save_settings(
+        request: TokenClassificationSettings = Body(
+            ..., description=f"The {task} dataset settings"
+        ),
+        name: str = DATASET_NAME_PATH_PARAM,
+        ws_params: CommonTaskQueryParams = Depends(),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        user: User = Security(auth.get_user, scopes=["write:dataset.settings"]),
+    ) -> TokenClassificationSettings:
+
+        found_ds = datasets.find_by_name(
+            user=user,
+            name=name,
+            task=task,
+            workspace=ws_params.workspace,
+        )
+        # TODO(frascuchon): validate settings...
+        settings = await datasets.save_settings(
+            user=user,
+            dataset=found_ds,
+            settings=svc_settings_class.parse_obj(request.dict()),
+        )
+        return TokenClassificationSettings.parse_obj(settings)
+
+    @router.delete(
+        path=base_endpoint,
+        operation_id=f"delete_{task}_settings",
+        name=f"delete_{task}_settings",
+        description=f"Delete {task} dataset settings",
+    )
+    async def delete_settings(
+        name: str = DATASET_NAME_PATH_PARAM,
+        ws_params: CommonTaskQueryParams = Depends(),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        user: User = Security(auth.get_user, scopes=["delete:dataset.settings"]),
+    ) -> None:
+        found_ds = datasets.find_by_name(
+            user=user,
+            name=name,
+            task=task,
+            workspace=ws_params.workspace,
+        )
+        await datasets.delete_settings(
+            user=user,
+            dataset=found_ds,
+        )
+
+    return router

--- a/src/rubrix/server/apis/v0/models/commons/params.py
+++ b/src/rubrix/server/apis/v0/models/commons/params.py
@@ -1,0 +1,7 @@
+from fastapi import Path
+
+from rubrix._constants import DATASET_NAME_REGEX_PATTERN
+
+DATASET_NAME_PATH_PARAM = Path(
+    ..., regex=DATASET_NAME_REGEX_PATTERN, description="The dataset name"
+)

--- a/src/rubrix/server/apis/v0/models/dataset_settings.py
+++ b/src/rubrix/server/apis/v0/models/dataset_settings.py
@@ -1,0 +1,42 @@
+from typing import List, Optional, Union
+
+from pydantic import BaseModel, Field, validator
+
+
+class AbstractDatasetSettings(BaseModel):
+    pass
+
+
+class LabelsSchema(BaseModel):
+    class Schema(BaseModel):
+        id: str = Field(description="The label id")
+        name: str = Field(description="The label name")
+        description: Optional[str] = Field(None, description="The label description")
+
+    labels: Union[List[str], List[Schema]] = Field(description="A set of labels")
+
+    @validator("labels", pre=True)
+    def normalize_labels(cls, labels):
+        """
+        Labels schema accept a list of strings. Those string will be converted
+        into ``LabelsSchema.Schema`` objects
+        """
+        if not labels:
+            return labels
+        if isinstance(labels[0], str):
+            return [LabelsSchema.Schema(id=label, name=label) for label in labels]
+        return labels
+
+
+class WithLabelsSchemaSettings(AbstractDatasetSettings):
+    labels_schema: Optional[LabelsSchema] = Field(
+        None, description="The dataset labels schema"
+    )
+
+
+class TextClassificationSettings(WithLabelsSchemaSettings):
+    pass
+
+
+class TokenClassificationSettings(WithLabelsSchemaSettings):
+    pass

--- a/src/rubrix/server/elasticseach/client_wrapper.py
+++ b/src/rubrix/server/elasticseach/client_wrapper.py
@@ -21,6 +21,7 @@ from opensearchpy.helpers import bulk as es_bulk
 from opensearchpy.helpers import scan as es_scan
 
 from rubrix.logging import LoggingMixin
+from rubrix.server.elasticseach import query_helpers
 from rubrix.server.errors import InvalidTextSearchError
 
 try:
@@ -223,11 +224,15 @@ class ElasticsearchWrapper(LoggingMixin):
 
     def delete_index_template(self, index_template: str):
         """Deletes an index template"""
-        self.__client__.indices.delete_template(name=index_template, ignore=[400, 404])
+        if self.__client__.indices.exists_index_template(index_template):
+            self.__client__.indices.delete_template(
+                name=index_template, ignore=[400, 404]
+            )
 
     def delete_index(self, index: str):
         """Deletes an elasticsearch index"""
-        self.__client__.indices.delete(index, ignore=[400, 404])
+        if self.index_exists(index):
+            self.__client__.indices.delete(index, ignore=[400, 404])
 
     def add_document(self, index: str, doc_id: str, document: Dict[str, Any]):
         """
@@ -264,8 +269,10 @@ class ElasticsearchWrapper(LoggingMixin):
         -------
             The elasticsearch document if found, None otherwise
         """
+
         try:
-            return self.__client__.get(index=index, id=doc_id)
+            if self.__client__.exists(index=index, id=doc_id):
+                return self.__client__.get(index=index, id=doc_id)
         except NotFoundError:
             return None
 
@@ -286,7 +293,8 @@ class ElasticsearchWrapper(LoggingMixin):
         -------
 
         """
-        self.__client__.delete(index=index, id=doc_id, refresh=True)
+        if self.__client__.exists(index=index, id=doc_id):
+            self.__client__.delete(index=index, id=doc_id, refresh=True)
 
     def add_documents(
         self,
@@ -395,7 +403,8 @@ class ElasticsearchWrapper(LoggingMixin):
         self,
         index: str,
         doc_id: str,
-        document: Dict[str, Any],
+        document: Optional[Dict[str, Any]] = None,
+        script: Optional[str] = None,
         partial_update: bool = False,
     ):
         """
@@ -418,11 +427,14 @@ class ElasticsearchWrapper(LoggingMixin):
         -------
 
         """
+        # TODO: validate either doc or script are provided
         if partial_update:
+            body = {"script": script} if script else {"doc": document}
+
             self.__client__.update(
                 index=index,
                 id=doc_id,
-                body={"doc": document},
+                body=body,
                 refresh=True,
                 retry_on_conflict=500,  # TODO: configurable
             )
@@ -560,7 +572,7 @@ class ElasticsearchWrapper(LoggingMixin):
             index=index, size=0, query={"aggs": {aggregation_name: aggregation}}
         )
 
-        return es_helpers.parse_aggregations(results["aggregations"]).get(
+        return query_helpers.parse_aggregations(results["aggregations"]).get(
             aggregation_name
         )
 

--- a/src/rubrix/server/services/datasets.py
+++ b/src/rubrix/server/services/datasets.py
@@ -20,7 +20,7 @@ from fastapi import Depends
 
 from rubrix.server.apis.v0.models.commons.model import TaskType
 from rubrix.server.apis.v0.models.datasets import DatasetDB
-from rubrix.server.daos.datasets import BaseDatasetDB, DatasetsDAO
+from rubrix.server.daos.datasets import BaseDatasetDB, DatasetsDAO, SettingsDB
 from rubrix.server.errors import (
     EntityAlreadyExistsError,
     EntityNotFoundError,
@@ -30,6 +30,10 @@ from rubrix.server.errors import (
 from rubrix.server.security.model import User
 
 Dataset = TypeVar("Dataset", bound=DatasetDB)
+
+
+class SVCDatasetSettings(SettingsDB):
+    pass
 
 
 class DatasetsService:
@@ -218,3 +222,52 @@ class DatasetsService:
         workspaces = self.__dao__.get_all_workspaces()
         # include the non-workspace workspace?
         return workspaces
+
+    async def get_settings(
+        self, user: User, dataset: Dataset, class_type: Type[SVCDatasetSettings]
+    ) -> SVCDatasetSettings:
+        """
+        Get the configured settings for dataset
+
+        Args:
+            user: the connected user
+            dataset: the target dataset
+            class_type: the settings class
+
+        Returns:
+            An instance of class_type settings configured for provided dataset
+
+        """
+        settings = self.__dao__.load_settings(dataset=dataset, as_class=class_type)
+        if not settings:
+            raise EntityNotFoundError(name=dataset.name, type=class_type)
+        return class_type.parse_obj(settings.dict())
+
+    async def save_settings(
+        self, user: User, dataset: Dataset, settings: SVCDatasetSettings
+    ) -> SVCDatasetSettings:
+        """
+        Save a set of settings for a dataset
+
+        Args:
+            user: The user executing the command
+            dataset: The dataset
+            settings: The dataset settings
+
+        Returns:
+            Stored dataset settings
+
+        """
+        self.__dao__.save_settings(dataset=dataset, settings=settings)
+        return settings
+
+    async def delete_settings(self, user: User, dataset: Dataset) -> None:
+        """
+        Deletes the dataset settings
+
+        Args:
+            user: The user executing the command
+            dataset:  The dataset
+
+        """
+        self.__dao__.delete_settings(dataset=dataset)

--- a/tests/server/text_classification/test_api_settings.py
+++ b/tests/server/text_classification/test_api_settings.py
@@ -1,0 +1,59 @@
+import rubrix as rb
+from rubrix.server.apis.v0.models.commons.model import TaskType
+
+
+def create_dataset(client, name: str):
+    response = client.post(
+        "/api/datasets/", json={"name": name, "task": TaskType.text_classification}
+    )
+    assert response.status_code == 200
+
+
+def test_create_dataset_settings(mocked_client):
+    name = "test_create_dataset_settings"
+    rb.delete(name)
+    create_dataset(mocked_client, name)
+
+    response = create_settings(mocked_client, name)
+    assert response.status_code == 200
+
+    created = response.json()
+    response = fetch_settings(mocked_client, name)
+    assert response.json() == created
+
+
+def create_settings(mocked_client, name):
+    response = mocked_client.put(
+        f"/api/datasets/{TaskType.text_classification}/{name}/settings",
+        json={"labels_schema": {"labels": ["Label1", "Label2"]}},
+    )
+    return response
+
+
+def test_get_dataset_settings_not_found(mocked_client):
+    name = "test_get_dataset_settings"
+    rb.delete(name)
+    create_dataset(mocked_client, name)
+
+    response = fetch_settings(mocked_client, name)
+    assert response.status_code == 404
+
+
+def test_delete_settings(mocked_client):
+    name = "test_delete_settings"
+    rb.delete(name)
+
+    create_dataset(mocked_client, name)
+    assert create_settings(mocked_client, name).status_code == 200
+
+    response = mocked_client.delete(
+        f"/api/datasets/{TaskType.text_classification}/{name}/settings"
+    )
+    assert response.status_code == 200
+    assert fetch_settings(mocked_client, name).status_code == 404
+
+
+def fetch_settings(mocked_client, name):
+    return mocked_client.get(
+        f"/api/datasets/{TaskType.text_classification}/{name}/settings"
+    )

--- a/tests/server/token_classification/test_api_settings.py
+++ b/tests/server/token_classification/test_api_settings.py
@@ -1,0 +1,59 @@
+import rubrix as rb
+from rubrix.server.apis.v0.models.commons.model import TaskType
+
+
+def create_dataset(client, name: str):
+    response = client.post(
+        "/api/datasets/", json={"name": name, "task": TaskType.token_classification}
+    )
+    assert response.status_code == 200
+
+
+def test_create_dataset_settings(mocked_client):
+    name = "test_create_dataset_settings"
+    rb.delete(name)
+    create_dataset(mocked_client, name)
+
+    response = create_settings(mocked_client, name)
+    assert response.status_code == 200
+
+    created = response.json()
+    response = fetch_settings(mocked_client, name)
+    assert response.json() == created
+
+
+def create_settings(mocked_client, name):
+    response = mocked_client.put(
+        f"/api/datasets/{TaskType.token_classification}/{name}/settings",
+        json={"labels_schema": {"labels": ["Label1", "Label2"]}},
+    )
+    return response
+
+
+def test_get_dataset_settings_not_found(mocked_client):
+    name = "test_get_dataset_settings"
+    rb.delete(name)
+    create_dataset(mocked_client, name)
+
+    response = fetch_settings(mocked_client, name)
+    assert response.status_code == 404
+
+
+def test_delete_settings(mocked_client):
+    name = "test_delete_settings"
+    rb.delete(name)
+
+    create_dataset(mocked_client, name)
+    assert create_settings(mocked_client, name).status_code == 200
+
+    response = mocked_client.delete(
+        f"/api/datasets/{TaskType.token_classification}/{name}/settings"
+    )
+    assert response.status_code == 200
+    assert fetch_settings(mocked_client, name).status_code == 404
+
+
+def fetch_settings(mocked_client, name):
+    return mocked_client.get(
+        f"/api/datasets/{TaskType.token_classification}/{name}/settings"
+    )


### PR DESCRIPTION
Following the work started in #1466, this PR provides fully operative endpoints to save, fetch and delete dataset settings for text and token classification tasks.

In a future PR, we will include also required validations when logging records to preserve the configured labels schema for those datasets that already have one.