### PR TITLE
Feat: Improve from datasets

### DIFF
--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -246,7 +246,9 @@ class DatasetBase:
         row: Dict[str, Any], columns: List[str]
     ) -> Dict[str, Any]:
         """Joins columns of a `datasets.Dataset` row into a dict, and deletes the single columns.
-        UPDATES TE ROW!
+
+        Updates the ``row`` dictionary!
+        
 
         Args:
             row: A row of a `datasets.Dataset`

--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -65,8 +65,8 @@ class DatasetBase:
     """
 
     _RECORD_TYPE = None
-    # record arguments that can get multiple input columns from a datasets.Dataset or a pandas.DataFrame
-    _ARGS_WITH_MULTIPLE_INPUT_COLUMNS = ["inputs", "metadata"]
+    # record fields that can hold multiple input columns from a datasets.Dataset or a pandas.DataFrame
+    _RECORD_FIELDS_WITH_MULTIPLE_INPUT_COLUMNS = ["inputs", "metadata"]
 
     @classmethod
     def _record_init_args(cls) -> List[str]:
@@ -159,55 +159,79 @@ class DatasetBase:
         """Imports records from a `datasets.Dataset`.
 
         Columns that are not supported are ignored.
-        THE CONCRETE SIGNATURE AND DOC STRING SHOULD BE IMPLEMENTED BY THE CHILD CLASS.
 
         Args:
             dataset: A datasets Dataset from which to import the records.
-            **kwargs: Mappings from record arguments to column names
 
         Returns:
             The imported records in a Rubrix Dataset.
         """
-        import datasets
-
-        assert not isinstance(dataset, datasets.DatasetDict), (
-            "ERROR: `datasets.DatasetDict` are not supported. "
-            "Please, select the dataset split before"
-        )
-
-        dataset, columns_to_be_joined = cls._prepare_columns(dataset, **kwargs)
-
-        return cls._from_datasets(dataset, columns_to_be_joined)
+        raise NotImplementedError
 
     @classmethod
