### PR TITLE
docs: raise small-text version to 1.1.0 and adapt tutorial

### DIFF
--- a/docs/tutorials/active_learning_with_small_text.ipynb
+++ b/docs/tutorials/active_learning_with_small_text.ipynb
@@ -77,7 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install \"rubrix[listeners]\" datasets \"small-text>=1.1.0\" \"transformers[torch]\""
+    "%pip install \"rubrix[listeners]\" \"datasets~=2.5.0\" \"small-text>=1.1.0\" \"transformers[torch]\""
    ]
   },
   {

--- a/docs/tutorials/active_learning_with_small_text.ipynb
+++ b/docs/tutorials/active_learning_with_small_text.ipynb
@@ -77,7 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install \"rubrix[listeners]\" datasets \"small-text\" \"transformers[torch]\""
+    "%pip install \"rubrix[listeners]\" datasets \"small-text>=1.1.0\" \"transformers[torch]\""
    ]
   },
   {
@@ -111,7 +111,7 @@
    "source": [
     "import datasets\n",
     "\n",
-    "trec = datasets.load_dataset('trec', revision=\"bc790b9ce61d4c2b1ea9622cd65da40182725a61\")"
+    "trec = datasets.load_dataset('trec', version=datasets.Version(\"2.0.0\"))\n"
    ]
   },
   {
@@ -130,7 +130,7 @@
     "We first need to wrap the dataset in a specific data class provided by [small-text](https://github.com/webis-de/small-text), the excellent active learning framework we will use in this tutorial. \n",
     "Since we will choose a [Hugging Face transformer](https://huggingface.co/docs/transformers/index) in the active learner, small-text will expect a `TransformersDataset` object that already contains the tokenized input text.\n",
     "\n",
-    "So, let's tokenize our data with the tokenizer corresponding to the transformer model we will choose."
+    "In order to build a `TransformersDataset` object, we first need a tokenizer:"
    ]
   },
   {
@@ -140,20 +140,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import torch\n",
     "from transformers import AutoTokenizer\n",
     "\n",
-    "# Choose transformer model\n",
-    "TRANSFORMER_MODEL = \"prajjwal1/bert-tiny\"\n",
-    "\n",
+    "# Choose transformer model: In non-gpu environments we use a tiny model to reduce the runtime\n",
+    "if torch.cuda.is_available():\n",
+    "    transformer_model = \"prajjwal1/bert-tiny\"\n",
+    "else:\n",
+    "    transformer_model = \"bert-base-uncased\"\n",
+    "    \n",
     "# Init tokenizer\n",
-    "tokenizer = AutoTokenizer.from_pretrained(TRANSFORMER_MODEL)\n",
-    "\n",
-    "# Helper function to tokenize the input text\n",
-    "def tokenize(examples):\n",
-    "    return tokenizer(examples[\"text\"], padding=\"max_length\", max_length=64, truncation=True)\n",
-    "\n",
-    "# Tokenize dataset\n",
-    "trec_tokenized = trec.map(tokenize, batched=True, remove_columns=[\"text\"])"
+    "tokenizer = AutoTokenizer.from_pretrained(transformer_model)"
    ]
   },
   {
@@ -161,31 +158,29 @@
    "id": "14cbd644-3d38-42bf-a9e6-e54e6f60aea6",
    "metadata": {},
    "source": [
-    "After tokenizing the input text, we can create the dataset for small-text.\n",
-    "It expects a tuple of [PyTorch tensors](https://pytorch.org/docs/stable/tensors.html) containing the `inputs_ids`, the `attention_mask`, and a label if available."
+    "With this, we can create a `TransformersDataset` by calling `TransformersDataset.from_arrays()` which expects a list of texts, a numpy array (which indicates single-label classification), a tokenizer, and lastly the possible (integer values) of target labels within this dataset."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "99ec2d1b-7a84-4a6a-ba38-9fffdaa52c43",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "from small_text.integrations.transformers import TransformersDataset\n",
+    "import numpy as np\n",
+    "from small_text import TransformersDataset\n",
     "\n",
-    "# Set convenient output format \n",
-    "trec_tokenized.set_format(\"torch\")\n",
+    "num_classes = trec[\"train\"].features[\"coarse_label\"].num_classes\n",
+    "target_labels = np.arange(num_classes)\n",
     "\n",
-    "# Create tuples from the tokenized training data\n",
-    "data = [\n",
-    "    # Need to add an extra dimension to indicate a batch size of 1 -> [None]\n",
-    "    (row[\"input_ids\"][None], row[\"attention_mask\"][None], int(row[\"coarse_label\"])) \n",
-    "    for row in trec_tokenized[\"train\"]\n",
-    "]\n",
+    "train_text = [row[\"text\"] for row in trec[\"train\"]]\n",
+    "train_labels = np.array([row[\"coarse_label\"] for row in trec[\"train\"]])\n",
     "\n",
     "# Create the dataset for small-text\n",
-    "dataset = TransformersDataset(data)"
+    "dataset = TransformersDataset.from_arrays(train_text, train_labels, tokenizer, target_labels=target_labels)"
    ]
   },
   {
@@ -204,11 +199,10 @@
    "outputs": [],
    "source": [
     "# Create test dataset\n",
-    "data_test = [\n",
-    "    (row[\"input_ids\"][None], row[\"attention_mask\"][None], int(row[\"coarse_label\"])) \n",
-    "    for row in trec_tokenized[\"test\"]\n",
-    "]\n",
-    "dataset_test = TransformersDataset(data_test)"
+    "test_text = [row[\"text\"] for row in trec[\"test\"]]\n",
+    "test_labels = np.array([row[\"coarse_label\"] for row in trec[\"test\"]])\n",
+    "\n",
+    "dataset_test = TransformersDataset.from_arrays(test_text, test_labels, tokenizer, target_labels=np.arange(num_classes))"
    ]
   },
   {
@@ -241,15 +235,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from small_text.integrations.transformers.classifiers.factories import TransformerBasedClassificationFactory\n",
-    "from small_text.integrations.transformers import TransformerModelArguments\n",
-    "from small_text.query_strategies import BreakingTies\n",
-    "from small_text.active_learner import PoolBasedActiveLearner\n",
-    "\n",
+    "from small_text import (\n",
+    "    BreakingTies, \n",
+    "    PoolBasedActiveLearner, \n",
+    "    TransformerBasedClassificationFactory, \n",
+    "    TransformerModelArguments\n",
+    ")\n",
     "\n",
     "# Define our classifier\n",
     "clf_factory = TransformerBasedClassificationFactory(\n",
-    "    TransformerModelArguments(TRANSFORMER_MODEL),\n",
+    "    TransformerModelArguments(transformer_model),\n",
     "    num_classes=6,\n",
     "    # If you have a cuda device, specify it here.\n",
     "    # Otherwise, just remove the following line.\n",
@@ -279,7 +274,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from small_text.initialization import random_initialization\n",
+    "from small_text import random_initialization\n",
     "import numpy as np\n",
     "# Fix seed for reproducibility \n",
     "np.random.seed(42)\n",
@@ -313,7 +308,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "29d03264-f583-47e1-a39f-3335ce9573e7",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import rubrix as rb\n",
@@ -482,23 +479,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "id": "9bb5bdde-bdbd-47df-a525-d1354440f765",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEKCAYAAAAfGVI8AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAu9UlEQVR4nO3deXxU5dn/8c+VhBDWQCBsYRXCEtZIAEWt7MVqQfSnotZdaau4t1artdan7dNqbevTUltX3HEDxJUgiorIEghbgkCAAAlkgQQICdmv3x8zsSNmmSwnM5O53q8XL+acuefMF03mmnOfc9+3qCrGGGOCV4ivAxhjjPEtKwTGGBPkrBAYY0yQs0JgjDFBzgqBMcYEOSsExhgT5BwtBCIyU0R2ikiaiNxfzfP9RGSliGwVkVUi0tvJPMYYY75PnBpHICKhwC5gOpABbACuVNVUjzZvAe+r6osiMgW4QVWvcSSQMcaYajl5RjAeSFPVvapaCiwCZp/WJg741P34s2qeN8YY47AwB48dAxz02M4AJpzWZgtwCfAkMAfoICJdVPVoTQft2rWr9u/fv4mjGmNMy7Zx48Yjqhpd3XNOFgJv/AL4p4hcD3wBZAIVpzcSkXnAPIC+ffuSlJTUnBmNMSbgicj+mp5zsmsoE+jjsd3bve9bqnpIVS9R1XjgQfe+Y6cfSFWfVtUEVU2Ijq62oBljjGkgJwvBBiBWRAaISDgwF1jm2UBEuopIVYYHgOcdzGOMMaYajhUCVS0H5gPLgR3Am6qaIiKPisgsd7NJwE4R2QV0B/7gVB5jjDHVc+z2UackJCSoXSMwxpj6EZGNqppQ3XM2stgYY4KcFQJjjAlyVgiMMSbIWSEwxhg/VlxWwdd7jvLkJ7tJOXTckffw9YAyY4wxHk4Ul7ExPZ91+/LYkJ7H1oxjlFUoIhDVPpzhvSKb/D2tEBhjjA/lFpSwIT2P9ftcf3ZknUAVwkKEUb0juencMxg/oDNj+0UR2aaVIxmsEBhjTDNRVTLyT33ng3/vkUIAIlqFMLZfZ+6cGsv4AVHE9+lMm/DQZsllhcAYYxyiquzJPck694f+hn15HDpeDEDHiDDG9Y/iinF9GDcgihG9IgkP881lWysExhjThNJyTvL5rlzW7zvKhvR88gpLAYju0JrxA6L4af8oxg+IYkj3DoSEiI/TulghMMaYRqqoVFbuyGbhmnTW7HHNot8nqg2Th3RjwoAoxg2Ion+Xtoj4xwf/6awQGGNMAx0vKuONpAO89PV+MvJP0TMygvtmDuHiMTH06tTG1/G8ZoXAGGPqaWdWAQvXpLMkOYPiskrGD4jiwR8NY3pcd8JCA294lhUCY4zxQkWl8smObBZ+lc7Xe4/SOiyEi8fEcN3E/sT16ujreI1ihcAYY2pxrKiUNzYc5KWv95N57BQxndrwq5lDmTuuD53bhfs6XpOwQmCMMdX4JusEL65JZ0lyJsVllZx1RhS/uWgY04YFZvdPbawQGGOMW3lFpav7Z006a/fmEdEqhDnxMVx7dn+G9Qzs7p/aWCEwxgS9/MJS3kg6yMse3T8PXDCUK8b1oVPbltH9UxsrBMaYoLXj8H+7f0rKKzn7jC785qI4pg3r1uK6f2pjhcAYE3TyC0t56N3tfLD1MBGtQrjkzN5cN7EfQ3u03O6f2lghMMYElVU7c7jv7a3kF5Vy17RYrp/YPyi6f2rjaCEQkZnAk0Ao8Kyq/um05/sCLwKd3G3uV9UPncxkjAlOp0or+OOHO3h57X4Gd2/PCzeMc2Ru/0DkWCEQkVBgATAdyAA2iMgyVU31aPYQ8KaqPiUiccCHQH+nMhljgtPmg8e4543N7D1SyM3nDuAXPxxCRKvmmeI5EDh5RjAeSFPVvQAisgiYDXgWAgWqOuUigUMO5jHGBJnyikoWfLaH//t0N907tOa1mycwcVBXX8fyO04WghjgoMd2BjDhtDaPAIkicjvQDpjmYB5jTBDZm3uSu9/cwpaDx5gTH8Mjs4Y7tsJXoPP1xeIrgYWq+oSInA28LCIjVLXSs5GIzAPmAfTt29cHMY0xgUJVeWXdAf7wQSqtw0L551XxXDSql69j+TUnC0Em0Mdju7d7n6ebgJkAqvq1iEQAXYEcz0aq+jTwNEBCQoI6FdgYE9hyThRz3ztbWbUzl/Niu/L4/xtNj8gIX8fye04Wgg1ArIgMwFUA5gJXndbmADAVWCgiw4AIINfBTMaYFuqjbYf59ZJtnCqr4NHZw7nmrH5+uxCMv3GsEKhquYjMB5bjujX0eVVNEZFHgSRVXQbcCzwjInfjunB8varaN35jjNdOFJfxyLIUFm/KZFTvSP56+RgGdWvv61gBxdFrBO4xAR+etu9hj8epwDlOZjDGtFxr9x7l3je3kHWimDumxnL7lEG0CqKpIZqKry8WG2NMvZWUV/BE4i6e+XIv/aLa8tbPzubMvp19HStgWSEwxgSUHYdPcPcbm/kmq4CrJ/TlwQuH0TbcPsoaw/7rGePnVNUueuJaKvLZL/fyROIuOrZpxQvXj2Py0G6+jtUiWCEwxk+pKr9dlsJnO3N44fpxDOrWwdeRfOZgXhH3vrWF9fvy+OHw7vzvJaOIaiHLRPoDKwTG+CFV5XfvpfLS1/uJaBXCFf9Zy8s3TQj4RdLrI/tEMat3H+GrtCMkpmYD8JfLRnPpmTF2htTErBAY44ceX76ThWvSufGcAfzkrL5c/ew6rnxmLS/fNJ5RvTv5Op4jTpaUs27vUb50f/jvzjkJQJd24UyP68490wfTJ6qtj1O2TBJot+0nJCRoUlKSr2MY45h/frqbvyTu4srxffnjnBGICAfzirjq2bUcKyzjhRvGkdA/ytcxG62sopKtGce+/eBPPnCM8kololUI4wd04dxBXTh3UDRDe3QgJMTOABpLRDaqakK1z1khMMZ/PPvlXn7/wQ4uiY/hL5eN/s4H4OHjp7j6mXUcPl7Mc9clBNwsmqrKntxCVu/OZXXaUdbuPcrJknJEYFRMJOcM6sq5sV05s29nmyLaAVYIjAkAr67bz4NLtvOjkT34v7nx1a6Zm1tQwk+eXUf60UL+fc1YJg/x77tmcgtK+CrtCKvTXN/6Dx8vBqBfl7acM6gr5w3qytkDuwT9CmHNwQqBMX7unY0Z/OLtLUwe0o1//2Qs4WE1j47NKyzl2ufXsTOrgH9ceSYzR/RoxqS1KyotZ92+PL7a7frw/yarAIBObVtxzkDXN/5zB3W1vn4fsEJgjB/7YOthbn99E2cP7MJz143zqlvk+Kkyrn9hPVszjvO3K8Ywa7Rvp1murFReWbefxz7eycmScsLDQhjXvzPnDorm3EFdGd6ro/Xz+1hthcDuGjLGh1buyObORcmM7deZZ65N8LpvPLJNK16+aQI3LtzAnYuSKS6r4PKEPnW/0AG7swu4f/E2Nu7P57zYrsz7wRmM6x9l/fwBxAqBMT6yevcRfv7KJuJ6deT568fVe5qE9q3DePGG8cx7OYn73t5KSVkF15zd35mw1Sgtr+SpVXtY8FkabVuH8tfLRzMn3u7xD0RWCIzxgfX78rjlpSTOiG7HSzeOp0NEw5ZQbBMeyjPXJjD/tU385t0USsorufm8M5o47fdt3J/PA4u3siv7JLNG9+LhH8fRtX1rx9/XOMMKgTHNbPPBY9y4cAM9O0Xwys0TGn3HTESrUP519VjufmMzv/9gB6dKK7h9amwTpf2uwpJyHl++kxe/Tqdnxwievz6BKUO7O/JepvlYITCmGaUeOsF1z68nql04r918VpN9iw4PC+HJuWNoHRbCEyt2UVxewS9mDGnSbprPdubw0JLtHDp+imvP6scvZw6lfWv7CGkJ7P+iMc0kLaeAa55bR9vwUF69eUKTr6UbFhrCXy4bTetWoSz4bA+nSiv5zUXDGl0Mjp4s4X/eT2Xp5kMM6taet392NmP7Bf7IZvNfVgiMaQb7jxZy9bPrEBFevXmCY/fRh4QIf5wzgtZhITz/1T6Kyyv4/ewRDbp1U1VZujmTR99L5WRJOXdOjeXWyQNpHWZ3A7U0VgiMcVjmsVNc9cw6SssrWTTvbM6IdnY9XRHhtz+Oo014KE+t2kNxWQWPXTqq2pHKNcnIL+LBJdv5fFcu8X078edLRzG4e/BOg93SWSEwxkE5J4q5+pm1nCgu4/VbzmJIj+b5MBUR7vvhECLCQvnbJ7soKa/k71eMqXM934pK5cU16fwlcScAj/w4jmvO7k+oDQZr0RwtBCIyE3gSCAWeVdU/nfb834DJ7s22QDdV7eRkJmOaS15hKVc/u46cghJevmkCI2Iim/X9RYQ7p8US0SqE//3oG0rKKllwdXyNXTs7swr41Ttb2XzwGJOGRPOHOSOJ6dSmWTMb33CsEIhIKLAAmA5kABtEZJmqpla1UdW7PdrfDsQ7lceY5nT8VBnXPLeOA3lFvHDDOMb2893C6j89fyARrUL57bIUbnlpI//5yVjahP+3GJSUV7Dg0zSe+nwPHSJa8eRc15QVNjAseDh5RjAeSFPVvQAisgiYDaTW0P5K4LcO5jGmWZwsKef6F9azK7uAZ65NYOJA308Xfd3E/kS0CuH+xdu4YeF6nrtuHO1ah5GUnsev3tnKntxCLomP4aGL4mwJyCDkZCGIAQ56bGcAE6prKCL9gAHApw7mMcZxxWUV3PziBrZmHGfBVWcyyY+mib5iXF8iWoVyz5tbuOa5dQzvFcnLa/cT06kNL944nvMHR/s6ovERf7lYPBd4W1UrqntSROYB8wD69u3bnLmM8VpJeQU/fXkj6/bl8fcrxvjV9NBVZo+JITw0hDsWJZN88Bg3njOAe2cMpp0NDAtqTv7fzwQ8p0Ps7d5XnbnAbTUdSFWfBp4G1zTUTRXQmKZSXlHJ7a8l8/muXB67dBSzx8T4OlKNLhjZk7c7tSEsVBjeq3kvYBv/5GQh2ADEisgAXAVgLnDV6Y1EZCjQGfjawSzGOOqj7Vkkpmbz8EVxXD7ON9NB18foPp18HcH4Ee9HmNSTqpYD84HlwA7gTVVNEZFHRWSWR9O5wCINtBVyjPGwPCWLru3DuW5if19HMabeHO0YVNUPgQ9P2/fwaduPOJnBGKeVlFewamcuF43qaQOvTEBy7IzAmGCxdm8eJ0vKmTHcpmM2gckKgTGNlJiSRdvwUL8YL2BMQ1ghMKYRKiuVFanZTBoSbWv0moBlhcCYRtiScYycghKmx1m3kAlcVgiMaYQVqdmEhghThlghMIHLCoExjZCYms1ZZ0QR2bZhi88b4w+sEBjTQHtyT5KWc5IZcf43lYQx9WGFwJgGWpGaDcA0uz5gApwVAmMaaEVqNiNiOtriLSbgWSEwpgFyCorZdCDfuoVMi2CFwJgGWLkjB1VsNLFpEawQGNMAiSlZ9I1qy5DuzbMYvTFOskJgTD2dLCnnqz1HmR7X3db1NS2CFQJj6umLXbmUllcyw+4WMi2EFQJj6ikxJYuoduGM7dfZ11GMaRJWCIyph7KKSlZ+k8PUod0IC7VfH9My2E+yMfWwbm8eBcXlNsmcaVGsEBhTDytSs4hoFcJ5sdG+jmJMk7FCYIyXVJXE1Gx+EBtNm3Bbe8C0HFYIjPHS9swTHD5ezIzhNprYtCyOFgIRmSkiO0UkTUTur6HN5SKSKiIpIvKak3mMaYzE1CxCBKYM7ebrKMY0qTCnDiwiocACYDqQAWwQkWWqmurRJhZ4ADhHVfNFxH7DjN9akZrNuP5RRLUL93UUY5qUk2cE44E0Vd2rqqXAImD2aW1uARaoaj6AquY4mMeYBtt/tJBvsgqsW8i0SE4WghjgoMd2hnufp8HAYBH5SkTWishMB/MY02BVaw/YaGLTEtVZCETkxyLiVMEIA2KBScCVwDMi0qmaDPNEJElEknJzcx2KYkzNElOyGdazI32i2vo6ijFNzpsP+CuA3SLymIgMrcexM4E+Htu93fs8ZQDLVLVMVfcBu3AVhu9Q1adVNUFVE6Kj7f5t07yOniwhaX+eDSIzLVadhUBVfwLEA3uAhSLytfsbel3z724AYkVkgIiEA3OBZae1WYrrbAAR6Yqrq2hvvf4Fxjhs5Tc5VKp1C5mWy6suH1U9AbyN64JvT2AOsElEbq/lNeXAfGA5sAN4U1VTRORREZnlbrYcOCoiqcBnwC9V9WiD/zXGOCAxJZuYTm0Y3qujr6MY44g6bx91f2jfAAwCXgLGq2qOiLQFUoF/1PRaVf0Q+PC0fQ97PFbgHvcfY/xOUWk5X+7O5crxfW3tAdNieTOO4FLgb6r6hedOVS0SkZuciWWMf/hi1xFKbO0B08J5UwgeAQ5XbYhIG6C7qqar6kqnghnjD1akZhPZphXjBkT5OooxjvHmGsFbQKXHdoV7nzEtWnlFJSu/yWbq0G60srUHTAvmzU93mHtkMADuxzbG3rR4G9LzOVZUxozh1i1kWjZvCkGux10+iMhs4IhzkYzxD4mpWbQOC+EHg23simnZvLlG8DPgVRH5JyC4po241tFUxviYqpKYks25g7rSNtyxuRmN8Qt1/oSr6h7gLBFp794+6XgqY3xsx+ECMo+d4o6pg3wdxRjHefVVR0QuBIYDEVX3Uqvqow7mMsanElOzEIGpw+z6gGn5vJl07t+45hu6HVfX0GVAP4dzGeNTiSnZJPTrTNf2rX0dxRjHeXOxeKKqXgvkq+rvgLNxzQlkTIt0MK+I1MMnbJI5EzS8KQTF7r+LRKQXUIZrviFjWqRPdrjWHpgeZ4vQmODgzTWC99xrBDwObAIUeMbJUMb4UmJKNoO7t2dA13a+jmJMs6i1ELgXpFmpqseAd0TkfSBCVY83Rzhjmlt+YSnr0/P4+fkDfR3FmGZTa9eQqlbiWoC+arvEioBpyT79JoeKSrXrAyaoeHONYKWIXCo2B68JAitSs+nRMYKRMZG+jmJMs/GmEPwU1yRzJSJyQkQKROSEw7mMaXbFZRV8viuX6XHdCQmx7z0meHgzsriuJSmNaRFW7z7CqbIKm2TOBB1vVij7QXX7T1+oxphAl5iaRYeIMCYM6OLrKMY0K29uH/2lx+MIYDywEZjiSCJjfKCiUlm5I4fJQ7oRHmZrD5jg4k3X0I89t0WkD/B3pwIZ4wubDuRztLDUuoVMUGrIV58MYJg3DUVkpojsFJE0Ebm/muevF5FcEdns/nNzA/IY02iJKVmEh4Zwvq09YIKQN9cI/oFrNDG4CscYXCOM63pdKK4xCNNxFY8NIrJMVVNPa/qGqs6vT2hjmpKqkpiazcRBXegQ0crXcYxpdt5cI0jyeFwOvK6qX3nxuvFAmqruBRCRRcBs4PRCYIxP7co+yf6jRcz7wRm+jmKMT3hTCN4GilW1Alzf9EWkraoW1fG6GFyrmVXJACZU0+5S951Ju4C7VfVgNW2MccyK1CwAptvaAyZIeTWyGGjjsd0G+KSJ3v89oL+qjgJWAC9W10hE5olIkogk5ebmNtFbG+OSmJpNfN9OdOsY4esoxviEN4UgwnN5Svfjtl68LhPo47Hd273vW6p6VFVL3JvPAmOrO5CqPq2qCaqaEB1tF/NM0zl07BRbM44zw6acNkHMm0JQKCJnVm2IyFjglBev2wDEisgAEQkH5gLLPBuIiOe6BrOAHV4c15gmU7X2gN02aoKZN9cI7gLeEpFDuJaq7IFr6cpaqWq5iMwHlgOhwPOqmiIijwJJqroMuENEZuG6CJ0HXN+gf4UxDZSYks0Z0e0YGN3e11GM8RlvBpRtEJGhwBD3rp2qWubNwVX1Q+DD0/Y97PH4AeAB7+Ma03SOnypj7d6j3Hye3S1kgps3i9ffBrRT1e2quh1oLyK3Oh/NGGet2plDeaVat5AJet5cI7jFvUIZAKqaD9ziWCJjmkliSjbRHVozpncnX0cxxqe8KQShnovSuEcMhzsXyRjnlZRXsGpnDtOG2doDxnhzsfhj4A0R+Y97+6fAR85FMsZ5a/YcpbDU1h4wBrwrBL8C5gE/c29vxXXnkDEBKzElm3bhoUwcaGsPGFNn15B7Aft1QDqu+YOmYPf7mwBWWamsSM1m0tButA4L9XUcY3yuxjMCERkMXOn+cwR4A0BVJzdPNGOckXzwGEdOljAjzrqFjIHau4a+Ab4ELlLVNAARubtZUhnjoMTULMJChElDuvk6ijF+obauoUuAw8BnIvKMiEzFNbLYmIBVWl5JYko2Zw/sQmQbW3vAGKilEKjqUlWdCwwFPsM11UQ3EXlKRGY0Uz5jmszxojKue349+44UcnlCn7pfYEyQ8OZicaGqvuZeu7g3kIzrTiJjAsb+o4XMeeorkvbn8dfLR/Pj0b18HckYv+HN7aPfco8qftr9x5iAkJSex7yXN1Kpyis3TWDCGXbLqDGe6lUIjAk0727O5Jdvb6VXZAQv3DCeAV3b+TqSMX7HmykmjKlVYUk5mw7ko6q+jvItVeUfK3dz56LNjOndiSW3nmNFwJga2BmBabTHPv6GF7/ez6Qh0Tw6awR9u3izgJ1zSssreWDxNt7ZlMGc+Bj+dOlIGzhmTC3sjMA0Sml5Jcu2HCK2W3s27Mtj+t8+55+f7qakvMIneY4VlXLNc+t4Z1MGd08bzF8vH21FwJg6WCEwjfLFrlzyi8q4/4KhrLx3ElOHdeMvibu44MkvWbPnSLNmST9SyJx/rSH5wDGenDuGO6fF4jFxrjGmBlYITKMs2ZxJ57at+MHgaHpERvCvq8fywg3jKKuo5Kpn1nH3G5vJLShxPMeG9Dzm/OsrjhWV8uotE5g9Jsbx9zSmpbBCYBrsRHEZn6Rm8+PRvWgV+t8fpclDurHi7vO5fcog3t96iKlPrOKVtfuprHTmYvLS5EyufmYdnduGs+TWcxjXP8qR9zGmpbJCYBrs4+1ZlJRXcnH89799R7QK5d4ZQ/jozh8wvFckDy3dzpyn1rA983iTvb+q8vdPdnHXG5uJ79uJxbdOpL/dGWRMvVkhMA22NDmTfl3aEt+nU41tBnVrz2u3TODvV4whM7+IWf9czaPvpXKypLxR711SXsE9b27h75/s5pIzY3j5pgl0amsL5xnTEI4WAhGZKSI7RSRNRO6vpd2lIqIikuBkHtN0Dh8/xdd7j3LxmJg6L8iKCBfHx7DynklcOb4vL6zZx9QnVvHhtsMNGnuQX1jKNc+uZ0lyJr+YMZgnLhtNeJh9pzGmoRz77XGvbbwAuACIA64Ukbhq2nUA7sS1+I0JEMs2H0KVaruFahLZthV/mDOSxT+fSJd2rbn11U1c/8IG9h8t9PoY+44UcslTa9iccYz/uzKe+VPsziBjGsvJr1HjgTRV3auqpcAiYHY17f4H+DNQ7GAW08SWJGcypk+nBo3Wje/bmWXzz+Hhi+JISs9jxt++4B8r6x57sG7vUeb86yuOnyrj9VsmMMsmjjOmSThZCGKAgx7bGe593xKRM4E+qvpBbQcSkXkikiQiSbm5uU2f1NTLjsMn+CargDn1OBs4XVhoCDeeO4CV905i2rDuPLHCPfYgrfqxB4s3ZfCT59YR1S6cJbdOZGw/uzPImKbis45VEQkB/grcW1dbVX1aVRNUNSE6Otr5cKZWSzdnEhYiXDSqZ6OP1SMyggVXn8nCG8ZRXqFc9ew67lqU/O3YA1Xlryt2cc+bW0joF8WSn59Dvy52Z5AxTcnJuYYyAc/VP3q791XpAIwAVrn7eHsAy0RklqomOZjLNEJlpfJu8iHOHxxNl/atm+y4k4Z0I/HuLiz4LI1/f76Hld/kcN8Ph5C0P593Nx/isrG9+cOckXZR2BgHOFkINgCxIjIAVwGYC1xV9aSqHge6Vm2LyCrgF1YE/NvafUfJOlHMgxcOa/JjV409mD0mht8s3c5v3k0B4Jc/HMKtkwbaRWFjHOJYIVDVchGZDywHQoHnVTVFRB4FklR1mVPvbZyzNDmT9q3DmDasu2PvUTX24KPtWbQJD2WyLTJvjKMcnYZaVT8EPjxt38M1tJ3kZBbTeMVlFXy0LYuZI3rQJtzZGT1FhB+NbPw1CGNM3azD1Xht5Y4cCkrKG3W3kDHG/1ghMF5bkpxJ946tOcvW/DWmRbFCYLySV1jKqp05zB4TQ2iIXbQ1piWxQmC88sG2w5RXKhfbPP/GtDhWCIxXliZnMqR7B4b17ODrKMaYJmaFwNRp/9FCNu7P5+L4umcaNcYEHisEpk5Lkw8BMHuMTfJmTEtkhcDUSlVZujmTs86IolenNr6OY4xxgBUCU6stGcfZd6TQxg4Y04JZITC1WpqcSXhYCDNH2ChfY1oqKwSmRmUVlby35RDThnUjsk0rX8cxxjjECoGp0erdRzhaWGpjB4xp4awQ+KHyikrmv7aJZVsO+TTHkuRMOrVtxSSb/dOYFs3R2UdNwyxJzuT9rYdZuSOH0b0jfbIi18mSchJTs7j0zN62GIwxLZz9hvuZsopK/vFpGoO7tycsVPjFW1uoqNRmz7F8exbFZZV2t5AxQcAKgZ9ZvCmDA3lF3H/BUH43azgb0vN5fvW+Zs+xdHMmfaLaMLZf52Z/b2NM87JC4EdKy11nA6P7dGLykG7MiY9hRlx3Hk/cye7sgmbLkX2imK/SjjBnjE0pYUwwsELgR97emEFG/inumhaLiCAi/GHOSNq3DuPet7ZQVlHZLDne23KISoXZ1i1kTFCwQuAnSssrWfBZGvF9OzFpcPS3+6M7tOb3F49ga8Zxnlq1p1myLEnOZHTvSAZGt2+W9zPG+JYVAj/xZtJBMo+d4u5pg7/XHfOjkT2ZPaYX/7dyN9szjzuaY1d2ASmHTnCxnQ0YEzQcLQQiMlNEdopImojcX83zPxORbSKyWURWi0ick3n8VUl5BQs+S2Nsv86cF9u12ja/mzWcqHbh3PPmZkrKKxzLsjQ5k9AQ4aJRNtOoMcHCsUIgIqHAAuACIA64spoP+tdUdaSqjgEeA/7qVB5/9saGgxw+Xsw9079/NlClU9tw/nzpKHZln+RvK3Y7kqOyUnl38yHOi+1KdIfWjryHMcb/OHlGMB5IU9W9qloKLAJmezZQ1RMem+0Ax26Yzyko5uWv0506fIMVl7nOBsb3j2LiwNoXhZ88tBtzx/Xh6S/2sHF/XpNn2ZCeR+axUzZ2wJgg42QhiAEOemxnuPd9h4jcJiJ7cJ0R3FHdgURknogkiUhSbm5ug8K8vu4gv3k3hU+/yW7Q653y+voDZJ8o4a7psV7dqvnghcPoGdmGe9/cQlFpeZNmWbo5k7bhoUyP696kxzXG+DefXyxW1QWqOhD4FfBQDW2eVtUEVU2Ijo6urkmdfjbpDIZ078ADi7dxvKisEYmbTnFZBf9atYezzohi4sDqrw2crkNEKx6/bBTpR4t47OOdTZrl/a2HmTm8B23DbeYRY4KJk4UgE+jjsd3bva8mi4CLnQrTOiyUv1w2miMnS3n0/VSn3qZeXl13gNyCEu6eNrher5s4sCvXT+zPwjXprEk70iRZVu3MoaC43O4WMiYIOVkINgCxIjJARMKBucAyzwYiEuuxeSHgzFVQt5G9I/n5+QN5Z1OGz7uITpVW8NSqPZwzqAsTzqj92kB1fjVzKAO6tuOXb2+loLjxZziLN2US3aF1ndcpjDEtj2OFQFXLgfnAcmAH8KaqpojIoyIyy91svoikiMhm4B7gOqfyVLl96iCGdO/A/e/4tovolbX7OXKy/mcDVdqEu85wDh8/xe/f39GoLMeKSvlsZw6zRvciLNTnvYXGmGbm6G+9qn6oqoNVdaCq/sG972FVXeZ+fKeqDlfVMao6WVVTnMwD/+0iOlpYyu/ed/ztqlVUWs6/P9/DebFdSegf1eDjjO3XmZ+eP5A3kg426gzng22HKatQu1vImCAVlF//RvaO5NZJA1m8KZNPUpu/i+ilr/dztLCUuxp4NuDprmmxDO3RgV+9s438wtIGHWNpciaDurVneK+Ojc5jjAk8QVkIAG6f4voA/fWS5u0iOllSzn8+38P5g6ObZIrn1mGhPHH5aPILS/ntsvqf4RzMK2JDej5z4m2mUWOCVdAWgvCwkP92Eb3XfF1EL65JJ7+ojLunN/5soMrwXpHcOTWWZVsO8cHWw/V67bubXTdyzRptU0oYE6yCthAAjIiJ5LZJA1mc3DxdRAXFZTzz5V6mDO3GmD6dmvTYP580kNG9I3lo6TZyC0q8eo2qsiQ5k/H9o+gT1bZJ8xhjAkdQFwKA+e4uogeWbONYUcP62L314pp0jhWVcde02Lob11NYaAhPXD6awtIKHli8DdW6Z+vYnnmCPbmFNnbAmCAX9IWgqosov7CU373n3ECzE8VlPP3FXqYN68ao3p0ceY9B3Tpw3w+H8MmObBZvqm3snsuS5EzCQ0O4cGRPR/IYYwJD0BcCcHUR3Tp5EEuSM1nhUBfRC6vTOVFc3iR3CtXmhnMGML5/FI+8l8KhY6dqbFdeUcmyLYeYPDSayLatHM1kjPFvVgjc5k8exLCeHfm1A11Ex0+V8ezqvcyI686ImMgmPfbpQkOExy8bRUWl8qt3ttbYRfTVnqMcOVnCnPjejuYxxvg/KwRuri6iUeQXlvJIA27DrM1zq/dR0AxnA1X6dWnHr380jC93H+HVdQeqbbM0OZOOEWFMHtqwSfyMMS2HFQIPw3tFctvkQSzdfIjElKwmOebxojJeWL2PC0b0IK4ZB2xdPaEv58V25Y8f7mD/0cLvPFdYUs7H27O4cFQvWoeFNlsmY4x/skJwmtu+7SLa3uCRup6eXb2XgpJy7nTgTqHaiAh/vnQUoSHCL9/aSkXlf7uIVqRmc6qswqaUMMYAVgi+p6qL6FhRKY80cqBZfmEpz6/ex4UjezK0R/NP39CrUxse+fFw1qfn8cJX+77dvyQ5k5hObUhogpHNxpjAZ4WgGsN7RTJ/yiDe3XyI5Y3oInrmy70UlVU0+9mAp0vOjGF6XHceW76TtJwCcgtK+HJ3LhfH9yIkxKaUMMZYIajRrZNcXUQPNrCL6OjJEhauSeeiUb0Y3L2DAwm9IyL8cc5I2oWHcs+bW1ianEmlwsVjrFvIGONihaAGje0ievrLvZwqq+DOqYMcSFc/0R1a84c5I9macZzHl+9kRExHYn1YnIwx/sUKQS0a2kV05GQJL63Zz+zRvRjUzT8+cH80siezRveitKLSzgaMMd9hhaAOt00eRFw9u4j+8/keSsoruGOq764NVOd/Zo/g1kkDuXxcn7obG2OChhWCOrQKdc1FdKzIu/n+cwqKeXntfi6Oj+GM6PbNkNB7kW1bcd/MoXSMsCkljDH/ZYXAC3G9OnL7FNd8/x9vr72L6D+f76WsQrljin+dDRhjTE2sEHjp1skDGd6rIw8t3UZeDV1EOSeKeWXtfubEx9C/a7tmTmiMMQ3jaCEQkZkislNE0kTk/mqev0dEUkVkq4isFJF+TuZpjKououOnymrsIvrXqj2UV9rZgDEmsDhWCEQkFFgAXADEAVeKSNxpzZKBBFUdBbwNPOZUnqYwrKeri+i9LYf4ePt3l4TMOl7Ma+sP8P/O7E3fLrbalzEmcDh5RjAeSFPVvapaCiwCZns2UNXPVLXIvbkW8Ps5kX8+aSAjYjry0NLt3+ki+teqNCorlflTfD9uwBhj6sPJQhADHPTYznDvq8lNwEfVPSEi80QkSUSScnNzmzBi/Xl2ET387nYADh07xaL1B7ksoY+t/WuMCTh+cbFYRH4CJACPV/e8qj6tqgmqmhAd7fv584f26MgdU2J5f+thPtp2mAWfpaHY2YAxJjCFOXjsTMBz5FJv977vEJFpwIPA+apa4mCeJvWzSQNZnprFg0u3U1BcxuUJfYjp1MbXsYwxpt6cPCPYAMSKyAARCQfmAss8G4hIPPAfYJaq5jiYpclVdREVFJchCLdNtrMBY0xgcuyMQFXLRWQ+sBwIBZ5X1RQReRRIUtVluLqC2gNviQjAAVWd5VSmpja0R0f+cWU8xWWV9LKzAWNMgJKaFjf3VwkJCZqUlOTrGMYYE1BEZKOqJlT3nF9cLDbGGOM7VgiMMSbIWSEwxpggZ4XAGGOCnBUCY4wJclYIjDEmyFkhMMaYIGeFwBhjglzADSgTkVxgfwNf3hU40oRxnBZIeQMpKwRW3kDKCoGVN5CyQuPy9lPVamftDLhC0BgiklTTyDp/FEh5AykrBFbeQMoKgZU3kLKCc3mta8gYY4KcFQJjjAlywVYInvZ1gHoKpLyBlBUCK28gZYXAyhtIWcGhvEF1jcAYY8z3BdsZgTHGmNMETSEQkZkislNE0kTkfl/nqYmI9BGRz0QkVURSROROX2fyhoiEikiyiLzv6yy1EZFOIvK2iHwjIjtE5GxfZ6qNiNzt/jnYLiKvi0iErzN5EpHnRSRHRLZ77IsSkRUistv9d2dfZqxSQ9bH3T8LW0VkiYh08mHEb1WX1eO5e0VERaRrU71fUBQCEQkFFgAXAHHAlSIS59tUNSoH7lXVOOAs4DY/zurpTmCHr0N44UngY1UdCozGjzOLSAxwB5CgqiNwrfQ317epvmchMPO0ffcDK1U1Fljp3vYHC/l+1hXACFUdBewCHmjuUDVYyPezIiJ9gBnAgaZ8s6AoBMB4IE1V96pqKbAImO3jTNVS1cOqusn9uADXB1WMb1PVTkR6AxcCz/o6S21EJBL4AfAcgKqWquoxn4aqWxjQRkTCgLbAIR/n+Q5V/QLIO233bOBF9+MXgYubM1NNqsuqqomqWu7eXAv0bvZg1ajhvyvA34D7gCa9uBsshSAGOOixnYGff7gCiEh/IB5Y5+Modfk7rh/OSh/nqMsAIBd4wd2N9ayItPN1qJqoaibwF1zf/g4Dx1U10bepvNJdVQ+7H2cB3X0Zph5uBD7ydYiaiMhsIFNVtzT1sYOlEAQcEWkPvAPcpaonfJ2nJiJyEZCjqht9ncULYcCZwFOqGg8U4j/dFt/j7lufjauA9QLaichPfJuqftR1W6Lf35ooIg/i6pZ91ddZqiMibYFfAw87cfxgKQSZQB+P7d7ufX5JRFrhKgKvqupiX+epwznALBFJx9XlNkVEXvFtpBplABmqWnWG9TauwuCvpgH7VDVXVcuAxcBEH2fyRraI9ARw/53j4zy1EpHrgYuAq9V/76cfiOsLwRb371pvYJOI9GiKgwdLIdgAxIrIABEJx3XBbZmPM1VLRARXH/YOVf2rr/PURVUfUNXeqtof13/XT1XVL7+1qmoWcFBEhrh3TQVSfRipLgeAs0SkrfvnYip+fHHbwzLgOvfj64B3fZilViIyE1e35ixVLfJ1npqo6jZV7aaq/d2/axnAme6f6UYLikLgvhg0H1iO6xfpTVVN8W2qGp0DXIPrm/Vm958f+TpUC3I78KqIbAXGAH/0bZyauc9c3gY2Adtw/b761UhYEXkd+BoYIiIZInIT8CdguojsxnVW8ydfZqxSQ9Z/Ah2AFe7ftX/7NKRbDVmdez//PRMyxhjTHILijMAYY0zNrBAYY0yQs0JgjDFBzgqBMcYEOSsExhgT5KwQmKAlIifdf/cXkaua+Ni/Pm17TVMe35imZIXAGOgP1KsQuCeBq813CoGqBsKIYBOkrBAY4xrwdJ57QNHd7rUVHheRDe556n8KICKTRORLEVmGe0SyiCwVkY3uNQPmuff9CdeMoZtF5FX3vqqzD3Efe7uIbBORKzyOvcpjrYRX3aOJjXFcXd9qjAkG9wO/UNWLANwf6MdVdZyItAa+EpGqWT/PxDV//T739o2qmicibYANIvKOqt4vIvNVdUw173UJrhHNo4Gu7td84X4uHhiOa6rpr3CNMl/d1P9YY05nZwTGfN8M4FoR2YxrCvAuQKz7ufUeRQDgDhHZgmsu+z4e7WpyLvC6qlaoajbwOTDO49gZqloJbMbVZWWM4+yMwJjvE+B2VV3+nZ0ik3BNXe25PQ04W1WLRGQV0JilJEs8Hldgv5+mmdgZgTFQgGvisSrLgZ+7pwNHRAbXsIBNJJDvLgJDcS0tWqWs6vWn+RK4wn0dIhrXimnrm+RfYUwD2TcOY2ArUOHu4lmIa13j/rjmexdcq5pdXM3rPgZ+JiI7gJ24uoeqPA1sFZFNqnq1x/4lwNnAFlwLttynqlnuQmKMT9jso8YYE+Ssa8gYY4KcFQJjjAlyVgiMMSbIWSEwxpggZ4XAGGOCnBUCY4wJclYIjDEmyFkhMMaYIPf/AUJP1OW6Usr1AAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "\n",
@@ -581,7 +565,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.0"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/active_learning_with_small_text.ipynb
+++ b/docs/tutorials/active_learning_with_small_text.ipynb
@@ -144,7 +144,7 @@
     "from transformers import AutoTokenizer\n",
     "\n",
     "# Choose transformer model: In non-gpu environments we use a tiny model to reduce the runtime\n",
-    "if torch.cuda.is_available():\n",
+    "if not torch.cuda.is_available():\n",
     "    transformer_model = \"prajjwal1/bert-tiny\"\n",
     "else:\n",
     "    transformer_model = \"bert-base-uncased\"\n",


### PR DESCRIPTION
Hi,

with the new small-text v1.1.0 release the requirement that all classes must be in the training data (#1693) is now gone and should not cause any more problems.

- Moreover, I changed the code to use the new convenience methods to construct a `TransformersDataset`.
- The small-text imports have (finally) been cleaned up and you can import all public methods from the top level.
- For dataset construction, passing the target_labels is now recommended (and I changed that as it returns a warning otherwise).
- Since the new TREC dataset (despite your configured `revision` parameter) always fell back to the old version (which resulted in an error since the attributes don't mach) therefore I changed this to use the `version` parameter instead. This seems to work well and it is probably reasonable to pin the example to a dataset version. 

- Proposal: I changed the transformer model name to use a larger model if a GPU (i.e. if CUDA) is available. Otherwise, with only the tiny model, people might undererstimate the strength of this combination.

I did manually test it only until the labeling starts. Sorry, short on time today :).

This PR is just intended to make this as easy as possible for you. Don't feel obligated to use this and change/revert anything that does not fit.
