### PR TITLE
feat(#1432): configure dataset settings

### DIFF
--- a/docs/guides/dataset_settings.ipynb
+++ b/docs/guides/dataset_settings.ipynb
@@ -37,7 +37,7 @@
     "rb.configure_dataset(name=\"my_dataset\", settings=settings)\n",
     "\n",
     "# Logging to the newly created dataset triggers the validation checks\n",
-    "rb.log(rb.TextClassificationRecord(text=\"text\", annotation=\"A\"), \"my_dataset\")\n",
+    "rb.log(rb.TextClassificationRecord(text=\"text\", annotation=\"D\"), \"my_dataset\")\n",
     "#BadRequestApiError: Rubrix server returned an error with http status: 400"
    ]
   }

--- a/docs/guides/dataset_settings.ipynb
+++ b/docs/guides/dataset_settings.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "6e18e959-4a78-4b9e-bec3-7dc8c6ac95c9",
    "metadata": {},
    "outputs": [],
@@ -34,7 +34,11 @@
     "settings = rb.TextClassificationSettings(labels_schema=[\"A\", \"B\", \"C\"])\n",
     "\n",
     "# Apply seetings to a new or already existing dataset\n",
-    "rb.configure_dataset(name=\"my_dataset\", settings=settings)"
+    "rb.configure_dataset(name=\"my_dataset\", settings=settings)\n",
+    "\n",
+    "# Logging to the newly created dataset triggers the validation checks\n",
+    "rb.log(rb.TextClassificationRecord(text=\"text\", annotation=\"A\"), \"my_dataset\")\n",
+    "#BadRequestApiError: Rubrix server returned an error with http status: 400"
    ]
   }
  ],

--- a/docs/guides/dataset_settings.ipynb
+++ b/docs/guides/dataset_settings.ipynb
@@ -1,0 +1,62 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f3320e28-1d17-4b04-a3b0-51645806b0f9",
+   "metadata": {},
+   "source": [
+    "# Dataset settings\n",
+    "\n",
+    "Rubrix datasets have certain *settings* that you can configure via the `rb.*Settings` classes, for example `rb.TextClassificationSettings`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e950e24-9d19-41d5-826f-43d9fe37f999",
+   "metadata": {},
+   "source": [
+    "## Define a labeling schema\n",
+    "\n",
+    "You can define a labeling schema for your Rubrix dataset, which fixes the allowed labels for your predictions and annotations.\n",
+    "Once you set a labeling schema, each time you log to the corresponding dataset, Rubrix will perform validations of the added predictions and annotations to make sure they comply with the schema."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e18e959-4a78-4b9e-bec3-7dc8c6ac95c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import rubrix as rb\n",
+    "\n",
+    "# Define labeling schema\n",
+    "settings = rb.TextClassificationSettings(labels_schema=[\"A\", \"B\", \"C\"])\n",
+    "\n",
+    "# Apply seetings to a new or already existing dataset\n",
+    "rb.configure_dataset(name=\"my_dataset\", settings=settings)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/guides/dataset_settings.ipynb
+++ b/docs/guides/dataset_settings.ipynb
@@ -31,7 +31,7 @@
     "import rubrix as rb\n",
     "\n",
     "# Define labeling schema\n",
-    "settings = rb.TextClassificationSettings(labels_schema=[\"A\", \"B\", \"C\"])\n",
+    "settings = rb.TextClassificationSettings(label_schema=[\"A\", \"B\", \"C\"])\n",
     "\n",
     "# Apply seetings to a new or already existing dataset\n",
     "rb.configure_dataset(name=\"my_dataset\", settings=settings)\n",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -178,6 +178,7 @@ You can join the conversation on our Github page and our Github forum.
    guides/monitoring
    guides/metrics
    guides/datasets
+   guides/dataset_settings
    guides/queries
 
 .. toctree::

--- a/src/rubrix/__init__.py
+++ b/src/rubrix/__init__.py
@@ -55,7 +55,7 @@ if _TYPE_CHECKING:
     from rubrix.datasets import (
         TextClassificationSettings,
         TokenClassificationSettings,
-        create_dataset,
+        configure_dataset,
     )
     from rubrix.monitoring.model_monitor import monitor
     from rubrix.server.server import app
@@ -86,7 +86,7 @@ _import_structure = {
     ],
     "monitoring.model_monitor": ["monitor"],
     "datasets": [
-        "create_dataset",
+        "configure_dataset",
         "TextClassificationSettings",
         "TokenClassificationSettings",
     ],

--- a/src/rubrix/__init__.py
+++ b/src/rubrix/__init__.py
@@ -52,6 +52,11 @@ if _TYPE_CHECKING:
         TokenAttributions,
         TokenClassificationRecord,
     )
+    from rubrix.datasets import (
+        TextClassificationSettings,
+        TokenClassificationSettings,
+        create_dataset,
+    )
     from rubrix.monitoring.model_monitor import monitor
     from rubrix.server.server import app
 
@@ -80,6 +85,11 @@ _import_structure = {
         "read_pandas",
     ],
     "monitoring.model_monitor": ["monitor"],
+    "datasets": [
+        "create_dataset",
+        "TextClassificationSettings",
+        "TokenClassificationSettings",
+    ],
     "server.app": ["app"],
 }
 

--- a/src/rubrix/client/api.py
+++ b/src/rubrix/client/api.py
@@ -29,6 +29,7 @@ from rubrix._constants import (
     DEFAULT_API_KEY,
     RUBRIX_WORKSPACE_HEADER_NAME,
 )
