### PR TITLE
docs: Add MajorityVoter to references + Add comments about multi-label support of the label models

### DIFF
--- a/docs/guides/weak-supervision.ipynb
+++ b/docs/guides/weak-supervision.ipynb
@@ -885,6 +885,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e9947561-f177-46cd-a965-bf78ed11cd0a",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Note\n",
+    "\n",
+    "The `Snorkel` label model is not suited for multi-label classification tasks and does not support them.\n",
+    "    \n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b5f6346d-1a34-4efa-87de-f3e69b7550ca",
    "metadata": {},
    "source": [
@@ -1145,6 +1159,20 @@
     "\n",
     "# we fit the model\n",
     "flyingsquid_model.fit()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21b834d9-ca48-480f-89ee-493dd974ba95",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Note\n",
+    "\n",
+    "The `FlyingSquid` label model is not suited for multi-label classification tasks and does not support them.\n",
+    "    \n",
+    "</div>"
    ]
   },
   {

--- a/docs/reference/python/python_labeling.rst
+++ b/docs/reference/python/python_labeling.rst
@@ -20,7 +20,7 @@ Labeling tools for the text classification task.
    :members: WeakLabels, WeakMultiLabels
 
 .. automodule:: rubrix.labeling.text_classification.label_models
-   :members: Snorkel, FlyingSquid
+   :members: MajorityVoter, Snorkel, FlyingSquid
 
 .. automodule:: rubrix.labeling.text_classification.label_errors
    :members: find_label_errors

--- a/docs/tutorials/weak-supervision-multi-label.ipynb
+++ b/docs/tutorials/weak-supervision-multi-label.ipynb
@@ -5,10 +5,7 @@
    "id": "7641399c-d8bc-411b-952b-32a9f2100776",
    "metadata": {},
    "source": [
-    "# 🗂 Weak supervision in multi-label text classification tasks\n",
-    "\n",
-    "WORK IN PROGRESS: This tutorial is a work in progress and you can expect some changes within the next few releases.\n",
-    "We will showcase new features here as soon as they are available."
+    "# 🗂 Weak supervision in multi-label text classification tasks"
    ]
   },
   {
@@ -30,6 +27,20 @@
     "Note\n",
     "\n",
     "If you are new to weak supervision, check out our [weak supervision guide](../guides/weak-supervision.ipynb) and our first [weak supervision tutorial](weak-supervision-with-rubrix.ipynb).\n",
+    "    \n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e7ad103-6b57-48ea-a125-7395f561941b",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "Note\n",
+    "\n",
+    "The `Snorkel` and `FlyingSquid` label models are not suited for multi-label classification tasks and do not support them.\n",
     "    \n",
     "</div>"
    ]
@@ -587,7 +598,8 @@
     "### Create training set\n",
     "\n",
     "When we are happy with our heuristics, it is time to combine them and compute weak labels for the training of our downstream model.\n",
