### PR TITLE
handle inaccessible api_url exception

### DIFF
--- a/src/rubrix/client/api.py
+++ b/src/rubrix/client/api.py
@@ -149,8 +149,10 @@ class Api:
         self._agent = _RubrixLogAgent(self)
 
     def __del__(self):
-        del self._client
-        del self._agent
+        if hasattr(self,"_client"):
+            del self._client
+        if hasattr(self,"_agent"):
+            del self._agent
 
     @property
     def client(self):

--- a/src/rubrix/client/sdk/client.py
+++ b/src/rubrix/client/sdk/client.py
@@ -19,6 +19,7 @@ import httpx
 
 from rubrix._constants import API_KEY_HEADER_NAME
 from rubrix.client.sdk._helpers import build_raw_response
+from rubrix.client.sdk.commons.errors import RubrixClientError
 
 
 @dataclasses.dataclass
@@ -74,13 +75,17 @@ class Client(_ClientCommonDefaults, _Client):
 
     def get(self, path: str, *args, **kwargs):
         path = self._normalize_path(path)
-        response = self.__httpx__.get(
-            url=path,
-            headers=self.get_headers(),
-            *args,
-            **kwargs,
-        )
-        return build_raw_response(response).parsed
+        try:
+            response = self.__httpx__.get(
+                url=path,
+                headers=self.get_headers(),
+                *args,
+                **kwargs,
+            )
+            return build_raw_response(response).parsed
+        except httpx.ConnectError as err:
+            err_str = f"Your Api endpoint at {self.base_url} is not available or not responding."
+            raise RubrixClientError(err_str) from None
 
     def post(self, path: str, *args, **kwargs):
         path = self._normalize_path(path)

--- a/src/rubrix/client/sdk/client.py
+++ b/src/rubrix/client/sdk/client.py
@@ -78,7 +78,8 @@ class Client(_ClientCommonDefaults, _Client):
         @functools.wraps(func)
         def inner(self, *args, **kwargs):
             try:
-                func(self, *args, **kwargs)
+                result = func(self, *args, **kwargs)
+                return result
             except httpx.ConnectError as err:
                 err_str = f"Your Api endpoint at {self.base_url} is not available or not responding."
                 raise RubrixClientError(err_str) from None


### PR DESCRIPTION
Description:
On entering wrong inaccessible api_url end user gets to see nested error trace

Current error trace looks like:
```
```
Traceback (most recent call last):
  File "/home/ankushchander/workplace/.virtualenv/rubrix-env/lib/python3.8/site-packages/httpx/_exceptions.py", line 339, in map_exceptions
    yield
  File "/home/ankushchander/workplace/.virtualenv/rubrix-env/lib/python3.8/site-packages/httpx/_client.py", line 854, in _send_single_request
    (status_code, headers, stream, ext) = transport.request(
  File "/home/ankushchander/workplace/.virtualenv/rubrix-env/lib/python3.8/site-packages/httpcore/_sync/connection_pool.py", line 200, in request
    response = connection.request(
  File "/home/ankushchander/workplace/.virtualenv/rubrix-env/lib/python3.8/site-packages/httpcore/_sync/connection.py", line 87, in request
    self.socket = self._open_socket(timeout)
  File "/home/ankushchander/workplace/.virtualenv/rubrix-env/lib/python3.8/site-packages/httpcore/_sync/connection.py", line 108, in _open_socket
    return self.backend.open_tcp_stream(
  File "/home/ankushchander/workplace/.virtualenv/rubrix-env/lib/python3.8/site-packages/httpcore/_backends/sync.py", line 144, in open_tcp_stream
    return SyncSocketStream(sock=sock)
  File "/usr/lib/python3.8/contextlib.py", line 131, in __exit__
    self.gen.throw(type, value, traceback)
  File "/home/ankushchander/workplace/.virtualenv/rubrix-env/lib/python3.8/site-packages/httpcore/_exceptions.py", line 12, in map_exceptions
    raise to_exc(exc) from None
httpcore.ConnectError: [Errno 111] Connection refused

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/ankushchander/workplace/open_source/rubrix-tryout/test_rubrix.py", line 5, in <module>
    rb.init(api_url="http://localhost:80000")
  File "/home/ankushchander/workplace/open_source/rubrix/src/rubrix/client/api.py", line 603, in wrapped_func
    return func(*args, **kwargs)
  File "/home/ankushchander/workplace/open_source/rubrix/src/rubrix/client/api.py", line 617, in init
    __ACTIVE_API__ = Api(*args, **kwargs)
  File "/home/ankushchander/workplace/open_source/rubrix/src/rubrix/client/api.py", line 144, in __init__
    self._user: User = users_api.whoami(client=self._client)
  File "/home/ankushchander/workplace/open_source/rubrix/src/rubrix/client/sdk/users/api.py", line 9, in whoami
    response = client.get("/api/me")
  File "/home/ankushchander/workplace/open_source/rubrix/src/rubrix/client/sdk/client.py", line 79, in get
    response = self.__httpx__.get(
  File "/home/ankushchander/workplace/.virtualenv/rubrix-env/lib/python3.8/site-packages/httpx/_client.py", line 900, in get
    return self.request(
  File "/home/ankushchander/workplace/.virtualenv/rubrix-env/lib/python3.8/site-packages/httpx/_client.py", line 721, in request
    return self.send(
  File "/home/ankushchander/workplace/.virtualenv/rubrix-env/lib/python3.8/site-packages/httpx/_client.py", line 753, in send
    response = self._send_handling_auth(
  File "/home/ankushchander/workplace/.virtualenv/rubrix-env/lib/python3.8/site-packages/httpx/_client.py", line 791, in _send_handling_auth
    response = self._send_handling_redirects(
  File "/home/ankushchander/workplace/.virtualenv/rubrix-env/lib/python3.8/site-packages/httpx/_client.py", line 823, in _send_handling_redirects
    response = self._send_single_request(request, timeout)
  File "/home/ankushchander/workplace/.virtualenv/rubrix-env/lib/python3.8/site-packages/httpx/_client.py", line 854, in _send_single_request
    (status_code, headers, stream, ext) = transport.request(
  File "/usr/lib/python3.8/contextlib.py", line 131, in __exit__
    self.gen.throw(type, value, traceback)
  File "/home/ankushchander/workplace/.virtualenv/rubrix-env/lib/python3.8/site-packages/httpx/_exceptions.py", line 356, in map_exceptions
    raise mapped_exc(message, **kwargs) from exc  # type: ignore
httpx.ConnectError: [Errno 111] Connection refused
Exception ignored in: <function Api.__del__ at 0x7ff17980f310>
Traceback (most recent call last):
  File "/home/ankushchander/workplace/open_source/rubrix/src/rubrix/client/api.py", line 155, in __del__
    del self._agent
AttributeError: _agent
```
```