+from rubrix.client.apis.datasets import Datasets
 from rubrix.client.datasets import (
     Dataset,
     DatasetForText2Text,
@@ -156,6 +157,10 @@ class Api:
     def client(self):
         """The underlying authenticated client"""
         return self._client
+
+    @property
+    def datasets(self) -> Datasets:
+        return Datasets(client=self._client)
 
     def set_workspace(self, workspace: str):
         """Sets the active workspace.

--- a/src/rubrix/client/apis/__init__.py
+++ b/src/rubrix/client/apis/__init__.py
@@ -1,0 +1,1 @@
+from .base import AbstractApi, api_compatibility

--- a/src/rubrix/client/apis/__init__.py
+++ b/src/rubrix/client/apis/__init__.py
@@ -1,1 +1,2 @@
-from .base import AbstractApi, api_compatibility
+from .base import AbstractApi
+from .status import api_compatibility

--- a/src/rubrix/client/apis/base.py
+++ b/src/rubrix/client/apis/base.py
@@ -1,3 +1,6 @@
+from types import TracebackType
+from typing import Optional, Tuple, Type
+
 from rubrix.client.sdk.client import AuthenticatedClient
 from rubrix.client.sdk.commons.errors import ApiCompatibilityError, GenericApiError
 
@@ -7,17 +10,42 @@ class AbstractApi:
         self.__client__ = client
 
 
-def api_compatibility_check(min_version: str):
-    def decorator(func):
-        def inner(*args, **kwargs):
-            try:
-                return func(*args, **kwargs)
-            except GenericApiError as gap:
-                response = gap.ctx.get("response")
-                if "Method Not Allowed" == response:
-                    raise ApiCompatibilityError(min_version)
-                raise gap
+class _ApiCompatibilityContextManager:
+    def __init__(self, min_version: Tuple[int, int, int]):
+        self._min_version = min_version
 
-        return inner
+    def __enter__(self):
+        # TODO: If a client is provided, check minimal version against the server version
+        pass
 
-    return decorator
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ):
+        if not exc_val:
+            return
+
+        if isinstance(exc_val, GenericApiError):
+            response = exc_val.ctx.get("response")
+            if "Method Not Allowed" == response:
+                raise ApiCompatibilityError(
+                    ".".join(map(str, self._min_version))
+                ) from exc_val
+            raise exc_val
+
+
+def api_compatibility(
+    min_version: Tuple[int, int, int], client: Optional[AuthenticatedClient] = None
+):
+    """
+    Handles problems related to server API compatibility.
+
+    Args:
+        min_version: the minimal version that the Rubrix client can work with
+        client: An http client abstraction connecting to server instance. If provided, some extra
+            checks could be applied
+
+    """
+    return _ApiCompatibilityContextManager(min_version=min_version)

--- a/src/rubrix/client/apis/base.py
+++ b/src/rubrix/client/apis/base.py
@@ -1,0 +1,23 @@
+from rubrix.client.sdk.client import AuthenticatedClient
+from rubrix.client.sdk.commons.errors import ApiCompatibilityError, GenericApiError
+
+
+class AbstractApi:
+    def __init__(self, client: AuthenticatedClient):
+        self.__client__ = client
+
+
+def api_compatibility_check(min_version: str):
+    def decorator(func):
+        def inner(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except GenericApiError as gap:
+                response = gap.ctx.get("response")
+                if "Method Not Allowed" == response:
+                    raise ApiCompatibilityError(min_version)
+                raise gap
+
+        return inner
+
+    return decorator

--- a/src/rubrix/client/apis/base.py
+++ b/src/rubrix/client/apis/base.py
@@ -2,7 +2,10 @@ from types import TracebackType
 from typing import Optional, Tuple, Type
 
 from rubrix.client.sdk.client import AuthenticatedClient
-from rubrix.client.sdk.commons.errors import ApiCompatibilityError, GenericApiError
+from rubrix.client.sdk.commons.errors import (
+    ApiCompatibilityError,
+    MethodNotAllowedApiError,
+)
 
 
 class AbstractApi:
@@ -27,13 +30,12 @@ class _ApiCompatibilityContextManager:
         if not exc_val:
             return
 
-        if isinstance(exc_val, GenericApiError):
-            response = exc_val.ctx.get("response")
-            if "Method Not Allowed" == response:
-                raise ApiCompatibilityError(
-                    ".".join(map(str, self._min_version))
-                ) from exc_val
-            raise exc_val
+        if exc_type == MethodNotAllowedApiError:
+            raise ApiCompatibilityError(
+                ".".join(map(str, self._min_version))
+            ) from exc_val
+
+        raise exc_val
 
 
 def api_compatibility(

--- a/src/rubrix/client/apis/base.py
+++ b/src/rubrix/client/apis/base.py
@@ -1,53 +1,6 @@
-from types import TracebackType
-from typing import Optional, Tuple, Type
-
 from rubrix.client.sdk.client import AuthenticatedClient
-from rubrix.client.sdk.commons.errors import (
-    ApiCompatibilityError,
-    MethodNotAllowedApiError,
-)
 
 
 class AbstractApi:
     def __init__(self, client: AuthenticatedClient):
         self.__client__ = client
-
-
-class _ApiCompatibilityContextManager:
-    def __init__(self, min_version: Tuple[int, int, int]):
-        self._min_version = min_version
-
-    def __enter__(self):
-        # TODO: If a client is provided, check minimal version against the server version
-        pass
-
-    def __exit__(
-        self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
-    ):
-        if not exc_val:
-            return
-
-        if exc_type == MethodNotAllowedApiError:
-            raise ApiCompatibilityError(
-                ".".join(map(str, self._min_version))
-            ) from exc_val
-
-        raise exc_val
-
-
-def api_compatibility(
-    min_version: Tuple[int, int, int], client: Optional[AuthenticatedClient] = None
-):
-    """
-    Handles problems related to server API compatibility.
-
-    Args:
-        min_version: the minimal version that the Rubrix client can work with
-        client: An http client abstraction connecting to server instance. If provided, some extra
-            checks could be applied
-
-    """
-    return _ApiCompatibilityContextManager(min_version=min_version)

--- a/src/rubrix/client/apis/datasets.py
+++ b/src/rubrix/client/apis/datasets.py
@@ -1,0 +1,144 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Optional, Set, Union
+
+from pydantic import BaseModel, Field
+
+from rubrix.client.apis.base import AbstractApi, api_compatibility_check
+from rubrix.client.sdk.commons.errors import NotFoundApiError
+from rubrix.client.sdk.datasets.api import get_dataset
+from rubrix.client.sdk.datasets.models import TaskType
+
+
+@dataclass
+class _AbstractSettings:
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "_AbstractSettings":
+        """
+        Creates a settings instance from a plain python dictionary
+
+        Args:
+            data: The data dict
+
+        Returns:
+            A new ``cls`` settings instance
+        """
+        raise NotImplementedError()
+
+
+@dataclass
+class LabelsSchemaSettings(_AbstractSettings):
+    """
+    A base dataset settings class for labels schema management
+
+    Args:
+        labels_schema: The label's schema for the dataset
+
+    """
+
+    labels_schema: Set[str]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "LabelsSchemaSettings":
+        labels_schema = data.get("labels_schema", {})
+        labels = {label["name"] for label in labels_schema.get("labels", [])}
+        return cls(labels_schema=labels)
+
+
+@dataclass
+class TextClassificationSettings(LabelsSchemaSettings):
+    """
+    The settings for text classification datasets
+
+    Args:
+        labels_schema: The label's schema for the dataset
+
+    """
+
+
+@dataclass
+class TokenClassificationSettings(LabelsSchemaSettings):
+    """
+    The settings for token classification datasets
+
+    Args:
+        labels_schema: The label's schema for the dataset
+
+    """
+
+
+Settings = Union[TextClassificationSettings, TokenClassificationSettings]
+
+__TASK_TO_SETTINGS__ = {
+    TaskType.text_classification: TextClassificationSettings,
+    TaskType.token_classification: TokenClassificationSettings,
+}
+
+
+class Datasets(AbstractApi):
+    """Dataset client api class"""
+
+    _API_PREFIX = "/api/datasets"
+
+    __SETTINGS_MIN_API_VERSION__ = "0.15.0"
+
+    class _DatasetApiModel(BaseModel):
+        name: str
+        task: TaskType
+        owner: str = None
+        created_at: datetime = None
+        last_updated: datetime = None
+
+        tags: Dict[str, str] = Field(default_factory=dict)
+        metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    class _SettingsApiModel(BaseModel):
+        labels_schema: Dict[str, Any]
+
+    def find_by_name(self, name: str) -> _DatasetApiModel:
+        dataset = get_dataset(self.__client__, name=name).parsed
+        return self._DatasetApiModel.parse_obj(dataset)
+
+    @api_compatibility_check(min_version=__SETTINGS_MIN_API_VERSION__)
+    def create(self, name: str, settings: Settings):
+        task = (
+            TaskType.text_classification
+            if isinstance(settings, TextClassificationSettings)
+            else TaskType.token_classification
+        )
+
+        dataset = self._DatasetApiModel(name=name, task=task)
+        self.__client__.post(f"{self._API_PREFIX}/", json=dataset.dict())
+        self.save_settings(dataset, settings=settings)
+
+    @api_compatibility_check(min_version=__SETTINGS_MIN_API_VERSION__)
+    def save_settings(self, dataset: _DatasetApiModel, settings: Settings):
+        settings_ = self._SettingsApiModel(
+            labels_schema={"labels": [label for label in settings.labels_schema]}
+        )
+
+        # TODO: use the api compatiblity check as a with block (passing the abstract api and the minimal version
+        self.__client__.put(
+            f"{self._API_PREFIX}/{dataset.task}/{dataset.name}/settings",
+            json=settings_.dict(),
+        )
+
+    @api_compatibility_check(min_version=__SETTINGS_MIN_API_VERSION__)
+    def load_settings(self, name: str) -> Optional[Settings]:
+        """
+        Load the dataset settings
+
+        Args:
+            name: The dataset name
+
+        Returns:
+            Settings defined for the dataset
+        """
+        dataset = self.find_by_name(name)
+        try:
+            response = self.__client__.get(
+                f"{self._API_PREFIX}/{dataset.task}/{dataset.name}/settings"
+            )
+            return __TASK_TO_SETTINGS__.get(dataset.task).from_dict(response)
+        except NotFoundApiError:
+            return None

--- a/src/rubrix/client/apis/datasets.py
+++ b/src/rubrix/client/apis/datasets.py
@@ -32,17 +32,17 @@ class LabelsSchemaSettings(_AbstractSettings):
     A base dataset settings class for labels schema management
 
     Args:
-        labels_schema: The label's schema for the dataset
+        label_schema: The label's schema for the dataset
 
     """
 
-    labels_schema: Set[str]
+    label_schema: Set[str]
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "LabelsSchemaSettings":
-        labels_schema = data.get("labels_schema", {})
-        labels = {label["name"] for label in labels_schema.get("labels", [])}
-        return cls(labels_schema=labels)
+        label_schema = data.get("label_schema", {})
+        labels = {label["name"] for label in label_schema.get("labels", [])}
+        return cls(label_schema=labels)
 
 
 @dataclass
@@ -51,7 +51,7 @@ class TextClassificationSettings(LabelsSchemaSettings):
     The settings for text classification datasets
 
     Args:
-        labels_schema: The label's schema for the dataset
+        label_schema: The label's schema for the dataset
 
     """
 
@@ -62,7 +62,7 @@ class TokenClassificationSettings(LabelsSchemaSettings):
     The settings for token classification datasets
 
     Args:
-        labels_schema: The label's schema for the dataset
+        label_schema: The label's schema for the dataset
 
     """
 
@@ -93,7 +93,7 @@ class Datasets(AbstractApi):
         metadata: Dict[str, Any] = Field(default_factory=dict)
 
     class _SettingsApiModel(BaseModel):
-        labels_schema: Dict[str, Any]
+        label_schema: Dict[str, Any]
 
     def find_by_name(self, name: str) -> _DatasetApiModel:
         dataset = get_dataset(self.__client__, name=name).parsed
@@ -135,7 +135,7 @@ class Datasets(AbstractApi):
             )
 
         settings_ = self._SettingsApiModel(
-            labels_schema={"labels": [label for label in settings.labels_schema]}
+            label_schema={"labels": [label for label in settings.label_schema]}
         )
 
         with api_compatibility(self, min_version=self.__SETTINGS_MIN_API_VERSION__):

