### PR TITLE
fix(#1548): access datasets for superusers when workspace is not provided

### DIFF
--- a/src/rubrix/server/security/model.py
+++ b/src/rubrix/server/security/model.py
@@ -95,10 +95,10 @@ class User(BaseModel):
             The original workspace name if user belongs to it
 
         """
-        if workspace is None or workspace == self.default_workspace:
-            return self.default_workspace
         if not workspace and self.is_superuser():
             return workspace
+        if workspace is None or workspace == self.default_workspace:
+            return self.default_workspace
         if workspace not in (self.workspaces or []):
             raise EntityNotFoundError(name=workspace, type="Workspace")
         return workspace

--- a/src/rubrix/server/security/model.py
+++ b/src/rubrix/server/security/model.py
@@ -95,10 +95,10 @@ class User(BaseModel):
             The original workspace name if user belongs to it
 
         """
-        if not workspace and self.is_superuser():
-            return workspace
         if workspace is None or workspace == self.default_workspace:
             return self.default_workspace
+        if not workspace and self.is_superuser():
+            return workspace
         if workspace not in (self.workspaces or []):
             raise EntityNotFoundError(name=workspace, type="Workspace")
         return workspace

--- a/src/rubrix/server/services/datasets.py
+++ b/src/rubrix/server/services/datasets.py
@@ -99,7 +99,9 @@ class DatasetsService:
         if found_ds is None:
             raise EntityNotFoundError(name=name, type=Dataset)
         if found_ds.owner and owner and found_ds.owner != owner:
-            raise ForbiddenOperationError()
+            raise EntityNotFoundError(
+                name=name, type=Dataset
+            ) if user.is_superuser() else ForbiddenOperationError()
 
         return cast(Dataset, found_ds)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from tests.helpers import SecuredClient
 
 
 @pytest.fixture
-def mocked_client(monkeypatch):
+def mocked_client(monkeypatch) -> SecuredClient:
     with TestClient(app, raise_server_exceptions=False) as _client:
         client = SecuredClient(_client)
 

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -3,7 +3,6 @@ import pytest
 import rubrix as rb
 from rubrix import TextClassificationSettings, TokenClassificationSettings
 from rubrix.client import api
-from rubrix.client.sdk.commons.errors import AlreadyExistsApiError
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
~~We still check when creating a new dataset in a different workspace when exists a dataset with the same name in a different one.~~

Closes #1548 