### PR TITLE
fix: handle separately 401 and 403 api errors in UI

### DIFF
--- a/frontend/plugins/vuex-orm-axios.js
+++ b/frontend/plugins/vuex-orm-axios.js
@@ -42,7 +42,7 @@ export default ({ $axios, app }) => {
 
   $axios.onError((error) => {
     const code = parseInt(error.response && error.response.status);
-    if (error instanceof ExpiredAuthSessionError || [401, 403].includes(code)) {
+    if (error instanceof ExpiredAuthSessionError || 401 === code) {
       app.$auth.logout();
     }
 
@@ -70,13 +70,13 @@ export default ({ $axios, app }) => {
         break;
       case 404:
         Notification.dispatch("notify", {
-          message: "Warning: " + error.response.data.detail,
+          message: "Warning: " + messageDetail.params.detail,
           type: "warning",
         });
         break;
       default:
         Notification.dispatch("notify", {
-          message: error,
+          message: "Error: " + messageDetail.params.detail,
           type: "error",
         });
     }

--- a/frontend/plugins/vuex-orm-axios.js
+++ b/frontend/plugins/vuex-orm-axios.js
@@ -70,13 +70,13 @@ export default ({ $axios, app }) => {
         break;
       case 404:
         Notification.dispatch("notify", {
-          message: "Warning: " + messageDetail.params.detail,
+          message: `Warning: ${messageDetail.params.detail}`,
           type: "warning",
         });
         break;
       default:
         Notification.dispatch("notify", {
-          message: "Error: " + messageDetail.params.detail,
+          message: `Error:  ${messageDetail.params.detail}`,
           type: "error",
         });
     }

--- a/scripts/migrations/es_migration_25042021.py
+++ b/scripts/migrations/es_migration_25042021.py
@@ -1,9 +1,24 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 from itertools import zip_longest
 from typing import Any, Dict, List, Optional
 
 from elasticsearch import Elasticsearch
-from elasticsearch.helpers import scan, bulk
+from elasticsearch.helpers import bulk, scan
 from pydantic import BaseSettings
+
 from rubrix.server.tasks.commons import TaskType
 
 
@@ -97,9 +112,7 @@ if __name__ == "__main__":
         source_index_info = client.get(index=source_datasets_index, id=dataset)
 
         target_dataset_name = f"{dataset}-{settings.task}".lower()
-        target_index = target_record_index_pattern.format(
-            target_dataset_name
-        )
+        target_index = target_record_index_pattern.format(target_dataset_name)
 
         target_index_info = source_index_info["_source"]
         target_index_info["task"] = settings.task


### PR DESCRIPTION
Since the changes included in #1713, users without permission trying to delete datasets from UI will hit into a re-login operation.

This PR handles separate authentication errors (401) and forbidden errors (403).

We should find a better way to handle error codes and info in general.

Refs: #1713