### PR TITLE
docs: using official token class. mapper since is compatible now

### DIFF
--- a/docs/tutorials/09-automatic_fastapi_log.ipynb
+++ b/docs/tutorials/09-automatic_fastapi_log.ipynb
@@ -252,40 +252,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Mapper"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import re\n",
-    "import datetime\n",
-    "\n",
-    "from rubrix.client.models import TokenClassificationRecord\n",
-    "\n",
-    "def custom_mapper(inputs, outputs):\n",
-    "    spaces_regex = re.compile(r\"\\s+\")\n",
-    "    text = inputs\n",
-    "    return TokenClassificationRecord(\n",
-    "        text=text,\n",
-    "        tokens=spaces_regex.split(text),\n",
-    "        prediction=[\n",
-    "            (entity[\"label\"], entity[\"start\"], entity[\"end\"])\n",
-    "            for entity in (\n",
-    "                outputs.get(\"entities\") if isinstance(outputs, dict) else outputs\n",
-    "            )\n",
-    "        ],\n",
-    "        event_timestamp=datetime.datetime.now(),\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### FastAPI application"
    ]
   },
@@ -295,13 +261,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from rubrix.monitoring.asgi import RubrixLogHTTPMiddleware, token_classification_mapper\n",
+    "\n",
     "app_spacy = FastAPI()\n",
     "\n",
     "app_spacy.add_middleware(\n",
     "    RubrixLogHTTPMiddleware,\n",
     "    api_endpoint=\"/spacy/\",\n",
     "    dataset=\"monitoring_spacy\",\n",
-    "    records_mapper=custom_mapper\n",
+    "    records_mapper=token_classification_mapper\n",
     ")\n",
     "\n",
     "# prediction endpoint using spacy pipeline\n",

--- a/scripts/migrations/es_migration_25042021.py
+++ b/scripts/migrations/es_migration_25042021.py
@@ -1,9 +1,24 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 from itertools import zip_longest
 from typing import Any, Dict, List, Optional
 
 from elasticsearch import Elasticsearch
-from elasticsearch.helpers import scan, bulk
+from elasticsearch.helpers import bulk, scan
 from pydantic import BaseSettings
+
 from rubrix.server.tasks.commons import TaskType
 
 
@@ -97,9 +112,7 @@ if __name__ == "__main__":
         source_index_info = client.get(index=source_datasets_index, id=dataset)
 
         target_dataset_name = f"{dataset}-{settings.task}".lower()
-        target_index = target_record_index_pattern.format(
-            target_dataset_name
-        )
+        target_index = target_record_index_pattern.format(target_dataset_name)
 
         target_index_info = source_index_info["_source"]
         target_index_info["task"] = settings.task


### PR DESCRIPTION
Once the issue #482  is resolved, we can remove the custom mapper for spacy on this tutorial and use the one provided by the monitoring module.