### PR TITLE
feat(Datasets): restrict dataset deletion only to creators and super-users

### DIFF
--- a/src/rubrix/server/services/datasets.py
+++ b/src/rubrix/server/services/datasets.py
@@ -141,7 +141,12 @@ class DatasetsService:
             as_dataset_class=None,
         )
         if found:
-            self.__dao__.delete_dataset(dataset)
+            if user.is_superuser() or user.username == dataset.created_by:
+                self.__dao__.delete_dataset(dataset)
+            else:
+                raise ForbiddenOperationError(
+                    f"Only the creators or super-users can delete datasets"
+                )
 
     def update(
         self,

--- a/src/rubrix/server/services/datasets.py
+++ b/src/rubrix/server/services/datasets.py
@@ -145,7 +145,7 @@ class DatasetsService:
                 self.__dao__.delete_dataset(dataset)
             else:
                 raise ForbiddenOperationError(
-                    f"Only the creators or super-users can delete datasets"
+                    f"You don't have the necessary permissions to delete this dataset. Only dataset creators or administrators can delete datasets"
                 )
 
     def update(

--- a/src/rubrix/server/services/datasets.py
+++ b/src/rubrix/server/services/datasets.py
@@ -145,7 +145,8 @@ class DatasetsService:
                 self.__dao__.delete_dataset(dataset)
             else:
                 raise ForbiddenOperationError(
-                    f"You don't have the necessary permissions to delete this dataset. Only dataset creators or administrators can delete datasets"
+                    f"You don't have the necessary permissions to delete this dataset. "
+                    "Only dataset creators or administrators can delete datasets"
                 )
 
     def update(

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -3,6 +3,7 @@ import pytest
 import rubrix as rb
 from rubrix import TextClassificationSettings, TokenClassificationSettings
 from rubrix.client import api
+from rubrix.client.sdk.commons.errors import ForbiddenApiError
 
 
 @pytest.mark.parametrize(
@@ -37,3 +38,17 @@ def test_settings_workflow(mocked_client, settings_, wrong_settings):
 
     with pytest.raises(ValueError, match="Task type mismatch"):
         rb.configure_dataset(dataset, wrong_settings)
+
+
+def test_delete_dataset_by_non_creator(mocked_client):
+    try:
+        dataset = "test_delete_dataset_by_non_creator"
+        rb.delete(dataset)
+        rb.configure_dataset(
+            dataset, settings=TextClassificationSettings(label_schema={"A", "B", "C"})
+        )
+        mocked_client.change_current_user("mock-user")
+        with pytest.raises(ForbiddenApiError):
+            rb.delete(dataset)
+    finally:
+        mocked_client.reset_default_user()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,20 +3,45 @@ from typing import List
 from fastapi import FastAPI
 from starlette.testclient import TestClient
 
-from rubrix._constants import API_KEY_HEADER_NAME
+from rubrix._constants import API_KEY_HEADER_NAME, RUBRIX_WORKSPACE_HEADER_NAME
 from rubrix.client.api import active_api
 from rubrix.server.security import auth
 from rubrix.server.security.auth_provider.local.settings import settings
+from rubrix.server.security.auth_provider.local.users.model import UserInDB
 
 
 class SecuredClient:
     def __init__(self, client: TestClient):
         self._client = client
         self._header = {API_KEY_HEADER_NAME: settings.default_apikey}
+        self._current_user = None
 
     @property
     def fastpi_app(self) -> FastAPI:
         return self._client.app
+
+    def change_current_user(self, username):
+        default_user = auth.users.__dao__.__users__["rubrix"]
+        new_user = UserInDB(
+            username=username,
+            hashed_password=username,  # Even if required, we can ignore it
+            api_key=username,
+            workspaces=["rubrix"],  # The default workspace
+        )
+
+        auth.users.__dao__.__users__[username] = new_user
+        rb_api = active_api()
+        rb_api._user = new_user
+        rb_api.set_workspace(default_user.username)
+        rb_api.client.token = new_user.api_key
+
+    def reset_default_user(self):
+        default_user = auth.users.__dao__.__users__["rubrix"]
+
+        rb_api = active_api()
+        rb_api._user = default_user
+        rb_api.client.token = default_user.api_key
+        rb_api.client.headers.pop(RUBRIX_WORKSPACE_HEADER_NAME)
 
     def add_workspaces_to_rubrix_user(self, workspaces: List[str]):
         rubrix_user = auth.users.__dao__.__users__["rubrix"]


### PR DESCRIPTION
This PR includes restrictions on dataset deletion. Only datasets the creator or super-users (with full workspaces access) can delete datasets

@dvsrepo just review the error message, pls