### PR TITLE
ci: HF tests only for master and releases branches

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -86,10 +86,14 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ env.CACHE_NUMBER }}-${{ hashFiles('pyproject.toml') }}
 
-      - name: Run tests 📈
-        if: steps.filter.outputs.python_code == 'true'
+      - name: Set hugginface hub credentials
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/releases')
         env:
           HF_HUB_ACCESS_TOKEN: ${{ secrets.HF_HUB_ACCESS_TOKEN }}
+        run: echo "Enable HF access token"
+
+      - name: Run tests 📈
+        if: steps.filter.outputs.python_code == 'true'
         run: |
           pytest --cov=rubrix --cov-report=xml
           pip install "spacy<3.0" && python -m spacy download en_core_web_sm


### PR DESCRIPTION
Running tests from contributor PRs fails when trying to connect to huggingface hub. We will enable those tests only for master and release branches