### PR TITLE
Documentation improvements

### DIFF
--- a/docs/getting_started/advanced_setup_guides.md
+++ b/docs/getting_started/advanced_setup_guides.md
@@ -168,8 +168,8 @@ you will lose all your datasets in Rubrix!
 :::
 
 ### Persisting ElasticSearch data
-To avoid losing all the data when the docker-compose/server goes down, you can add some persistence by mounting a local
-volume in docker compose and granting the required permissions. 
+To avoid losing all the data when the docker-compose/server goes down, you can add some persistence by mounting a 
+volume in the docker compose. 
 
 To this end, **modify the elasticsearch service and create a new volume** in the docker-compse.yml file:
 

--- a/docs/getting_started/advanced_setup_guides.md
+++ b/docs/getting_started/advanced_setup_guides.md
@@ -191,7 +191,7 @@ services:
       - rubrix
     # Add the volume to the elasticsearch service
     volumes:
-      - ./elasticdata:/usr/share/elasticsearch/data
+      - elasticdata:/usr/share/elasticsearch/data
   rubrix:
     # ... here goes the rest of the docker-compose.yaml
   
@@ -204,12 +204,12 @@ volumes:
 
 ```
 
-Then create the elasticdata/ directory and add the required permissions:
-```bash
-mkdir elasticdata && sudo chown -R 1000:1000 elasticdata/
-```
+Then, even if the ElasticSearch service goes down the data will be persisted in the elasticdata volume. To check it
+you can execute the command:
 
-Then, even if the ElasticSearch service goes down the data will be persisted in the elasticdata/ directory.
+```bash
+docker volume ls
+```
 
 Note that if you want to apply these changes, and you already have a previous docker-compose instance running, you need 
 to execute the **up** command again:


### PR DESCRIPTION
Elasticsearch persistence how-to added to the docker compose installation guide.
Warning added that the current version might be used with "docker compose" (without  "-")
Minor typo fixes