### PR TITLE
fix(#1659): normalize id sort config

### DIFF
--- a/src/rubrix/server/daos/datasets.py
+++ b/src/rubrix/server/daos/datasets.py
@@ -29,6 +29,7 @@ from rubrix.server.elasticseach.mappings.datasets import (
 from rubrix.server.errors import WrongTaskError
 
 NO_WORKSPACE = ""
+MAX_NUMBER_OF_LISTED_DATASETS = 2500
 
 
 class DatasetsDAO:
@@ -112,6 +113,9 @@ class DatasetsDAO:
 
         docs = self._es.list_documents(
             index=DATASETS_INDEX_NAME,
+            fetch_once=True,
+            # TODO(@frascuchon): include id as part of the document as keyword to enable sorting by id
+            size=MAX_NUMBER_OF_LISTED_DATASETS,
             query={
                 "query": query_helpers.filters.boolean_filter(
                     should_filters=filters, minimum_should_match=len(filters)
@@ -231,6 +235,7 @@ class DatasetsDAO:
             results = self._es.list_documents(
                 index=DATASETS_INDEX_NAME,
                 query={"query": {"term": {"name.keyword": name}}},
+                fetch_once=True,
             )
             results = list(results)
             if len(results) == 0:

--- a/src/rubrix/server/daos/records.py
+++ b/src/rubrix/server/daos/records.py
@@ -312,6 +312,7 @@ class DatasetRecordsDAO:
             docs = self._es.list_documents(
                 index,
                 query=es_query,
+                sort_cfg=sort_cfg,
             )
         for doc in docs:
             yield self.__esdoc2record__(doc)

--- a/src/rubrix/server/daos/records.py
+++ b/src/rubrix/server/daos/records.py
@@ -289,22 +289,29 @@ class DatasetRecordsDAO:
         -------
             An iterable over found dataset records
         """
+        index = dataset_records_index(dataset.id)
         search = search or RecordSearch()
+
+        sort_cfg = self.__normalize_sort_config__(
+            index=index, sort=[{"id": {"order": "asc"}}]
+        )
         es_query = {
             "query": search.query or {"match_all": {}},
             "highlight": self.__configure_query_highlight__(task=dataset.task),
-            "sort": [{"id": {"order": "asc"}}]  # Sort the search so the consistency is maintained in every search
+            "sort": sort_cfg,  # Sort the search so the consistency is maintained in every search
         }
+
         if id_from:
             # Scroll method does not accept read_after, thus, this case is handled as a search
             es_query["search_after"] = [id_from]
-            results = self._es.search(index=dataset_records_index(dataset.id), query=es_query, size=limit)
+            results = self._es.search(index=index, query=es_query, size=limit)
             hits = results["hits"]
             docs = hits["hits"]
 
         else:
             docs = self._es.list_documents(
-                dataset_records_index(dataset.id), query=es_query,
+                index,
+                query=es_query,
             )
         for doc in docs:
             yield self.__esdoc2record__(doc)


### PR DESCRIPTION
The `DatasetsDAO` class is using the `list_documents` method, but no `id` field is defined for that index. The option of using `_id` field as default sorting does not work for elasticsearch 8.x without customizing some extra cluster-level settings that entangle the whole process. So, is not a general solution.

As a workaround, we fix the max number of datasets to fetch disabling the sort configuration for those cases.

The full fix will be included once #1661 is implemented.