--- a/src/rubrix/client/apis/status.py
+++ b/src/rubrix/client/apis/status.py
@@ -1,0 +1,69 @@
+import dataclasses
+from types import TracebackType
+from typing import ContextManager, Optional, Type
+
+from packaging.version import parse
+from pydantic import BaseModel
+
+from rubrix.client.apis import AbstractApi
+from rubrix.client.sdk.client import AuthenticatedClient
+from rubrix.client.sdk.commons.errors import ApiCompatibilityError
+
+
+@dataclasses.dataclass(frozen=True)
+class ApiInfo:
+
+    rubrix_version: str
+
+
+class Status(AbstractApi):
+    class _ApiInfo(BaseModel):
+        rubrix_version: str
+
+    def get_info(self) -> ApiInfo:
+        """
+        Get the connected API info
+
+        """
+
+        response = self.__client__.get("/api/_info")
+        api_info = self._ApiInfo.parse_obj(response)
+        return ApiInfo(rubrix_version=api_info.rubrix_version)
+
+
+class _ApiCompatibilityContextManager(ContextManager):
+    def __init__(self, client: AuthenticatedClient, min_version: str):
+        self._min_version = parse(min_version)
+        self._status_api = Status(client=client) if client else None
+
+    def __enter__(self):
+        if self._status_api:
+            api_info = self._status_api.get_info()
+            api_version = parse(api_info.rubrix_version)
+            if api_version.is_devrelease:
+                api_version = parse(api_version.base_version)
+            if not api_version >= self._min_version:
+                raise ApiCompatibilityError(str(self._min_version))
+        pass
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ):
+        pass
+
+
+def api_compatibility(api: AbstractApi, min_version: str):
+    """
+    Handles problems related to server API compatibility.
+
+    Args:
+        api: The api component where apply the api compatibility
+        min_version: the minimal version that the Rubrix client can work with
+
+    """
+    return _ApiCompatibilityContextManager(
+        min_version=min_version, client=api.__client__
+    )

