### PR TITLE
fix: Update progress bar when refreshing after adding new records

### DIFF
--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -282,15 +282,9 @@ async function _refreshDatasetAggregations({ dataset }) {
     size: 0,
   });
 
-  const globalResults = await _querySearch({
-    dataset,
-    query: {},
-    size: 0,
-  });
-
   return await _updateTaskDataset({
     dataset,
-    data: { globalResults, results: { aggregations } },
+    data: { results: { aggregations } },
   });
 }
 
@@ -635,7 +629,6 @@ const actions = {
       size: pagination.size,
       page: pagination.page,
     });
-    await _refreshDatasetAggregations({ dataset: paginatedDataset });
     await _fetchAnnotationProgress(paginatedDataset);
   },
 };

--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -282,9 +282,15 @@ async function _refreshDatasetAggregations({ dataset }) {
     size: 0,
   });
 
+  const globalResults = await _querySearch({
+    dataset,
+    query: {},
+    size: 0,
+  });
+
   return await _updateTaskDataset({
     dataset,
-    data: { results: { aggregations } },
+    data: { globalResults, results: { aggregations } },
   });
 }
 
@@ -630,11 +636,6 @@ const actions = {
       page: pagination.page,
     });
     await _refreshDatasetAggregations({ dataset: paginatedDataset });
-    await _updateAnnotationProgress({
-      id: dataset.name,
-      total: dataset.globalResults.total,
-      aggregations: dataset.globalResults.aggregations,
-    });
   },
 };
 

--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -630,6 +630,11 @@ const actions = {
       page: pagination.page,
     });
     await _refreshDatasetAggregations({ dataset: paginatedDataset });
+    await _updateAnnotationProgress({
+      id: dataset.name,
+      total: dataset.globalResults.total,
+      aggregations: dataset.globalResults.aggregations,
+    });
   },
 };
 

--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -629,6 +629,7 @@ const actions = {
       size: pagination.size,
       page: pagination.page,
     });
+    await _refreshDatasetAggregations({ dataset: paginatedDataset });
     await _fetchAnnotationProgress(paginatedDataset);
   },
 };

--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -636,6 +636,7 @@ const actions = {
       page: pagination.page,
     });
     await _refreshDatasetAggregations({ dataset: paginatedDataset });
+    await _fetchAnnotationProgress(paginatedDataset);
   },
 };
 


### PR DESCRIPTION
closes #1590

this PR forces "Refresh" button to update progress metrics