### PR TITLE
fix(#1532): correct domain for filter score histogram

### DIFF
--- a/frontend/components/commons/header/filters/FilterScore.vue
+++ b/frontend/components/commons/header/filters/FilterScore.vue
@@ -135,7 +135,7 @@ export default {
     },
     encoding: {
       x: {
-        scale: { zero: true },
+        scale: { nice: 1 },
         bin: { maxbins: 100, extent: [0.0, 1.0] },
         field: "key",
         type: "quantitative",


### PR DESCRIPTION
This PR forces the histogram to display a correct range and domain from 0 to 1

Closes #1532

