### PR TITLE
refactor(server): moving common base models to services layer

### DIFF
--- a/src/rubrix/server/apis/v0/models/commons/model.py
+++ b/src/rubrix/server/apis/v0/models/commons/model.py
@@ -18,68 +18,31 @@ Common model for task definitions
 """
 
 from dataclasses import dataclass
-from datetime import datetime
-from enum import Enum
-from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
-from uuid import uuid4
+from typing import Any, Dict, Generic, TypeVar
 
 from fastapi import Query
-from pydantic import BaseModel, Field, validator
+from pydantic import validator
 from pydantic.generics import GenericModel
 
 from rubrix._constants import MAX_KEYWORD_LENGTH
 from rubrix.server.apis.v0.helpers import flatten_dict
+from rubrix.server.services.search.model import (
+    BaseSearchResults,
+    BaseSearchResultsAggregations,
+    QueryRange,
+    SortableField,
+)
+from rubrix.server.services.tasks.commons import (
+    Annotation,
+    BaseAnnotation,
+    BaseRecordDB,
+    BulkResponse,
+    EsRecordDataFieldNames,
+    PredictionStatus,
+    TaskStatus,
+    TaskType,
+)
 from rubrix.utils import limit_value_length
-
-
-class EsRecordDataFieldNames(str, Enum):
-    """Common elasticsearch field names"""
-
-    predicted_as = "predicted_as"
-    annotated_as = "annotated_as"
-    annotated_by = "annotated_by"
-    predicted_by = "predicted_by"
-    status = "status"
-    predicted = "predicted"
-    score = "score"
-    words = "words"
-    event_timestamp = "event_timestamp"
-    last_updated = "last_updated"
-
-    def __str__(self):
-        return self.value
-
-
-class SortOrder(str, Enum):
-    asc = "asc"
-    desc = "desc"
-
-
-class SortableField(BaseModel):
-    """Sortable field structure"""
-
-    id: str
-    order: SortOrder = SortOrder.asc
-
-
-class BulkResponse(BaseModel):
-    """
-    Data info for bulk results
-
-    Attributes
-    ----------
-
-    dataset:
-        The dataset name
-    processed:
-        Number of records in bulk
-    failed:
-        Number of failed records
-    """
-
-    dataset: str
-    processed: int
-    failed: int = 0
 
 
 @dataclass
@@ -92,70 +55,7 @@ class PaginationParams:
     )
 
 
-class BaseAnnotation(BaseModel):
-    """
-    Annotation class base
-
-    Attributes:
-    -----------
-
-    agent:
-        Which agent or component makes the annotation. We should find model annotations, user annotations,
-        or some other human-supervised automatic process.
-    """
-
-    agent: str = Field(max_length=64)
-
-
-class TaskType(str, Enum):
-    """
-    The available task types:
-
-    **text_classification**, for text classification tasks
-    **token_classification**, for token classification tasks
-
-    """
-
-    text_classification = "TextClassification"
-    token_classification = "TokenClassification"
-    text2text = "Text2Text"
-    multi_task_text_token_classification = "MultitaskTextTokenClassification"
-
-
-class TaskStatus(str, Enum):
-    """
-    Task data status:
-
-    **Default**, default status, for no provided status records.
-    **Edited**, normally used when original annotation was modified but not yet validated (confirmed).
-    **Discarded**, for records that will be excluded for analysis.
-    **Validated**, when annotation was confirmed as ok.
-
-    """
-
-    default = "Default"
-    edited = "Edited"  # TODO: DEPRECATE
-    discarded = "Discarded"
-    validated = "Validated"
-
-
-class PredictionStatus(str, Enum):
-    """
-    The prediction status:
-
-    **OK**, for record containing a success prediction
-    **KO**, for record containing a wrong prediction
-
-    """
-
-    OK = "ok"
-    KO = "ko"
-
-
-Annotation = TypeVar("Annotation", bound=BaseAnnotation)
-
-
-class BaseRecord(GenericModel, Generic[Annotation]):
+class BaseRecord(BaseRecordDB, GenericModel, Generic[Annotation]):
     """
     Minimal dataset record information
 