--- a/src/rubrix/client/sdk/_helpers.py
+++ b/src/rubrix/client/sdk/_helpers.py
@@ -1,0 +1,37 @@
+from typing import Any, Dict, Type, TypeVar, Union
+
+import httpx
+
+from rubrix.client.sdk.commons.errors_handler import handle_response_error
+from rubrix.client.sdk.commons.models import ErrorMessage, HTTPValidationError, Response
+
+
+def build_raw_response(
+    response: httpx.Response,
+) -> Response[Union[Dict[str, Any], ErrorMessage, HTTPValidationError]]:
+    return build_typed_response(response, response_type_class=dict)
+
+
+ResponseType = TypeVar("ResponseType")
+
+
+def build_typed_response(
+    response: httpx.Response,
+    response_type_class: Type[ResponseType],
+) -> Response[Union[ResponseType, ErrorMessage, HTTPValidationError]]:
+    parsed_response = response.json()
+
+    check_response_error(response, expected_response=response_type_class)
+    parsed_response = response_type_class(**parsed_response)
+    return Response(
+        status_code=response.status_code,
+        content=response.content,
+        headers=response.headers,
+        parsed=parsed_response,
+    )
+
+
+def check_response_error(response: httpx.Response, **kwargs) -> bool:
+    if 200 <= response.status_code < 400:
+        return False
+    handle_response_error(response, **kwargs)

--- a/src/rubrix/client/sdk/client.py
+++ b/src/rubrix/client/sdk/client.py
@@ -12,18 +12,20 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import dataclasses
+from typing import Dict, TypeVar
 
-from typing import Dict
-
-from pydantic import BaseModel, Field
+import httpx
 
 from rubrix._constants import API_KEY_HEADER_NAME
+from rubrix.client.sdk._helpers import build_raw_response
 
 
-class Client(BaseModel):
-    base_url: str
-    cookies: Dict[str, str] = Field(default_factory=dict)
-    headers: Dict[str, str] = Field(default_factory=dict)
+@dataclasses.dataclass
+class _ClientCommonDefaults:
+
+    cookies: Dict[str, str] = dataclasses.field(default_factory=dict)
+    headers: Dict[str, str] = dataclasses.field(default_factory=dict)
     timeout: float = 5.0
 
     def get_headers(self) -> Dict[str, str]:
@@ -37,10 +39,85 @@ class Client(BaseModel):
         return self.timeout
 
 
