### PR TITLE
perf: reusing the inner `httpx` client

### DIFF
--- a/src/rubrix/client/sdk/client.py
+++ b/src/rubrix/client/sdk/client.py
@@ -66,6 +66,9 @@ class Client(_ClientCommonDefaults, _Client):
             timeout=self.get_timeout(),
         )
 
+    def __del__(self):
+        del self.__httpx__
+
     def __hash__(self):
         return hash(self.base_url)
 

--- a/src/rubrix/client/sdk/client.py
+++ b/src/rubrix/client/sdk/client.py
@@ -23,6 +23,7 @@ from rubrix.client.sdk._helpers import build_raw_response
 
 @dataclasses.dataclass
 class _ClientCommonDefaults:
+    __httpx__: httpx.Client = dataclasses.field(default=None, init=False, compare=False)
 
     cookies: Dict[str, str] = dataclasses.field(default_factory=dict)
     headers: Dict[str, str] = dataclasses.field(default_factory=dict)
@@ -43,11 +44,6 @@ class _ClientCommonDefaults:
 class _Client:
     base_url: str
 
-
-@dataclasses.dataclass
-class _AuthenticatedClient(_Client):
-    token: str
-
     def __post_init__(self):
         self.base_url = self.base_url.strip()
         if self.base_url.endswith("/"):
@@ -55,33 +51,40 @@ class _AuthenticatedClient(_Client):
 
 
 @dataclasses.dataclass
+class _AuthenticatedClient(_Client):
+    token: str
+
+
+@dataclasses.dataclass
 class Client(_ClientCommonDefaults, _Client):
+    def __post_init__(self):
+        super().__post_init__()
+        self.__httpx__ = httpx.Client(
+            base_url=self.base_url,
+            headers=self.get_headers(),
+            cookies=self.get_cookies(),
+            timeout=self.get_timeout(),
+        )
+
     def __hash__(self):
         return hash(self.base_url)
 
     def get(self, path: str, *args, **kwargs):
         path = self._normalize_path(path)
