### PR TITLE
fix(#1503): Count filter values when loading a dataset with a route query

### DIFF
--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -108,7 +108,7 @@ async function _loadTaskDataset(dataset) {
   if (total === undefined || aggregations === undefined) {
     const globalResults = await _querySearch({
       dataset: _dataset,
-      query: {},
+      query: _dataset.query,
       size: 0,
     });
 


### PR DESCRIPTION
fix #1503
This PR includes the route query filters for the filter counter calculation