### PR TITLE
fix: delete records feature

### DIFF
--- a/docs/reference/python/python_client.rst
+++ b/docs/reference/python/python_client.rst
@@ -15,7 +15,7 @@ Methods
 -------
 
 .. automodule:: rubrix
-   :members: init, log, load, copy, delete, set_workspace, get_workspace
+   :members: init, log, load, copy, delete, set_workspace, get_workspace, delete_records
 
 .. _python ref records:
 

--- a/scripts/migrations/es_migration_25042021.py
+++ b/scripts/migrations/es_migration_25042021.py
@@ -1,9 +1,24 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 from itertools import zip_longest
 from typing import Any, Dict, List, Optional
 
 from elasticsearch import Elasticsearch
-from elasticsearch.helpers import scan, bulk
+from elasticsearch.helpers import bulk, scan
 from pydantic import BaseSettings
+
 from rubrix.server.tasks.commons import TaskType
 
 
@@ -97,9 +112,7 @@ if __name__ == "__main__":
         source_index_info = client.get(index=source_datasets_index, id=dataset)
 
         target_dataset_name = f"{dataset}-{settings.task}".lower()
-        target_index = target_record_index_pattern.format(
-            target_dataset_name
-        )
+        target_index = target_record_index_pattern.format(target_dataset_name)
 
         target_index_info = source_index_info["_source"]
         target_index_info["task"] = settings.task

--- a/src/rubrix/client/api.py
+++ b/src/rubrix/client/api.py
@@ -447,11 +447,10 @@ class Api:
             deletion).
 
         Examples:
-            **Delete by id**:
+            >>> ## Delete by id
             >>> import rubrix as rb
             >>> rb.delete_records(name="example-dataset", ids=[1,3,5])
-
-            **Discard records by query**:
+            >>> ## Discard records by query
             >>> import rubrix as rb
             >>> rb.delete_records(name="example-dataset", query="metadata.code=33", discard_only=True)
         """

--- a/src/rubrix/client/api.py
+++ b/src/rubrix/client/api.py
@@ -422,26 +422,18 @@ class Api:
     ) -> Tuple[int, int]:
         """Delete records from a Rubrix dataset.
 
-        Parameters:
-        -----------
-            name:
-                The dataset name.
-            query:
-                An ElasticSearch query with the
-                `query string syntax <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
-            ids:
-                If provided, deletes dataset records with given ids.
-            discard_only:
-                If `True`, matched records won't be deleted. Instead, they will be marked
-                as `Discarded`
-            discard_when_forbidden:
-                Only super-user or dataset creator can delete records from a dataset.
+        Args:
+            name: The dataset name.
+            query: An ElasticSearch query with the `query string syntax
+                <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
+            ids: If provided, deletes dataset records with given ids.
+            discard_only: If `True`, matched records won't be deleted. Instead, they will be marked as `Discarded`
+            discard_when_forbidden: Only super-user or dataset creator can delete records from a dataset.
                 So, running "hard" deletion for other users will raise an `ForbiddenApiError` error.
                 If this parameter is `True`, the client API will automatically try to mark as ``Discarded``
                 records instead. Default, `True`
 
         Returns:
-        --------
             The total of matched records and real number of processed errors. These numbers could not
             be the same if some data conflicts are found during operations (some matched records change during
             deletion).

--- a/src/rubrix/client/sdk/client.py
+++ b/src/rubrix/client/sdk/client.py
@@ -123,7 +123,8 @@ class Client(_ClientCommonDefaults, _Client):
     @with_httpx_error_handler
     def delete(self, path: str, *args, **kwargs):
         path = self._normalize_path(path)
-        response = self.__httpx__.delete(
+        response = self.__httpx__.request(
+            method="DELETE",
             url=path,
             headers=self.get_headers(),
             *args,

--- a/src/rubrix/server/services/storage/service.py
+++ b/src/rubrix/server/services/storage/service.py
@@ -30,9 +30,9 @@ from rubrix.server.services.tasks.commons import ServiceRecord
 
 @dataclasses.dataclass
 class DeleteRecordsOut:
-    processed: int
-    discarded: Optional[int] = None
-    deleted: Optional[int] = None
+    processed: int = 0
+    discarded: int = 0
+    deleted: int = 0
 
 
 class RecordsStorageService:
@@ -97,7 +97,7 @@ class RecordsStorageService:
             )
 
         return DeleteRecordsOut(
-            processed=processed,
-            discarded=discarded,
-            deleted=deleted,
+            processed=processed or 0,
+            discarded=discarded or 0,
+            deleted=deleted or 0,
         )

--- a/tests/functional_tests/datasets/test_delete_records_from_datasets.py
+++ b/tests/functional_tests/datasets/test_delete_records_from_datasets.py
@@ -89,3 +89,22 @@ def test_delete_records_without_permission(mocked_client):
         assert matched, processed == (1, 1)
     finally:
         mocked_client.reset_default_user()
+
+
+def test_delete_records_with_unmatched_records(mocked_client):
+    dataset = "test_delete_records_with_unmatched_records"
+    import rubrix as rb
+
+    rb.delete(dataset)
+    rb.log(
+        name=dataset,
+        records=[
+            rb.TextClassificationRecord(
+                id=i, text="This is the text", metadata=dict(idx=i)
+            )
+            for i in range(0, 50)
+        ],
+    )
+
+    matched, processed = rb.delete_records(dataset, ids=["you-wont-find-me-here"])
+    assert (matched, processed) == (0, 0)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -80,6 +80,11 @@ class SecuredClient:
         headers = {**self._header, **request_headers}
         return self._client.delete(*args, headers=headers, **kwargs)
 
+    def request(self, *args, **kwargs):
+        request_headers = kwargs.pop("headers", {})
+        headers = {**self._header, **request_headers}
+        return self._client.request(*args, headers=headers, **kwargs)
+
     def post(self, *args, **kwargs):
         request_headers = kwargs.pop("headers", {})
         headers = {**self._header, **request_headers}


### PR DESCRIPTION
Some problems detected:

- Change from `httpx.delete` to `httpx.request` with `method="DELETE"`, since the delete method does not accept body param (data or json)
- Fix response data when no records match for deletion

Refs #1714 