### PR TITLE
feat(Error Logging): send error detail in response for generic server errors

### DIFF
--- a/src/rubrix/server/errors/base_errors.py
+++ b/src/rubrix/server/errors/base_errors.py
@@ -57,7 +57,9 @@ class ValidationError(RubrixServerError):
 
 class GenericRubrixServerError(RubrixServerError):
     def __init__(self, error: Exception):
-        self.error = error
+        self.type = f"{type(error).__module__}.{type(error).__name__}"
+        self.message = str(error)
+        self.args = error.args
 
     @classmethod
     def api_documentation(cls):
@@ -68,20 +70,6 @@ class GenericRubrixServerError(RubrixServerError):
                 }
             },
         }
-
-    @classmethod
-    def get_error_code(cls):
-        raise NotImplementedError(
-            "This class method is not supported for generic server error"
-        )
-
-    @property
-    def code(self) -> str:
-        return f"{type(self.error).__module__}.{type(self.error).__name__}"
-
-    @property
-    def arguments(self):
-        return {}
 
 
 class ForbiddenOperationError(RubrixServerError):

--- a/tests/server/test_errors.py
+++ b/tests/server/test_errors.py
@@ -1,0 +1,10 @@
+from rubrix.server.errors import GenericRubrixServerError
+
+
+def test_generic_error():
+
+    err = GenericRubrixServerError(error=ValueError("this is an error"))
+    assert (
+        str(err)
+        == "rubrix.api.errors::GenericRubrixServerError(type=builtins.ValueError,message=this is an error)"
+    )


### PR DESCRIPTION
This PR applies changes to send an error context from the server side for generic server errors. This change will more info to the client about what's happening.

@dvsrepo I think this PR will like you.

Refs: #1275 