### PR TITLE
fix(#1539): checkbox behavior with value 0

### DIFF
--- a/frontend/components/core/ReCheckbox.vue
+++ b/frontend/components/core/ReCheckbox.vue
@@ -56,8 +56,9 @@ export default {
     classes() {
       return {
         checked: Array.isArray(this.areChecked)
-          ? this.areChecked.includes(this.value) ||
-            _.find(this.areChecked, this.value)
+          ? Array.isArray(this.areChecked)
+            ? this.areChecked.includes(this.value)
+            : _.find(this.areChecked, this.value)
           : this.checked,
         disabled: this.disabled,
       };


### PR DESCRIPTION
fix #1539

This PR prevents that 0 is automatically checked when another option is selected in the filter.