### PR TITLE
fix(#1557): Allow text editing when clicking the "edit" button

### DIFF
--- a/frontend/components/text2text/results/RecordText2Text.vue
+++ b/frontend/components/text2text/results/RecordText2Text.vue
@@ -139,6 +139,7 @@ export default {
     &:hover {
       ::v-deep .button-primary--outline {
         opacity: 1 !important;
+        pointer-events: all;
         transition: opacity 0.5s ease-in-out 0.2s !important;
       }
     }


### PR DESCRIPTION
fix #1557
This PR makes the button be reactive to the pointer event