### PR TITLE
fix(#1575): show predicted ok/ko in Text Classifier explore mode

### DIFF
--- a/frontend/models/Common.js
+++ b/frontend/models/Common.js
@@ -20,17 +20,14 @@ class BaseRecord {
   metadata;
   prediction;
   annotation;
-  predicted;
   status;
   selected;
   event_timestamp;
-
   constructor({
     id,
     metadata,
     prediction,
     annotation,
-    predicted,
     status,
     selected,
     event_timestamp,
@@ -40,7 +37,6 @@ class BaseRecord {
     this.metadata = metadata;
     this.prediction = prediction;
     this.annotation = annotation;
-    this.predicted = predicted;
     this.status = status;
     this.selected = selected || false;
     this.event_timestamp = event_timestamp;

--- a/frontend/models/TextClassification.js
+++ b/frontend/models/TextClassification.js
@@ -43,6 +43,24 @@ class TextClassificationRecord extends BaseRecord {
     }
     return [this.prediction.labels[0].class];
   }
+
+  get annotated_as() {
+    if (this.annotation === undefined) {
+      return [];
+    }
+    let labels = this.annotation.labels;
+    if (this.multi_label) {
+      return labels.map((l) => l.class);
+    }
+    return [this.annotation.labels[0].class];
+  }
+
+  get predicted() {
+    if (!this.multi_label && this.predicted_as && this.annotated_as) {
+      return this.predicted_as[0] === this.annotated_as[0] ? "ok" : "ko";
+    }
+    return undefined;
+  }
 }
 
 class TextClassificationSearchQuery extends BaseSearchQuery {


### PR DESCRIPTION
fix #1575

This PR shows predicted ok/ko in Text Classifier explore mode for single label datasets