@@ -170,28 +70,6 @@ class BaseRecord(GenericModel, Generic[Annotation]):
         The timestamp when record event was triggered
 
     """
-
-    id: Optional[Union[int, str]] = Field(None)
-    metadata: Dict[str, Any] = Field(default=None)
-    event_timestamp: Optional[datetime] = None
-    status: Optional[TaskStatus] = None
-    prediction: Optional[Annotation] = None
-    annotation: Optional[Annotation] = None
-    metrics: Dict[str, Any] = Field(default_factory=dict)
-    search_keywords: Optional[List[str]] = None
-
-    @validator("search_keywords")
-    def remove_duplicated_keywords(cls, value) -> List[str]:
-        """Remove duplicated keywords"""
-        if value:
-            return list(set(value))
-
-    @validator("id", always=True)
-    def default_id_if_none_provided(cls, id: Optional[str]) -> str:
-        """Validates id info and sets a random uuid if not provided"""
-        if id is None:
-            return str(uuid4())
-        return id
 
     @validator("metadata", pre=True)
     def flatten_metadata(cls, metadata: Dict[str, Any]):
@@ -213,149 +91,24 @@ class BaseRecord(GenericModel, Generic[Annotation]):
             metadata = limit_value_length(metadata, max_length=MAX_KEYWORD_LENGTH)
         return metadata
 
-    @validator("status", always=True)
-    def fill_default_value(cls, status: TaskStatus):
-        """Fastapi validator for set default task status"""
-        return TaskStatus.default if status is None else status
-
-    @classmethod
-    def task(cls) -> TaskType:
-        """The task type related to this task info"""
-        raise NotImplementedError
-
-    @property
-    def predicted(self) -> Optional[PredictionStatus]:
-        """The task record prediction status (if any)"""
-        return None
-
-    @property
-    def predicted_as(self) -> Optional[List[str]]:
-        """Predictions strings representation"""
-        return None
-
-    @property
-    def annotated_as(self) -> Optional[List[str]]:
-        """Annotations strings representation"""
-        return None
-
-    @property
-    def scores(self) -> Optional[List[float]]:
-        """Prediction scores"""
-        return None
-
-    def all_text(self) -> str:
-        """All textual information related to record"""
-        raise NotImplementedError
-
-    @property
-    def predicted_by(self) -> List[str]:
-        """The prediction agents"""
-        if self.prediction:
-            return [self.prediction.agent]
-        return []
-
-    @property
-    def annotated_by(self) -> List[str]:
-        """The annotation agents"""
-        if self.annotation:
-            return [self.annotation.agent]
-        return []
-
-    def extended_fields(self) -> Dict[str, Any]:
-        """
-        Used for extends fields to store in db. Tasks that would include extra
-        properties than commons (predicted, annotated_as,....) could implement
-        this method.
-        """
-        return {
-            EsRecordDataFieldNames.predicted: self.predicted,
-            EsRecordDataFieldNames.annotated_as: self.annotated_as,
-            EsRecordDataFieldNames.predicted_as: self.predicted_as,
-            EsRecordDataFieldNames.annotated_by: self.annotated_by,
-            EsRecordDataFieldNames.predicted_by: self.predicted_by,
-            EsRecordDataFieldNames.score: self.scores,
-        }
-
-    def dict(self, *args, **kwargs) -> "DictStrAny":
-        """
-        Extends base component dict extending object properties
-        and user defined extended fields
-        """
-        return {
-            **super().dict(*args, **kwargs),
-            **self.extended_fields(),
-        }
-
-
-class BaseSearchResultsAggregations(BaseModel):
-
-    """
-    API for result aggregations
-
-    Attributes:
-    -----------
-    predicted_as: Dict[str, int]
-        Occurrence info about more relevant predicted terms
-    annotated_as: Dict[str, int]
-        Occurrence info about more relevant annotated terms
-    annotated_by: Dict[str, int]
-        Occurrence info about more relevant annotation agent terms
-    predicted_by: Dict[str, int]
-        Occurrence info about more relevant prediction agent terms
-    status: Dict[str, int]
-        Occurrence info about task status
-    predicted: Dict[str, int]
-        Occurrence info about task prediction status
-    words: Dict[str, int]
-        The word cloud aggregations
-    metadata: Dict[str, Dict[str, Any]]
-        The metadata fields aggregations
-    """
-
-    predicted_as: Dict[str, int] = Field(default_factory=dict)
-    annotated_as: Dict[str, int] = Field(default_factory=dict)
-    annotated_by: Dict[str, int] = Field(default_factory=dict)
-    predicted_by: Dict[str, int] = Field(default_factory=dict)
-    status: Dict[str, int] = Field(default_factory=dict)
-    predicted: Dict[str, int] = Field(default_factory=dict)
-    score: Dict[str, int] = Field(default_factory=dict)
-    words: Dict[str, int] = Field(default_factory=dict)
-    metadata: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
-
 
 Record = TypeVar("Record", bound=BaseRecord)
-Aggregations = TypeVar("Aggregations", bound=BaseSearchResultsAggregations)
-
-
-class BaseSearchResults(GenericModel, Generic[Record, Aggregations]):
-    """
-    API search results
-
-    Attributes:
-    -----------
-
-    total:
-        The total number of records
-    records:
-        The selected records to return
-    aggregations:
-        Requested aggregations
-    """
-
-    total: int = 0
-    records: List[Record] = Field(default_factory=list)
-    aggregations: Aggregations = None
-
-
-class QueryRange(BaseModel):
-    """Score range filter"""
-
-    range_from: float = Field(default=0.0, alias="from")
-    range_to: float = Field(default=None, alias="to")
-
-    class Config:
-        allow_population_by_field_name = True
 
 
 class ScoreRange(QueryRange):
     pass
+
+
+__ALL__ = [
+    QueryRange,
+    SortableField,
+    BaseSearchResults,
+    BaseSearchResultsAggregations,
+    Annotation,
+    TaskStatus,
+    TaskType,
+    EsRecordDataFieldNames,
+    BaseAnnotation,
+    PredictionStatus,
+    BulkResponse,
+]

--- a/src/rubrix/server/services/datasets.py
+++ b/src/rubrix/server/services/datasets.py
@@ -28,7 +28,7 @@ from rubrix.server.errors import (
 )
 from rubrix.server.security.model import User
 
-Dataset = TypeVar("Dataset", bound=DatasetDB)
+Dataset = TypeVar("Dataset", bound=BaseDatasetDB)
 
 
 class SVCDatasetSettings(SettingsDB):

--- a/src/rubrix/server/services/metrics.py
+++ b/src/rubrix/server/services/metrics.py
@@ -2,8 +2,6 @@ from typing import Callable, Optional, Type, TypeVar, Union
 
 from fastapi import Depends
 
-from rubrix.server.apis.v0.models.commons.model import BaseRecord
-from rubrix.server.apis.v0.models.datasets import BaseDatasetDB
 from rubrix.server.apis.v0.models.metrics.base import (
     ElasticsearchMetric,
     NestedPathElasticsearchMetric,
@@ -13,7 +11,9 @@ from rubrix.server.apis.v0.models.metrics.commons import *
 from rubrix.server.daos.models.records import RecordSearch
 from rubrix.server.daos.records import DatasetRecordsDAO, dataset_records_dao
 from rubrix.server.errors import WrongInputParamError
+from rubrix.server.services.datasets import Dataset
 from rubrix.server.services.search.query_builder import EsQueryBuilder
+from rubrix.server.services.tasks.commons.record import BaseRecordDB
 
 GenericQuery = TypeVar("GenericQuery")
 
@@ -60,9 +60,9 @@ class MetricsService:
 
     def summarize_metric(
         self,
-        dataset: BaseDatasetDB,
+        dataset: Dataset,
         metric: BaseMetric,
-        record_class: Optional[Type[BaseRecord]] = None,
+        record_class: Optional[Type[BaseRecordDB]] = None,
         query: Optional[GenericQuery] = None,
         **metric_params,
     ) -> Dict[str, Any]:
@@ -102,7 +102,7 @@ class MetricsService:
         self,
         metric: ElasticsearchMetric,
         metric_params: Dict[str, Any],
-        dataset: BaseDatasetDB,
+        dataset: Dataset,
         query: GenericQuery,
     ) -> Dict[str, Any]:
         """
