### PR TITLE
Bugfixes/review pr 1709

### DIFF
--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -551,7 +551,10 @@ def test_token_classification_spans(span, valid):
         )
     else:
         with pytest.raises(
-            ValueError, match="The entity spans \['s'\] are not aligned"
+            ValueError,
+            match="Following entity spans are not aligned with provided tokenization\n"
+            r"Spans:\n- \[s\] defined in Esto es...\n"
+            r"Tokens:\n\['Esto', 'es', 'una', 'prueba'\]",
         ):
             rb.TokenClassificationRecord(
                 text=texto,

--- a/tests/utils/test_span_utils.py
+++ b/tests/utils/test_span_utils.py
@@ -67,7 +67,9 @@ def test_validate_misaligned_spans():
     span_utils = SpanUtils("test this.", ["test", "this", "."])
     with pytest.raises(
         ValueError,
-        match="The entity spans \['test '\] are not aligned with following tokens: \['test', 'this', '.'\]",
+        match="Following entity spans are not aligned with provided tokenization\n"
+        r"Spans:\n- \[test \] defined in test this.\n"
+        r"Tokens:\n\['test', 'this', '.'\]",
     ):
         span_utils.validate([("mock", 0, 5)])
 
@@ -76,8 +78,10 @@ def test_validate_not_valid_and_misaligned_spans():
     span_utils = SpanUtils("test this.", ["test", "this", "."])
     with pytest.raises(
         ValueError,
-        match="Following entity spans are not valid: \[\('mock', 2, 1\)\]\n"
-        "The entity spans \['test '\] are not aligned with following tokens: \['test', 'this', '.'\]",
+        match=r"Following entity spans are not valid: \[\('mock', 2, 1\)\]\n"
+        "Following entity spans are not aligned with provided tokenization\n"
+        r"Spans:\n- \[test \] defined in test this.\n"
+        r"Tokens:\n\['test', 'this', '.'\]",
     ):
         span_utils.validate([("mock", 2, 1), ("mock", 0, 5)])
 


### PR DESCRIPTION
With this change, errors will be shown as following:
```bash
ValueError: Following entity spans are not aligned with provided tokenization
Spans:
- [Th] defined in This is...
- [his is] defined in This is a te...
- [is a text in Ja] defined in This is a text in Japan. ...
- [a t] defined in ...s is a text i...
Tokens
['This', 'is', 'a', 'text', 'in', 'Japan', '.', 'And', 'This', 'too', 'but', 'for', 'Paris']
```