### PR TITLE
fix(#1264): discard first space after a token

### DIFF
--- a/src/rubrix/server/apis/v0/models/token_classification.py
+++ b/src/rubrix/server/apis/v0/models/token_classification.py
@@ -136,7 +136,7 @@ class CreationTokenClassificationRecord(BaseRecord[TokenClassificationAnnotation
     @validator("tokens")
     def remove_empty_tokens(cls, tokens: List[str]):
         # TODO: maybe launch a warning about changing provided tokens
-        return [t for t in tokens if t.strip()]
+        return [t for t in tokens if t.replace(" ", "")]
 
     @validator("text")
     def check_text_content(cls, text: str):

--- a/src/rubrix/server/apis/v0/models/token_classification.py
+++ b/src/rubrix/server/apis/v0/models/token_classification.py
@@ -134,11 +134,6 @@ class CreationTokenClassificationRecord(BaseRecord[TokenClassificationAnnotation
             raise IndexError(f"Token id {token_idx} out of bounds")
         return self.__tokens2chars__[token_idx]
 
-    @validator("tokens")
-    def remove_empty_tokens(cls, tokens: List[str]):
-        # TODO: maybe launch a warning about changing provided tokens
-        return [t for t in tokens if t.replace(" ", "")]
-
     @validator("text")
     def check_text_content(cls, text: str):
         assert text and text.strip(), "No text or empty text provided"
@@ -160,10 +155,15 @@ class CreationTokenClassificationRecord(BaseRecord[TokenClassificationAnnotation
         """
 
         def chars2tokens_index():
+            def is_space_after_token(char, idx: int, chars_map) -> str:
+                return char == " " and idx - 1 in chars_map
+
             chars_map = {}
             current_token = 0
             current_token_char_start = 0
             for idx, char in enumerate(self.text):
+                if is_space_after_token(char, idx, chars_map):
+                    continue
                 relative_idx = idx - current_token_char_start
                 if (
                     relative_idx < len(self.tokens[current_token])

--- a/src/rubrix/server/apis/v0/models/token_classification.py
+++ b/src/rubrix/server/apis/v0/models/token_classification.py
@@ -122,6 +122,7 @@ class CreationTokenClassificationRecord(BaseRecord[TokenClassificationAnnotation
         super().__init__(**data)
 
         self.__chars2tokens__, self.__tokens2chars__ = self.__build_indices_map__()
+
         self.check_annotation(self.prediction)
         self.check_annotation(self.annotation)
 
@@ -162,7 +163,6 @@ class CreationTokenClassificationRecord(BaseRecord[TokenClassificationAnnotation
             chars_map = {}
             current_token = 0
             current_token_char_start = 0
-
             for idx, char in enumerate(self.text):
                 relative_idx = idx - current_token_char_start
                 if (
@@ -201,21 +201,8 @@ class CreationTokenClassificationRecord(BaseRecord[TokenClassificationAnnotation
         annotation: Optional[TokenClassificationAnnotation],
     ):
         """Validates entities in terms of offset spans"""
-
-        def adjust_span_bounds(start, end):
-            if start < 0:
-                start = 0
-            if entity.end > len(self.text):
-                end = len(self.text)
-            while start <= len(self.text) and not self.text[start].strip():
-                start += 1
-            while not self.text[end - 1].strip():
-                end -= 1
-            return start, end
-
         if annotation:
             for entity in annotation.entities:
-                entity.start, entity.end = adjust_span_bounds(entity.start, entity.end)
                 mention = self.text[entity.start : entity.end]
                 assert len(mention) > 0, f"Empty offset defined for entity {entity}"
 

--- a/src/rubrix/server/apis/v0/models/token_classification.py
+++ b/src/rubrix/server/apis/v0/models/token_classification.py
@@ -122,7 +122,6 @@ class CreationTokenClassificationRecord(BaseRecord[TokenClassificationAnnotation
         super().__init__(**data)
 
         self.__chars2tokens__, self.__tokens2chars__ = self.__build_indices_map__()
-
         self.check_annotation(self.prediction)
         self.check_annotation(self.annotation)
 
@@ -133,6 +132,11 @@ class CreationTokenClassificationRecord(BaseRecord[TokenClassificationAnnotation
         if token_idx not in self.__tokens2chars__:
             raise IndexError(f"Token id {token_idx} out of bounds")
         return self.__tokens2chars__[token_idx]
+
+    @validator("tokens")
+    def remove_empty_tokens(cls, tokens: List[str]):
+        # TODO: maybe launch a warning about changing provided tokens
+        return [t for t in tokens if t.strip()]
 
     @validator("text")
     def check_text_content(cls, text: str):
@@ -158,6 +162,7 @@ class CreationTokenClassificationRecord(BaseRecord[TokenClassificationAnnotation
             chars_map = {}
             current_token = 0
             current_token_char_start = 0
+
             for idx, char in enumerate(self.text):
                 relative_idx = idx - current_token_char_start
                 if (
@@ -196,8 +201,21 @@ class CreationTokenClassificationRecord(BaseRecord[TokenClassificationAnnotation
         annotation: Optional[TokenClassificationAnnotation],
     ):
         """Validates entities in terms of offset spans"""
+
+        def adjust_span_bounds(start, end):
+            if start < 0:
+                start = 0
+            if entity.end > len(self.text):
+                end = len(self.text)
+            while start <= len(self.text) and not self.text[start].strip():
+                start += 1
+            while not self.text[end - 1].strip():
+                end -= 1
+            return start, end
+
         if annotation:
             for entity in annotation.entities:
+                entity.start, entity.end = adjust_span_bounds(entity.start, entity.end)
                 mention = self.text[entity.start : entity.end]
                 assert len(mention) > 0, f"Empty offset defined for entity {entity}"
 

--- a/tests/server/token_classification/test_model.py
+++ b/tests/server/token_classification/test_model.py
@@ -81,10 +81,12 @@ def test_entities_with_spaces():
 
 
 def test_model_dict():
+    text = "This is  a  great  space"
+    tokens = ["This", "is", " ", "a", " ", "great", " ", "space"]
     record = TokenClassificationRecord(
         id="1",
-        text="This is  a  great  space",
-        tokens=["This", "is", " ", "a", " ", "great", " ", "space"],
+        text=text,
+        tokens=tokens,
         prediction=TokenClassificationAnnotation(
             agent="test",
             entities=[
@@ -100,10 +102,10 @@ def test_model_dict():
             "agent": "test",
             "entities": [{"end": 24, "label": "test", "score": 1.0, "start": 9}],
         },
-        "raw_text": "This is  a  great  space",
+        "raw_text": text,
+        "text": text,
+        "tokens": tokens,
         "status": "Default",
-        "text": "This is  a  great  space",
-        "tokens": ["This", "is", "a", "great", "space"],
     }
 
 
@@ -244,7 +246,7 @@ def test_whitespace_in_tokens():
     from spacy import load
 
     nlp = load("en_core_web_sm")
-    text = "every four  (4)"
+    text = "every four (4)  "
     doc = nlp(text)
 
     record = {
@@ -258,4 +260,4 @@ def test_whitespace_in_tokens():
 
     record = CreationTokenClassificationRecord.parse_obj(record)
     assert record
-    print(record.dict())
+    assert record.tokens == ["every", "four", "(", "4", ")", " "]

--- a/tests/server/token_classification/test_model.py
+++ b/tests/server/token_classification/test_model.py
@@ -103,7 +103,7 @@ def test_model_dict():
         "raw_text": "This is  a  great  space",
         "status": "Default",
         "text": "This is  a  great  space",
-        "tokens": ["This", "is", " ", "a", " ", "great", " ", "space"],
+        "tokens": ["This", "is", "a", "great", "space"],
     }
 
 

--- a/tests/server/token_classification/test_model.py
+++ b/tests/server/token_classification/test_model.py
@@ -19,6 +19,7 @@ from pydantic import ValidationError
 from rubrix._constants import MAX_KEYWORD_LENGTH
 from rubrix.server.apis.v0.models.commons.model import PredictionStatus
 from rubrix.server.apis.v0.models.token_classification import (
+    CreationTokenClassificationRecord,
     EntitySpan,
     TokenClassificationAnnotation,
     TokenClassificationQuery,
@@ -237,3 +238,24 @@ def test_annotated_without_entities():
     assert record.annotated_by == [record.annotation.agent]
     assert record.predicted_by == [record.prediction.agent]
     assert record.predicted == PredictionStatus.KO
+
+
+def test_whitespace_in_tokens():
+    from spacy import load
+
+    nlp = load("en_core_web_sm")
+    text = "every four  (4)"
+    doc = nlp(text)
+
+    record = {
+        "text": text,
+        "tokens": list(map(str, doc)),
+        "prediction": {
+            "agent": "mock",
+            "entities": [{"start": 0, "end": len(text), "label": "mock"}],
+        },
+    }
+
+    record = CreationTokenClassificationRecord.parse_obj(record)
+    assert record
+    print(record.dict())


### PR DESCRIPTION
In this PR we discard from token candidates the first space after a token.

Closes #1264 