### PR TITLE
fix(#1483): close global actions "Annotate as" selector after deselect records checkbox

### DIFF
--- a/frontend/components/core/ReCheckbox.vue
+++ b/frontend/components/core/ReCheckbox.vue
@@ -25,7 +25,7 @@
     >
       <slot />
     </label>
-    <div class="checkbox-container" tabindex="0" @click.stop="toggleCheck">
+    <div class="checkbox-container" tabindex="0" @click="toggleCheck">
       <input
         :id="id"
         type="checkbox"


### PR DESCRIPTION
fix #1483

This PR removes the stop event modifier from the checkbox allowing to close global actions after deselect checkbox