### PR TITLE
docs: Fix typo in Getting Started -> Concepts

### DIFF
--- a/docs/getting_started/concepts.md
+++ b/docs/getting_started/concepts.md
@@ -101,7 +101,7 @@ record = rb.TokenClassificationRecord(
 Text2text tasks, like text generation, are tasks where the model receives and outputs a sequence of tokens. Examples of such tasks are machine translation, text summarization, paraphrase generation, etc.
 
 ```python
-record = rb.Text2Text(
+record = rb.Text2TextRecord(
     text = "Michael is a professor at Harvard",
 
     # The prediction is a list of texts or tuples if you want to add a score to a prediction


### PR DESCRIPTION
Closes #1617 