### PR TITLE
fix(#1658): align agents for predictions annotations

### DIFF
--- a/src/rubrix/server/daos/models/records.py
+++ b/src/rubrix/server/daos/models/records.py
@@ -76,6 +76,10 @@ class BaseRecordInDB(GenericModel, Generic[AnnotationDB]):
         annotation = values.get(annotation_field)
         annotations = values.get(field_to_update) or {}
 
+        if annotations:
+            for key, value in annotations.items():
+                value.agent = key  # Maybe we want key and agents with different values
+
         if annotation:
             annotations.update(
                 {
@@ -87,12 +91,8 @@ class BaseRecordInDB(GenericModel, Generic[AnnotationDB]):
             values[field_to_update] = annotations
 
         if annotations and not annotation:
-            for key, value in annotations.items():
-                new_annotation = value.__class__.parse_obj(
-                    {**value.dict(), "agent": key}
-                )
-                values[annotation_field] = new_annotation
-                break
+            # set first annotation
+            values[annotation_field] = list(annotations.values())[0]
 
         return values
 

--- a/tests/server/text_classification/test_model.py
+++ b/tests/server/text_classification/test_model.py
@@ -398,3 +398,30 @@ def test_annotated_without_labels_for_multilabel():
     )
 
     assert record.predicted == PredictionStatus.OK
+
+
+def test_using_predictions_dict():
+    record = ServiceTextClassificationRecord(
+        inputs={"text": "this is a text"},
+        predictions={
+            "carl": TextClassificationAnnotation(
+                agent="wat at", labels=[ClassPrediction(class_label="YES")]
+            ),
+            "BOB": TextClassificationAnnotation(
+                agent="wot wot", labels=[ClassPrediction(class_label="NO")]
+            ),
+        },
+    )
+
+    assert record.prediction.dict() == {
+        "agent": "carl",
+        "labels": [{"class_label": "YES", "score": 1.0}],
+    }
+    assert record.predictions == {
+        "BOB": TextClassificationAnnotation(
+            agent="BOB", labels=[ClassPrediction(class_label="NO")]
+        ),
+        "carl": TextClassificationAnnotation(
+            agent="carl", labels=[ClassPrediction(class_label="YES")]
+        ),
+    }

--- a/tests/server/text_classification/test_model.py
+++ b/tests/server/text_classification/test_model.py
@@ -418,10 +418,18 @@ def test_using_predictions_dict():
         "labels": [{"class_label": "YES", "score": 1.0}],
     }
     assert record.predictions == {
-        "BOB": TextClassificationAnnotation(
-            agent="BOB", labels=[ClassPrediction(class_label="NO")]
-        ),
+        "BOB": TextClassificationAnnotation(labels=[ClassPrediction(class_label="NO")]),
         "carl": TextClassificationAnnotation(
-            agent="carl", labels=[ClassPrediction(class_label="YES")]
+            labels=[ClassPrediction(class_label="YES")]
         ),
     }
+
+
+def test_with_no_agent_at_all():
+    with pytest.raises(ValidationError):
+        ServiceTextClassificationRecord(
+            inputs={"text": "this is a text"},
+            prediction=TextClassificationAnnotation(
+                labels=[ClassPrediction(class_label="YES")]
+            ),
+        )


### PR DESCRIPTION
This PR includes changes related to #1658 to align/normalize predictions/annotations keys with the `agent` fields:

- For the `prediction` field, agents will be computed from the key
- For the `predictions` field, agents will be set to `None`