### PR TITLE
fix(#1516): restore read_only to copied dataset

### DIFF
--- a/src/rubrix/server/elasticseach/client_wrapper.py
+++ b/src/rubrix/server/elasticseach/client_wrapper.py
@@ -503,6 +503,7 @@ class ElasticsearchWrapper(LoggingMixin):
             )
         finally:
             self.index_read_only(index, read_only=index_read_only)
+            self.index_read_only(clone_to, read_only=index_read_only)
 
     def is_index_read_only(self, index: str) -> bool:
         """
@@ -544,7 +545,9 @@ class ElasticsearchWrapper(LoggingMixin):
 
         """
         self.__client__.indices.put_settings(
-            index=index, body={"settings": {"index.blocks.write": read_only}}
+            index=index,
+            body={"settings": {"index.blocks.write": read_only}},
+            ignore=404,
         )
 
     def create_field_mapping(

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -373,20 +373,20 @@ def test_dataset_copy(mocked_client):
     mocked_client.delete(f"/api/datasets/{dataset_copy}")
     mocked_client.delete(f"/api/datasets/{dataset_copy}?workspace={other_workspace}")
 
-    api.log(
-        rb.TextClassificationRecord(
-            id=0,
-            inputs="This is the record input",
-            annotation_agent="test",
-            annotation=["T"],
-        ),
-        name=dataset,
+    record = rb.TextClassificationRecord(
+        id=0,
+        inputs="This is the record input",
+        annotation_agent="test",
+        annotation=["T"],
     )
+    api.log(record, name=dataset)
     api.copy(dataset, name_of_copy=dataset_copy)
     df = api.load(name=dataset)
     df_copy = api.load(name=dataset_copy)
 
     assert df.equals(df_copy)
+
+    api.log(record, name=dataset_copy)
 
     with pytest.raises(AlreadyExistsApiError):
         api.copy(dataset, name_of_copy=dataset_copy)


### PR DESCRIPTION
Closes #1516 