### PR TITLE
fix: Show predicted OK/KO when predictions exist

### DIFF
--- a/frontend/models/TextClassification.js
+++ b/frontend/models/TextClassification.js
@@ -56,7 +56,12 @@ class TextClassificationRecord extends BaseRecord {
   }
 
   get predicted() {
-    if (!this.multi_label && this.predicted_as && this.annotated_as) {
+    if (
+      !this.multi_label &&
+      this.prediction &&
+      this.predicted_as &&
+      this.annotated_as
+    ) {
       return this.predicted_as[0] === this.annotated_as[0] ? "ok" : "ko";
     }
     return undefined;

--- a/frontend/specs/components/text-classification/results/RecordTextClassification.spec.js
+++ b/frontend/specs/components/text-classification/results/RecordTextClassification.spec.js
@@ -7,34 +7,43 @@ const $route = {
   query: {},
 };
 
+const props = {
+  record: new TextClassificationRecord({
+    annotation: {
+      agent: "recognai",
+      labels:[
+        {class:"Test", score:1}
+      ]
+    },
+    inputs: {
+      text: "My text",
+    },
+    multi_label: false,
+    prediction: {
+      agent: "test",
+      labels: [
+        { class: "Test", score: 0.6 },
+        { class: "A", score: 0.4 },
+        { class: "B", score: 0.2 },
+      ],
+    },
+  }),
+  dataset: {
+    task: "TextClassification",
+    query: {
+      text: "mock test",
+    },
+    isMultiLabel: false,
+    viewSettings: {
+      viewMode: "explore",
+    },
+    labels: ["Test", "A", "B"],
+  },
+}
+
 function mountComponent() {
   return mount(Component, {
-    propsData: {
-      record: new TextClassificationRecord({
-        inputs: {
-          text: "My text",
-          multi_label: true,
-          prediction: {
-            agent: "test",
-            labels: [
-              { class: "Test", score: 0.6 },
-              { class: "A", score: 0.4 },
-              { class: "B", score: 0.2 },
-            ],
-          },
-        },
-      }),
-      dataset: {
-        task: "TextClassification",
-        query: {
-          text: "mock test",
-        },
-        viewSettings: {
-          annotationEnabled: false,
-        },
-        labels: ["Test", "A", "B"],
-      },
-    },
+    propsData: props,
     mocks: {
       $route,
     },
@@ -58,4 +67,16 @@ describe("RecordTextClassification", () => {
     const wrapper = mountComponent();
     expect(wrapper).toMatchSnapshot();
   });
+
+  test('renders with empty prediction correctly', () => {
+    const wrapper = mount(Component, {
+      propsData: {
+        ...props,
+        record: {
+          prediction: {}
+        }
+      }
+    })
+    expect(wrapper).toMatchSnapshot()
+  })
 });

--- a/frontend/specs/components/text-classification/results/RecordTextClassification.spec.js
+++ b/frontend/specs/components/text-classification/results/RecordTextClassification.spec.js
@@ -11,9 +11,7 @@ const props = {
   record: new TextClassificationRecord({
     annotation: {
       agent: "recognai",
-      labels:[
-        {class:"Test", score:1}
-      ]
+      labels: [{ class: "Test", score: 1 }],
     },
     inputs: {
       text: "My text",
@@ -39,7 +37,7 @@ const props = {
     },
     labels: ["Test", "A", "B"],
   },
-}
+};
 
 function mountComponent() {
   return mount(Component, {
@@ -68,15 +66,15 @@ describe("RecordTextClassification", () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  test('renders with empty prediction correctly', () => {
+  test("renders with empty prediction correctly", () => {
     const wrapper = mount(Component, {
       propsData: {
         ...props,
         record: {
-          prediction: {}
-        }
-      }
-    })
-    expect(wrapper).toMatchSnapshot()
-  })
+          prediction: {},
+        },
+      },
+    });
+    expect(wrapper).toMatchSnapshot();
+  });
 });

--- a/frontend/specs/components/text-classification/results/__snapshots__/RecordTextClassification.spec.js.snap
+++ b/frontend/specs/components/text-classification/results/__snapshots__/RecordTextClassification.spec.js.snap
@@ -7,6 +7,22 @@ exports[`RecordTextClassification renders properly 1`] = `
     <classifierexplorationarea dataset="[object Object]" record="[object Object]"></classifierexplorationarea>
     <!---->
   </div>
+  <div class="record__labels"><svg version="1.1" viewBox="0 0 40 40" class="svg-icon svg-fill icon__predicted ok" style="width: 40px; height: 40px;">
+      <path pid="0" d="M17.604 25.882l-5.786-5.785 1.929-1.929 3.857 3.857 7.713-7.713 1.929 1.928-9.642 9.642z" _fill="#000"></path>
+      <path pid="1" fill-rule="evenodd" clip-rule="evenodd" d="M5 20c0-8.284 6.716-15 15-15 8.284 0 15 6.716 15 15 0 8.284-6.716 15-15 15-8.284 0-15-6.716-15-15zm15 12.273c-6.778 0-12.273-5.495-12.273-12.273S13.222 7.727 20 7.727 32.273 13.222 32.273 20 26.778 32.273 20 32.273z" _fill="#000"></path>
+    </svg>
+    <re-tag name="Test"></re-tag>
+  </div>
+</div>
+`;
+
+exports[`RecordTextClassification renders with empty prediction correctly 1`] = `
+<div class="record">
+  <div class="record--left">
+    <recordinputs record="[object Object]"></recordinputs>
+    <classifierexplorationarea dataset="[object Object]" record="[object Object]"></classifierexplorationarea>
+    <!---->
+  </div>
   <div class="record__labels">
     <!---->
   </div>


### PR DESCRIPTION
this PR prevents the OK/KO from being displayed when there is any prediction

Closes #1619