-    def _prepare_columns(
-        cls, dataset: "datasets.Dataset", **kwargs
+    def _prepare_dataset_and_column_mapping(
+        cls,
+        dataset: "datasets.Dataset",
+        column_mapping: Dict[str, Union[str, List[str]]],
     ) -> Tuple["datasets.Dataset", Dict[str, List[str]]]:
-        """Helper function to rename the columns of Dataset/DataFrame and keep track of the columns that will be joined.
+        """Renames and removes columns, and extracts the mapping of the columns to be joined.
 
-        TODO: from_pandas should also use these shortcuts
         Args:
-            dataset: The dataset
-            **kwargs: Mappings from record arguments to column names
+            dataset: A datasets Dataset from which to import the records.
+            column_mapping: Mappings from record fields to column names.
 
         Returns:
-            The dataset with renamed columns and a dict keeping track of the columns to be joined.
+            The prepared dataset and a mapping for the columns to be joined
         """
-        kwargs = {key: val for key, val in kwargs.items() if val is not None}
+        import datasets
 
-        columns_to_be_joined = {}
-        for arg in cls._ARGS_WITH_MULTIPLE_INPUT_COLUMNS:
-            columns = kwargs.pop(arg, None)
-            if columns is not None:
-                columns_to_be_joined[arg] = (
-                    [columns] if isinstance(columns, str) else columns
-                )
+        if isinstance(dataset, datasets.DatasetDict):
+            raise ValueError(
+                "`datasets.DatasetDict` are not supported. Please, select the dataset split before."
+            )
 
-        dataset = dataset.rename_columns({old: new for new, old in kwargs.items()})
+        # clean column mappings
+        column_mapping = {
+            key: val for key, val in column_mapping.items() if val is not None
+        }
 
+        cols_to_be_renamed, cols_to_be_joined = {}, {}
+        for field, col in column_mapping.items():
+            if field in cls._RECORD_FIELDS_WITH_MULTIPLE_INPUT_COLUMNS:
+                cols_to_be_joined[field] = [col] if isinstance(col, str) else col
+            else:
+                cols_to_be_renamed[col] = field
+
+        dataset = dataset.rename_columns(cols_to_be_renamed)
+
+        dataset = cls._remove_unsupported_columns(
+            dataset,
+            extra_columns=[col for cols in cols_to_be_joined.values() for col in cols],
+        )
+
+        return dataset, cols_to_be_joined
+
+    @classmethod
+    def _remove_unsupported_columns(
+        cls,
+        dataset: "datasets.Dataset",
+        extra_columns: List[str],
+    ) -> "datasets.Dataset":
+        """Helper function to remove unsupported columns from the `datasets.Dataset` following the record type.
+
+        Args:
+            dataset: The dataset.
+            extra_columns: Extra columns to be kept.
+
+        Returns:
+            The dataset with unsupported columns removed.
+        """
         not_supported_columns = [
-            col for col in dataset.column_names if col not in cls._record_init_args()
+            col
+            for col in dataset.column_names
+            if col not in cls._record_init_args() + extra_columns
         ]
+
         if not_supported_columns:
             _LOGGER.warning(
                 f"Following columns are not supported by the {cls._RECORD_TYPE.__name__}"
@@ -215,43 +239,55 @@ class DatasetBase:
             )
             dataset = dataset.remove_columns(not_supported_columns)
 
-        return dataset, columns_to_be_joined
-
-    @classmethod
-    def _prepare_hf_dataset(
-        cls,
-        dataset: "dataset.Dataset",
-        id: Optional[str] = None,
-        text: Optional[str] = None,
-        annotation: Optional[str] = None,
-        metadata: Optional[Union[str, List[str]]] = None,
-    ) -> "dataclasses.Dataset":
-        for field, parser in [
-            (id, cls._parse_id_field),
-            (text, cls._parse_text_field),
-            (metadata, cls._parse_metadata_field),
-            (annotation, cls._parse_annotation_field),
-        ]:
-            if field:
-                dataset = parser(dataset, field)
         return dataset
 
-    @classmethod
-    def _from_datasets(
-        cls, dataset: "datasets.Dataset", columns_to_be_joined: Dict[str, List[str]]
-    ) -> "Dataset":
-        """Helper method to create a Rubrix Dataset from a datasets Dataset.
+    @staticmethod
+    def _join_datasets_columns_and_delete(
+        row: Dict[str, Any], columns: List[str]
+    ) -> Dict[str, Any]:
+        """Joins columns of a `datasets.Dataset` row into a dict, and deletes the single columns.
+        UPDATES TE ROW!
+        """
+        joined_cols = {}
+        for col in columns:
+            joined_cols[col] = row[col]
+            del row[col]
 
-        Must be implemented by the child class.
+        return joined_cols
+
+    @staticmethod
+    def _parse_datasets_column_with_classlabel(
+        column_value: Union[str, List[str], int, List[int]],
+        feature: Optional[Any],
+    ) -> Optional[Union[str, List[str], int, List[int]]]:
+        """Helper function to parse a datasets.Dataset column with a potential ClassLabel feature.
 
         Args:
-            dataset: A datasets Dataset.
-            columns_to_be_joined: A dict that indicates for which record argument we need to join columns.
+            column_value: The value from the datasets Dataset column.
+            feature: The feature of the annotation column to optionally convert ints to strs.
 
         Returns:
-            A Rubrix Dataset
+            The input value for the annotation field.
         """
-        raise NotImplementedError
+        import datasets
+
+        # extract ClassLabel feature
+        if isinstance(feature, list):
+            feature = feature[0]
+        if isinstance(feature, datasets.Sequence):
+            feature = feature.feature
+        if not isinstance(feature, datasets.ClassLabel):
+            feature = None
+
+        if feature is None:
+            return column_value
+
+        try:
+            return feature.int2str(column_value)
+        # integers don't have to map to the names ...
+        # it seems that sometimes -1 is used to denote "no label"
+        except ValueError:
+            return None
 
     def to_pandas(self) -> pd.DataFrame:
         """Exports your records to a `pandas.DataFrame`.
@@ -311,39 +347,6 @@ class DatasetBase:
         """
         raise NotImplementedError
 
-    @classmethod
-    def _parse_id_field(
-        cls, dataset: "datasets.Dataset", field: str
-    ) -> "datasets.Dataset":
-        return dataset.rename_column(field, "id")
-
-    @classmethod
-    def _parse_text_field(
-        cls, dataset: "datasets.Dataset", field: str
-    ) -> "datasets.Dataset":
-        return dataset.rename_column(field, "text")
-
-    @classmethod
-    def _parse_metadata_field(
-        cls, dataset: "datasets.Dataset", fields: Union[str, List[str]]
-    ) -> "datasets.Dataset":
-
-        if isinstance(fields, str):
-            fields = [fields]
-
-        def parse_metadata_from_dataset(example):
-            return {"metadata": {k: example[k] for k in fields}}
-
-        return dataset.map(
-            parse_metadata_from_dataset, desc="Parsing metadata"
-        ).remove_columns(fields)
-
-    @classmethod
-    def _parse_annotation_field(
-        cls, dataset: "datasets.Dataset", field: str
-    ) -> "datasets.Dataset":
-        return dataset.rename_column(field, "annotation")
-
 
 def _prepend_docstring(record_type: Type[Record]):
     docstring = f"""This Dataset contains {record_type.__name__} records.
@@ -401,7 +404,6 @@ class DatasetForTextClassification(DatasetBase):
 
     @classmethod
     def from_datasets(
-        # we implement this to have more specific type hints
         cls,
         dataset: "datasets.Dataset",
         text: Optional[str] = None,
@@ -435,37 +437,87 @@ class DatasetForTextClassification(DatasetBase):
             ... })
             >>> DatasetForTextClassification.from_datasets(ds)
         """
-        import datasets
-
-        assert not isinstance(dataset, datasets.DatasetDict), (
-            "ERROR: `datasets.DatasetDict` are not supported. "
-            "Please, select the dataset split before"
-        )
-
-        dataset, columns_to_be_joined = cls._prepare_columns(
+        dataset, cols_to_be_joined = cls._prepare_dataset_and_column_mapping(
             dataset,
-            text=text,
-            inputs=inputs,
-            annotation=annotation,
-            id=id,
-            metadata=metadata,
+            dict(
+                text=text,
+                id=id,
+                inputs=inputs,
+                annotation=annotation,
+                metadata=metadata,
+            ),
         )
 
-        not_supported_columns = [
-            col
-            for col in dataset.column_names
-            if (
-                col not in cls._record_init_args()
-                and col not in [c for cs in columns_to_be_joined.values() for c in cs]
+        records = []
+        for row in dataset:
+            row["inputs"] = cls._parse_inputs_field(
+                row, cols_to_be_joined.get("inputs")
             )
-        ]
-        if not_supported_columns:
-            _LOGGER.warning(
-                f"Following columns are not supported by the {cls._RECORD_TYPE.__name__}"
-                f" model and are ignored: {not_supported_columns}"
-            )
-            dataset = dataset.remove_columns(not_supported_columns)
-        return cls._from_datasets(dataset, columns_to_be_joined)
+
+            if row.get("annotation") is not None:
+                row["annotation"] = cls._parse_datasets_column_with_classlabel(
+                    row["annotation"], dataset.features["annotation"]
+                )
+
+            if row.get("prediction"):
+                row["prediction"] = (
+                    [
+                        (
+                            pred["label"],
+                            pred["score"],
+                        )
+                        for pred in row["prediction"]
+                    ]
+                    if row["prediction"] is not None
+                    else None
+                )
+
+            if row.get("explanation"):
+                row["explanation"] = (
+                    {
+                        key: [
+                            TokenAttributions(**tokattr_kwargs)
+                            for tokattr_kwargs in val
+                        ]
+                        for key, val in row["explanation"].items()
+                    }
+                    if row["explanation"] is not None
+                    else None
+                )
+
+            if cols_to_be_joined.get("metadata"):
+                row["metadata"] = cls._join_datasets_columns_and_delete(
+                    row, cols_to_be_joined["metadata"]
+                )
+
+            records.append(TextClassificationRecord.parse_obj(row))
+
+        return cls(records)
+
+    @classmethod
+    def _parse_inputs_field(
+        cls,
+        row: Dict[str, Any],
+        columns: Optional[List[str]],
+    ) -> Optional[Union[Dict[str, str], str]]:
+        """Helper function to parse the inputs field.
+
+        Args:
+            row: A row of the dataset.Datasets
+            columns: A list of columns to be joined for the inputs field, optional.
+
+        Returns:
+            None, a dictionary or a string as input for the inputs field.
+        """
+        inputs = row.get("inputs")
+
+        if columns is not None:
+            row["inputs"] = cls._join_datasets_columns_and_delete(row, columns)
+
+        if isinstance(inputs, dict):
+            inputs = {key: val for key, val in inputs.items() if val is not None}
+
+        return inputs
 
     @classmethod
     def from_pandas(
@@ -506,139 +558,6 @@ class DatasetForTextClassification(DatasetBase):
                 ds_dict[key] = [getattr(rec, key) for rec in self._records]
 
         return ds_dict
-
-    @classmethod
-    def _from_datasets(
-        cls, dataset: "datasets.Dataset", columns_to_be_joined: Dict[str, List[str]]
-    ) -> "DatasetForTextClassification":
-        records = []
-        for row in dataset:
-
-            row["inputs"] = cls._parse_inputs_field(
-                row, columns_to_be_joined.get("inputs")
-            )
-
-            row["metadata"] = cls._parse_metadata_field(
-                row, columns_to_be_joined.get("metadata")
-            )
-
-            if row.get("annotation") is not None:
-                row["annotation"] = cls._parse_annotation_field(
-                    row["annotation"], dataset.features["annotation"]
-                )
-
-            if row.get("prediction"):
-                row["prediction"] = (
-                    [
-                        (
-                            pred["label"],
-                            pred["score"],
-                        )
-                        for pred in row["prediction"]
-                    ]
-                    if row["prediction"] is not None
-                    else None
-                )
-
-            if row.get("explanation"):
-                row["explanation"] = (
-                    {
-                        key: [
-                            TokenAttributions(**tokattr_kwargs)
-                            for tokattr_kwargs in val
-                        ]
-                        for key, val in row["explanation"].items()
-                    }
-                    if row["explanation"] is not None
-                    else None
-                )
-
-            records.append(TextClassificationRecord.parse_obj(row))
-        return cls(records)
-
-    @staticmethod
-    def _parse_inputs_field(
-        row: Dict[str, Any],
-        columns: Optional[List[str]],
-    ) -> Optional[Union[Dict[str, str], str]]:
-        """Helper function to parse the inputs field.
-
-        Args:
-            row: A row of the dataset.Datasets
-            columns: A list of columns to be joined for the inputs field, optional.
-
-        Returns:
-            None, a dictionary or a string as input for the inputs field.
-        """
-        inputs = row.get("inputs")
-
-        if columns is not None:
-            inputs = {}
-            for col in columns:
-                inputs[col] = row[col]
-                del row[col]
-
-        if isinstance(inputs, dict):
-            inputs = {key: val for key, val in inputs.items() if val is not None}
-
-        return inputs
-
-    @staticmethod
-    def _parse_metadata_field(
-        row: Dict[str, Any], columns: Optional[List[str]]
-    ) -> Optional[Any]:
-        """Helper function to parse the metadata field.
-
-        Args:
-            row: A row of the datasets.Dataset
-            columns: A list of columns to be joined for the metadata field, optional.
-
-        Returns:
-            None or Any as input for the metadata field.
-        """
-        metadata = row.get("metadata")
-
-        if columns is not None:
-            metadata = {}
-            for col in columns:
-                metadata[col] = row[col]
-                del row[col]
-
-        return metadata
-
-    @staticmethod
-    def _parse_annotation_field(
-        annotation: Union[str, List[str], int, List[int]],
-        feature: Optional[Any],
-    ) -> Optional[Union[str, List[str], int, List[int]]]:
-        """Helper function to parse the annotation field.
-
-        Args:
-            annotation: The value from the annotation column.
-            feature: The feature of the annotation column to optionally convert ints to strs.
-
-        Returns:
-            The input value for the annotation field.
-        """
-        import datasets
-
-        # extract ClassLabel feature
-        if isinstance(feature, list):
-            feature = feature[0]
-        if isinstance(feature, datasets.Sequence):
-            feature = feature.feature
-        if not isinstance(feature, datasets.ClassLabel):
-            feature = None
-
-        if feature is None:
-            return annotation
-
-        try:
-            return feature.int2str(annotation)
-        # integers don't have to map to the names ...
-        # it seems that sometimes -1 is used to denote "no label"
-        except ValueError:
-            return None
 
     @classmethod
     def _from_pandas(cls, dataframe: pd.DataFrame) -> "DatasetForTextClassification":
@@ -741,21 +660,22 @@ class DatasetForTokenClassification(DatasetBase):
 
     _RECORD_TYPE = TokenClassificationRecord
 
+    def __init__(self, records: Optional[List[TokenClassificationRecord]] = None):
+        # we implement this to have more specific type hints
+        super().__init__(records=records)
+
     @classmethod
     def _record_init_args(cls) -> List[str]:
         """Adds the `tags` argument to default record init arguments"""
         parent_fields = super(DatasetForTokenClassification, cls)._record_init_args()
         return parent_fields + ["tags"]  # compute annotation from tags
 
-    def __init__(self, records: Optional[List[TokenClassificationRecord]] = None):
-        # we implement this to have more specific type hints
-        super().__init__(records=records)
-
     @classmethod
     def from_datasets(
         cls,
         dataset: "datasets.Dataset",
         text: Optional[str] = None,
+        id: Optional[str] = None,
         tokens: Optional[str] = None,
         tags: Optional[str] = None,
         metadata: Optional[Union[str, List[str]]] = None,
@@ -767,6 +687,7 @@ class DatasetForTokenClassification(DatasetBase):
         Args:
             dataset: A datasets Dataset from which to import the records.
             text: The field name used as record text. Default: `None`
+            id: The field name used as record id. Default: `None`
             tokens: The field name used as record tokens. Default: `None`
             tags: The field name used as record tags. Default: `None`
             metadata: The field name used as record metadata. Default: `None`
@@ -785,10 +706,43 @@ class DatasetForTokenClassification(DatasetBase):
             ... })
             >>> DatasetForTokenClassification.from_datasets(ds)
         """
-        # we implement this to have more specific type hints
-        return super().from_datasets(
-            dataset, text=text, tokens=tokens, tags=tags, metadata=metadata
+        dataset, cols_to_be_joined = cls._prepare_dataset_and_column_mapping(
+            dataset,
+            dict(
+                text=text,
+                tokens=tokens,
+                tags=tags,
+                id=id,
+                metadata=metadata,
+            ),
         )
+
+        records = []
+        for row in dataset:
+            # TODO: fails with a KeyError if no tokens column is present and no mapping is indicated
+            if not row["tokens"]:
+                _LOGGER.warning(f"Ignoring row with no tokens.")
+                continue
+
+            if row.get("tags"):
+                row["tags"] = cls._parse_datasets_column_with_classlabel(
+                    row["tags"], dataset.features["tags"]
+                )
+
+            if row.get("prediction"):
+                row["prediction"] = cls.__entities_to_tuple__(row["prediction"])
+
+            if row.get("annotation"):
+                row["annotation"] = cls.__entities_to_tuple__(row["annotation"])
+
+            if cols_to_be_joined.get("metadata"):
+                row["metadata"] = cls._join_datasets_columns(
+                    row, cols_to_be_joined["metadata"]
+                )
+
+            records.append(TokenClassificationRecord.parse_obj(row))
+
+        return cls(records)
 
     @classmethod
     def from_pandas(
@@ -936,71 +890,6 @@ class DatasetForTokenClassification(DatasetBase):
             else (ent["label"], ent["start"], ent["end"], ent["score"] or 0.0)
             for ent in entities
         ]
-
-    @classmethod
-    def _prepare_hf_dataset(
-        cls,
-        dataset: "dataset.Dataset",
-        tokens: Optional[str] = None,
-        tags: Optional[str] = None,
-        **kwargs,
-    ) -> "dataclasses.Dataset":
-        dataset = super()._prepare_hf_dataset(dataset, **kwargs)
-        if tokens:
-            dataset = cls._parse_tokens_field(dataset, field=tokens)
-        if tags:
-            dataset = cls._parse_tags_field(dataset, field=tags)
-        return dataset
-
-    @classmethod
-    def _from_datasets(
-        cls,
-        dataset: "datasets.Dataset",
-    ) -> "DatasetForTokenClassification":
-
-        records = []
-        for row in dataset:
-            if row.get("prediction"):
-                row["prediction"] = cls.__entities_to_tuple__(row["prediction"])
-            if row.get("annotation"):
-                row["annotation"] = cls.__entities_to_tuple__(row["annotation"])
-            if not row["tokens"]:
-                _LOGGER.warning(f"Ignoring row with no tokens.")
-                continue
-            records.append(TokenClassificationRecord.parse_obj(row))
-        return cls(records)
-
-    @classmethod
-    def _parse_tokens_field(
-        cls, dataset: "datasets.Dataset", field: str
-    ) -> "datasets.Dataset":
-        def parse_tokens_from_example(example):
-            tokens: List[str] = example[field]
-            data = {"tokens": tokens}
-
-            if "text" not in example:
-                data["text"] = " ".join(tokens)
-            return data
-
-        return dataset.map(parse_tokens_from_example, desc="Parsing tokens")
-
-    @classmethod
-    def _parse_tags_field(
-        cls, dataset: "datasets.Dataset", field: str = str
-    ) -> "datasets.Dataset":
-        import datasets
-
-        labels = dataset.features[field]
-        if isinstance(labels, datasets.Sequence):
-            labels = labels.feature
-        int2str = (
-            labels.int2str if isinstance(labels, datasets.ClassLabel) else lambda x: x
-        )
-
-        def parse_tags_from_example(example):
-            return {"tags": [int2str(t) for t in example[field] or []]}
-
-        return dataset.map(parse_tags_from_example, desc="Parsing tags")
 
     @classmethod
     def _from_pandas(cls, dataframe: pd.DataFrame) -> "DatasetForTokenClassification":

--- a/src/rubrix/client/datasets.py
+++ b/src/rubrix/client/datasets.py
@@ -248,7 +248,6 @@ class DatasetBase:
         """Joins columns of a `datasets.Dataset` row into a dict, and deletes the single columns.
 
         Updates the ``row`` dictionary!
-        
 
         Args:
             row: A row of a `datasets.Dataset`

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -619,8 +619,8 @@ class TestDatasetForTokenClassification:
             dataset_ds, tokens="empty_tokens"
         )
 
-        assert caplog.record_tuples[1][1] == 30
-        assert caplog.record_tuples[1][2] == "Ignoring row with no tokens."
+        assert caplog.record_tuples[0][1] == 30
+        assert caplog.record_tuples[0][2] == "Ignoring row with no tokens."
 
         assert len(dataset_rb) == 1
         assert dataset_rb[0].tokens == ["mock"]


### PR DESCRIPTION
This PR improves a bit the `Dataset*.from_datasets` mechanics. Instead of running x-times over the entire dataset for parsing x columns, we do the parsing of all columns in one go over the dataset.

- improves performance
- makes the ignore columns message less confusing

It also provides a "proper" fix to support the new datasets 2.3.0 version (not the push_to_hub issue, but the one when renaming a column).