### PR TITLE
feat: check dataset settings integrity

### DIFF
--- a/src/rubrix/server/apis/v0/handlers/text_classification.py
+++ b/src/rubrix/server/apis/v0/handlers/text_classification.py
@@ -121,7 +121,7 @@ async def bulk_records(
             user=current_user, dataset=dataset, mappings=task_mappings
         )
 
-    await validator.validate_dataset(
+    await validator.validate_dataset_records(
         user=current_user, dataset=dataset, records=bulk.records
     )
 

--- a/src/rubrix/server/apis/v0/handlers/text_classification.py
+++ b/src/rubrix/server/apis/v0/handlers/text_classification.py
@@ -40,6 +40,7 @@ from rubrix.server.apis.v0.models.text_classification import (
     TextClassificationSearchResults,
     UpdateLabelingRule,
 )
+from rubrix.server.apis.v0.validators.text_classification import DatasetValidator
 from rubrix.server.errors import EntityNotFoundError
 from rubrix.server.security import auth
 from rubrix.server.security.model import User
@@ -59,7 +60,7 @@ router = APIRouter(tags=[TASK_TYPE], prefix="/datasets")
     response_model=BulkResponse,
     response_model_exclude_none=True,
 )
-def bulk_records(
+async def bulk_records(
     name: str,
     bulk: TextClassificationBulkData,
     common_params: CommonTaskQueryParams = Depends(),
@@ -67,6 +68,7 @@ def bulk_records(
         TextClassificationService.get_instance
     ),
     datasets: DatasetsService = Depends(DatasetsService.get_instance),
+    validator: DatasetValidator = Depends(DatasetValidator.get_instance),
     current_user: User = Security(auth.get_user, scopes=[]),
 ) -> BulkResponse:
     """
@@ -84,6 +86,8 @@ def bulk_records(
         the Service
     datasets:
         The dataset service
+    validator:
+        The dataset validator component
     current_user:
         Current request user
 
@@ -116,6 +120,10 @@ def bulk_records(
         datasets.create_dataset(
             user=current_user, dataset=dataset, mappings=task_mappings
         )
+
+    await validator.validate_dataset(
+        user=current_user, dataset=dataset, records=bulk.records
+    )
 
     result = service.add_records(
         dataset=dataset,

--- a/src/rubrix/server/apis/v0/handlers/text_classification_dataset_settings.py
+++ b/src/rubrix/server/apis/v0/handlers/text_classification_dataset_settings.py
@@ -21,7 +21,7 @@ __svc_settings_class__: Type[SVCDatasetSettings] = type(
 def configure_router(router: APIRouter):
 
     task = TaskType.text_classification
-    base_endpoint = f"/{{name}}/{task}/settings"
+    base_endpoint = f"/{task}/{{name}}/settings"
 
     @router.get(
         path=base_endpoint,

--- a/src/rubrix/server/apis/v0/handlers/token_classification.py
+++ b/src/rubrix/server/apis/v0/handlers/token_classification.py
@@ -114,7 +114,7 @@ async def bulk_records(
             user=current_user, dataset=dataset, mappings=task_mappings
         )
 
-    await validator.validate_dataset(
+    await validator.validate_dataset_records(
         user=current_user,
         dataset=dataset,
         records=bulk.records,

--- a/src/rubrix/server/apis/v0/handlers/token_classification.py
+++ b/src/rubrix/server/apis/v0/handlers/token_classification.py
@@ -35,6 +35,7 @@ from rubrix.server.apis.v0.models.token_classification import (
     TokenClassificationSearchRequest,
     TokenClassificationSearchResults,
 )
+from rubrix.server.apis.v0.validators.token_classification import DatasetValidator
 from rubrix.server.errors import EntityNotFoundError
 from rubrix.server.security import auth
 from rubrix.server.security.model import User
@@ -56,12 +57,13 @@ router = APIRouter(tags=[TASK_TYPE], prefix="/datasets")
     response_model=BulkResponse,
     response_model_exclude_none=True,
 )
-def bulk_records(
+async def bulk_records(
     name: str,
     bulk: TokenClassificationBulkData,
     common_params: CommonTaskQueryParams = Depends(),
     service: TokenClassificationService = Depends(token_classification_service),
     datasets: DatasetsService = Depends(DatasetsService.get_instance),
+    validator: DatasetValidator = Depends(DatasetValidator.get_instance),
     current_user: User = Security(auth.get_user, scopes=[]),
 ) -> BulkResponse:
     """
@@ -111,6 +113,12 @@ def bulk_records(
         datasets.create_dataset(
             user=current_user, dataset=dataset, mappings=task_mappings
         )
+
+    await validator.validate_dataset(
+        user=current_user,
+        dataset=dataset,
+        records=bulk.records,
+    )
 
     result = service.add_records(
         dataset=dataset,

--- a/src/rubrix/server/apis/v0/handlers/token_classification_dataset_settings.py
+++ b/src/rubrix/server/apis/v0/handlers/token_classification_dataset_settings.py
@@ -20,7 +20,7 @@ __svc_settings_class__: Type[SVCDatasetSettings] = type(
 
 def configure_router(router: APIRouter):
     task = TaskType.token_classification
-    base_endpoint = f"/{{name}}/{task}/settings"
+    base_endpoint = f"/{task}/{{name}}/settings"
 
     @router.get(
         path=base_endpoint,

--- a/src/rubrix/server/apis/v0/handlers/token_classification_dataset_settings.py
+++ b/src/rubrix/server/apis/v0/handlers/token_classification_dataset_settings.py
@@ -6,18 +6,21 @@ from rubrix.server.apis.v0.models.commons.model import TaskType
 from rubrix.server.apis.v0.models.commons.params import DATASET_NAME_PATH_PARAM
 from rubrix.server.apis.v0.models.commons.workspace import CommonTaskQueryParams
 from rubrix.server.apis.v0.models.dataset_settings import TokenClassificationSettings
+from rubrix.server.apis.v0.validators.token_classification import DatasetValidator
 from rubrix.server.security import auth
 from rubrix.server.security.model import User
 from rubrix.server.services.datasets import DatasetsService, SVCDatasetSettings
 
+__svc_settings_class__: Type[SVCDatasetSettings] = type(
+    f"{TaskType.token_classification}_DatasetSettings",
+    (SVCDatasetSettings, TokenClassificationSettings),
+    {},
+)
+
 
 def configure_router(router: APIRouter):
-
     task = TaskType.token_classification
-    base_endpoint = f"/{task}/{{name}}/settings"
-    svc_settings_class: Type[SVCDatasetSettings] = type(
-        f"{task}_DatasetSettings", (SVCDatasetSettings, TokenClassificationSettings), {}
-    )
+    base_endpoint = f"/{{name}}/{task}/settings"
 
     @router.get(
         path=base_endpoint,
@@ -42,7 +45,7 @@ def configure_router(router: APIRouter):
         )
 
         settings = await datasets.get_settings(
-            user=user, dataset=found_ds, class_type=svc_settings_class
+            user=user, dataset=found_ds, class_type=__svc_settings_class__
         )
         return TokenClassificationSettings.parse_obj(settings)
 
@@ -61,6 +64,7 @@ def configure_router(router: APIRouter):
         name: str = DATASET_NAME_PATH_PARAM,
         ws_params: CommonTaskQueryParams = Depends(),
         datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        validator: DatasetValidator = Depends(DatasetValidator.get_instance),
         user: User = Security(auth.get_user, scopes=["write:dataset.settings"]),
     ) -> TokenClassificationSettings:
 
@@ -70,11 +74,13 @@ def configure_router(router: APIRouter):
             task=task,
             workspace=ws_params.workspace,
         )
-        # TODO(frascuchon): validate settings...
+        await validator.validate_dataset_settings(
+            user=user, dataset=found_ds, settings=request
+        )
         settings = await datasets.save_settings(
             user=user,
             dataset=found_ds,
-            settings=svc_settings_class.parse_obj(request.dict()),
+            settings=__svc_settings_class__.parse_obj(request.dict()),
         )
         return TokenClassificationSettings.parse_obj(settings)
 

--- a/src/rubrix/server/apis/v0/validators/text_classification.py
+++ b/src/rubrix/server/apis/v0/validators/text_classification.py
@@ -1,0 +1,105 @@
+from typing import List, Optional, Set, Type
+
+from fastapi import Depends
+
+from rubrix.server.apis.v0.models.commons.model import TaskType
+from rubrix.server.apis.v0.models.dataset_settings import TextClassificationSettings
+from rubrix.server.apis.v0.models.datasets import Dataset
+from rubrix.server.apis.v0.models.metrics.text_classification import DatasetLabels
+from rubrix.server.apis.v0.models.text_classification import (
+    CreationTextClassificationRecord,
+    TextClassificationRecord,
+)
+from rubrix.server.errors import BadRequestError, EntityNotFoundError
+from rubrix.server.security.model import User
+from rubrix.server.services.datasets import DatasetsService, SVCDatasetSettings
+
+__svc_settings_class__: Type[SVCDatasetSettings] = type(
+    f"{TaskType.text_classification}_DatasetSettings",
+    (SVCDatasetSettings, TextClassificationSettings),
+    {},
+)
+
+from rubrix.server.services.metrics import MetricsService
+
+
+class DatasetValidator:
+
+    _INSTANCE = None
+
+    def __init__(self, datasets: DatasetsService, metrics: MetricsService):
+        self.__datasets__ = datasets
+        self.__metrics__ = metrics
+
+    @classmethod
+    def get_instance(
+        cls,
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        metrics: MetricsService = Depends(MetricsService.get_instance),
+    ):
+        if not cls._INSTANCE:
+            cls._INSTANCE = cls(datasets, metrics=metrics)
+        return cls._INSTANCE
+
+    async def validate_dataset_settings(
+        self, user: User, dataset: Dataset, settings: TextClassificationSettings
+    ):
+        if settings and settings.labels_schema:
+            results = self.__metrics__.summarize_metric(
+                dataset=dataset,
+                metric=DatasetLabels(),
+                record_class=TextClassificationRecord,
+                query=None,
+            )
+            if results:
+                labels = results.get("labels", [])
+                labels_schema = set(
+                    [label.name for label in settings.labels_schema.labels]
+                )
+                for label in labels:
+                    if label not in labels_schema:
+                        raise BadRequestError(
+                            f"The label {label} was found in the dataset but not in provided labels schema. "
+                            "\nPlease, provide a valid labels schema according to stored records in the dataset"
+                        )
+
+    async def validate_dataset_records(
+        self,
+        user: User,
+        dataset: Dataset,
+        records: Optional[List[CreationTextClassificationRecord]] = None,
+    ):
+        try:
+            settings: TextClassificationSettings = await self.__datasets__.get_settings(
+                user=user, dataset=dataset, class_type=__svc_settings_class__
+            )
+            if settings and settings.labels_schema:
+                labels_schema = set(
+                    [label.name for label in settings.labels_schema.labels]
+                )
+                for r in records:
+                    if r.prediction:
+                        self.__check_label_classes__(
+                            labels_schema,
+                            [label.class_label for label in r.prediction.labels],
+                        )
+                    if r.annotation:
+                        self.__check_label_classes__(
+                            labels_schema,
+                            [label.class_label for label in r.annotation.labels],
+                        )
+        except EntityNotFoundError:
+            pass
+
+    @staticmethod
+    def __check_label_classes__(
+        labels_schema: Set[str],
+        labels: List[str],
+    ):
+        for label in labels:
+            if label not in labels_schema:
+                raise BadRequestError(
+                    detail=f"Provided records contain the {label} label,"
+                    " that is not included in the labels schema."
+                    "\nPlease, annotate your records using labels defined in the labels schema."
+                )

--- a/src/rubrix/server/apis/v0/validators/token_classification.py
+++ b/src/rubrix/server/apis/v0/validators/token_classification.py
@@ -1,0 +1,103 @@
+from typing import List, Set, Type
+
+from fastapi import Depends
+
+from rubrix.server.apis.v0.models.commons.model import TaskType
+from rubrix.server.apis.v0.models.dataset_settings import TokenClassificationSettings
+from rubrix.server.apis.v0.models.datasets import Dataset
+from rubrix.server.apis.v0.models.metrics.token_classification import DatasetLabels
+from rubrix.server.apis.v0.models.token_classification import (
+    CreationTokenClassificationRecord,
+    TokenClassificationAnnotation,
+    TokenClassificationRecord,
+)
+from rubrix.server.errors import BadRequestError, EntityNotFoundError
+from rubrix.server.security.model import User
+from rubrix.server.services.datasets import DatasetsService, SVCDatasetSettings
+
+__svc_settings_class__: Type[SVCDatasetSettings] = type(
+    f"{TaskType.token_classification}_DatasetSettings",
+    (SVCDatasetSettings, TokenClassificationSettings),
+    {},
+)
+
+from rubrix.server.services.metrics import MetricsService
+
+
+class DatasetValidator:
+    _INSTANCE = None
+
+    def __init__(self, datasets: DatasetsService, metrics: MetricsService):
+        self.__datasets__ = datasets
+        self.__metrics__ = metrics
+
+    @classmethod
+    def get_instance(
+        cls,
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        metrics: MetricsService = Depends(MetricsService.get_instance),
+    ):
+        if not cls._INSTANCE:
+            cls._INSTANCE = cls(datasets, metrics=metrics)
+        return cls._INSTANCE
+
+    async def validate_dataset_settings(
+        self, user: User, dataset: Dataset, settings: TokenClassificationSettings
+    ):
+        if settings and settings.labels_schema:
+            results = self.__metrics__.summarize_metric(
+                dataset=dataset,
+                metric=DatasetLabels(),
+                record_class=TokenClassificationRecord,
+                query=None,
+            )
+            if results:
+                labels = results.get("labels", [])
+                labels_schema = set(
+                    [label.name for label in settings.labels_schema.labels]
+                )
+                for label in labels:
+                    if label not in labels_schema:
+                        raise BadRequestError(
+                            f"The label {label} was found in the dataset but not in provided labels schema. "
+                            "\nPlease, provide a valid labels schema according to stored records in the dataset"
+                        )
+
+    async def validate_dataset_records(
+        self,
+        user: User,
+        dataset: Dataset,
+        records: List[CreationTokenClassificationRecord],
+    ):
+        try:
+            settings: TokenClassificationSettings = (
+                await self.__datasets__.get_settings(
+                    user=user, dataset=dataset, class_type=__svc_settings_class__
+                )
+            )
+            if settings and settings.labels_schema:
+                labels_schema = set(
+                    [label.name for label in settings.labels_schema.labels]
+                )
+
+                for r in records:
+                    if r.prediction:
+                        self.__check_label_entities__(labels_schema, r.prediction)
+                    if r.annotation:
+                        self.__check_label_entities__(labels_schema, r.annotation)
+        except EntityNotFoundError:
+            pass
+
+    @staticmethod
+    def __check_label_entities__(
+        labels_schema: Set[str], annotation: TokenClassificationAnnotation
+    ):
+        if not annotation:
+            return
+        for entity in annotation.entities:
+            if entity.label not in labels_schema:
+                raise BadRequestError(
+                    detail=f"Provided records contain the {entity.label} label,"
+                    " that is not included in the labels schema."
+                    "\nPlease, annotate your records using labels defined in the labels schema."
+                )

--- a/src/rubrix/server/daos/models/records.py
+++ b/src/rubrix/server/daos/models/records.py
@@ -33,7 +33,7 @@ class RecordSearch(BaseModel):
         The elasticsearch search aggregations
     """
 
-    query: Optional[Dict[str, Any]]
+    query: Optional[Dict[str, Any]] = None
     sort: List[Dict[str, Any]] = Field(default_factory=list)
     aggregations: Optional[Dict[str, Any]]
     include_default_aggregations: bool = True

--- a/src/rubrix/server/daos/records.py
+++ b/src/rubrix/server/daos/records.py
@@ -308,7 +308,7 @@ class DatasetRecordsDAO:
         """
         search = search or RecordSearch()
         es_query = {
-            "query": search.query,
+            "query": search.query or {"match_all": {}},
             "highlight": self.__configure_query_highlight__(task=dataset.task),
         }
         docs = self._es.list_documents(

--- a/src/rubrix/server/services/search/service.py
+++ b/src/rubrix/server/services/search/service.py
@@ -117,8 +117,8 @@ class SearchRecordsService:
     def scan_records(
         self,
         dataset: Dataset,
-        query: BaseSearchQuery,
         record_type: Type[BaseRecord],
+        query: Optional[BaseSearchQuery] = None,
     ) -> Iterable[Record]:
         """Scan records for a queried"""
         for doc in self.__dao__.scan_dataset(

--- a/tests/server/text_classification/test_api_settings.py
+++ b/tests/server/text_classification/test_api_settings.py
@@ -53,6 +53,69 @@ def test_delete_settings(mocked_client):
     assert fetch_settings(mocked_client, name).status_code == 404
 
 
+def test_validate_settings_when_logging_data(mocked_client):
+    name = "test_validate_settings_when_logging_data"
+    rb.delete(name)
+
+    create_dataset(mocked_client, name)
+    assert create_settings(mocked_client, name).status_code == 200
+
+    response = log_some_data(mocked_client, name)
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": {
+            "code": "rubrix.api.errors::BadRequestError",
+            "params": {
+                "message": "Provided records contain the Mocking label, "
+                "that is not included in the labels schema.\n"
+                "Please, annotate your records using labels "
+                "defined in the labels schema."
+            },
+        }
+    }
+
+
+def test_validate_settings_after_logging(mocked_client):
+    name = "test_validate_settings_after_logging"
+
+    rb.delete(name)
+    response = log_some_data(mocked_client, name)
+    assert response.status_code == 200
+
+    response = create_settings(mocked_client, name)
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": {
+            "code": "rubrix.api.errors::BadRequestError",
+            "params": {
+                "message": "The label Mocking was found in the dataset but "
+                "not in provided labels schema. \n"
+                "Please, provide a valid labels schema "
+                "according to stored records in the dataset"
+            },
+        }
+    }
+
+
+def log_some_data(mocked_client, name):
+    return mocked_client.post(
+        f"/api/datasets/{name}/TextClassification:bulk",
+        json={
+            "records": [
+                {
+                    "inputs": {"data": "my data"},
+                    "prediction": {
+                        "agent": "test",
+                        "labels": [
+                            {"class": "Mocking", "score": 0.2},
+                        ],
+                    },
+                }
+            ]
+        },
+    )
+
+
 def fetch_settings(mocked_client, name):
     return mocked_client.get(
         f"/api/datasets/{TaskType.text_classification}/{name}/settings"

--- a/tests/server/token_classification/test_api_settings.py
+++ b/tests/server/token_classification/test_api_settings.py
@@ -53,6 +53,73 @@ def test_delete_settings(mocked_client):
     assert fetch_settings(mocked_client, name).status_code == 404
 
 
+def test_validate_settings_when_logging_data(mocked_client):
+    name = "test_validate_settings_when_logging_data"
+    rb.delete(name)
+
+    create_dataset(mocked_client, name)
+    assert create_settings(mocked_client, name).status_code == 200
+
+    response = log_some_data(mocked_client, name)
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": {
+            "code": "rubrix.api.errors::BadRequestError",
+            "params": {
+                "message": "Provided records contain the BAD label, "
+                "that is not included in the labels schema.\n"
+                "Please, annotate your records using labels "
+                "defined in the labels schema."
+            },
+        }
+    }
+
+
+def log_some_data(mocked_client, name):
+    response = mocked_client.post(
+        f"/api/datasets/{name}/TokenClassification:bulk",
+        json={
+            "records": [
+                {
+                    "tokens": "This is a text".split(" "),
+                    "raw_text": "This is a text",
+                    "prediction": {
+                        "agent": "test",
+                        "entities": [{"start": 0, "end": 4, "label": "BAD"}],
+                    },
+                    "annotation": {
+                        "agent": "test",
+                        "entities": [{"start": 0, "end": 4, "label": "BAD"}],
+                    },
+                }
+            ]
+        },
+    )
+    return response
+
+
+def test_validate_settings_after_logging(mocked_client):
+    name = "test_validate_settings_after_logging"
+    rb.delete(name)
+    response = log_some_data(mocked_client, name)
+    assert response.status_code == 200
+
+    response = create_settings(mocked_client, name)
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": {
+            "code": "rubrix.api.errors::BadRequestError",
+            "params": {
+                "message": "The label BAD was found in the dataset but "
+                "not in provided labels schema. \n"
+                "Please, provide a valid labels schema "
+                "according to stored records in the "
+                "dataset"
+            },
+        }
+    }
+
+
 def fetch_settings(mocked_client, name):
     return mocked_client.get(
         f"/api/datasets/{TaskType.token_classification}/{name}/settings"


### PR DESCRIPTION
After creating the dataset settings API in #1468, this PR includes:

- logging validation to preserve label schema when logging 
- settings validation when updating settings and the dataset already contains some records