### PR TITLE
tests: use `inputs`  field for dict inputs

### DIFF
--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -372,7 +372,7 @@ class TestDatasetForTextClassification:
 
         rb_ds = rb.DatasetForTextClassification.from_datasets(
             ds,
-            text="id",
+            inputs="id",
             annotation="labels",
         )
         assert rb_ds[0].inputs == {"id": "eecwqtt"}


### PR DESCRIPTION
This PR fixes a test failing after `inputs` to `text` included in #1702 