### PR TITLE
Collection of changes, primarily regarding test suite and its coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,5 +88,18 @@ testpaths = [
     "tests"
 ]
 
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "def __str__",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "if _TYPE_CHECKING:",
+    "if typing.TYPE_CHECKING:"
+]
+
 [tool.isort]
 profile = "black"

--- a/src/rubrix/client/api.py
+++ b/src/rubrix/client/api.py
@@ -213,14 +213,11 @@ class Api:
             >>> rb.copy("my_dataset", name_of_copy="new_dataset")
             >>> rb.load("new_dataset")
         """
-        response = datasets_api.copy_dataset(
+        datasets_api.copy_dataset(
             client=self._client,
             name=dataset,
             json_body=CopyDatasetRequest(name=name_of_copy, target_workspace=workspace),
         )
-
-        if response.status_code == 409:
-            raise RuntimeError(f"A dataset with name '{name_of_copy}' already exists.")
 
     def delete(self, name: str) -> None:
         """Deletes a dataset.

--- a/src/rubrix/client/models.py
+++ b/src/rubrix/client/models.py
@@ -202,7 +202,7 @@ class TextClassificationRecord(_Validators):
         """Check if either text or inputs were provided. Copy text to inputs."""
         if isinstance(values.get("inputs"), str):
             warnings.warn(
-                "In the future, the `inputs` argument of the `TextClassificationRecord` will not accept strings."
+                "In the future, the `inputs` argument of the `TextClassificationRecord` will not accept strings. "
                 "Please use the `text` argument in that case. Make sure to adapt your code accordingly.",
                 category=FutureWarning,
             )

--- a/src/rubrix/labeling/text_classification/weak_labels.py
+++ b/src/rubrix/labeling/text_classification/weak_labels.py
@@ -239,7 +239,9 @@ class WeakLabelsBase:
         )
 
         if normalize_by_coverage:
-            overlaps_or_conflicts /= coverage
+            # ignore division by 0 warnings, as we convert the nan back to 0.0 afterwards
+            with np.errstate(divide="ignore", invalid="ignore"):
+                overlaps_or_conflicts /= coverage
             return np.nan_to_num(overlaps_or_conflicts)
 
         return overlaps_or_conflicts
@@ -658,8 +660,9 @@ class WeakLabels(WeakLabelsBase):
                 annotation if annotation is not None else self._annotation,
             )
 
