### PR TITLE
Incompatible attribute type fixed

### DIFF
--- a/src/rubrix/client/apis/datasets.py
+++ b/src/rubrix/client/apis/datasets.py
@@ -85,9 +85,9 @@ class Datasets(AbstractApi):
     class _DatasetApiModel(BaseModel):
         name: str
         task: TaskType
-        owner: str = None
-        created_at: datetime = None
-        last_updated: datetime = None
+        owner: Optional[str] = None
+        created_at: Optional[datetime] = None
+        last_updated: Optional[datetime] = None
 
         tags: Dict[str, str] = Field(default_factory=dict)
         metadata: Dict[str, Any] = Field(default_factory=dict)


### PR DESCRIPTION
Pyre type checker warning.

**"filename"**: "src/rubrix/client/apis/datasets.py"
**"warning_type"**: "Incompatible attribute type [8]",
**"warning_message"**: " Attribute `owner` declared in class `Datasets._DatasetApiModel` has type `str` but is used as type `None`.",
**"warning_line"**: 88
**"fix"**: adding Optional types