@@ -136,7 +136,7 @@ class MetricsService:
 
     def __compute_metric_params__(
         self,
-        dataset: BaseDatasetDB,
+        dataset: Dataset,
         metric: ElasticsearchMetric,
         query: Optional[GenericQuery],
         provided_params: Dict[str, Any],
@@ -154,7 +154,7 @@ class MetricsService:
 
     def __metric_results__(
         self,
-        dataset: BaseDatasetDB,
+        dataset: Dataset,
         query: Optional[GenericQuery],
         metric_aggregation: Union[Dict[str, Any], List[Dict[str, Any]]],
     ) -> Dict[str, Any]:

--- a/src/rubrix/server/services/search/model.py
+++ b/src/rubrix/server/services/search/model.py
@@ -1,40 +1,25 @@
-from typing import Any, Dict, List, Optional, TypeVar, Union
+from enum import Enum
+from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
 
 from pydantic import BaseModel, Field
+from pydantic.generics import GenericModel
 
-from rubrix.server.apis.v0.models.commons.model import (
-    BaseRecord,
-    SortableField,
-    TaskStatus,
-)
+from rubrix.server.services.tasks.commons.record import Record, TaskStatus
+
+
+class SortOrder(str, Enum):
+    asc = "asc"
+    desc = "desc"
+
+
+class SortableField(BaseModel):
+    """Sortable field structure"""
+
+    id: str
+    order: SortOrder = SortOrder.asc
 
 
 class BaseSearchQuery(BaseModel):
-
-    """
-    Base search query fields
-
-    Attributes:
-    -----------
-    ids: Optional[List[Union[str, int]]]
-        Record ids list
-
-    query_text: str
-        Text query over inputs
-
-    metadata: Optional[Dict[str, Union[str, List[str]]]]
-        Text query over metadata fields. Default=None
-
-    predicted_by: List[str]
-        List of predicted agents
-
-    annotated_by: List[str]
-        List of annotation agents
-
-    status: List[TaskStatus]
-        List of task status
-
-    """
 
     query_text: Optional[str] = None
     advanced_query_dsl: bool = False
@@ -45,8 +30,16 @@ class BaseSearchQuery(BaseModel):
     predicted_by: List[str] = Field(default_factory=list)
 
     status: List[TaskStatus] = Field(default_factory=list)
-
     metadata: Optional[Dict[str, Union[str, List[str]]]] = None
+
+
+class QueryRange(BaseModel):
+
+    range_from: float = Field(default=0.0, alias="from")
+    range_to: float = Field(default=None, alias="to")
+
+    class Config:
+        allow_population_by_field_name = True
 
 
 class SortConfig(BaseModel):
@@ -56,11 +49,43 @@ class SortConfig(BaseModel):
     valid_fields: List[str] = Field(default_factory=list)
 
 
-Record = TypeVar("Record", bound=BaseRecord)
+class BaseSearchResultsAggregations(BaseModel):
+
+    predicted_as: Dict[str, int] = Field(default_factory=dict)
+    annotated_as: Dict[str, int] = Field(default_factory=dict)
+    annotated_by: Dict[str, int] = Field(default_factory=dict)
+    predicted_by: Dict[str, int] = Field(default_factory=dict)
+    status: Dict[str, int] = Field(default_factory=dict)
+    predicted: Dict[str, int] = Field(default_factory=dict)
+    score: Dict[str, int] = Field(default_factory=dict)
+    words: Dict[str, int] = Field(default_factory=dict)
+    metadata: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
+
+
+Aggregations = TypeVar("Aggregations", bound=BaseSearchResultsAggregations)
+
+
+class BaseSearchResults(GenericModel, Generic[Record, Aggregations]):
+    """
+    API search results
+
+    Attributes:
+    -----------
+
+    total:
+        The total number of records
+    records:
+        The selected records to return
+    aggregations:
+        Requested aggregations
+    """
+
+    total: int = 0
+    records: List[Record] = Field(default_factory=list)
+    aggregations: Aggregations = None
 
 
 class SearchResults(BaseModel):
     total: int
-
     records: List[Record]
     metrics: Dict[str, Any] = Field(default_factory=dict)

--- a/src/rubrix/server/services/search/query_builder.py
+++ b/src/rubrix/server/services/search/query_builder.py
@@ -6,11 +6,10 @@ from fastapi import Depends
 from luqum.elasticsearch import ElasticsearchQueryBuilder, SchemaAnalyzer
 from luqum.parser import parser
 
-from rubrix.server.apis.v0.models.commons.model import QueryRange
-from rubrix.server.apis.v0.models.datasets import BaseDatasetDB
+from rubrix.server.daos.models.datasets import BaseDatasetDB
 from rubrix.server.daos.records import DatasetRecordsDAO
 from rubrix.server.elasticseach.query_helpers import filters
-from rubrix.server.services.search.model import BaseSearchQuery
+from rubrix.server.services.search.model import BaseSearchQuery, QueryRange
 
 SearchQuery = TypeVar("SearchQuery", bound=BaseSearchQuery)
 

--- a/src/rubrix/server/services/search/service.py
+++ b/src/rubrix/server/services/search/service.py
@@ -1,12 +1,8 @@
 import logging
-from typing import Iterable, List, Optional, Set, Type
+from typing import Iterable, List, Optional, Type
 
 from fastapi import Depends
 
-from rubrix.server.apis.v0.models.commons.model import (
-    BaseRecord,
-    EsRecordDataFieldNames,
-)
 from rubrix.server.apis.v0.models.metrics.base import BaseMetric
 from rubrix.server.daos.models.records import RecordSearch
 from rubrix.server.daos.records import DatasetRecordsDAO
@@ -20,6 +16,10 @@ from rubrix.server.services.search.model import (
     SortConfig,
 )
 from rubrix.server.services.search.query_builder import EsQueryBuilder
+from rubrix.server.services.tasks.commons.record import (
+    BaseRecordDB,
+    EsRecordDataFieldNames,
+)
 
 
 class SearchRecordsService:
@@ -53,7 +53,7 @@ class SearchRecordsService:
     def search(
         self,
         dataset: Dataset,
-        record_type: Type[BaseRecord],
+        record_type: Type[BaseRecordDB],
         query: Optional[BaseSearchQuery] = None,
         sort_config: Optional[SortConfig] = None,
         record_from: int = 0,
@@ -119,7 +119,7 @@ class SearchRecordsService:
     def scan_records(
         self,
         dataset: Dataset,
-        record_type: Type[BaseRecord],
+        record_type: Type[BaseRecordDB],
         query: Optional[BaseSearchQuery] = None,
     ) -> Iterable[Record]:
         """Scan records for a queried"""

--- a/src/rubrix/server/services/tasks/commons/__init__.py
+++ b/src/rubrix/server/services/tasks/commons/__init__.py
@@ -1,0 +1,2 @@
+from .logging import *
+from .record import *

--- a/src/rubrix/server/services/tasks/commons/logging.py
+++ b/src/rubrix/server/services/tasks/commons/logging.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel
+
+
+class BulkResponse(BaseModel):
+    """
+    Data info for bulk results
+
+    Attributes
+    ----------
+
+    dataset:
+        The dataset name
+    processed:
+        Number of records in bulk
+    failed:
+        Number of failed records
+    """
+
+    dataset: str
+    processed: int
+    failed: int = 0

--- a/src/rubrix/server/services/tasks/commons/record.py
+++ b/src/rubrix/server/services/tasks/commons/record.py
@@ -1,0 +1,152 @@
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
+from uuid import uuid4
+
+from pydantic import BaseModel, Field, validator
+from pydantic.generics import GenericModel
+
+
+class EsRecordDataFieldNames(str, Enum):
+
+    predicted_as = "predicted_as"
+    annotated_as = "annotated_as"
+    annotated_by = "annotated_by"
+    predicted_by = "predicted_by"
+    status = "status"
+    predicted = "predicted"
+    score = "score"
+    words = "words"
+    event_timestamp = "event_timestamp"
+    last_updated = "last_updated"
+
+    def __str__(self):
+        return self.value
+
+
+class BaseAnnotation(BaseModel):
+    agent: str = Field(max_length=64)
+
+
+class TaskType(str, Enum):
+
+    text_classification = "TextClassification"
+    token_classification = "TokenClassification"
+    text2text = "Text2Text"
+    multi_task_text_token_classification = "MultitaskTextTokenClassification"
+
+
+class TaskStatus(str, Enum):
+    default = "Default"
+    edited = "Edited"  # TODO: DEPRECATE
+    discarded = "Discarded"
+    validated = "Validated"
+
+
+class PredictionStatus(str, Enum):
+    OK = "ok"
+    KO = "ko"
+
+
+Annotation = TypeVar("Annotation", bound=BaseAnnotation)
+
+
+class BaseRecordDB(GenericModel, Generic[Annotation]):
+
+    id: Optional[Union[int, str]] = Field(default=None)
+    metadata: Dict[str, Any] = Field(default=None)
+    event_timestamp: Optional[datetime] = None
+    status: Optional[TaskStatus] = None
+    prediction: Optional[Annotation] = None
+    annotation: Optional[Annotation] = None
+    metrics: Dict[str, Any] = Field(default_factory=dict)
+    search_keywords: Optional[List[str]] = None
+
+    @validator("id", always=True, pre=True)
+    def default_id_if_none_provided(cls, id: Optional[str]) -> str:
+        """Validates id info and sets a random uuid if not provided"""
+        if id is None:
+            return str(uuid4())
+        return id
+
+    @validator("status", always=True)
+    def fill_default_value(cls, status: TaskStatus):
+        """Fastapi validator for set default task status"""
+        return TaskStatus.default if status is None else status
+
+    @validator("search_keywords")
+    def remove_duplicated_keywords(cls, value) -> List[str]:
+        """Remove duplicated keywords"""
+        if value:
+            return list(set(value))
+
+    @classmethod
+    def task(cls) -> TaskType:
+        """The task type related to this task info"""
+        raise NotImplementedError
+
+    @property
+    def predicted(self) -> Optional[PredictionStatus]:
+        """The task record prediction status (if any)"""
+        return None
+
+    @property
+    def predicted_as(self) -> Optional[List[str]]:
+        """Predictions strings representation"""
+        return None
+
+    @property
+    def annotated_as(self) -> Optional[List[str]]:
+        """Annotations strings representation"""
+        return None
+
+    @property
+    def scores(self) -> Optional[List[float]]:
+        """Prediction scores"""
+        return None
+
+    def all_text(self) -> str:
+        """All textual information related to record"""
+        raise NotImplementedError
+
+    @property
+    def predicted_by(self) -> List[str]:
+        """The prediction agents"""
+        if self.prediction:
+            return [self.prediction.agent]
+        return []
+
+    @property
+    def annotated_by(self) -> List[str]:
+        """The annotation agents"""
+        if self.annotation:
+            return [self.annotation.agent]
+        return []
+
+    def extended_fields(self) -> Dict[str, Any]:
+        """
+        Used for extends fields to store in db. Tasks that would include extra
+        properties than commons (predicted, annotated_as,....) could implement
+        this method.
+        """
+        return {
+            EsRecordDataFieldNames.predicted: self.predicted,
+            EsRecordDataFieldNames.annotated_as: self.annotated_as,
+            EsRecordDataFieldNames.predicted_as: self.predicted_as,
+            EsRecordDataFieldNames.annotated_by: self.annotated_by,
+            EsRecordDataFieldNames.predicted_by: self.predicted_by,
+            EsRecordDataFieldNames.score: self.scores,
+        }
+
+    def dict(self, *args, **kwargs) -> "DictStrAny":
+        """
+        Extends base component dict extending object properties
+        and user defined extended fields
+        """
+        return {
+            **super().dict(*args, **kwargs),
+            **self.extended_fields(),
+        }
+
+
+Record = TypeVar("Record", bound=BaseRecordDB)


### PR DESCRIPTION
In this PR we move base API models to the services layer, keeping in mind the `apis > services > daos` relations