### PR TITLE
docs: Add listeners dep to tutorial

### DIFF
--- a/docs/tutorials/active_learning_with_small_text.ipynb
+++ b/docs/tutorials/active_learning_with_small_text.ipynb
@@ -67,7 +67,7 @@
     "\n",
     "If you have not installed and launched Rubrix yet, check the [Setup and Installation Guide](https://rubrix.readthedocs.io/en/master/getting_started/setup%26installation.html).\n",
     "\n",
-    "For this tutorial, we also need some third-party libraries that you can install via pip:"
+    "For this tutorial, we also need some optional and third-party libraries that you can install via pip:"
    ]
   },
   {
@@ -77,7 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install datasets \"small-text\" \"transformers[torch]\""
+    "%pip install \"rubrix[listeners]\" datasets \"small-text\" \"transformers[torch]\""
    ]
   },
   {


### PR DESCRIPTION
Adds the missing optional dependencies to our small-text + listeners tutorial.