### PR TITLE
fix(#1527): check agents instead labels for `predicted` computation

### DIFF
--- a/src/rubrix/server/apis/v0/models/text_classification.py
+++ b/src/rubrix/server/apis/v0/models/text_classification.py
@@ -297,7 +297,7 @@ class CreationTextClassificationRecord(BaseRecord[TextClassificationAnnotation])
 
     @property
     def predicted(self) -> Optional[PredictionStatus]:
-        if self.predicted_as and self.annotated_as:
+        if self.predicted_by and self.predicted_by:
             return (
                 PredictionStatus.OK
                 if set(self.predicted_as) == set(self.annotated_as)

--- a/src/rubrix/server/apis/v0/models/text_classification.py
+++ b/src/rubrix/server/apis/v0/models/text_classification.py
@@ -297,7 +297,7 @@ class CreationTextClassificationRecord(BaseRecord[TextClassificationAnnotation])
 
     @property
     def predicted(self) -> Optional[PredictionStatus]:
-        if self.predicted_by and self.predicted_by:
+        if self.predicted_by and self.annotated_by:
             return (
                 PredictionStatus.OK
                 if set(self.predicted_as) == set(self.annotated_as)

--- a/tests/server/text_classification/test_model.py
+++ b/tests/server/text_classification/test_model.py
@@ -337,3 +337,34 @@ def test_query_with_uncovered_by_rules():
             },
         }
     }
+
+
+def test_empty_labels_for_no_multilabel():
+    with pytest.raises(
+        ValidationError,
+        match="Single label record must include only one annotation label",
+    ):
+        TextClassificationRecord(
+            inputs={"text": "The input text"},
+            annotation=TextClassificationAnnotation(agent="ann.", labels=[]),
+        )
+
+    record = TextClassificationRecord(
+        inputs={"text": "The input text"},
+        prediction=TextClassificationAnnotation(agent="ann.", labels=[]),
+        annotation=TextClassificationAnnotation(
+            agent="ann.", labels=[ClassPrediction(class_label="B")]
+        ),
+    )
+    assert record.predicted == PredictionStatus.KO
+
+
+def test_annotated_without_labels_for_multilabel():
+    record = TextClassificationRecord(
+        inputs={"text": "The input text"},
+        multi_label=True,
+        prediction=TextClassificationAnnotation(agent="pred.", labels=[]),
+        annotation=TextClassificationAnnotation(agent="ann.", labels=[]),
+    )
+
+    assert record.predicted == PredictionStatus.OK

--- a/tests/server/token_classification/test_model.py
+++ b/tests/server/token_classification/test_model.py
@@ -17,6 +17,7 @@ import pytest
 from pydantic import ValidationError
 
 from rubrix._constants import MAX_KEYWORD_LENGTH
+from rubrix.server.apis.v0.models.commons.model import PredictionStatus
 from rubrix.server.apis.v0.models.token_classification import (
     EntitySpan,
     TokenClassificationAnnotation,
@@ -220,3 +221,19 @@ def test_record_scores():
         ),
     )
     assert record.scores == [0.8, 0.1, 0.2]
+
+
+def test_annotated_without_entities():
+    text = "The text that i wrote"
+    record = TokenClassificationRecord(
+        text=text,
+        tokens=text.split(),
+        prediction=TokenClassificationAnnotation(
+            agent="pred.test", entities=[EntitySpan(start=0, end=3, label="DET")]
+        ),
+        annotation=TokenClassificationAnnotation(agent="test", entities=[]),
+    )
+
+    assert record.annotated_by == [record.annotation.agent]
+    assert record.predicted_by == [record.prediction.agent]
+    assert record.predicted == PredictionStatus.KO


### PR DESCRIPTION
Closes #1527 


Review after #1530 