### PR TITLE
feat(#1514): allow ent score None and change default value to 0.0

### DIFF
--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -849,7 +849,7 @@ class DatasetForTokenClassification(DatasetBase):
         return [
             (ent["label"], ent["start"], ent["end"])
             if len(ent) == 3
-            else (ent["label"], ent["start"], ent["end"], ent["score"] or 1.0)
+            else (ent["label"], ent["start"], ent["end"], ent["score"] or 0.0)
             for ent in entities
         ]
 

--- a/src/rubrix/client/models.py
+++ b/src/rubrix/client/models.py
@@ -281,7 +281,7 @@ class TokenClassificationRecord(_Validators):
     tokens: Optional[Union[List[str], Tuple[str, ...]]] = None
 
     prediction: Optional[
-        List[Union[Tuple[str, int, int], Tuple[str, int, int, float]]]
+        List[Union[Tuple[str, int, int], Tuple[str, int, int, Optional[float]]]]
     ] = None
     prediction_agent: Optional[str] = None
     annotation: Optional[List[Tuple[str, int, int]]] = None
@@ -378,14 +378,16 @@ class TokenClassificationRecord(_Validators):
     def add_default_score(
         cls,
         prediction: Optional[
-            List[Union[Tuple[str, int, int], Tuple[str, int, int, float]]]
+            List[Union[Tuple[str, int, int], Tuple[str, int, int, Optional[float]]]]
         ],
     ):
         """Adds the default score to the predictions if it is missing"""
         if prediction is None:
             return prediction
         return [
-            (pred[0], pred[1], pred[2], 1.0) if len(pred) == 3 else pred
+            (pred[0], pred[1], pred[2], 0.0)
+            if len(pred) == 3
+            else (pred[0], pred[1], pred[2], pred[3] or 0.0)
             for pred in prediction
         ]
 

--- a/tests/client/sdk/token_classification/test_models.py
+++ b/tests/client/sdk/token_classification/test_models.py
@@ -55,7 +55,12 @@ def test_query_schema(helpers):
 
 
 @pytest.mark.parametrize(
-    "prediction,expected", [([("label", 0, 4)], 1.0), ([("label", 0, 4, 0.5)], 0.5)]
+    "prediction,expected",
+    [
+        ([("label", 0, 4)], 0.0),
+        ([("label", 0, 4, None)], 0.0),
+        ([("label", 0, 4, 0.5)], 0.5),
+    ],
 )
 def test_from_client_prediction(prediction, expected):
     record = TokenClassificationRecord(

--- a/tests/client/test_models.py
+++ b/tests/client/test_models.py
@@ -183,11 +183,12 @@ def test_token_classification_with_mutation():
     "prediction,expected",
     [
         (None, None),
-        ([("mock", 0, 4)], [("mock", 0, 4, 1.0)]),
+        ([("mock", 0, 4)], [("mock", 0, 4, 0.0)]),
         ([("mock", 0, 4, 0.5)], [("mock", 0, 4, 0.5)]),
+        ([("mock", 0, 4, None)], [("mock", 0, 4, 0.0)]),
         (
-            [("mock", 0, 4), ("mock", 0, 4, 0.5)],
-            [("mock", 0, 4, 1.0), ("mock", 0, 4, 0.5)],
+            [("mock", 0, 4), ("mock", 0, 4, None), ("mock", 0, 4, 0.5)],
+            [("mock", 0, 4, 0.0), ("mock", 0, 4, 0.0), ("mock", 0, 4, 0.5)],
         ),
     ],
 )

--- a/tests/functional_tests/test_log_for_token_classification.py
+++ b/tests/functional_tests/test_log_for_token_classification.py
@@ -107,7 +107,7 @@ def test_log_record_that_makes_me_cry(mocked_client):
                     "chars_length": 6,
                     "density": 0.03225806451612903,
                     "label": "ENG",
-                    "score": 1.0,
+                    "score": 0.0,
                     "tokens_length": 1,
                     "value": "access",
                 }


### PR DESCRIPTION
Closes #1514

Changes the default entity score in the predictions to 0.0, and allows `None` values.