### PR TITLE
feat(Listeners): allow using query params in the condition through search parameter

### DIFF
--- a/src/rubrix/listeners/listener.py
+++ b/src/rubrix/listeners/listener.py
@@ -1,3 +1,4 @@
+import copy
 import dataclasses
 import logging
 import threading
@@ -158,7 +159,9 @@ class RBDatasetListener:
             name=self.dataset, task=dataset.task, query=self.formatted_query, size=0
         )
 
-        ctx.search = Search(total=search_results.total)
+        ctx.search = Search(
+            total=search_results.total, params=copy.deepcopy(ctx.query_params)
+        )
         condition_args = [ctx.search]
         if self.metrics:
             condition_args.append(ctx.metrics)

--- a/src/rubrix/listeners/listener.py
+++ b/src/rubrix/listeners/listener.py
@@ -1,5 +1,6 @@
 import copy
 import dataclasses
+import functools
 import logging
 import threading
 import time
@@ -77,6 +78,23 @@ class RBDatasetListener:
         """True if listener is running"""
         return self.__listener_job__ is not None
 
+    def __catch_exceptions__(self, cancel_on_failure=False):
+        def catch_exceptions_decorator(job_func):
+            @functools.wraps(job_func)
+            def wrapper(*args, **kwargs):
+                try:
+                    return job_func(*args, **kwargs)
+                except:
+                    import traceback
+
+                    print(traceback.format_exc())
+                    if cancel_on_failure:
+                        self.stop()  # We stop the scheduler
+
+            return wrapper
+
+        return catch_exceptions_decorator
+
     def start(self, *action_args, **action_kwargs):
         """
         Start listen to changes in the dataset. Additionally, args and kwargs can be passed to action
@@ -88,9 +106,13 @@ class RBDatasetListener:
         if self.is_running():
             raise ValueError("Listener is already running")
 
+        job_step = self.__catch_exceptions__(cancel_on_failure=True)(
+            self.__listener_iteration_job__
+        )
+
         self.__listener_job__ = self.__scheduler__.every(
             self.interval_in_seconds
-        ).seconds.do(self.__listener_iteration_job__, *action_args, **action_kwargs)
+        ).seconds.do(job_step, *action_args, **action_kwargs)
 
         class _ScheduleThread(threading.Thread):
             _WAIT_EVENT = threading.Event()
@@ -160,7 +182,7 @@ class RBDatasetListener:
         )
 
         ctx.search = Search(
-            total=search_results.total, params=copy.deepcopy(ctx.query_params)
+            total=search_results.total, query_params=copy.deepcopy(ctx.query_params)
         )
         condition_args = [ctx.search]
         if self.metrics:

--- a/src/rubrix/listeners/models.py
+++ b/src/rubrix/listeners/models.py
@@ -13,9 +13,11 @@ class Search:
 
     Args:
         total: The total number of records affected by the listener query
+        params: The query parameters applied to the executed search
     """
 
     total: int
+    params: Optional[Dict[str, Any]] = None
 
 
 class Metrics(Prodict):
@@ -63,7 +65,7 @@ class RBListenerContext:
         return self.__listener__.formatted_query
 
 
-ListenerCondition = Callable[[Search, Metrics], bool]
+ListenerCondition = Callable[[Search, Optional[RBListenerContext]], bool]
 ListenerAction = Union[
     Callable[[List[Record], RBListenerContext], bool],
     Callable[[RBListenerContext], bool],

--- a/src/rubrix/listeners/models.py
+++ b/src/rubrix/listeners/models.py
@@ -13,11 +13,11 @@ class Search:
 
     Args:
         total: The total number of records affected by the listener query
-        params: The query parameters applied to the executed search
+        query_params: The query parameters applied to the executed search
     """
 
     total: int
-    params: Optional[Dict[str, Any]] = None
+    query_params: Optional[Dict[str, Any]] = None
 
 
 class Metrics(Prodict):

--- a/tests/listeners/test_listener.py
+++ b/tests/listeners/test_listener.py
@@ -8,6 +8,12 @@ from rubrix import RBListenerContext, listener
 from rubrix.client.models import Record
 
 
+def condition_check_params(search):
+    if search:
+        assert "param" in search.params and search.params["param"] == 100
+    return True
+
+
 @pytest.mark.parametrize(
     argnames=["dataset", "query", "metrics", "condition", "query_params"],
     argvalues=[
@@ -17,7 +23,7 @@ from rubrix.client.models import Record
         ("dataset", "val", None, None, None),
         ("dataset", None, ["F1"], lambda search, metrics: False, None),
         ("dataset", "val", None, lambda q: False, None),
-        ("dataset", "val + {param}", None, lambda q: True, {"param": 100}),
+        ("dataset", "val + {param}", None, condition_check_params, {"param": 100}),
     ],
 )
 def test_listener_with_parameters(

--- a/tests/listeners/test_listener.py
+++ b/tests/listeners/test_listener.py
@@ -10,7 +10,7 @@ from rubrix.client.models import Record
 
 def condition_check_params(search):
     if search:
-        assert "param" in search.params and search.params["param"] == 100
+        assert "param" in search.query_params and search.query_params["param"] == 100
     return True
 
 

--- a/tests/listeners/test_listener.py
+++ b/tests/listeners/test_listener.py
@@ -73,6 +73,7 @@ def test_listener_with_parameters(
         test.action.start()
 
     time.sleep(1.5)
+    assert test.action.is_running()
     test.action.stop()
     assert not test.action.is_running()
 


### PR DESCRIPTION
In this PR the search query parameters (if any) are visible inside the condition method context. So you use the dynamic query parameters as part of your listener condition:

```python
def condition(search):
   return search.query_params["my-query-param"] == "cool" and search.total > 10
```


@chschroeder It would be nice if you can do some tests with changes in this PR, just to validate the solution. Please, let me know if it's okay for you.

Closes #1622 