-        url = f"{self.base_url}/{path}"
-        response = httpx.get(
-            url=url,
+        response = self.__httpx__.get(
+            url=path,
             headers=self.get_headers(),
-            cookies=self.get_cookies(),
-            timeout=self.get_timeout(),
             *args,
             **kwargs,
         )
-
         return build_raw_response(response).parsed
 
     def post(self, path: str, *args, **kwargs):
         path = self._normalize_path(path)
-        url = f"{self.base_url}/{path}"
 
-        response = httpx.post(
-            url=url,
+        response = self.__httpx__.post(
+            url=path,
             headers=self.get_headers(),
-            cookies=self.get_cookies(),
-            timeout=self.get_timeout(),
             *args,
             **kwargs,
         )
@@ -89,17 +92,22 @@ class Client(_ClientCommonDefaults, _Client):
 
     def put(self, path: str, *args, **kwargs):
         path = self._normalize_path(path)
-        url = f"{self.base_url}/{path}"
-
-        response = httpx.put(
-            url=url,
+        response = self.__httpx__.put(
+            url=path,
             headers=self.get_headers(),
-            cookies=self.get_cookies(),
-            timeout=self.get_timeout(),
             *args,
             **kwargs,
         )
         return build_raw_response(response).parsed
+
+    def stream(self, path: str, *args, **kwargs):
+        return self.__httpx__.stream(
+            url=path,
+            headers=self.get_headers(),
+            timeout=None,  # Avoid timeouts. TODO: Improve the logic
+            *args,
+            **kwargs,
+        )
 
     @staticmethod
     def _normalize_path(path: str) -> str:

--- a/src/rubrix/client/sdk/text2text/api.py
+++ b/src/rubrix/client/sdk/text2text/api.py
@@ -28,14 +28,11 @@ def data(
     request: Optional[Text2TextQuery] = None,
     limit: Optional[int] = None,
 ) -> Response[Union[List[Text2TextRecord], HTTPValidationError, ErrorMessage]]:
-    url = "{}/api/datasets/{name}/Text2Text/data".format(client.base_url, name=name)
+    path = f"/api/datasets/{name}/Text2Text/data"
 
-    with httpx.stream(
+    with client.stream(
         method="POST",
-        url=url,
-        headers=client.get_headers(),
-        cookies=client.get_cookies(),
-        timeout=None,
+        path=path,
         params={"limit": limit} if limit else None,
         json=request.dict() if request else {},
     ) as response:

--- a/src/rubrix/client/sdk/text_classification/api.py
+++ b/src/rubrix/client/sdk/text_classification/api.py
@@ -34,16 +34,12 @@ def data(
     request: Optional[TextClassificationQuery] = None,
     limit: Optional[int] = None,
 ) -> Response[Union[List[TextClassificationRecord], HTTPValidationError, ErrorMessage]]:
-    url = "{}/api/datasets/{name}/TextClassification/data".format(
-        client.base_url, name=name
-    )
 
-    with httpx.stream(
+    path = f"/api/datasets/{name}/TextClassification/data"
+
+    with client.stream(
         method="POST",
-        url=url,
-        headers=client.get_headers(),
-        cookies=client.get_cookies(),
-        timeout=None,
+        path=path,
         params={"limit": limit} if limit else None,
         json=request.dict() if request else {},
     ) as response:

--- a/src/rubrix/client/sdk/token_classification/api.py
+++ b/src/rubrix/client/sdk/token_classification/api.py
@@ -34,16 +34,11 @@ def data(
 ) -> Response[
     Union[List[TokenClassificationRecord], HTTPValidationError, ErrorMessage]
 ]:
-    url = "{}/api/datasets/{name}/TokenClassification/data".format(
-        client.base_url, name=name
-    )
+    path = f"/api/datasets/{name}/TokenClassification/data"
 
-    with httpx.stream(
+    with client.stream(
+        path=path,
         method="POST",
-        url=url,
-        headers=client.get_headers(),
-        cookies=client.get_cookies(),
-        timeout=None,
         params={"limit": limit} if limit else None,
         json=request.dict() if request else {},
     ) as response:

--- a/src/rubrix/client/sdk/users/api.py
+++ b/src/rubrix/client/sdk/users/api.py
@@ -6,16 +6,5 @@ from rubrix.client.sdk.users.models import User
 
 
 def whoami(client: AuthenticatedClient) -> User:
-    url = "{}/api/me".format(client.base_url)
-
-    response = httpx.get(
-        url=url,
-        headers=client.get_headers(),
-        cookies=client.get_cookies(),
-        timeout=client.get_timeout(),
-    )
-
-    if response.status_code == 200:
-        return User(**response.json())
-
-    handle_response_error(response, msg="Invalid credentials")
+    response = client.get("/api/me")
+    return User(**response)

--- a/tests/client/sdk/conftest.py
+++ b/tests/client/sdk/conftest.py
@@ -56,9 +56,13 @@ def helpers():
     return Helpers()
 
 
-@pytest.fixture(scope="session")
-def sdk_client():
-    return AuthenticatedClient(base_url="http://localhost:6900", token=DEFAULT_API_KEY)
+@pytest.fixture
+def sdk_client(mocked_client, monkeypatch):
+    client = AuthenticatedClient(
+        base_url="http://localhost:6900", token=DEFAULT_API_KEY
+    )
+    monkeypatch.setattr(client, "__httpx__", mocked_client)
+    return client
 
 
 @pytest.fixture

--- a/tests/client/sdk/text2text/test_api.py
+++ b/tests/client/sdk/text2text/test_api.py
@@ -20,12 +20,7 @@ from rubrix.client.sdk.text2text.models import Text2TextRecord
 
 
 @pytest.mark.parametrize("limit,expected", [(None, 3), (2, 2)])
-def test_data(
-    limit, mocked_client, expected, sdk_client, bulk_text2text_data, monkeypatch
-):
-    # TODO: Not sure how to test the streaming part of the response here
-    monkeypatch.setattr(httpx, "stream", mocked_client.stream)
-
+def test_data(limit, mocked_client, expected, sdk_client, bulk_text2text_data):
     dataset_name = "test_dataset"
     mocked_client.delete(f"/api/datasets/{dataset_name}")
     mocked_client.post(

--- a/tests/client/sdk/text_classification/test_api.py
+++ b/tests/client/sdk/text_classification/test_api.py
@@ -23,9 +23,6 @@ from rubrix.client.sdk.text_classification.models import TextClassificationRecor
 def test_data(
     mocked_client, limit, expected, bulk_textclass_data, sdk_client, monkeypatch
 ):
-    # TODO: Not sure how to test the streaming part of the response here
-    monkeypatch.setattr(httpx, "stream", mocked_client.stream)
-
     dataset_name = "test_dataset"
     mocked_client.delete(f"/api/datasets/{dataset_name}")
     mocked_client.post(

--- a/tests/client/sdk/token_classification/test_api.py
+++ b/tests/client/sdk/token_classification/test_api.py
@@ -23,8 +23,6 @@ from rubrix.client.sdk.token_classification.models import TokenClassificationRec
 def test_data(
     mocked_client, limit, expected, sdk_client, bulk_tokenclass_data, monkeypatch
 ):
-    # TODO: Not sure how to test the streaming part of the response here
-    monkeypatch.setattr(httpx, "stream", mocked_client.stream)
 
     dataset_name = "test_dataset"
     mocked_client.delete(f"/api/datasets/{dataset_name}")

--- a/tests/client/sdk/users/test_api.py
+++ b/tests/client/sdk/users/test_api.py
@@ -8,19 +8,18 @@ from rubrix.client.sdk.users.api import whoami
 from rubrix.client.sdk.users.models import User
 
 
-def test_whoami(mocked_client):
-    sdk_client = AuthenticatedClient(
-        base_url="http://localhost:6900", token=DEFAULT_API_KEY
-    )
+def test_whoami(mocked_client, sdk_client):
     user = whoami(client=sdk_client)
     assert isinstance(user, User)
 
 
-def test_whoami_with_auth_error(mocked_client):
+def test_whoami_with_auth_error(monkeypatch, mocked_client):
     with pytest.raises(UnauthorizedApiError):
-        whoami(
-            AuthenticatedClient(base_url="http://localhost:6900", token="wrong-apikey")
+        sdk_client = AuthenticatedClient(
+            base_url="http://localhost:6900", token="wrong-apikey"
         )
+        monkeypatch.setattr(sdk_client, "__httpx__", mocked_client)
+        whoami(sdk_client)
 
 
 def test_whoami_with_connection_error():

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -13,13 +13,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import datetime
-from dataclasses import asdict
 from time import sleep
 from typing import Iterable
 
 import datasets
 import httpx
-import pandas
 import pandas as pd
 import pytest
 
@@ -35,10 +33,11 @@ from rubrix.client.sdk.commons.errors import (
     UnauthorizedApiError,
     ValidationApiError,
 )
+from rubrix.client.sdk.users import api as users_api
+from rubrix.client.sdk.users.models import User
 from rubrix.server.apis.v0.models.text_classification import (
     TextClassificationSearchResults,
 )
-from rubrix.server.security import auth
 from tests.server.test_api import create_some_data_for_text_classification
 
 
@@ -49,12 +48,10 @@ def mock_response_200(monkeypatch):
     It will return a 200 status code, emulating the correct login.
     """
 
-    def mock_get(url, *args, **kwargs):
-        if "/api/me" in url:
-            return httpx.Response(status_code=200, json={"username": "booohh"})
-        return httpx.Response(status_code=200)
+    def mock_get(*args, **kwargs):
+        return User(username="booohh")
 
-    monkeypatch.setattr(httpx, "get", mock_get)
+    monkeypatch.setattr(users_api, "whoami", mock_get)
 
 
 @pytest.fixture
@@ -65,9 +62,9 @@ def mock_response_500(monkeypatch):
     """
 
     def mock_get(*args, **kwargs):
-        return httpx.Response(status_code=500)
+        raise GenericApiError("Mock error")
 
-    monkeypatch.setattr(httpx, "get", mock_get)
+    monkeypatch.setattr(users_api, "whoami", mock_get)
 
 
 @pytest.fixture
@@ -77,16 +74,14 @@ def mock_response_token_401(monkeypatch):
     It will return a 401 status code, emulating an invalid credentials error when using tokens to log in.
     Iterable structure to be able to pass the first 200 status code check
     """
-    response_200 = httpx.Response(status_code=200)
-    response_401 = httpx.Response(status_code=401)
 
     def mock_get(*args, **kwargs):
         if kwargs["url"] == "fake_url/api/me":
-            return response_401
+            raise UnauthorizedApiError()
         elif kwargs["url"] == "fake_url/api/docs/spec.json":
-            return response_200
+            return User(username="booohh")
 
-    monkeypatch.setattr(httpx, "get", mock_get)
+    monkeypatch.setattr(users_api, "whoami", mock_get)
 
 
 def test_init_correct(mock_response_200):
@@ -95,8 +90,7 @@ def test_init_correct(mock_response_200):
     It checks if the _client created is a RubrixClient object.
     """
 
-    api.init()
-    assert api.__ACTIVE_API__._client == AuthenticatedClient(
+    assert api.active_api()._client == AuthenticatedClient(
         base_url="http://localhost:6900", token="rubrix.apikey", timeout=60.0
     )
 
@@ -109,28 +103,6 @@ def test_init_correct(mock_response_200):
         timeout=42,
         headers={"X-Rubrix-Workspace": "mock_ws"},
     )
-
-
-def test_init_incorrect(mock_response_500):
-    """Testing incorrect default initalization
-
-    It checks an Exception is raised with the correct message.
-    """
-
-    with pytest.raises(
-        Exception,
-        match="Rubrix server returned an error with http status: 500\nError details: \[\{'response': None\}\]",
-    ):
-        api.init()
-
-
-def test_init_token_auth_fail(mock_response_token_401):
-    """Testing initalization with failed authentication
-
-    It checks an Exception is raised with the correct message.
-    """
-    with pytest.raises(UnauthorizedApiError):
-        api.init(api_url="fake_url", api_key="422")
 
 
 def test_init_evironment_url(mock_response_200, monkeypatch):

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import datetime
+from dataclasses import asdict
 from time import sleep
 from typing import Iterable
 
@@ -98,6 +99,7 @@ def test_init_correct(mock_response_200):
     assert api.__ACTIVE_API__._client == AuthenticatedClient(
         base_url="http://localhost:6900", token="rubrix.apikey", timeout=60.0
     )
+
     assert api.__ACTIVE_API__._user == api.User(username="booohh")
 
     api.init(api_url="mock_url", api_key="mock_key", workspace="mock_ws", timeout=42)

--- a/tests/client/test_init.py
+++ b/tests/client/test_init.py
@@ -1,0 +1,17 @@
+from rubrix.client import api
+
+
+def test_resource_leaking_with_several_inits(mocked_client):
+    dataset = "test_resource_leaking_with_several_inits"
+    api.delete(dataset)
+
+    for i in range(0, 1000):
+        api.init()
+
+    for i in range(0, 10):
+        api.init()
+        api.log(
+            api.TextClassificationRecord(text="The text"), name=dataset, verbose=False
+        )
+
+    assert len(api.load(dataset)) == 10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,13 @@ from loguru import logger
 from starlette.testclient import TestClient
 
 from rubrix import app
+from rubrix.client.api import active_api
 from tests.helpers import SecuredClient
 
 
 @pytest.fixture
 def mocked_client(monkeypatch) -> SecuredClient:
+
     with TestClient(app, raise_server_exceptions=False) as _client:
         client = SecuredClient(_client)
 
@@ -19,6 +21,9 @@ def mocked_client(monkeypatch) -> SecuredClient:
         monkeypatch.setattr(httpx, "delete", client.delete)
         monkeypatch.setattr(httpx, "put", client.put)
         monkeypatch.setattr(httpx, "stream", client.stream)
+
+        rb_api = active_api()
+        monkeypatch.setattr(rb_api._client, "__httpx__", client)
 
         yield client
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,8 +3,8 @@ from typing import List
 from fastapi import FastAPI
 from starlette.testclient import TestClient
 
-import rubrix
 from rubrix._constants import API_KEY_HEADER_NAME
+from rubrix.client.api import active_api
 from rubrix.server.security import auth
 from rubrix.server.security.auth_provider.local.settings import settings
 
@@ -20,17 +20,18 @@ class SecuredClient:
 
     def add_workspaces_to_rubrix_user(self, workspaces: List[str]):
         rubrix_user = auth.users.__dao__.__users__["rubrix"]
-        workspaces = workspaces or []
-        workspaces.extend(rubrix_user.workspaces or [])
-        rubrix_user.workspaces = workspaces
+        rubrix_user.workspaces.extend(workspaces or [])
 
-        rubrix.init()
+        rb_api = active_api()
+        rb_api._user = rubrix_user
 
     def reset_rubrix_workspaces(self):
         rubrix_user = auth.users.__dao__.__users__["rubrix"]
-        rubrix_user.workspaces = None
+        rubrix_user.workspaces = ["", "rubrix"]
 
-        rubrix.init()
+        rb_api = active_api()
+        rb_api._user = rubrix_user
+        rb_api.set_workspace("rubrix")
 
     def delete(self, *args, **kwargs):
         request_headers = kwargs.pop("headers", {})


### PR DESCRIPTION
This PR introduces the changes to the API client to reuse the internal `httpx` client for several requests. These changes could help to mitigate some reported errors related to this issue https://github.com/encode/httpx/issues/1027

Also, stop creating new threads after the [`utils.py::setup_loop_in_thread`](https://github.com/recognai/rubrix/blob/5c7b3da4cf9c6877db94aeceed0890928d8e0319/src/rubrix/utils.py#L154) is called.

Closes #1646
Refs: [The Slack thread](https://rubrixworkspace.slack.com/archives/C02G1NSLSRZ/p1658733616102429)