-    "Here we will use the simple `MajorityVoter`, that in the multi-label case, sets the probability of a label to 0 or 1 depending on whether at least one non-abstaining rule voted for the respective label or not."
+    "For this we will use the `MajorityVoter`.\n",
+    "In the multi-label case, it sets the probability of a label to 0 or 1 depending on whether at least one non-abstaining rule voted for the respective label or not."
    ]
   },
   {

--- a/src/rubrix/labeling/text_classification/label_models.py
+++ b/src/rubrix/labeling/text_classification/label_models.py
@@ -62,7 +62,7 @@ class LabelModel:
         """Fits the label model.
 
         Args:
-            include_annotated_records: Whether to include annotated records in the training.
+            include_annotated_records: Whether to include annotated records in the fitting.
         """
         raise NotImplementedError
 
@@ -103,6 +103,10 @@ class MajorityVoter(LabelModel):
         super().__init__(weak_labels=weak_labels)
 
     def fit(self, *args, **kwargs):
+        """Raises a NotImplementedError.
+
+        No need to call fit on the ``MajorityVoter``!
+        """
         raise NotImplementedError("No need to call fit on the 'MajorityVoter'!")
 
     def predict(
@@ -529,7 +533,7 @@ class Snorkel(LabelModel):
         """Fits the label model.
 
         Args:
-            include_annotated_records: Whether to include annotated records in the training.
+            include_annotated_records: Whether to include annotated records in the fitting.
             **kwargs: Additional kwargs are passed on to Snorkel's
                 `fit method <https://snorkel.readthedocs.io/en/latest/packages/_autosummary/labeling/snorkel.labeling.model.label_model.LabelModel.html#snorkel.labeling.model.label_model.LabelModel.fit>`__.
                 They must not contain ``L_train``, the label matrix is provided automatically.
@@ -780,7 +784,7 @@ class FlyingSquid(LabelModel):
         """Fits the label model.
 
         Args:
-            include_annotated_records: Whether to include annotated records in the training.
+            include_annotated_records: Whether to include annotated records in the fitting.
             **kwargs: Passed on to the FlyingSquid's
                 `LabelModel.fit() <https://github.com/HazyResearch/flyingsquid/blob/master/flyingsquid/label_model.py#L320>`__
                 method.

--- a/src/rubrix/labeling/text_classification/label_models.py
+++ b/src/rubrix/labeling/text_classification/label_models.py
@@ -342,6 +342,8 @@ class MajorityVoter(LabelModel):
         For more details about the metrics, check out the
         `sklearn docs <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_recall_fscore_support.html#sklearn-metrics-precision-recall-fscore-support>`__.
 
+        .. note:: Metrics are only calculated over non-abstained predictions!
+
         Args:
             tie_break_policy: Policy to break ties (IGNORED FOR MULTI-LABEL). You can choose among two policies:
 
@@ -354,8 +356,6 @@ class MajorityVoter(LabelModel):
 
         Returns:
             The scores/metrics in a dictionary or as a nicely formatted str.
-
-        .. note:: Metrics are only calculated over non-abstained predictions!
 
         Raises:
             MissingAnnotationError: If the ``weak_labels`` do not contain annotated records.
@@ -678,6 +678,8 @@ class Snorkel(LabelModel):
         For more details about the metrics, check out the
         `sklearn docs <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_recall_fscore_support.html#sklearn-metrics-precision-recall-fscore-support>`__.
 
+        .. note:: Metrics are only calculated over non-abstained predictions!
+
         Args:
             tie_break_policy: Policy to break ties. You can choose among three policies:
 
@@ -691,8 +693,6 @@ class Snorkel(LabelModel):
 
         Returns:
             The scores/metrics in a dictionary or as a nicely formatted str.
-
-        .. note:: Metrics are only calculated over non-abstained predictions!
 
         Raises:
             MissingAnnotationError: If the ``weak_labels`` do not contain annotated records.
@@ -989,6 +989,8 @@ class FlyingSquid(LabelModel):
         For more details about the metrics, check out the
         `sklearn docs <https://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_recall_fscore_support.html#sklearn-metrics-precision-recall-fscore-support>`__.
 
+        .. note:: Metrics are only calculated over non-abstained predictions!
+
         Args:
             tie_break_policy: Policy to break ties. You can choose among two policies:
 
@@ -1002,8 +1004,6 @@ class FlyingSquid(LabelModel):
 
         Returns:
             The scores/metrics in a dictionary or as a nicely formatted str.
-
-        .. note:: Metrics are only calculated over non-abstained predictions!
 
         Raises:
             NotFittedError: If the label model was still not fitted.

--- a/src/rubrix/labeling/text_classification/label_models.py
+++ b/src/rubrix/labeling/text_classification/label_models.py
@@ -471,7 +471,7 @@ class MajorityVoter(LabelModel):
 class Snorkel(LabelModel):
     """The label model by `Snorkel <https://github.com/snorkel-team/snorkel/>`__.
 
-    It is not suited for multi-label classification and does not support it!
+    .. note:: It is not suited for multi-label classification and does not support it!
 
     Args:
         weak_labels: A `WeakLabels` object containing the weak labels and records.
@@ -736,7 +736,7 @@ class Snorkel(LabelModel):
 class FlyingSquid(LabelModel):
     """The label model by `FlyingSquid <https://github.com/HazyResearch/flyingsquid>`__.
 
-    It is not suited for multi-label classification and does not support it!
+    .. note:: It is not suited for multi-label classification and does not support it!
 
     Args:
         weak_labels: A `WeakLabels` object containing the weak labels and records.

--- a/src/rubrix/labeling/text_classification/label_models.py
+++ b/src/rubrix/labeling/text_classification/label_models.py
@@ -20,8 +20,8 @@ from typing import Dict, List, Tuple, Union
 import numpy as np
 
 from rubrix import DatasetForTextClassification, TextClassificationRecord
-from rubrix.labeling.text_classification.weak_labels import WeakLabels, WeakMultiLabels
 from rubrix.client.datasets import Dataset
+from rubrix.labeling.text_classification.weak_labels import WeakLabels, WeakMultiLabels
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -92,8 +92,8 @@ class LabelModel:
 class MajorityVoter(LabelModel):
     """A basic label model that computes the majority vote across all rules.
 
-    For multi-label classification, it will simply vote for all labels with a non-zero probability,
-    that is labels that got at least one vote by the rules.
+    For single-label classification, it will predict the label with the most votes.
+    For multi-label classification, it will predict all labels that got at least one vote by the rules.
 
     Args:
         weak_labels: The weak labels object.
@@ -467,6 +467,8 @@ class MajorityVoter(LabelModel):
 class Snorkel(LabelModel):
     """The label model by `Snorkel <https://github.com/snorkel-team/snorkel/>`__.
 
+    It is not suited for multi-label classification and does not support it!
+
     Args:
         weak_labels: A `WeakLabels` object containing the weak labels and records.
         verbose: Whether to show print statements
@@ -729,6 +731,8 @@ class Snorkel(LabelModel):
 
 class FlyingSquid(LabelModel):
     """The label model by `FlyingSquid <https://github.com/HazyResearch/flyingsquid>`__.
+
+    It is not suited for multi-label classification and does not support it!
 
     Args:
         weak_labels: A `WeakLabels` object containing the weak labels and records.


### PR DESCRIPTION
This PR adds the `MajorityVoter` class to the python references (it was missing before).
It also adds some comments about multi-label classification support of each label model to the docs.