-class AuthenticatedClient(Client):
+@dataclasses.dataclass
+class _Client:
+    base_url: str
+
+
+@dataclasses.dataclass
+class _AuthenticatedClient(_Client):
+    token: str
+
+    def __post_init__(self):
+        self.base_url = self.base_url.strip()
+        if self.base_url.endswith("/"):
+            self.base_url = self.base_url[:-1]
+
+
+@dataclasses.dataclass
+class Client(_ClientCommonDefaults, _Client):
+    def __hash__(self):
+        return hash(self.base_url)
+
+    def get(self, path: str, *args, **kwargs):
+        path = self._normalize_path(path)
+        url = f"{self.base_url}/{path}"
+        response = httpx.get(
+            url=url,
+            headers=self.get_headers(),
+            cookies=self.get_cookies(),
+            timeout=self.get_timeout(),
+            *args,
+            **kwargs,
+        )
+
+        return build_raw_response(response).parsed
+
+    def post(self, path: str, *args, **kwargs):
+        path = self._normalize_path(path)
+        url = f"{self.base_url}/{path}"
+
+        response = httpx.post(
+            url=url,
+            headers=self.get_headers(),
+            cookies=self.get_cookies(),
+            timeout=self.get_timeout(),
+            *args,
+            **kwargs,
+        )
+        return build_raw_response(response)
+
+    def put(self, path: str, *args, **kwargs):
+        path = self._normalize_path(path)
+        url = f"{self.base_url}/{path}"
+
+        response = httpx.put(
+            url=url,
+            headers=self.get_headers(),
+            cookies=self.get_cookies(),
+            timeout=self.get_timeout(),
+            *args,
+            **kwargs,
+        )
+        return build_raw_response(response)
+
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        path = path.strip()
+        if path.startswith("/"):
+            return path[1:]
+        return path
+
+
+ResponseType = TypeVar("ResponseType")
+
+
+@dataclasses.dataclass
+class AuthenticatedClient(Client, _ClientCommonDefaults, _AuthenticatedClient):
     """A Client which has been authenticated for use on secured endpoints"""
 
-    token: str
+    def __hash__(self):
+        return hash((self.base_url, self.token))
 
     def get_headers(self) -> Dict[str, str]:
         """Get headers to be used in authenticated endpoints"""
@@ -49,6 +126,3 @@ class AuthenticatedClient(Client):
             API_KEY_HEADER_NAME: self.token,
             **super().get_headers(),
         }
-
-    def __hash__(self):
-        return hash((self.base_url, self.token))

--- a/src/rubrix/client/sdk/commons/api.py
+++ b/src/rubrix/client/sdk/commons/api.py
@@ -26,7 +26,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import json
-from typing import Any, Dict, List, Type, TypeVar, Union
+from typing import Any, List, Type, TypeVar, Union
 
 import httpx
 
@@ -141,29 +141,3 @@ def build_list_response(
         )
 
     return handle_response_error(response, item_class=item_class)
-
-
-ResponseType = TypeVar("ResponseType")
-
-
-def build_typed_response(
-    response: httpx.Response,
-    response_type_class: Type[ResponseType],
-) -> Response[Union[ResponseType, ErrorMessage, HTTPValidationError]]:
-    parsed_response = response.json()
-    if 200 <= response.status_code < 400:
-        parsed_response = response_type_class(**parsed_response)
-        return Response(
-            status_code=response.status_code,
-            content=response.content,
-            headers=response.headers,
-            parsed=parsed_response,
-        )
-
-    return handle_response_error(response, expected_response=response_type_class)
-
-
-def build_raw_response(
-    response: httpx.Response,
-) -> Response[Union[Dict[str, Any], ErrorMessage, HTTPValidationError]]:
-    return build_typed_response(response, response_type_class=dict)

--- a/src/rubrix/client/sdk/commons/errors.py
+++ b/src/rubrix/client/sdk/commons/errors.py
@@ -71,5 +71,9 @@ class AlreadyExistsApiError(RubrixApiResponseError):
     HTTP_STATUS = 409
 
 
+class MethodNotAllowedApiError(RubrixApiResponseError):
+    HTTP_STATUS = 405
+
+
 class GenericApiError(RubrixApiResponseError):
     HTTP_STATUS = 500

--- a/src/rubrix/client/sdk/commons/errors.py
+++ b/src/rubrix/client/sdk/commons/errors.py
@@ -2,6 +2,17 @@ class RubrixClientError(Exception):
     pass
 
 
+class ApiCompatibilityError(RubrixClientError):
+    def __init__(self, min_version: str):
+        self.min_version = min_version
+
+    def __str__(self):
+        return (
+            "\nThe rubrix server does not support this functionality."
+            f"\nPlease, use the client with a {self.min_version} version server instance."
+        )
+
+
 class RubrixApiResponseError(RubrixClientError):
 
     HTTP_STATUS: int

