### PR TITLE
feat(client): rubrix listener

### DIFF
--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -44,4 +44,4 @@ dependencies:
       - transformers[torch]~=4.18.0
       - loguru
       # install Rubrix in editable mode
-      - -e .[server]
+      - -e .[server,listeners]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,10 @@ server = [
     "hurry.filesize", # TODO: remove
     "psutil ~= 5.8.0",
 ]
+listeners = [
+    "schedule ~= 1.1.0",
+    "prodict ~= 0.8.0"
+]
 
 [project.urls]
 homepage = "https://www.rubrix.ml"

--- a/src/rubrix/__init__.py
+++ b/src/rubrix/__init__.py
@@ -57,6 +57,7 @@ if _TYPE_CHECKING:
         TokenClassificationSettings,
         configure_dataset,
     )
+    from rubrix.listeners import Metrics, RBListenerContext, Search, listener
     from rubrix.monitoring.model_monitor import monitor
     from rubrix.server.server import app
 
@@ -85,6 +86,7 @@ _import_structure = {
         "read_pandas",
     ],
     "monitoring.model_monitor": ["monitor"],
+    "listeners.listener": ["listener", "RBListenerContext", "Search", "Metrics"],
     "datasets": [
         "configure_dataset",
         "TextClassificationSettings",

--- a/src/rubrix/client/api.py
+++ b/src/rubrix/client/api.py
@@ -30,6 +30,8 @@ from rubrix._constants import (
     RUBRIX_WORKSPACE_HEADER_NAME,
 )
 from rubrix.client.apis.datasets import Datasets
+from rubrix.client.apis.metrics import MetricsAPI
+from rubrix.client.apis.searches import Searches
 from rubrix.client.datasets import (
     Dataset,
     DatasetForText2Text,
@@ -161,6 +163,14 @@ class Api:
     @property
     def datasets(self) -> Datasets:
         return Datasets(client=self._client)
+
+    @property
+    def searches(self):
+        return Searches(client=self._client)
+
+    @property
+    def metrics(self):
+        return MetricsAPI(client=self.client)
 
     def set_workspace(self, workspace: str):
         """Sets the active workspace.

--- a/src/rubrix/client/apis/metrics.py
+++ b/src/rubrix/client/apis/metrics.py
@@ -1,0 +1,26 @@
+from typing import Optional
+
+from rubrix.client.apis import AbstractAPI
+from rubrix.client.sdk.datasets.models import TaskType
+
+
+class MetricsAPI(AbstractAPI):
+
+    _API_URL_PATTERN = "/api/datasets/{task}/{name}/metrics/{metric}:summary"
+
+    def metric_summary(
+        self,
+        name: str,
+        task: TaskType,
+        metric: str,
+        query: Optional[str] = None,
+        **metric_params,
+    ):
+        url = self._API_URL_PATTERN.format(task=task, name=name, metric=metric)
+        metric_params = metric_params or {}
+        query_params = {k: v for k, v in metric_params.items() if v is not None}
+        if query_params:
+            url += "?" + "&".join([f"{k}={v}" for k, v in query_params.items()])
+
+        metric_summary = self.__client__.post(url, json={"query_text": query})
+        return metric_summary

--- a/src/rubrix/client/apis/metrics.py
+++ b/src/rubrix/client/apis/metrics.py
@@ -1,10 +1,10 @@
 from typing import Optional
 
-from rubrix.client.apis import AbstractAPI
+from rubrix.client.apis import AbstractApi
 from rubrix.client.sdk.datasets.models import TaskType
 
 
-class MetricsAPI(AbstractAPI):
+class MetricsAPI(AbstractApi):
 
     _API_URL_PATTERN = "/api/datasets/{task}/{name}/metrics/{metric}:summary"
 

--- a/src/rubrix/client/apis/searches.py
+++ b/src/rubrix/client/apis/searches.py
@@ -1,7 +1,7 @@
 import dataclasses
 from typing import List, Optional
 
-from rubrix.client.apis import AbstractAPI
+from rubrix.client.apis import AbstractApi
 from rubrix.client.models import Record
 from rubrix.client.sdk.datasets.models import TaskType
 from rubrix.client.sdk.text2text.models import Text2TextRecord
@@ -16,7 +16,7 @@ class SearchResults:
     records: List[Record]
 
 
-class Searches(AbstractAPI):
+class Searches(AbstractApi):
 
     _API_URL_PATTERN = "/api/datasets/{name}/{task}:search"
 

--- a/src/rubrix/client/apis/searches.py
+++ b/src/rubrix/client/apis/searches.py
@@ -1,0 +1,70 @@
+import dataclasses
+from typing import List, Optional
+
+from rubrix.client.apis import AbstractAPI
+from rubrix.client.models import Record
+from rubrix.client.sdk.datasets.models import TaskType
+from rubrix.client.sdk.text2text.models import Text2TextRecord
+from rubrix.client.sdk.text_classification.models import TextClassificationRecord
+from rubrix.client.sdk.token_classification.models import TokenClassificationRecord
+
+
+@dataclasses.dataclass
+class SearchResults:
+    total: int
+
+    records: List[Record]
+
+
+class Searches(AbstractAPI):
+
+    _API_URL_PATTERN = "/api/datasets/{name}/{task}:search"
+
+    def search_records(
+        self,
+        name: str,
+        task: TaskType,
+        query: Optional[str],
+        size: Optional[int] = None,
+    ):
+        """
+        Searches records over a dataset
+
+        Args:
+            name: The dataset name
+            task: The dataset task type
+            query: The query string
+            size: If provided, only the provided number of records will be fetched
+
+        Returns:
+            An instance of ``SearchResults`` class containing the search results
+        """
+
+        if task == TaskType.text_classification:
+            record_class = TextClassificationRecord
+        elif task == TaskType.token_classification:
+            record_class = TokenClassificationRecord
+        elif task == TaskType.text2text:
+            record_class = Text2TextRecord
+        else:
+            raise ValueError(f"Task {task} not supported")
+
+        url = self._API_URL_PATTERN.format(name=name, task=task)
+        if size:
+            url += f"{url}?size={size}"
+
+        query_request = {}
+        if query:
+            query_request["query_text"] = query
+
+        response = self.__client__.post(
+            path=url,
+            json={"query": query_request},
+        )
+
+        return SearchResults(
+            total=response["total"],
+            records=[
+                record_class.parse_obj(r).to_client() for r in response["records"]
+            ],
+        )

--- a/src/rubrix/client/sdk/client.py
+++ b/src/rubrix/client/sdk/client.py
@@ -85,7 +85,7 @@ class Client(_ClientCommonDefaults, _Client):
             *args,
             **kwargs,
         )
-        return build_raw_response(response)
+        return build_raw_response(response).parsed
 
     def put(self, path: str, *args, **kwargs):
         path = self._normalize_path(path)
@@ -99,7 +99,7 @@ class Client(_ClientCommonDefaults, _Client):
             *args,
             **kwargs,
         )
-        return build_raw_response(response)
+        return build_raw_response(response).parsed
 
     @staticmethod
     def _normalize_path(path: str) -> str:

--- a/src/rubrix/listeners/__init__.py
+++ b/src/rubrix/listeners/__init__.py
@@ -1,0 +1,2 @@
+from .listener import RBListenerContext, listener
+from .models import Metrics, RBListenerContext, Search

--- a/src/rubrix/listeners/listener.py
+++ b/src/rubrix/listeners/listener.py
@@ -1,0 +1,191 @@
+import dataclasses
+import logging
+import threading
+import time
+from typing import Callable, List, Optional, Union
+
+import schedule
+
+import rubrix
+from rubrix.client import api
+from rubrix.client.sdk.commons.errors import NotFoundApiError
+from rubrix.listeners.models import (
+    ListenerAction,
+    ListenerCondition,
+    Metrics,
+    RBListenerContext,
+    Search,
+)
+from rubrix.metrics.models import MetricSummary
+
+
+@dataclasses.dataclass
+class RBDatasetListener:
+    """
+    The Rubrix dataset listener class
+
+    Args:
+        dataset: The dataset over which listener is created
+        action: The action to execute when condition is satisfied
+        metrics: A list of metrics ids that will be required in condition
+        query: The query string to apply
+        condition: The condition to satisfy to execute the action
+        query_records: If ``False``, the records won't be passed as argument to the action.
+            Default: ``True``
+        interval_in_seconds: How often the listener is executed. Default to 30 seconds
+    """
+
+    _LOGGER = logging.getLogger(__name__)
+
+    dataset: str
+    action: ListenerAction
+    metrics: Optional[List[str]] = None
+    query: Optional[str] = None
+    condition: Optional[ListenerCondition] = None
+    query_records: bool = True
+    interval_in_seconds: int = 30
+
+    __listener_job__: Optional[schedule.Job] = dataclasses.field(
+        init=False, default=None
+    )
+    __stop_schedule_event__ = None
+    __current_thread__ = None
+    __scheduler__ = schedule.Scheduler()
+
+    def __post_init__(self):
+        self.metrics = self.metrics or []
+
+    def start(self):
+        """
+        Start listen to changes in the dataset
+
+
+        If the listener is already started, a ``ValueError`` will be raised
+
+        """
+        if self.__listener_job__:
+            raise ValueError("Listener is already running")
+
+        self.__listener_job__ = self.__scheduler__.every(
+            self.interval_in_seconds
+        ).seconds.do(self.__listener_iteration_job__)
+
+        class _ScheduleThread(threading.Thread):
+            _WAIT_EVENT = threading.Event()
+
+            @classmethod
+            def run(cls):
+                while not cls._WAIT_EVENT.is_set():
+                    self.__scheduler__.run_pending()
+                    time.sleep(self.interval_in_seconds - 1)
+
+            @classmethod
+            def stop(cls):
+                cls._WAIT_EVENT.set()
+
+        self.__current_thread__ = _ScheduleThread()
+        self.__current_thread__.start()
+
+    def stop(self):
+        """
+        Stops listener if it's still running.
+
+        If listener is already stopped, a ``ValueError`` will be raised
+
+        """
+        if not self.__listener_job__:
+            raise ValueError("Listener is not running")
+
+        if self.__listener_job__:
+            self.__scheduler__.cancel_job(self.__listener_job__)
+            self.__listener_job__ = None
+            self.__current_thread__.stop()
+            self.__current_thread__.join()  # TODO: improve it!
+
+    def __listener_iteration_job__(self):
+        """
+        Execute a complete listener iteration. The iteration consists on:
+
+        1. Query data and fetch configured metrics
+        2. Check search results and metrics with provided condition
+        3. Execute the action if condition is satisfied
+
+        """
+        current_api = api.active_api()
+        try:
+            dataset = current_api.datasets.find_by_name(self.dataset)
+        except NotFoundApiError:
+            self._LOGGER.warning(f"Not found dataset <{self.dataset}>")
+            return
+
+        if self.condition is None:
+            return self.__run_action__()
+
+        metrics = Metrics()
+        for metric in self.metrics:
+            metrics.update(
+                {
+                    metric: current_api.metrics.metric_summary(
+                        name=self.dataset, task=dataset.task, metric=metric
+                    )
+                }
+            )
+        search_results = current_api.searches.search_records(
+            name=self.dataset, task=dataset.task, query=self.query, size=0
+        )
+
+        ctx = RBListenerContext(
+            listener=self,
+            search=Search(total=search_results.total),
+            metrics=metrics,
+        )
+        condition_args = dict(query=ctx.search)
+        if metrics:
+            condition_args["metrics"] = ctx.metrics
+        if self.condition(**condition_args):
+            return self.__run_action__(ctx)
+
+    def __run_action__(self, ctx: Optional[RBListenerContext] = None):
+        args = [ctx] if ctx else []
+        if self.query_records:
+            args.insert(
+                0, rubrix.load(name=self.dataset, query=self.query, as_pandas=False)
+            )
+        return self.action(*args)
+
+
+def listener(
+    dataset: str,
+    query: Optional[str] = None,
+    metrics: Optional[List[str]] = None,
+    condition: Optional[Callable[[Union[Search, MetricSummary]], bool]] = None,
+    with_records: bool = True,
+    execution_interval_in_seconds: int = 30,
+):
+    """
+    Configures the decorated function as a Rubrix listener.
+
+    Args:
+        dataset: The dataset name
+        query: The query string
+        metrics: Required metrics for listener condition
+        condition: Defines condition over search and metrics that launch action when is satisfied
+        with_records: Include records as part or action arguments. If ``False``,
+            only the listener context ``RBListenerContext`` will be passed. Default: ``True``
+        execution_interval_in_seconds: Define the execution interval in seconds when listener
+            iteration will be executed.
+
+    """
+
+    def inner_decorator(func):
+        return RBDatasetListener(
+            dataset=dataset,
+            action=func,
+            condition=condition,
+            query=query,
+            metrics=metrics,
+            query_records=with_records,
+            interval_in_seconds=execution_interval_in_seconds,
+        )
+
+    return inner_decorator

--- a/src/rubrix/listeners/models.py
+++ b/src/rubrix/listeners/models.py
@@ -1,0 +1,64 @@
+import dataclasses
+from typing import Callable, List, Optional, Union
+
+from prodict import Prodict
+
+from rubrix.client.models import Record
+
+
+@dataclasses.dataclass
+class Search:
+    """
+    Search results for a single listener execution
+
+    Args:
+        total: The total number of records affected by the listener query
+    """
+
+    total: int
+
+
+class Metrics(Prodict):
+    """
+    Metrics results for a single listener execution. The metric
+    """
+
+    pass
+
+
+@dataclasses.dataclass
+class RBListenerContext:
+    """
+    The Rubrix listener execution context. This class keeps the context components related to a listener
+
+    Args:
+
+        listener: The rubrix listener instance
+        search: Search results for current execution
+        metrics: Metrics results for current execution
+    """
+
+    listener: "RBDatasetListener" = dataclasses.field(repr=False, hash=False)
+    search: Optional[Search] = None
+    metrics: Optional[Metrics] = None
+
+    def __post_init__(self):
+        self.__listener__ = self.listener
+        del self.listener
+
+    @property
+    def dataset(self) -> str:
+        """Computed property that returns the configured listener dataset name"""
+        return self.__listener__.dataset
+
+    @property
+    def query(self) -> Optional[str]:
+        """Computed property that returns the configured listener query string"""
+        return self.__listener__.query
+
+
+ListenerCondition = Callable[[Search, Metrics], bool]
+ListenerAction = Union[
+    Callable[[List[Record], RBListenerContext], bool],
+    Callable[[RBListenerContext], bool],
+]

--- a/tests/listeners/test_listener.py
+++ b/tests/listeners/test_listener.py
@@ -1,0 +1,71 @@
+import time
+from typing import List
+
+import pytest
+
+import rubrix as rb
+from rubrix import RBListenerContext, listener
+from rubrix.client.models import Record
+
+
+@pytest.mark.parametrize(
+    argnames=["dataset", "query", "metrics", "condition"],
+    argvalues=[
+        ("dataset", None, ["F1"], None),
+        ("dataset", "val", None, lambda s: True),
+        ("dataset", None, ["F1"], lambda s, m: True),
+        ("dataset", "val", None, None),
+        ("dataset", None, ["F1"], lambda search, metrics: False),
+        ("dataset", "val", None, lambda q: False),
+    ],
+)
+def test_listener_with_parameters(mocked_client, dataset, query, metrics, condition):
+    rb.delete(dataset)
+
+    class TestListener:
+        executed = False
+        error = None
+
+        @listener(
+            dataset=dataset,
+            query=query,
+            metrics=metrics,
+            condition=condition,
+            execution_interval_in_seconds=1,
+        )
+        def action(self, records: List[Record], ctx: RBListenerContext):
+            try:
+                self.executed = True
+
+                assert ctx.dataset == dataset
+                assert ctx.query == query
+                if metrics:
+                    for metric in metrics:
+                        assert metric in ctx.metrics
+            except Exception as error:
+                self.error = error
+
+    test = TestListener()
+    test.action.start(test)
+
+    time.sleep(1.5)
+    rb.log(rb.TextClassificationRecord(text="This is a text"), name=dataset)
+
+    with pytest.raises(ValueError):
+        test.action.start()
+
+    time.sleep(1.5)
+    test.action.stop()
+
+    with pytest.raises(ValueError):
+        test.action.stop()
+
+    if condition:
+        res = condition(None, None) if metrics else condition(None)
+        if not res:
+            assert not test.executed, "Condition is False but action was executed"
+
+    else:
+        assert test.executed
+        if test.error:
+            raise test.error


### PR DESCRIPTION
The missing component for MLOPs:

Some examples of use:

```python
import time
from typing import List

import rubrix as rb

from rubrix import listener, RBListenerContext


@listener(
    dataset="other-dataset",
    query="status:Validated AND last_updated: [now-5m TO *]",  # we set a time-windows of 5 minutes
    condition=lambda query: 80 <= query.total <= 100,
)
def next_batch_iteration(records: List[rb.TokenClassificationRecord]):
    # Do something with the records
    pass


@listener(
    dataset="sst2_listener",
    query="status:Validated AND (NOT _exists_:metadata.pending_update)",
    condition=lambda query: query.total > 0,
)
def update_external_db(
    records: List[rb.TextClassificationRecord], ctx: RBListenerContext
):
    for record in records:
        # update a mongo db or something else
        record.metadata["pending_update"] = False
    rb.log(records, name=ctx.dataset)  # update received records


@listener(
    dataset="sst2_listener",
    metrics=["F1"],
    condition=lambda query, metrics: metrics.F1.f1_macro < 0.95,
    with_records=False,
    execution_interval_in_seconds=15,
)
def some_dataset_listener(
    ctx: RBListenerContext,
):  # include a cxt: RubrixListenerContext as param instead of name, query,...args
    print(f"The model is degrading the performance: {ctx.metrics.F1}")
    # send an alert
    # or launch a model re-training
    # or buy something in amazon

some_dataset_listener.start()
update_external_db.start()

try:
    while True:
        time.sleep(1)
except KeyboardInterrupt:
    some_dataset_listener.stop()
    update_external_db.stop()
```

Waiting for your API use feedback before implementing the tests @dvsrepo @dcfidalgo 