### PR TITLE
test: configure numpy to disable multi threading

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,3 +13,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+# The following configuration tries to limit use of numpy threading and
+# possible problems with fault segmentation
+# For more info, please visit https://gist.github.com/EricCousineau-TRI/8a2d1550f5fa4be4fed87d55a522dbf2
+import os
+
+os.environ.update(
+    OMP_NUM_THREADS="1",
+    OPENBLAS_NUM_THREADS="1",
+    NUMEXPR_NUM_THREADS="1",
+    MKL_NUM_THREADS="1",
+)


### PR DESCRIPTION
Some mac OS X users are noticing segmentation Fault errors running the tests locally. Those errors are caused by some multi-threading configuration related to NumPy. 

This PR preset the NumPy configuration to avoid those segmentation fault errors 