--- a/src/rubrix/client/sdk/commons/errors_handler.py
+++ b/src/rubrix/client/sdk/commons/errors_handler.py
@@ -7,6 +7,7 @@ from rubrix.client.sdk.commons.errors import (
     BadRequestApiError,
     ForbiddenApiError,
     GenericApiError,
+    MethodNotAllowedApiError,
     NotFoundApiError,
     UnauthorizedApiError,
     ValidationApiError,
@@ -29,18 +30,18 @@ def handle_response_error(
 
     if response.status_code == BadRequestApiError.HTTP_STATUS:
         error_type = BadRequestApiError
-    if response.status_code == UnauthorizedApiError.HTTP_STATUS:
+    elif response.status_code == UnauthorizedApiError.HTTP_STATUS:
         error_type = UnauthorizedApiError
-    if response.status_code == AlreadyExistsApiError.HTTP_STATUS:
+    elif response.status_code == AlreadyExistsApiError.HTTP_STATUS:
         error_type = AlreadyExistsApiError
-    if response.status_code == ForbiddenApiError.HTTP_STATUS:
+    elif response.status_code == ForbiddenApiError.HTTP_STATUS:
         error_type = ForbiddenApiError
-    if response.status_code == NotFoundApiError.HTTP_STATUS:
+    elif response.status_code == NotFoundApiError.HTTP_STATUS:
         error_type = NotFoundApiError
-    if response.status_code == ValidationApiError.HTTP_STATUS:
+    elif response.status_code == ValidationApiError.HTTP_STATUS:
         error_type = ValidationApiError
-
-    if error_type == ValidationApiError:
         error_args["client_ctx"] = client_ctx
+    elif response.status_code == MethodNotAllowedApiError.HTTP_STATUS:
+        error_type = MethodNotAllowedApiError
 
     raise error_type(**error_args)

--- a/src/rubrix/client/sdk/metrics/api.py
+++ b/src/rubrix/client/sdk/metrics/api.py
@@ -3,8 +3,9 @@ from typing import Any, Dict, List, Optional, Union
 
 import httpx
 
+from rubrix.client.sdk._helpers import build_raw_response
 from rubrix.client.sdk.client import AuthenticatedClient
-from rubrix.client.sdk.commons.api import build_list_response, build_raw_response
+from rubrix.client.sdk.commons.api import build_list_response
 from rubrix.client.sdk.commons.models import ErrorMessage, HTTPValidationError, Response
 from rubrix.client.sdk.metrics.models import MetricInfo
 

--- a/src/rubrix/client/sdk/text_classification/api.py
+++ b/src/rubrix/client/sdk/text_classification/api.py
@@ -16,12 +16,9 @@ from typing import List, Optional, Union
 
 import httpx
 
+from rubrix.client.sdk._helpers import build_typed_response
 from rubrix.client.sdk.client import AuthenticatedClient
-from rubrix.client.sdk.commons.api import (
-    build_data_response,
-    build_list_response,
-    build_typed_response,
-)
+from rubrix.client.sdk.commons.api import build_data_response, build_list_response
 from rubrix.client.sdk.commons.models import ErrorMessage, HTTPValidationError, Response
 from rubrix.client.sdk.text_classification.models import (
     LabelingRule,

--- a/src/rubrix/datasets/__init__.py
+++ b/src/rubrix/datasets/__init__.py
@@ -8,9 +8,12 @@ from rubrix.client.apis.datasets import (
 __all__ = [TextClassificationSettings, TokenClassificationSettings, Settings]
 
 
-def create_dataset(name: str, settings: Settings) -> None:
+def configure_dataset(name: str, settings: Settings) -> None:
     """
-    Creates a new with a set of configured labels
+    Configures a dataset with a set of configured labels. If dataset does not
+    exist yet, an empty dataset will be created.
+
+    A subset of settings can be provided.
 
     Args:
         name: The dataset name
@@ -18,4 +21,4 @@ def create_dataset(name: str, settings: Settings) -> None:
     """
     active_api = api.active_api()
     datasets = active_api.datasets
-    datasets.create(name, settings=settings)
+    datasets.configure(name, settings=settings)

--- a/src/rubrix/datasets/__init__.py
+++ b/src/rubrix/datasets/__init__.py
@@ -1,0 +1,21 @@
+from rubrix.client import api
+from rubrix.client.apis.datasets import (
+    Settings,
+    TextClassificationSettings,
+    TokenClassificationSettings,
+)
+
+__all__ = [TextClassificationSettings, TokenClassificationSettings, Settings]
+
+
+def create_dataset(name: str, settings: Settings) -> None:
+    """
+    Creates a new with a set of configured labels
+
+    Args:
+        name: The dataset name
+        settings: The dataset settings
+    """
+    active_api = api.active_api()
+    datasets = active_api.datasets
+    datasets.create(name, settings=settings)

--- a/src/rubrix/server/apis/v0/handlers/datasets.py
+++ b/src/rubrix/server/apis/v0/handlers/datasets.py
@@ -67,7 +67,7 @@ def list_datasets(
 
 
 @router.post(
-    "/",
+    "",
     response_model=Dataset,
     response_model_exclude_none=True,
     operation_id="create_dataset",

--- a/src/rubrix/server/apis/v0/models/dataset_settings.py
+++ b/src/rubrix/server/apis/v0/models/dataset_settings.py
@@ -29,7 +29,7 @@ class LabelsSchema(BaseModel):
 
 
 class WithLabelsSchemaSettings(AbstractDatasetSettings):
-    labels_schema: Optional[LabelsSchema] = Field(
+    label_schema: Optional[LabelsSchema] = Field(
         None, description="The dataset labels schema"
     )
 

--- a/src/rubrix/server/apis/v0/validators/text_classification.py
+++ b/src/rubrix/server/apis/v0/validators/text_classification.py
@@ -44,7 +44,7 @@ class DatasetValidator:
     async def validate_dataset_settings(
         self, user: User, dataset: Dataset, settings: TextClassificationSettings
     ):
-        if settings and settings.labels_schema:
+        if settings and settings.label_schema:
             results = self.__metrics__.summarize_metric(
                 dataset=dataset,
                 metric=DatasetLabels(),
@@ -53,11 +53,11 @@ class DatasetValidator:
             )
             if results:
                 labels = results.get("labels", [])
-                labels_schema = set(
-                    [label.name for label in settings.labels_schema.labels]
+                label_schema = set(
+                    [label.name for label in settings.label_schema.labels]
                 )
                 for label in labels:
-                    if label not in labels_schema:
+                    if label not in label_schema:
                         raise BadRequestError(
                             f"The label {label} was found in the dataset but not in provided labels schema. "
                             "\nPlease, provide a valid labels schema according to stored records in the dataset"
@@ -73,19 +73,19 @@ class DatasetValidator:
             settings: TextClassificationSettings = await self.__datasets__.get_settings(
                 user=user, dataset=dataset, class_type=__svc_settings_class__
             )
-            if settings and settings.labels_schema:
-                labels_schema = set(
-                    [label.name for label in settings.labels_schema.labels]
+            if settings and settings.label_schema:
+                label_schema = set(
+                    [label.name for label in settings.label_schema.labels]
                 )
                 for r in records:
                     if r.prediction:
                         self.__check_label_classes__(
-                            labels_schema,
+                            label_schema,
                             [label.class_label for label in r.prediction.labels],
                         )
                     if r.annotation:
                         self.__check_label_classes__(
-                            labels_schema,
+                            label_schema,
                             [label.class_label for label in r.annotation.labels],
                         )
         except EntityNotFoundError:
@@ -93,11 +93,11 @@ class DatasetValidator:
 
     @staticmethod
     def __check_label_classes__(
-        labels_schema: Set[str],
+        label_schema: Set[str],
         labels: List[str],
     ):
         for label in labels:
-            if label not in labels_schema:
+            if label not in label_schema:
                 raise BadRequestError(
                     detail=f"Provided records contain the {label} label,"
                     " that is not included in the labels schema."

--- a/src/rubrix/server/apis/v0/validators/token_classification.py
+++ b/src/rubrix/server/apis/v0/validators/token_classification.py
@@ -44,7 +44,7 @@ class DatasetValidator:
     async def validate_dataset_settings(
         self, user: User, dataset: Dataset, settings: TokenClassificationSettings
     ):
-        if settings and settings.labels_schema:
+        if settings and settings.label_schema:
             results = self.__metrics__.summarize_metric(
                 dataset=dataset,
                 metric=DatasetLabels(),
@@ -53,11 +53,11 @@ class DatasetValidator:
             )
             if results:
                 labels = results.get("labels", [])
-                labels_schema = set(
-                    [label.name for label in settings.labels_schema.labels]
+                label_schema = set(
+                    [label.name for label in settings.label_schema.labels]
                 )
                 for label in labels:
-                    if label not in labels_schema:
+                    if label not in label_schema:
                         raise BadRequestError(
                             f"The label {label} was found in the dataset but not in provided labels schema. "
                             "\nPlease, provide a valid labels schema according to stored records in the dataset"
@@ -75,27 +75,27 @@ class DatasetValidator:
                     user=user, dataset=dataset, class_type=__svc_settings_class__
                 )
             )
-            if settings and settings.labels_schema:
-                labels_schema = set(
-                    [label.name for label in settings.labels_schema.labels]
+            if settings and settings.label_schema:
+                label_schema = set(
+                    [label.name for label in settings.label_schema.labels]
                 )
 
                 for r in records:
                     if r.prediction:
-                        self.__check_label_entities__(labels_schema, r.prediction)
+                        self.__check_label_entities__(label_schema, r.prediction)
                     if r.annotation:
-                        self.__check_label_entities__(labels_schema, r.annotation)
+                        self.__check_label_entities__(label_schema, r.annotation)
         except EntityNotFoundError:
             pass
 
     @staticmethod
     def __check_label_entities__(
-        labels_schema: Set[str], annotation: TokenClassificationAnnotation
+        label_schema: Set[str], annotation: TokenClassificationAnnotation
     ):
         if not annotation:
             return
         for entity in annotation.entities:
-            if entity.label not in labels_schema:
+            if entity.label not in label_schema:
                 raise BadRequestError(
                     detail=f"Provided records contain the {entity.label} label,"
                     " that is not included in the labels schema."

--- a/tests/client/apis/test_base.py
+++ b/tests/client/apis/test_base.py
@@ -1,16 +1,14 @@
 import pytest
 
-from rubrix.client.apis import api_compatibility
+from rubrix.client import api
+from rubrix.client.apis import AbstractApi, api_compatibility
 from rubrix.client.sdk._helpers import handle_response_error
 from rubrix.client.sdk.commons.errors import ApiCompatibilityError
 
 
-@pytest.mark.parametrize(
-    "wrong_endpoint",
-    ["/api/blabla", "/oco", "/api/datasets/", "/api/datasets/bolos/neu"],
-)
-def test_api_compatibility(mocked_client, wrong_endpoint):
-
+def test_api_compatibility(mocked_client):
+    client = api.active_api().client
+    dummy_api = AbstractApi(client)
     with pytest.raises(ApiCompatibilityError):
-        with api_compatibility(min_version=(0, 15, 0)):
-            handle_response_error(mocked_client.post(wrong_endpoint))
+        with api_compatibility(api=dummy_api, min_version="1.0"):
+            handle_response_error(mocked_client.post("/api/datasets"))

--- a/tests/client/apis/test_base.py
+++ b/tests/client/apis/test_base.py
@@ -1,0 +1,16 @@
+import pytest
+
+from rubrix.client.apis import api_compatibility
+from rubrix.client.sdk._helpers import handle_response_error
+from rubrix.client.sdk.commons.errors import ApiCompatibilityError
+
+
+@pytest.mark.parametrize(
+    "wrong_endpoint",
+    ["/api/blabla", "/oco", "/api/datasets/", "/api/datasets/bolos/neu"],
+)
+def test_api_compatibility(mocked_client, wrong_endpoint):
+
+    with pytest.raises(ApiCompatibilityError):
+        with api_compatibility(min_version=(0, 15, 0)):
+            handle_response_error(mocked_client.post(wrong_endpoint))

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -10,12 +10,12 @@ from rubrix.client.sdk.commons.errors import AlreadyExistsApiError
     ("settings_", "wrong_settings"),
     [
         (
-            TextClassificationSettings(labels_schema={"A", "B"}),
-            TokenClassificationSettings(labels_schema={"PER", "ORG"}),
+            TextClassificationSettings(label_schema={"A", "B"}),
+            TokenClassificationSettings(label_schema={"PER", "ORG"}),
         ),
         (
-            TokenClassificationSettings(labels_schema={"PER", "ORG"}),
-            TextClassificationSettings(labels_schema={"A", "B"}),
+            TokenClassificationSettings(label_schema={"PER", "ORG"}),
+            TextClassificationSettings(label_schema={"A", "B"}),
         ),
     ],
 )
@@ -30,7 +30,7 @@ def test_settings_workflow(mocked_client, settings_, wrong_settings):
     found_settings = datasets_api.load_settings(dataset)
     assert found_settings == settings_
 
-    settings_.labels_schema = {"LALALA"}
+    settings_.label_schema = {"LALALA"}
     rb.configure_dataset(dataset, settings_)
 
     found_settings = datasets_api.load_settings(dataset)

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1,0 +1,37 @@
+import pytest
+
+import rubrix as rb
+from rubrix import TextClassificationSettings, TokenClassificationSettings
+from rubrix.client import api
+from rubrix.client.sdk.commons.errors import AlreadyExistsApiError
+
+
+@pytest.mark.parametrize(
+    ("settings_", "wrong_settings"),
+    [
+        (
+            TextClassificationSettings(labels_schema={"A", "B"}),
+            TokenClassificationSettings(labels_schema={"PER", "ORG"}),
+        ),
+        (
+            TokenClassificationSettings(labels_schema={"PER", "ORG"}),
+            TextClassificationSettings(labels_schema={"A", "B"}),
+        ),
+    ],
+)
+def test_settings_workflow(mocked_client, settings_, wrong_settings):
+    dataset = "test-dataset"
+    rb.delete(dataset)
+    rb.create_dataset(dataset, settings=settings_)
+
+    current_api = api.active_api()
+    datasets_api = current_api.datasets
+
+    found_settings = datasets_api.load_settings(dataset)
+    assert found_settings == settings_
+
+    with pytest.raises(AlreadyExistsApiError):
+        rb.create_dataset(dataset, settings_)
+
+    with pytest.raises(AlreadyExistsApiError):
+        rb.create_dataset(dataset, wrong_settings)

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -22,7 +22,7 @@ from rubrix.client.sdk.commons.errors import AlreadyExistsApiError
 def test_settings_workflow(mocked_client, settings_, wrong_settings):
     dataset = "test-dataset"
     rb.delete(dataset)
-    rb.create_dataset(dataset, settings=settings_)
+    rb.configure_dataset(dataset, settings=settings_)
 
     current_api = api.active_api()
     datasets_api = current_api.datasets
@@ -30,8 +30,11 @@ def test_settings_workflow(mocked_client, settings_, wrong_settings):
     found_settings = datasets_api.load_settings(dataset)
     assert found_settings == settings_
 
-    with pytest.raises(AlreadyExistsApiError):
-        rb.create_dataset(dataset, settings_)
+    settings_.labels_schema = {"LALALA"}
+    rb.configure_dataset(dataset, settings_)
 
-    with pytest.raises(AlreadyExistsApiError):
-        rb.create_dataset(dataset, wrong_settings)
+    found_settings = datasets_api.load_settings(dataset)
+    assert found_settings == settings_
+
+    with pytest.raises(ValueError, match="Task type mismatch"):
+        rb.configure_dataset(dataset, wrong_settings)

--- a/tests/server/datasets/test_api.py
+++ b/tests/server/datasets/test_api.py
@@ -43,7 +43,7 @@ def test_create_dataset(mocked_client):
         metadata={"config": {"the": "config"}},
     )
     response = mocked_client.post(
-        "/api/datasets/",
+        "/api/datasets",
         json=request,
     )
     assert response.status_code == 200
@@ -56,7 +56,7 @@ def test_create_dataset(mocked_client):
     assert dataset.task == TaskType.text_classification
 
     response = mocked_client.post(
-        "/api/datasets/",
+        "/api/datasets",
         json=request,
     )
     assert response.status_code == 409

--- a/tests/server/text_classification/test_api_settings.py
+++ b/tests/server/text_classification/test_api_settings.py
@@ -25,7 +25,7 @@ def test_create_dataset_settings(mocked_client):
 def create_settings(mocked_client, name):
     response = mocked_client.put(
         f"/api/datasets/{TaskType.text_classification}/{name}/settings",
-        json={"labels_schema": {"labels": ["Label1", "Label2"]}},
+        json={"label_schema": {"labels": ["Label1", "Label2"]}},
     )
     return response
 

--- a/tests/server/text_classification/test_api_settings.py
+++ b/tests/server/text_classification/test_api_settings.py
@@ -4,7 +4,7 @@ from rubrix.server.apis.v0.models.commons.model import TaskType
 
 def create_dataset(client, name: str):
     response = client.post(
-        "/api/datasets/", json={"name": name, "task": TaskType.text_classification}
+        "/api/datasets", json={"name": name, "task": TaskType.text_classification}
     )
     assert response.status_code == 200
 

--- a/tests/server/token_classification/test_api_settings.py
+++ b/tests/server/token_classification/test_api_settings.py
@@ -25,7 +25,7 @@ def test_create_dataset_settings(mocked_client):
 def create_settings(mocked_client, name):
     response = mocked_client.put(
         f"/api/datasets/{TaskType.token_classification}/{name}/settings",
-        json={"labels_schema": {"labels": ["Label1", "Label2"]}},
+        json={"label_schema": {"labels": ["Label1", "Label2"]}},
     )
     return response
 

--- a/tests/server/token_classification/test_api_settings.py
+++ b/tests/server/token_classification/test_api_settings.py
@@ -4,7 +4,7 @@ from rubrix.server.apis.v0.models.commons.model import TaskType
 
 def create_dataset(client, name: str):
     response = client.post(
-        "/api/datasets/", json={"name": name, "task": TaskType.token_classification}
+        "/api/datasets", json={"name": name, "task": TaskType.token_classification}
     )
     assert response.status_code == 200
 


### PR DESCRIPTION
Following the work to resolve issue #1432, this PR includes client functions to configure dataset settings passing the labels schema.

```python
import rubrix as rb

rb.configure_dataset(name="my-ds", settings=rb.TextClassificationSettings(labels_schema=["A", "B","C"]))
```

This PR must be merged after #1471 