-            # precision
-            precision = correct / (correct + incorrect)
+            # precision, ignore division by 0 warnings: we allow np.nan and np.inf
+            with np.errstate(divide="ignore", invalid="ignore"):
+                precision = correct / (correct + incorrect)
 
             return pd.DataFrame(
                 {
@@ -1043,8 +1046,9 @@ class WeakMultiLabels(WeakLabelsBase):
             # correct/incorrect
             correct, incorrect = self._compute_correct_incorrect(annotation)
 
-            # precision
-            precision = correct / (correct + incorrect)
+            # precision, ignore division by 0 warnings: we allow np.nan and np.inf
+            with np.errstate(divide="ignore", invalid="ignore"):
+                precision = correct / (correct + incorrect)
 
             return pd.DataFrame(
                 {

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -74,7 +74,7 @@ def singlelabel_textclassification_records(
             metadata={"mock_metadata": "mock"},
         ),
         rb.TextClassificationRecord(
-            inputs="mock",
+            text="mock",
             id="b",
             status="Default",
             metrics={"mock_metric": ["B", "I", "O"]},
@@ -165,7 +165,7 @@ def multilabel_textclassification_records(request) -> List[rb.TextClassification
             metrics={},
         ),
         rb.TextClassificationRecord(
-            inputs="mock",
+            text="mock",
             multi_label=True,
             id="b",
             status="Validated",

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -25,7 +25,6 @@ import pytest
 import rubrix as rb
 from rubrix.client import api
 from rubrix.client.api import InputValueError
-from rubrix.client.models import BulkResponse
 from rubrix.client.sdk.client import AuthenticatedClient
 from rubrix.client.sdk.commons.errors import (
     AlreadyExistsApiError,

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -379,7 +379,7 @@ def test_dataset_copy(mocked_client):
 
     record = rb.TextClassificationRecord(
         id=0,
-        inputs="This is the record input",
+        text="This is the record input",
         annotation_agent="test",
         annotation=["T"],
     )
@@ -415,7 +415,7 @@ def test_dataset_copy_to_another_workspace(mocked_client):
         api.log(
             rb.TextClassificationRecord(
                 id=0,
-                inputs="This is the record input",
+                text="This is the record input",
                 annotation_agent="test",
                 annotation=["T"],
             ),
@@ -608,7 +608,7 @@ def test_client_workspace(mocked_client):
 def test_load_sort(mocked_client):
     records = [
         rb.TextClassificationRecord(
-            inputs="test text",
+            text="test text",
             id=i,
         )
         for i in ["1str", 1, 2, 11, "2str", "11str"]
@@ -633,7 +633,7 @@ def test_load_sort(mocked_client):
 def test_load_workspace_from_different_workspace(mocked_client):
     records = [
         rb.TextClassificationRecord(
-            inputs="test text",
+            text="test text",
             id=i,
         )
         for i in ["1str", 1, 2, 11, "2str", "11str"]

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -71,7 +71,7 @@ class TestDatasetBase:
 
         with pytest.raises(
             WrongRecordTypeError,
-            match="various types: \['TextClassificationRecord', 'Text2TextRecord'\]",
+            match=r"various types: \['TextClassificationRecord', 'Text2TextRecord'\]",
         ):
             DatasetBase(
                 records=[

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -207,7 +207,7 @@ class TestDatasetBase:
             [rec.copy(deep=True) for rec in singlelabel_textclassification_records],
         )
 
-        record = rb.TextClassificationRecord(inputs="mock")
+        record = rb.TextClassificationRecord(text="mock")
         dataset[0] = record
 
         assert dataset._records[0] is record
@@ -273,7 +273,7 @@ class TestDatasetForTextClassification:
 
     def test_from_to_datasets_id(self):
         dataset_rb = rb.DatasetForTextClassification(
-            [rb.TextClassificationRecord(inputs="mock")]
+            [rb.TextClassificationRecord(text="mock")]
         )
         dataset_ds = dataset_rb.to_datasets()
         assert dataset_ds["id"] == [None]
@@ -282,7 +282,7 @@ class TestDatasetForTextClassification:
 
     def test_datasets_empty_metadata(self):
         dataset = rb.DatasetForTextClassification(
-            [rb.TextClassificationRecord(inputs="mock")]
+            [rb.TextClassificationRecord(text="mock")]
         )
         assert dataset.to_datasets()["metadata"] == [None]
 
@@ -372,14 +372,14 @@ class TestDatasetForTextClassification:
 
         rb_ds = rb.DatasetForTextClassification.from_datasets(
             ds,
-            inputs="id",
+            text="id",
             annotation="labels",
         )
         assert rb_ds[0].inputs == {"id": "eecwqtt"}
 
         rb_ds = rb.DatasetForTextClassification.from_datasets(
             ds,
-            inputs="text",
+            text="text",
             annotation="labels",
         )
         again_the_ds = rb_ds.to_datasets()
@@ -411,7 +411,7 @@ class TestDatasetForTextClassification:
         )
 
         rb_ds = rb.DatasetForTextClassification.from_datasets(
-            ds, inputs="review", annotation="star", metadata=["package_name", "date"]
+            ds, text="review", annotation="star", metadata=["package_name", "date"]
         )
 
         again_the_ds = rb_ds.to_datasets()

--- a/tests/client/test_init.py
+++ b/tests/client/test_init.py
@@ -5,7 +5,7 @@ def test_resource_leaking_with_several_inits(mocked_client):
     dataset = "test_resource_leaking_with_several_inits"
     api.delete(dataset)
 
-    for i in range(0, 1000):
+    for i in range(0, 20):
         api.init()
 
     for i in range(0, 10):

--- a/tests/client/test_init.py
+++ b/tests/client/test_init.py
@@ -5,6 +5,7 @@ def test_resource_leaking_with_several_inits(mocked_client):
     dataset = "test_resource_leaking_with_several_inits"
     api.delete(dataset)
 
+    # TODO: review performance in Windows. See https://github.com/recognai/rubrix/pull/1702
     for i in range(0, 20):
         api.init()
 

--- a/tests/client/test_models.py
+++ b/tests/client/test_models.py
@@ -53,7 +53,7 @@ def test_text_classification_record(annotation, status, expected_status):
 
 
 def test_text_classification_input_string():
-    assert TextClassificationRecord(inputs="A text") == TextClassificationRecord(
+    assert TextClassificationRecord(text="A text") == TextClassificationRecord(
         inputs=dict(text="A text")
     )
 

--- a/tests/functional_tests/search/test_search_service.py
+++ b/tests/functional_tests/search/test_search_service.py
@@ -124,7 +124,7 @@ def test_failing_metrics(service, mocked_client):
 
     rubrix.delete(dataset.name)
     rubrix.log(
-        rubrix.TextClassificationRecord(inputs="This is a text, yeah!"),
+        rubrix.TextClassificationRecord(text="This is a text, yeah!"),
         name=dataset.name,
     )
     results = service.search(

--- a/tests/labeling/text_classification/test_label_errors.py
+++ b/tests/labeling/text_classification/test_label_errors.py
@@ -122,7 +122,7 @@ def test_sort_by(monkeypatch, sort_by, expected):
         )
 
     record = rb.TextClassificationRecord(
-        inputs="mock", prediction=[("mock", 0.1)], annotation="mock"
+        text="mock", prediction=[("mock", 0.1)], annotation="mock"
     )
     find_label_errors(records=[record], sort_by=sort_by)
 
@@ -210,7 +210,7 @@ def test_construct_s_and_psx(records):
 def test_missing_predictions():
     records = [
         rb.TextClassificationRecord(
-            inputs="test", annotation="mock", prediction=[("mock2", 0.1)]
+            text="test", annotation="mock", prediction=[("mock2", 0.1)]
         )
     ]
     with pytest.raises(
@@ -221,7 +221,7 @@ def test_missing_predictions():
 
     records.append(
         rb.TextClassificationRecord(
-            inputs="test", annotation="mock", prediction=[("mock", 0.1)]
+            text="test", annotation="mock", prediction=[("mock", 0.1)]
         )
     )
     with pytest.raises(

--- a/tests/labeling/text_classification/test_label_models.py
+++ b/tests/labeling/text_classification/test_label_models.py
@@ -90,13 +90,13 @@ def weak_multi_labels(monkeypatch):
     def mock_load(*args, **kwargs):
         return [
             TextClassificationRecord(
-                inputs="test", multi_label=True, annotation=["scared"]
+                text="test", multi_label=True, annotation=["scared"]
             ),
             TextClassificationRecord(
-                inputs="test", multi_label=True, annotation=["sad", "scared"]
+                text="test", multi_label=True, annotation=["sad", "scared"]
             ),
-            TextClassificationRecord(inputs="test", multi_label=True, annotation=[]),
-            TextClassificationRecord(inputs="test", multi_label=True),
+            TextClassificationRecord(text="test", multi_label=True, annotation=[]),
+            TextClassificationRecord(text="test", multi_label=True),
         ]
 
     monkeypatch.setattr(

--- a/tests/labeling/text_classification/test_weak_labels.py
+++ b/tests/labeling/text_classification/test_weak_labels.py
@@ -384,7 +384,7 @@ class TestWeakLabels:
 
     def test_summary(self, monkeypatch, rules):
         def mock_load(*args, **kwargs):
-            return [TextClassificationRecord(inputs="test")] * 4
+            return [TextClassificationRecord(text="test")] * 4
 
         monkeypatch.setattr(
             "rubrix.labeling.text_classification.weak_labels.load", mock_load
@@ -464,7 +464,7 @@ class TestWeakLabels:
 
     def test_show_records(self, monkeypatch, rules):
         def mock_load(*args, **kwargs):
-            return [TextClassificationRecord(inputs="test", id=i) for i in range(5)]
+            return [TextClassificationRecord(text="test", id=i) for i in range(5)]
 
         monkeypatch.setattr(
             "rubrix.labeling.text_classification.weak_labels.load", mock_load
@@ -502,7 +502,7 @@ class TestWeakLabels:
 
     def test_change_mapping(self, monkeypatch, rules):
         def mock_load(*args, **kwargs):
-            return [TextClassificationRecord(inputs="test", id=i) for i in range(5)]
+            return [TextClassificationRecord(text="test", id=i) for i in range(5)]
 
         monkeypatch.setattr(
             "rubrix.labeling.text_classification.weak_labels.load", mock_load
@@ -558,7 +558,7 @@ class TestWeakLabels:
     @pytest.fixture
     def weak_labels(self, monkeypatch, rules):
         def mock_load(*args, **kwargs):
-            return [TextClassificationRecord(inputs="test", id=i) for i in range(3)]
+            return [TextClassificationRecord(text="test", id=i) for i in range(3)]
 
         monkeypatch.setattr(
             "rubrix.labeling.text_classification.weak_labels.load", mock_load
@@ -633,9 +633,9 @@ class TestWeakMultiLabels:
 
     def test_matrix_annotation(self, monkeypatch):
         expected_records = [
-            TextClassificationRecord(inputs="test without annot", multi_label=True),
+            TextClassificationRecord(text="test without annot", multi_label=True),
             TextClassificationRecord(
-                inputs="test with annot", annotation="positive", multi_label=True
+                text="test with annot", annotation="positive", multi_label=True
             ),
         ]
 
@@ -674,7 +674,7 @@ class TestWeakMultiLabels:
 
     def test_summary(self, monkeypatch, multilabel_rules):
         def mock_load(*args, **kwargs):
-            return [TextClassificationRecord(inputs="test", multi_label=True)] * 4
+            return [TextClassificationRecord(text="test", multi_label=True)] * 4
 
         monkeypatch.setattr(
             "rubrix.labeling.text_classification.weak_labels.load", mock_load
@@ -761,7 +761,7 @@ class TestWeakMultiLabels:
 
     def test_compute_correct_incorrect(self, monkeypatch):
         def mock_load(*args, **kwargs):
-            return [TextClassificationRecord(inputs="mock")]
+            return [TextClassificationRecord(text="mock")]
 
         monkeypatch.setattr(
             "rubrix.labeling.text_classification.weak_labels.load", mock_load
@@ -784,7 +784,7 @@ class TestWeakMultiLabels:
     def test_show_records(self, monkeypatch, multilabel_rules):
         def mock_load(*args, **kwargs):
             return [
-                TextClassificationRecord(inputs="test", id=i, multi_label=True)
+                TextClassificationRecord(text="test", id=i, multi_label=True)
                 for i in range(5)
             ]
 
@@ -832,7 +832,7 @@ class TestWeakMultiLabels:
     def weak_multi_labels(self, monkeypatch, rules):
         def mock_load(*args, **kwargs):
             return [
-                TextClassificationRecord(inputs="test", id=i, multi_label=True)
+                TextClassificationRecord(text="test", id=i, multi_label=True)
                 for i in range(3)
             ]
 

--- a/tests/labeling/text_classification/test_weak_labels.py
+++ b/tests/labeling/text_classification/test_weak_labels.py
@@ -18,7 +18,7 @@ from typing import Callable, List, Optional, Union
 import numpy as np
 import pandas as pd
 import pytest
-from pandas.util.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal
 
 from rubrix import TextClassificationRecord
 from rubrix.client.sdk.text_classification.models import (
@@ -420,7 +420,7 @@ class TestWeakLabels:
             },
             index=["first_rule", "rule_1", "rubrix_rule", "total"],
         )
-        pd.testing.assert_frame_equal(summary, expected)
+        assert_frame_equal(summary, expected)
 
         summary = weak_labels.summary(normalize_by_coverage=True)
         expected = pd.DataFrame(
@@ -437,7 +437,7 @@ class TestWeakLabels:
             },
             index=["first_rule", "rule_1", "rubrix_rule", "total"],
         )
-        pd.testing.assert_frame_equal(summary, expected)
+        assert_frame_equal(summary, expected)
 
         summary = weak_labels.summary(annotation=np.array([1, -1, 0, 1]))
         expected = pd.DataFrame(
@@ -458,7 +458,9 @@ class TestWeakLabels:
             },
             index=["first_rule", "rule_1", "rubrix_rule", "total"],
         )
-        pd.testing.assert_frame_equal(summary, expected)
+        # The "correct" and "incorrect" columns from `expected_summary` may infer a different
+        # dtype than `weak_multi_labels.summary()` returns.
+        assert_frame_equal(summary, expected, check_dtype=False)
 
     def test_show_records(self, monkeypatch, rules):
         def mock_load(*args, **kwargs):
@@ -715,7 +717,7 @@ class TestWeakMultiLabels:
             },
             index=["first_rule", "rule_1", "rubrix_rule", "total"],
         )
-        pd.testing.assert_frame_equal(summary, expected)
+        assert_frame_equal(summary, expected)
 
         summary = weak_labels.summary(normalize_by_coverage=True)
         expected = pd.DataFrame(
@@ -731,7 +733,7 @@ class TestWeakMultiLabels:
             },
             index=["first_rule", "rule_1", "rubrix_rule", "total"],
         )
-        pd.testing.assert_frame_equal(summary, expected)
+        assert_frame_equal(summary, expected)
 
         summary = weak_labels.summary(
             annotation=np.array([[0, 1], [-1, -1], [0, 1], [1, 1]])
@@ -753,7 +755,9 @@ class TestWeakMultiLabels:
             },
             index=["first_rule", "rule_1", "rubrix_rule", "total"],
         )
-        pd.testing.assert_frame_equal(summary, expected)
+        # The "correct" and "incorrect" columns from `expected_summary` may infer a different
+        # dtype than `weak_multi_labels.summary()` returns.
+        assert_frame_equal(summary, expected, check_dtype=False)
 
     def test_compute_correct_incorrect(self, monkeypatch):
         def mock_load(*args, **kwargs):
@@ -886,7 +890,11 @@ class TestWeakMultiLabels:
             },
             index=list(weak_multi_labels._rules_name2index.keys()) + ["total"],
         )
-        assert_frame_equal(weak_multi_labels.summary(), expected_summary)
+        # The "correct" and "incorrect" columns from `expected_summary` may infer a different
+        # dtype than `weak_multi_labels.summary()` returns.
+        assert_frame_equal(
+            weak_multi_labels.summary(), expected_summary, check_dtype=False
+        )
 
         expected_show_records = pd.DataFrame(
             map(lambda x: x.dict(), weak_multi_labels.records())

--- a/tests/labeling/text_classification/test_weak_labels.py
+++ b/tests/labeling/text_classification/test_weak_labels.py
@@ -195,12 +195,12 @@ class TestWeakLabelsBase:
             WeakLabels(rules=[lambda x: None], dataset="mock", query="mock")
         with pytest.raises(
             NoRecordsFoundError,
-            match="No records found in dataset 'mock' with ids \[-1\].",
+            match=r"No records found in dataset 'mock' with ids \[-1\].",
         ):
             WeakLabels(rules=[lambda x: None], dataset="mock", ids=[-1])
         with pytest.raises(
             NoRecordsFoundError,
-            match="No records found in dataset 'mock' with query 'mock' and with ids \[-1\].",
+            match=r"No records found in dataset 'mock' with query 'mock' and with ids \[-1\].",
         ):
             WeakLabels(rules=[lambda x: None], dataset="mock", query="mock", ids=[-1])
 


### PR DESCRIPTION
Hello!

## Pull request overview
* Speed up a very slow test that called `api.init()` 1000 times.
* Fix 3 tests that fail on Windows due to differences in `dtype`'s.
* Exclude blocks from code coverage checks that should not be included.
* Remove dead code in `rb.copy()`.
* Add a test for the `background` parameter on `rb.log()`.
* Prepare test suite for upcoming deprecation of strings passed via `inputs`.
* Solve several DeprecationWarnings regarding strings with invalid escape sequences.
* Silence several division by 0 warnings that should not be shown.
* Add a missing space in a `FutureWarning`.

## Details
This PR contains several standalone commits that I'll elaborate on separately. I highly recommend clicking on the relevant commit per section, as otherwise the PR may be very confusing. Each section should explain why I made the changes. If there are some changes that you do not agree with, then I'm able and willing to revert them.

## Speed up (a3e56694a64fde614068ebf07a0aa2d2bf9f0ff9)
<details>

#1640 has introduced a test that sequentially calls `api.init()` 1000 times, before calling some more `init` and `log`'s:

https://github.com/recognai/rubrix/blob/6a612ac8413d3fed21cdf0af8fd3a2dfb0e818b2/tests/client/test_init.py#L4-L17

When booted into Windows, each call to `api.init()` takes approximately 2.5 seconds, when my development environment is set up exactly like described in the [developer docs](https://docs.rubrix.ml/en/stable/community/developer_docs.html), with Elasticsearch running via docker, as described in the [readme](https://github.com/recognai/rubrix#get-started).

Consequently, this test did not complete executions within 5 minutes, and would take an estimated 40 minutes in total. As a result, I reduced the number of iterations from 1000 to 20. This should not reduce the usefulness of the test, while improving the test suite's performance. However, if my experienced performance is indicative of an issue, then perhaps it should be tackled directly as opposed to reducing the number of iterations like this PR proposes.
</details>

## Broken Windows tests (be0f36fd7a20a2cec2fc9b38699d24e9b2ce02b9)
<details>

On my Windows device, set up as described above, 3 tests from [/tests/labeling/text_classification/test_weak_labels.py](https://github.com/recognai/rubrix/blob/master/tests/labeling/text_classification/test_weak_labels.py) fail, all due to differences in `dtype` between the expected result and the predicted result of `WeakLabels().summary()`.
```python
>       assert_frame_equal(weak_multi_labels.summary(), expected_summary)
E       AssertionError: Attributes of DataFrame.iloc[:, 4] (column name="correct") are different
E       
E       Attribute "dtype" are different
E       [left]:  int32
E       [right]: int64

tests\labeling\text_classification\test_weak_labels.py:889: AssertionError
```

On my device, the "correct" and "incorrect" result are inferred to be `int64` for the expected value, while an `int32` array is given as input to the `summary` method's `annotation` parameter. Presumably, this difference does not exist on Unix. Either, we enforce a specific `dtype`, or we relax the test to ignore `dtype` differences. I've gone with the latter.
</details>

## Coverage exclusion (ea3ba61cae9925a28c488b64f78803c48e419e4f)
<details>

Certain code blocks, e.g. under `if TYPE_CHECKING:` and `if __name__ == "__main__"` do not benefit from being included in coverage metrics, as we would not write tests for these. See e.g. page 17 of the [coverage.py documentation pdf](https://buildmedia.readthedocs.org/media/pdf/coverage/coverage-5.0a3/coverage.pdf) for an example of common `exclude_lines` values.
</details>

## Dead code (7f66e8c0526eb1baec06a129ee5e30a1f955e57a)
<details>

See `rb.copy()` here:
https://github.com/recognai/rubrix/blob/6a612ac8413d3fed21cdf0af8fd3a2dfb0e818b2/src/rubrix/client/api.py#L203-L223
This method calls `datasets_api.copy_dataset`:
https://github.com/recognai/rubrix/blob/6a612ac8413d3fed21cdf0af8fd3a2dfb0e818b2/src/rubrix/client/sdk/datasets/api.py#L43-L58
Which calls `_build_response`:
https://github.com/recognai/rubrix/blob/6a612ac8413d3fed21cdf0af8fd3a2dfb0e818b2/src/rubrix/client/sdk/datasets/api.py#L85-L97

This method returns a `Response` if the status_code is 200, and otherwise calls `handle_response_error`, which always throws an error. With other words, the only way for `response = datasets_api.copy_dataset` in `rb.copy()` to be successfully executed is if `status_code == 200`. As such, it will never be 409.

Note also that the `RuntimeError` is now implemented via `AlreadyExistsApiError`, which is tested via `tests/client/test_api.py::test_dataset_copy` already.
</details>

## Get complete coverage of `rb.log` (7a25dc71b336e61c10c46410cfd7efabe8396e05, 16e8ebf561a4afd023f3c63ff5d8a48aad1d8607)
<details>

`rb.log()` is arguably one of the more important user-facing methods of Rubrix, and so it should be tested fully in my opinion. With this commit I've added a test on the last parameter that was not used in any of the tests: `background`.
</details>

## Prepare for deprecation (4a08bb9fb2716f55a2ec6f56b93abc1cc048d613)
<details>

#1246 introduced a `text` parameter to `TextClassificationRecord` to replace strings passed to the `inputs` parameter. It also added a `FutureWarning` for occurrences of strings passed to `inputs`:
https://github.com/recognai/rubrix/blob/6a612ac8413d3fed21cdf0af8fd3a2dfb0e818b2/src/rubrix/client/models.py#L203-L208

However, many tests still used e.g. `TextClassificationRecord(inputs="mock")`. I've resolved this now, and left only this case intact:
https://github.com/recognai/rubrix/blob/6a612ac8413d3fed21cdf0af8fd3a2dfb0e818b2/tests/client/test_models.py#L72-L76
</details>

## Solve DeprecationWarning (ab5c7ca4)
<details>

Running all tests produces the following warnings (among others):
```python
tests\client\test_dataset.py:74
  F:\GitHub\rubrix\tests\client\test_dataset.py:74: DeprecationWarning: invalid escape sequence \[
    match="various types: \['TextClassificationRecord', 'Text2TextRecord'\]",

tests\labeling\text_classification\test_weak_labels.py:198
  F:\GitHub\rubrix\tests\labeling\text_classification\test_weak_labels.py:198: DeprecationWarning: invalid escape sequence \[
    match="No records found in dataset 'mock' with ids \[-1\].",

tests\labeling\text_classification\test_weak_labels.py:203
  F:\GitHub\rubrix\tests\labeling\text_classification\test_weak_labels.py:203: DeprecationWarning: invalid escape sequence \[
    match="No records found in dataset 'mock' with query 'mock' and with ids \[-1\].",
```
I've simply prepended these strings with `r`.
</details>

## Silencing warnings (f7720e71)
<details>

In some situations, Rubrix performs divisions by 0, e.g. in `test_summary`:
https://github.com/recognai/rubrix/blob/6a612ac8413d3fed21cdf0af8fd3a2dfb0e818b2/tests/labeling/text_classification/test_weak_labels.py#L442-L461
Hence the `np.nan` in the precision. In this situation, we don't actually want to throw warnings. There are two relevant ones: `0 / 0` and `x / 0` with `x != 0`. The two give different warnings:
```python
>>> import numpy as np
>>> np.array([1]) / np.array([0])
<stdin>:1: RuntimeWarning: divide by zero encountered in divide
array([inf])
>>> np.array([0]) / np.array([0]) 
<stdin>:1: RuntimeWarning: invalid value encountered in divide
array([nan])
```
We can ignore both of them in a codeblock like so:
```python
with np.errstate(divide="ignore", invalid="ignore"):
    ...
```
See the [documentation for `numpy.errstate`](https://numpy.org/doc/stable/reference/generated/numpy.errstate.html) for more info.
</details>

## Missing space in warning (c7b9edfd4e46e087abdda65a0f6ece3904203dd9)
<details>

The strings in the following snippet get combined together such that the produced string includes "... not accept strings.Please use the ...":
https://github.com/recognai/rubrix/blob/6a612ac8413d3fed21cdf0af8fd3a2dfb0e818b2/src/rubrix/client/models.py#L204-L207

I've simply added a space after `strings.`.
</details>

---

Note that there are still a ton of warnings of the test suite that may need to be looked at! In particular the `OpenSearchWarning`s seem potentially problematic.

I had a lot of fun learning about your module today! It seems very intriguing.
Let me know if you need anything from me.

- Tom Aarsen