### PR TITLE
fix: 'MajorityVoter.score' when using multi-labels

### DIFF
--- a/src/rubrix/labeling/text_classification/label_models.py
+++ b/src/rubrix/labeling/text_classification/label_models.py
@@ -375,6 +375,7 @@ class MajorityVoter(LabelModel):
             probabilities = self._compute_multi_label_probs(wl_matrix)
 
             annotation, prediction = self._score_multi_label(probabilities)
+            target_names = self._weak_labels.labels
         else:
             if isinstance(tie_break_policy, str):
                 tie_break_policy = TieBreakPolicy(tie_break_policy)
@@ -384,11 +385,12 @@ class MajorityVoter(LabelModel):
             annotation, prediction = self._score_single_label(
                 probabilities, tie_break_policy
             )
+            target_names = self._weak_labels.labels[: annotation.max() + 1]
 
         return classification_report(
             annotation,
             prediction,
-            target_names=self._weak_labels.labels[: annotation.max() + 1],
+            target_names=target_names,
             output_dict=not output_str,
         )
 

--- a/tests/labeling/text_classification/test_label_models.py
+++ b/tests/labeling/text_classification/test_label_models.py
@@ -395,7 +395,6 @@ class TestMajorityVoter:
 
         assert np.allclose(annotation, np.array([[0, 0, 1], [1, 0, 1]]))
         assert np.allclose(prediction, np.array([[0, 0, 1], [1, 1, 1]]))
-        mj.score()
 
 
 class TestSnorkel:

--- a/tests/labeling/text_classification/test_label_models.py
+++ b/tests/labeling/text_classification/test_label_models.py
@@ -320,9 +320,10 @@ class TestMajorityVoter:
             assert probabilities is None
             if wls == "weak_labels":
                 assert tie_break_policy == TieBreakPolicy.ABSTAIN
-            else:
-                assert tie_break_policy is None
-            return np.array([[1, 1], [0, 0]]), np.array([[1, 1], [1, 0]])
+                return np.array([1, 0]), np.array([1, 1])
+
+            assert tie_break_policy is None
+            return np.array([[1, 1, 1], [0, 0, 0]]), np.array([[1, 1, 1], [1, 0, 0]])
 
         single_or_multi = "multi" if wls == "weak_multi_labels" else "single"
         monkeypatch.setattr(
@@ -394,6 +395,7 @@ class TestMajorityVoter:
 
         assert np.allclose(annotation, np.array([[0, 0, 1], [1, 0, 1]]))
         assert np.allclose(prediction, np.array([[0, 0, 1], [1, 1, 1]]))
+        mj.score()
 
 
 class TestSnorkel:


### PR DESCRIPTION
Fixes the issue mentioned in #1628. 
Now the `MajorityVoter.score` works for multi-label cases with a number of labels > 2.
 