### PR TITLE
refactor: Normalize paths for API

### DIFF
--- a/src/argilla/server/apis/v0/handlers/text2text.py
+++ b/src/argilla/server/apis/v0/handlers/text2text.py
@@ -19,6 +19,7 @@ from typing import Iterable, Optional
 from fastapi import APIRouter, Depends, Query, Security
 from fastapi.responses import StreamingResponse
 
+from argilla.server.apis.v0.handlers import metrics
 from argilla.server.apis.v0.models.commons.model import BulkResponse
 from argilla.server.apis.v0.models.commons.params import (
     CommonTaskHandlerDependencies,
@@ -48,203 +49,211 @@ from argilla.server.services.tasks.text2text.models import (
     ServiceText2TextRecord,
 )
 
-TASK_TYPE = TaskType.text2text
-BASE_ENDPOINT = "/{name}/" + TASK_TYPE
 
-TasksFactory.register_task(
-    task_type=TaskType.text2text,
-    dataset_class=Text2TextDataset,
-    query_request=Text2TextQuery,
-    record_class=ServiceText2TextRecord,
-    metrics=Text2TextMetrics,
-)
+def configure_router():
+    task_type = TaskType.text2text
+    base_endpoint = "/{name}/" + task_type
 
+    TasksFactory.register_task(
+        task_type=TaskType.text2text,
+        dataset_class=Text2TextDataset,
+        query_request=Text2TextQuery,
+        record_class=ServiceText2TextRecord,
+        metrics=Text2TextMetrics,
+    )
 
-router = APIRouter(tags=[TASK_TYPE], prefix="/datasets")
+    router = APIRouter(tags=[task_type], prefix="/datasets")
 
+    @router.post(
+        path=f"{base_endpoint}:bulk",
+        operation_id="bulk_records",
+        response_model=BulkResponse,
+        response_model_exclude_none=True,
+    )
+    async def bulk_records(
+        name: str,
+        bulk: Text2TextBulkRequest,
+        common_params: CommonTaskHandlerDependencies = Depends(),
+        service: Text2TextService = Depends(Text2TextService.get_instance),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        current_user: User = Security(auth.get_user, scopes=[]),
+    ) -> BulkResponse:
 
-@router.post(
-    BASE_ENDPOINT + ":bulk",
-    operation_id="bulk_records",
-    response_model=BulkResponse,
-    response_model_exclude_none=True,
-)
-async def bulk_records(
-    name: str,
-    bulk: Text2TextBulkRequest,
-    common_params: CommonTaskHandlerDependencies = Depends(),
-    service: Text2TextService = Depends(Text2TextService.get_instance),
-    datasets: DatasetsService = Depends(DatasetsService.get_instance),
-    current_user: User = Security(auth.get_user, scopes=[]),
-) -> BulkResponse:
+        task = task_type
+        owner = current_user.check_workspace(common_params.workspace)
+        try:
+            dataset = datasets.find_by_name(
+                current_user,
+                name=name,
+                task=task,
+                workspace=owner,
+                as_dataset_class=TasksFactory.get_task_dataset(task_type),
+            )
+            datasets.update(
+                user=current_user,
+                dataset=dataset,
+                tags=bulk.tags,
+                metadata=bulk.metadata,
+            )
+        except EntityNotFoundError:
+            dataset_class = TasksFactory.get_task_dataset(task)
+            dataset = dataset_class.parse_obj({**bulk.dict(), "name": name})
+            dataset.owner = owner
+            datasets.create_dataset(user=current_user, dataset=dataset)
 
-    task = TASK_TYPE
-    owner = current_user.check_workspace(common_params.workspace)
-    try:
-        dataset = datasets.find_by_name(
-            current_user,
-            name=name,
-            task=task,
-            workspace=owner,
-            as_dataset_class=TasksFactory.get_task_dataset(TASK_TYPE),
-        )
-        datasets.update(
-            user=current_user,
+        result = await service.add_records(
             dataset=dataset,
-            tags=bulk.tags,
-            metadata=bulk.metadata,
+            records=[ServiceText2TextRecord.parse_obj(r) for r in bulk.records],
         )
-    except EntityNotFoundError:
-        dataset_class = TasksFactory.get_task_dataset(task)
-        dataset = dataset_class.parse_obj({**bulk.dict(), "name": name})
-        dataset.owner = owner
-        datasets.create_dataset(user=current_user, dataset=dataset)
+        return BulkResponse(
+            dataset=name,
+            processed=result.processed,
+            failed=result.failed,
+        )
 
-    result = await service.add_records(
-        dataset=dataset,
-        records=[ServiceText2TextRecord.parse_obj(r) for r in bulk.records],
+    @router.post(
+        path=f"{base_endpoint}:search",
+        response_model=Text2TextSearchResults,
+        response_model_exclude_none=True,
+        operation_id="search_records",
     )
-    return BulkResponse(
-        dataset=name,
-        processed=result.processed,
-        failed=result.failed,
-    )
-
-
-@router.post(
-    BASE_ENDPOINT + ":search",
-    response_model=Text2TextSearchResults,
-    response_model_exclude_none=True,
-    operation_id="search_records",
-)
-def search_records(
-    name: str,
-    search: Text2TextSearchRequest = None,
-    common_params: CommonTaskHandlerDependencies = Depends(),
-    include_metrics: bool = Query(
-        False, description="If enabled, return related record metrics"
-    ),
-    pagination: RequestPagination = Depends(),
-    service: Text2TextService = Depends(Text2TextService.get_instance),
-    datasets: DatasetsService = Depends(DatasetsService.get_instance),
-    current_user: User = Security(auth.get_user, scopes=[]),
-) -> Text2TextSearchResults:
-
-    search = search or Text2TextSearchRequest()
-    query = search.query or Text2TextQuery()
-    dataset = datasets.find_by_name(
-        user=current_user,
-        name=name,
-        task=TASK_TYPE,
-        workspace=common_params.workspace,
-        as_dataset_class=TasksFactory.get_task_dataset(TASK_TYPE),
-    )
-    result = service.search(
-        dataset=dataset,
-        query=ServiceText2TextQuery.parse_obj(query),
-        sort_by=search.sort,
-        record_from=pagination.from_,
-        size=pagination.limit,
-        exclude_metrics=not include_metrics,
-    )
-
-    return Text2TextSearchResults(
-        total=result.total,
-        records=[Text2TextRecord.parse_obj(r) for r in result.records],
-        aggregations=Text2TextSearchAggregations.parse_obj(result.metrics)
-        if result.metrics
-        else None,
-    )
-
-
-def scan_data_response(
-    data_stream: Iterable[Text2TextRecord],
-    chunk_size: int = 1000,
-    limit: Optional[int] = None,
-) -> StreamingResponseWithErrorHandling:
-    """Generate an textual stream data response for a dataset scan"""
-
-    async def stream_generator(stream):
-        """Converts dataset scan into a text stream"""
-
-        def grouper(n, iterable, fillvalue=None):
-            args = [iter(iterable)] * n
-            return itertools.zip_longest(fillvalue=fillvalue, *args)
-
-        if limit:
-            stream = takeuntil(stream, limit=limit)
-
-        for batch in grouper(
-            n=chunk_size,
-            iterable=stream,
-        ):
-            filtered_records = filter(lambda r: r is not None, batch)
-            yield "\n".join(
-                map(
-                    lambda r: r.json(by_alias=True, exclude_none=True), filtered_records
-                )
-            ) + "\n"
-
-    return StreamingResponseWithErrorHandling(
-        stream_generator(data_stream), media_type="application/json"
-    )
-
-
-@router.post(
-    BASE_ENDPOINT + "/data",
-    operation_id="stream_data",
-)
-async def stream_data(
-    name: str,
-    query: Optional[Text2TextQuery] = None,
-    common_params: CommonTaskHandlerDependencies = Depends(),
-    limit: Optional[int] = Query(None, description="Limit loaded records", gt=0),
-    service: Text2TextService = Depends(Text2TextService.get_instance),
-    datasets: DatasetsService = Depends(DatasetsService.get_instance),
-    current_user: User = Security(auth.get_user, scopes=[]),
-    id_from: Optional[str] = None,
-) -> StreamingResponse:
-    """
-        Creates a data stream over dataset records
-
-    Parameters
-    ----------
-    name
-        The dataset name
-    query:
-        The stream data query
-    common_params:
-        The task common query params
-    limit:
-        The load number of records limit. Optional
-    service:
-        The dataset records service
-    datasets:
-        The datasets service
-    current_user:
-        Request user
-    id_from:
-        If provided, read the samples after this record ID
-
-    """
-    query = query or Text2TextQuery()
-    dataset = datasets.find_by_name(
-        user=current_user,
-        name=name,
-        task=TASK_TYPE,
-        workspace=common_params.workspace,
-        as_dataset_class=TasksFactory.get_task_dataset(TASK_TYPE),
-    )
-    data_stream = map(
-        Text2TextRecord.parse_obj,
-        service.read_dataset(
-            dataset,
-            query=ServiceText2TextQuery.parse_obj(query),
-            id_from=id_from,
-            limit=limit,
+    def search_records(
+        name: str,
+        search: Text2TextSearchRequest = None,
+        common_params: CommonTaskHandlerDependencies = Depends(),
+        include_metrics: bool = Query(
+            False, description="If enabled, return related record metrics"
         ),
+        pagination: RequestPagination = Depends(),
+        service: Text2TextService = Depends(Text2TextService.get_instance),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        current_user: User = Security(auth.get_user, scopes=[]),
+    ) -> Text2TextSearchResults:
+
+        search = search or Text2TextSearchRequest()
+        query = search.query or Text2TextQuery()
+        dataset = datasets.find_by_name(
+            user=current_user,
+            name=name,
+            task=task_type,
+            workspace=common_params.workspace,
+            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+        )
+        result = service.search(
+            dataset=dataset,
+            query=ServiceText2TextQuery.parse_obj(query),
+            sort_by=search.sort,
+            record_from=pagination.from_,
+            size=pagination.limit,
+            exclude_metrics=not include_metrics,
+        )
+
+        return Text2TextSearchResults(
+            total=result.total,
+            records=[Text2TextRecord.parse_obj(r) for r in result.records],
+            aggregations=Text2TextSearchAggregations.parse_obj(result.metrics)
+            if result.metrics
+            else None,
+        )
+
+    def scan_data_response(
+        data_stream: Iterable[Text2TextRecord],
+        chunk_size: int = 1000,
+        limit: Optional[int] = None,
+    ) -> StreamingResponseWithErrorHandling:
+        """Generate an textual stream data response for a dataset scan"""
+
+        async def stream_generator(stream):
+            """Converts dataset scan into a text stream"""
+
+            def grouper(n, iterable, fillvalue=None):
+                args = [iter(iterable)] * n
+                return itertools.zip_longest(fillvalue=fillvalue, *args)
+
+            if limit:
+                stream = takeuntil(stream, limit=limit)
+
+            for batch in grouper(
+                n=chunk_size,
+                iterable=stream,
+            ):
+                filtered_records = filter(lambda r: r is not None, batch)
+                yield "\n".join(
+                    map(
+                        lambda r: r.json(by_alias=True, exclude_none=True),
+                        filtered_records,
+                    )
+                ) + "\n"
+
+        return StreamingResponseWithErrorHandling(
+            stream_generator(data_stream), media_type="application/json"
+        )
+
+    @router.post(
+        path=f"{base_endpoint}/data",
+        operation_id="stream_data",
     )
-    return scan_data_response(
-        data_stream=data_stream,
-        limit=limit,
+    async def stream_data(
+        name: str,
+        query: Optional[Text2TextQuery] = None,
+        common_params: CommonTaskHandlerDependencies = Depends(),
+        limit: Optional[int] = Query(None, description="Limit loaded records", gt=0),
+        service: Text2TextService = Depends(Text2TextService.get_instance),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        current_user: User = Security(auth.get_user, scopes=[]),
+        id_from: Optional[str] = None,
+    ) -> StreamingResponse:
+        """
+            Creates a data stream over dataset records
+
+        Parameters
+        ----------
+        name
+            The dataset name
+        query:
+            The stream data query
+        common_params:
+            The task common query params
+        limit:
+            The load number of records limit. Optional
+        service:
+            The dataset records service
+        datasets:
+            The datasets service
+        current_user:
+            Request user
+        id_from:
+            If provided, read the samples after this record ID
+
+        """
+        query = query or Text2TextQuery()
+        dataset = datasets.find_by_name(
+            user=current_user,
+            name=name,
+            task=task_type,
+            workspace=common_params.workspace,
+            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+        )
+        data_stream = map(
+            Text2TextRecord.parse_obj,
+            service.read_dataset(
+                dataset,
+                query=ServiceText2TextQuery.parse_obj(query),
+                id_from=id_from,
+                limit=limit,
+            ),
+        )
+        return scan_data_response(
+            data_stream=data_stream,
+            limit=limit,
+        )
+
+    metrics.configure_router(
+        router,
+        cfg=TasksFactory.get_task_by_task_type(task_type),
     )
+
+    return router
+
+
+router = configure_router()

--- a/src/argilla/server/apis/v0/handlers/text_classification.py
+++ b/src/argilla/server/apis/v0/handlers/text_classification.py
@@ -19,7 +19,11 @@ from typing import Iterable, List, Optional
 from fastapi import APIRouter, Depends, Query, Security
 from fastapi.responses import StreamingResponse
 
-from argilla.server.apis.v0.handlers import text_classification_dataset_settings
+from argilla.server.apis.v0.handlers import (
+    metrics,
+    text_classification_dataset_settings,
+)
+from argilla.server.apis.v0.helpers import deprecate_endpoint
 from argilla.server.apis.v0.models.commons.model import BulkResponse
 from argilla.server.apis.v0.models.commons.params import (
     CommonTaskHandlerDependencies,
@@ -31,16 +35,13 @@ from argilla.server.apis.v0.models.text_classification import (
     LabelingRule,
     LabelingRuleMetricsSummary,
     TextClassificationBulkRequest,
+    TextClassificationDataset,
     TextClassificationQuery,
     TextClassificationRecord,
     TextClassificationSearchAggregations,
     TextClassificationSearchRequest,
     TextClassificationSearchResults,
     UpdateLabelingRule,
-)
-from argilla.server.apis.v0.models.token_classification import (
-    TokenClassificationDataset,
-    TokenClassificationQuery,
 )
 from argilla.server.apis.v0.validators.text_classification import DatasetValidator
 from argilla.server.commons.config import TasksFactory
@@ -52,483 +53,493 @@ from argilla.server.security import auth
 from argilla.server.security.model import User
 from argilla.server.services.datasets import DatasetsService
 from argilla.server.services.tasks.text_classification import TextClassificationService
+from argilla.server.services.tasks.text_classification.metrics import (
+    TextClassificationMetrics,
+)
 from argilla.server.services.tasks.text_classification.model import (
     ServiceLabelingRule,
     ServiceTextClassificationQuery,
     ServiceTextClassificationRecord,
 )
-from argilla.server.services.tasks.token_classification.metrics import (
-    TokenClassificationMetrics,
-)
-from argilla.server.services.tasks.token_classification.model import (
-    ServiceTokenClassificationRecord,
-)
-
-TASK_TYPE = TaskType.text_classification
-BASE_ENDPOINT = "/{name}/" + TASK_TYPE
-NEW_BASE_ENDPOINT = f"/{TASK_TYPE}/{{name}}"
-
-TasksFactory.register_task(
-    task_type=TaskType.token_classification,
-    dataset_class=TokenClassificationDataset,
-    query_request=TokenClassificationQuery,
-    record_class=ServiceTokenClassificationRecord,
-    metrics=TokenClassificationMetrics,
-)
 
 
-router = APIRouter(tags=[TASK_TYPE], prefix="/datasets")
+def configure_router():
+    task_type = TaskType.text_classification
 
-
-@router.post(
-    BASE_ENDPOINT + ":bulk",
-    operation_id="bulk_records",
-    response_model=BulkResponse,
-    response_model_exclude_none=True,
-)
-async def bulk_records(
-    name: str,
-    bulk: TextClassificationBulkRequest,
-    common_params: CommonTaskHandlerDependencies = Depends(),
-    service: TextClassificationService = Depends(
-        TextClassificationService.get_instance
-    ),
-    datasets: DatasetsService = Depends(DatasetsService.get_instance),
-    validator: DatasetValidator = Depends(DatasetValidator.get_instance),
-    current_user: User = Security(auth.get_user, scopes=[]),
-) -> BulkResponse:
-
-    task = TASK_TYPE
-    owner = current_user.check_workspace(common_params.workspace)
-    try:
-        dataset = datasets.find_by_name(
-            current_user,
-            name=name,
-            task=task,
-            workspace=owner,
-            as_dataset_class=TasksFactory.get_task_dataset(TASK_TYPE),
-        )
-        datasets.update(
-            user=current_user,
-            dataset=dataset,
-            tags=bulk.tags,
-            metadata=bulk.metadata,
-        )
-    except EntityNotFoundError:
-        dataset_class = TasksFactory.get_task_dataset(task)
-        dataset = dataset_class.parse_obj({**bulk.dict(), "name": name})
-        dataset.owner = owner
-        datasets.create_dataset(user=current_user, dataset=dataset)
-
-    # TODO(@frascuchon): Validator should be applied in the service layer
-    records = [ServiceTextClassificationRecord.parse_obj(r) for r in bulk.records]
-    await validator.validate_dataset_records(
-        user=current_user, dataset=dataset, records=records
+    TasksFactory.register_task(
+        task_type=task_type,
+        dataset_class=TextClassificationDataset,
+        query_request=TextClassificationQuery,
+        record_class=ServiceTextClassificationRecord,
+        metrics=TextClassificationMetrics,
     )
 
-    result = await service.add_records(
-        dataset=dataset,
-        records=records,
+    base_endpoint = f"/{{name}}/{task_type}"
+    new_base_endpoint = f"/{task_type}/{{name}}"
+
+    router = APIRouter(tags=[task_type], prefix="/datasets")
+
+    @router.post(
+        f"{base_endpoint}:bulk",
+        operation_id="bulk_records",
+        response_model=BulkResponse,
+        response_model_exclude_none=True,
     )
-    return BulkResponse(
-        dataset=name,
-        processed=result.processed,
-        failed=result.failed,
-    )
-
-
-@router.post(
-    BASE_ENDPOINT + ":search",
-    response_model=TextClassificationSearchResults,
-    response_model_exclude_none=True,
-    operation_id="search_records",
-)
-def search_records(
-    name: str,
-    search: TextClassificationSearchRequest = None,
-    common_params: CommonTaskHandlerDependencies = Depends(),
-    include_metrics: bool = Query(
-        False, description="If enabled, return related record metrics"
-    ),
-    pagination: RequestPagination = Depends(),
-    service: TextClassificationService = Depends(
-        TextClassificationService.get_instance
-    ),
-    datasets: DatasetsService = Depends(DatasetsService.get_instance),
-    current_user: User = Security(auth.get_user, scopes=[]),
-) -> TextClassificationSearchResults:
-    """
-    Searches data from dataset
-
-    Parameters
-    ----------
-    name:
-        The dataset name
-    search:
-        The search query request
-    common_params:
-        Common query params
-    include_metrics:
-        Flag to enable include metrics
-    pagination:
-        The pagination params
-    service:
-        The dataset records service
-    datasets:
-        The dataset service
-    current_user:
-        The current request user
-
-
-    Returns
-    -------
-        The search results data
-
-    """
-
-    search = search or TextClassificationSearchRequest()
-    query = search.query or TextClassificationQuery()
-    dataset = datasets.find_by_name(
-        user=current_user,
-        name=name,
-        task=TASK_TYPE,
-        workspace=common_params.workspace,
-        as_dataset_class=TasksFactory.get_task_dataset(TASK_TYPE),
-    )
-    result = service.search(
-        dataset=dataset,
-        query=ServiceTextClassificationQuery.parse_obj(query),
-        sort_by=search.sort,
-        record_from=pagination.from_,
-        size=pagination.limit,
-        exclude_metrics=not include_metrics,
-    )
-
-    return TextClassificationSearchResults(
-        total=result.total,
-        records=result.records,
-        aggregations=TextClassificationSearchAggregations.parse_obj(result.metrics)
-        if result.metrics
-        else None,
-    )
-
-
-def scan_data_response(
-    data_stream: Iterable[TextClassificationRecord],
-    chunk_size: int = 1000,
-    limit: Optional[int] = None,
-) -> StreamingResponseWithErrorHandling:
-    """Generate an textual stream data response for a dataset scan"""
-
-    async def stream_generator(stream):
-        """Converts dataset scan into a text stream"""
-
-        def grouper(n, iterable, fillvalue=None):
-            args = [iter(iterable)] * n
-            return itertools.zip_longest(fillvalue=fillvalue, *args)
-
-        if limit:
-            stream = takeuntil(stream, limit=limit)
-
-        for batch in grouper(
-            n=chunk_size,
-            iterable=stream,
-        ):
-            filtered_records = filter(lambda r: r is not None, batch)
-            yield "\n".join(
-                map(
-                    lambda r: r.json(by_alias=True, exclude_none=True), filtered_records
-                )
-            ) + "\n"
-
-    return StreamingResponseWithErrorHandling(
-        stream_generator(data_stream), media_type="application/json"
-    )
-
-
-@router.post(
-    BASE_ENDPOINT + "/data",
-    operation_id="stream_data",
-)
-async def stream_data(
-    name: str,
-    query: Optional[TextClassificationQuery] = None,
-    common_params: CommonTaskHandlerDependencies = Depends(),
-    id_from: Optional[str] = None,
-    limit: Optional[int] = Query(None, description="Limit loaded records", gt=0),
-    service: TextClassificationService = Depends(
-        TextClassificationService.get_instance
-    ),
-    datasets: DatasetsService = Depends(DatasetsService.get_instance),
-    current_user: User = Security(auth.get_user, scopes=[]),
-) -> StreamingResponse:
-    """
-        Creates a data stream over dataset records
-
-    Parameters
-    ----------
-    name
-        The dataset name
-    query:
-        The stream data query
-    common_params:
-        Common query params
-    limit:
-        The load number of records limit. Optional
-    service:
-        The dataset records service
-    datasets:
-        The datasets service
-    current_user:
-        Request user
-
-    id_from:
-        Search after the given record ID
-
-    """
-    query = query or TextClassificationQuery()
-    dataset = datasets.find_by_name(
-        user=current_user,
-        name=name,
-        task=TASK_TYPE,
-        workspace=common_params.workspace,
-        as_dataset_class=TasksFactory.get_task_dataset(TASK_TYPE),
-    )
-
-    data_stream = map(
-        TextClassificationRecord.parse_obj,
-        service.read_dataset(
-            dataset,
-            query=ServiceTextClassificationQuery.parse_obj(query),
-            id_from=id_from,
-            limit=limit,
+    async def bulk_records(
+        name: str,
+        bulk: TextClassificationBulkRequest,
+        common_params: CommonTaskHandlerDependencies = Depends(),
+        service: TextClassificationService = Depends(
+            TextClassificationService.get_instance
         ),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        validator: DatasetValidator = Depends(DatasetValidator.get_instance),
+        current_user: User = Security(auth.get_user, scopes=[]),
+    ) -> BulkResponse:
+
+        task = task_type
+        owner = current_user.check_workspace(common_params.workspace)
+        try:
+            dataset = datasets.find_by_name(
+                current_user,
+                name=name,
+                task=task,
+                workspace=owner,
+                as_dataset_class=TasksFactory.get_task_dataset(task_type),
+            )
+            datasets.update(
+                user=current_user,
+                dataset=dataset,
+                tags=bulk.tags,
+                metadata=bulk.metadata,
+            )
+        except EntityNotFoundError:
+            dataset_class = TasksFactory.get_task_dataset(task)
+            dataset = dataset_class.parse_obj({**bulk.dict(), "name": name})
+            dataset.owner = owner
+            datasets.create_dataset(user=current_user, dataset=dataset)
+
+        # TODO(@frascuchon): Validator should be applied in the service layer
+        records = [ServiceTextClassificationRecord.parse_obj(r) for r in bulk.records]
+        await validator.validate_dataset_records(
+            user=current_user, dataset=dataset, records=records
+        )
+
+        result = await service.add_records(
+            dataset=dataset,
+            records=records,
+        )
+        return BulkResponse(
+            dataset=name,
+            processed=result.processed,
+            failed=result.failed,
+        )
+
+    @router.post(
+        f"{base_endpoint}:search",
+        response_model=TextClassificationSearchResults,
+        response_model_exclude_none=True,
+        operation_id="search_records",
     )
-    return scan_data_response(
-        data_stream=data_stream,
-        limit=limit,
+    def search_records(
+        name: str,
+        search: TextClassificationSearchRequest = None,
+        common_params: CommonTaskHandlerDependencies = Depends(),
+        include_metrics: bool = Query(
+            False, description="If enabled, return related record metrics"
+        ),
+        pagination: RequestPagination = Depends(),
+        service: TextClassificationService = Depends(
+            TextClassificationService.get_instance
+        ),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        current_user: User = Security(auth.get_user, scopes=[]),
+    ) -> TextClassificationSearchResults:
+        """
+        Searches data from dataset
+
+        Parameters
+        ----------
+        name:
+            The dataset name
+        search:
+            The search query request
+        common_params:
+            Common query params
+        include_metrics:
+            Flag to enable include metrics
+        pagination:
+            The pagination params
+        service:
+            The dataset records service
+        datasets:
+            The dataset service
+        current_user:
+            The current request user
+
+
+        Returns
+        -------
+            The search results data
+
+        """
+
+        search = search or TextClassificationSearchRequest()
+        query = search.query or TextClassificationQuery()
+        dataset = datasets.find_by_name(
+            user=current_user,
+            name=name,
+            task=task_type,
+            workspace=common_params.workspace,
+            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+        )
+        result = service.search(
+            dataset=dataset,
+            query=ServiceTextClassificationQuery.parse_obj(query),
+            sort_by=search.sort,
+            record_from=pagination.from_,
+            size=pagination.limit,
+            exclude_metrics=not include_metrics,
+        )
+
+        return TextClassificationSearchResults(
+            total=result.total,
+            records=result.records,
+            aggregations=TextClassificationSearchAggregations.parse_obj(result.metrics)
+            if result.metrics
+            else None,
+        )
+
+    def scan_data_response(
+        data_stream: Iterable[TextClassificationRecord],
+        chunk_size: int = 1000,
+        limit: Optional[int] = None,
+    ) -> StreamingResponseWithErrorHandling:
+        """Generate an textual stream data response for a dataset scan"""
+
+        async def stream_generator(stream):
+            """Converts dataset scan into a text stream"""
+
+            def grouper(n, iterable, fillvalue=None):
+                args = [iter(iterable)] * n
+                return itertools.zip_longest(fillvalue=fillvalue, *args)
+
+            if limit:
+                stream = takeuntil(stream, limit=limit)
+
+            for batch in grouper(
+                n=chunk_size,
+                iterable=stream,
+            ):
+                filtered_records = filter(lambda r: r is not None, batch)
+                yield "\n".join(
+                    map(
+                        lambda r: r.json(by_alias=True, exclude_none=True),
+                        filtered_records,
+                    )
+                ) + "\n"
+
+        return StreamingResponseWithErrorHandling(
+            stream_generator(data_stream), media_type="application/json"
+        )
+
+    @router.post(
+        f"{base_endpoint}/data",
+        operation_id="stream_data",
     )
+    async def stream_data(
+        name: str,
+        query: Optional[TextClassificationQuery] = None,
+        common_params: CommonTaskHandlerDependencies = Depends(),
+        id_from: Optional[str] = None,
+        limit: Optional[int] = Query(None, description="Limit loaded records", gt=0),
+        service: TextClassificationService = Depends(
+            TextClassificationService.get_instance
+        ),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        current_user: User = Security(auth.get_user, scopes=[]),
+    ) -> StreamingResponse:
+        """
+            Creates a data stream over dataset records
 
+        Parameters
+        ----------
+        name
+            The dataset name
+        query:
+            The stream data query
+        common_params:
+            Common query params
+        limit:
+            The load number of records limit. Optional
+        service:
+            The dataset records service
+        datasets:
+            The datasets service
+        current_user:
+            Request user
 
-@router.get(
-    f"{NEW_BASE_ENDPOINT}/labeling/rules",
-    operation_id="list_labeling_rules",
-    description="List all dataset labeling rules",
-    response_model=List[LabelingRule],
-    response_model_exclude_none=True,
-)
-async def list_labeling_rules(
-    name: str,
-    common_params: CommonTaskHandlerDependencies = Depends(),
-    datasets: DatasetsService = Depends(DatasetsService.get_instance),
-    service: TextClassificationService = Depends(
-        TextClassificationService.get_instance
-    ),
-    current_user: User = Security(auth.get_user, scopes=[]),
-) -> List[LabelingRule]:
+        id_from:
+            Search after the given record ID
 
-    dataset = datasets.find_by_name(
-        user=current_user,
-        name=name,
-        task=TASK_TYPE,
-        workspace=common_params.workspace,
-        as_dataset_class=TasksFactory.get_task_dataset(TASK_TYPE),
+        """
+        query = query or TextClassificationQuery()
+        dataset = datasets.find_by_name(
+            user=current_user,
+            name=name,
+            task=task_type,
+            workspace=common_params.workspace,
+            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+        )
+
+        data_stream = map(
+            TextClassificationRecord.parse_obj,
+            service.read_dataset(
+                dataset,
+                query=ServiceTextClassificationQuery.parse_obj(query),
+                id_from=id_from,
+                limit=limit,
+            ),
+        )
+        return scan_data_response(
+            data_stream=data_stream,
+            limit=limit,
+        )
+
+    @deprecate_endpoint(
+        path=f"{new_base_endpoint}/labeling/rules",
+        new_path=f"{base_endpoint}/labeling/rules",
+        router_method=router.get,
+        operation_id="list_labeling_rules",
+        description="List all dataset labeling rules",
+        response_model=List[LabelingRule],
+        response_model_exclude_none=True,
     )
+    async def list_labeling_rules(
+        name: str,
+        common_params: CommonTaskHandlerDependencies = Depends(),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        service: TextClassificationService = Depends(
+            TextClassificationService.get_instance
+        ),
+        current_user: User = Security(auth.get_user, scopes=[]),
+    ) -> List[LabelingRule]:
 
-    return [
-        LabelingRule.parse_obj(rule) for rule in service.get_labeling_rules(dataset)
-    ]
+        dataset = datasets.find_by_name(
+            user=current_user,
+            name=name,
+            task=task_type,
+            workspace=common_params.workspace,
+            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+        )
 
+        return [
+            LabelingRule.parse_obj(rule) for rule in service.get_labeling_rules(dataset)
+        ]
 
-@router.post(
-    f"{NEW_BASE_ENDPOINT}/labeling/rules",
-    operation_id="create_rule",
-    description="Creates a new dataset labeling rule",
-    response_model=LabelingRule,
-    response_model_exclude_none=True,
-)
-async def create_rule(
-    name: str,
-    rule: CreateLabelingRule,
-    common_params: CommonTaskHandlerDependencies = Depends(),
-    service: TextClassificationService = Depends(
-        TextClassificationService.get_instance
-    ),
-    datasets: DatasetsService = Depends(DatasetsService.get_instance),
-    current_user: User = Security(auth.get_user, scopes=[]),
-) -> LabelingRule:
-
-    dataset = datasets.find_by_name(
-        user=current_user,
-        name=name,
-        task=TASK_TYPE,
-        workspace=common_params.workspace,
-        as_dataset_class=TasksFactory.get_task_dataset(TASK_TYPE),
+    @deprecate_endpoint(
+        path=f"{new_base_endpoint}/labeling/rules",
+        new_path=f"{base_endpoint}/labeling/rules",
+        router_method=router.post,
+        operation_id="create_rule",
+        description="Creates a new dataset labeling rule",
+        response_model=LabelingRule,
+        response_model_exclude_none=True,
     )
+    async def create_rule(
+        name: str,
+        rule: CreateLabelingRule,
+        common_params: CommonTaskHandlerDependencies = Depends(),
+        service: TextClassificationService = Depends(
+            TextClassificationService.get_instance
+        ),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        current_user: User = Security(auth.get_user, scopes=[]),
+    ) -> LabelingRule:
 
-    rule = ServiceLabelingRule(
-        **rule.dict(),
-        author=current_user.username,
+        dataset = datasets.find_by_name(
+            user=current_user,
+            name=name,
+            task=task_type,
+            workspace=common_params.workspace,
+            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+        )
+
+        rule = ServiceLabelingRule(
+            **rule.dict(),
+            author=current_user.username,
+        )
+        service.add_labeling_rule(
+            dataset,
+            rule=rule,
+        )
+        return LabelingRule.parse_obj(rule)
+
+    @deprecate_endpoint(
+        path=f"{new_base_endpoint}/labeling/rules/{{query:path}}/metrics",
+        new_path=f"{base_endpoint}/labeling/rules/{{query:path}}/metrics",
+        router_method=router.get,
+        operation_id="compute_rule_metrics",
+        description="Computes dataset labeling rule metrics",
+        response_model=LabelingRuleMetricsSummary,
+        response_model_exclude_none=True,
     )
-    service.add_labeling_rule(
-        dataset,
-        rule=rule,
+    async def compute_rule_metrics(
+        name: str,
+        query: str,
+        labels: Optional[List[str]] = Query(
+            None, description="Label related to query rule", alias="label"
+        ),
+        common_params: CommonTaskHandlerDependencies = Depends(),
+        service: TextClassificationService = Depends(
+            TextClassificationService.get_instance
+        ),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        current_user: User = Security(auth.get_user, scopes=[]),
+    ) -> LabelingRuleMetricsSummary:
+
+        dataset = datasets.find_by_name(
+            user=current_user,
+            name=name,
+            task=task_type,
+            workspace=common_params.workspace,
+            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+        )
+
+        return service.compute_rule_metrics(dataset, rule_query=query, labels=labels)
+
+    @deprecate_endpoint(
+        path=f"{new_base_endpoint}/labeling/rules/metrics",
+        new_path=f"{base_endpoint}/labeling/rules/metrics",
+        router_method=router.get,
+        operation_id="compute_dataset_rules_metrics",
+        description="Computes overall metrics for dataset labeling rules",
+        response_model=DatasetLabelingRulesMetricsSummary,
+        response_model_exclude_none=True,
     )
-    return LabelingRule.parse_obj(rule)
+    async def compute_dataset_rules_metrics(
+        name: str,
+        common_params: CommonTaskHandlerDependencies = Depends(),
+        service: TextClassificationService = Depends(
+            TextClassificationService.get_instance
+        ),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        current_user: User = Security(auth.get_user, scopes=[]),
+    ) -> DatasetLabelingRulesMetricsSummary:
+        dataset = datasets.find_by_name(
+            user=current_user,
+            name=name,
+            task=task_type,
+            workspace=common_params.workspace,
+            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+        )
+        metrics = service.compute_overall_rules_metrics(dataset)
+        return DatasetLabelingRulesMetricsSummary.parse_obj(metrics)
 
-
-@router.get(
-    f"{NEW_BASE_ENDPOINT}/labeling/rules/{{query:path}}/metrics",
-    operation_id="compute_rule_metrics",
-    description="Computes dataset labeling rule metrics",
-    response_model=LabelingRuleMetricsSummary,
-    response_model_exclude_none=True,
-)
-async def compute_rule_metrics(
-    name: str,
-    query: str,
-    labels: Optional[List[str]] = Query(
-        None, description="Label related to query rule", alias="label"
-    ),
-    common_params: CommonTaskHandlerDependencies = Depends(),
-    service: TextClassificationService = Depends(
-        TextClassificationService.get_instance
-    ),
-    datasets: DatasetsService = Depends(DatasetsService.get_instance),
-    current_user: User = Security(auth.get_user, scopes=[]),
-) -> LabelingRuleMetricsSummary:
-
-    dataset = datasets.find_by_name(
-        user=current_user,
-        name=name,
-        task=TASK_TYPE,
-        workspace=common_params.workspace,
-        as_dataset_class=TasksFactory.get_task_dataset(TASK_TYPE),
+    @deprecate_endpoint(
+        path=f"{new_base_endpoint}/labeling/rules/{{query:path}}",
+        new_path=f"{base_endpoint}/labeling/rules/{{query:path}}",
+        router_method=router.delete,
+        operation_id="delete_labeling_rule",
+        description="Deletes a labeling rule from dataset",
     )
+    async def delete_labeling_rule(
+        name: str,
+        query: str,
+        common_params: CommonTaskHandlerDependencies = Depends(),
+        service: TextClassificationService = Depends(
+            TextClassificationService.get_instance
+        ),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        current_user: User = Security(auth.get_user, scopes=[]),
+    ) -> None:
 
-    return service.compute_rule_metrics(dataset, rule_query=query, labels=labels)
+        dataset = datasets.find_by_name(
+            user=current_user,
+            name=name,
+            task=task_type,
+            workspace=common_params.workspace,
+            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+        )
 
+        service.delete_labeling_rule(dataset, rule_query=query)
 
-@router.get(
-    f"{NEW_BASE_ENDPOINT}/labeling/rules/metrics",
-    operation_id="compute_dataset_rules_metrics",
-    description="Computes overall metrics for dataset labeling rules",
-    response_model=DatasetLabelingRulesMetricsSummary,
-    response_model_exclude_none=True,
-)
-async def compute_dataset_rules_metrics(
-    name: str,
-    common_params: CommonTaskHandlerDependencies = Depends(),
-    service: TextClassificationService = Depends(
-        TextClassificationService.get_instance
-    ),
-    datasets: DatasetsService = Depends(DatasetsService.get_instance),
-    current_user: User = Security(auth.get_user, scopes=[]),
-) -> DatasetLabelingRulesMetricsSummary:
-    dataset = datasets.find_by_name(
-        user=current_user,
-        name=name,
-        task=TASK_TYPE,
-        workspace=common_params.workspace,
-        as_dataset_class=TasksFactory.get_task_dataset(TASK_TYPE),
+    @deprecate_endpoint(
+        path=f"{new_base_endpoint}/labeling/rules/{{query:path}}",
+        new_path=f"{base_endpoint}/labeling/rules/{{query:path}}",
+        router_method=router.get,
+        operation_id="get_rule",
+        description="Get the dataset labeling rule",
+        response_model=LabelingRule,
+        response_model_exclude_none=True,
     )
-    metrics = service.compute_overall_rules_metrics(dataset)
-    return DatasetLabelingRulesMetricsSummary.parse_obj(metrics)
+    async def get_rule(
+        name: str,
+        query: str,
+        common_params: CommonTaskHandlerDependencies = Depends(),
+        service: TextClassificationService = Depends(
+            TextClassificationService.get_instance
+        ),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        current_user: User = Security(auth.get_user, scopes=[]),
+    ) -> LabelingRule:
 
+        dataset = datasets.find_by_name(
+            user=current_user,
+            name=name,
+            task=task_type,
+            workspace=common_params.workspace,
+            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+        )
+        rule = service.find_labeling_rule(
+            dataset,
+            rule_query=query,
+        )
+        return LabelingRule.parse_obj(rule)
 
-@router.delete(
-    f"{NEW_BASE_ENDPOINT}/labeling/rules/{{query:path}}",
-    operation_id="delete_labeling_rule",
-    description="Deletes a labeling rule from dataset",
-)
-async def delete_labeling_rule(
-    name: str,
-    query: str,
-    common_params: CommonTaskHandlerDependencies = Depends(),
-    service: TextClassificationService = Depends(
-        TextClassificationService.get_instance
-    ),
-    datasets: DatasetsService = Depends(DatasetsService.get_instance),
-    current_user: User = Security(auth.get_user, scopes=[]),
-) -> None:
-
-    dataset = datasets.find_by_name(
-        user=current_user,
-        name=name,
-        task=TASK_TYPE,
-        workspace=common_params.workspace,
-        as_dataset_class=TasksFactory.get_task_dataset(TASK_TYPE),
+    @deprecate_endpoint(
+        path=f"{new_base_endpoint}/labeling/rules/{{query:path}}",
+        new_path=f"{base_endpoint}/labeling/rules/{{query:path}}",
+        router_method=router.patch,
+        operation_id="update_rule",
+        description="Update dataset labeling rule attributes",
+        response_model=LabelingRule,
+        response_model_exclude_none=True,
     )
+    async def update_rule(
+        name: str,
+        query: str,
+        update: UpdateLabelingRule,
+        common_params: CommonTaskHandlerDependencies = Depends(),
+        service: TextClassificationService = Depends(
+            TextClassificationService.get_instance
+        ),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        current_user: User = Security(auth.get_user, scopes=[]),
+    ) -> LabelingRule:
 
-    service.delete_labeling_rule(dataset, rule_query=query)
+        dataset = datasets.find_by_name(
+            user=current_user,
+            name=name,
+            task=task_type,
+            workspace=common_params.workspace,
+            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+        )
 
+        rule = service.update_labeling_rule(
+            dataset,
+            rule_query=query,
+            labels=update.labels,
+            description=update.description,
+        )
+        return LabelingRule.parse_obj(rule)
 
-@router.get(
-    f"{NEW_BASE_ENDPOINT}/labeling/rules/{{query:path}}",
-    operation_id="get_rule",
-    description="Get the dataset labeling rule",
-    response_model=LabelingRule,
-    response_model_exclude_none=True,
-)
-async def get_rule(
-    name: str,
-    query: str,
-    common_params: CommonTaskHandlerDependencies = Depends(),
-    service: TextClassificationService = Depends(
-        TextClassificationService.get_instance
-    ),
-    datasets: DatasetsService = Depends(DatasetsService.get_instance),
-    current_user: User = Security(auth.get_user, scopes=[]),
-) -> LabelingRule:
-
-    dataset = datasets.find_by_name(
-        user=current_user,
-        name=name,
-        task=TASK_TYPE,
-        workspace=common_params.workspace,
-        as_dataset_class=TasksFactory.get_task_dataset(TASK_TYPE),
+    text_classification_dataset_settings.configure_router(router)
+    metrics.configure_router(
+        router,
+        cfg=TasksFactory.get_task_by_task_type(task_type),
     )
-    rule = service.find_labeling_rule(
-        dataset,
-        rule_query=query,
-    )
-    return LabelingRule.parse_obj(rule)
+    return router
 
 
-@router.patch(
-    f"{NEW_BASE_ENDPOINT}/labeling/rules/{{query:path}}",
-    operation_id="update_rule",
-    description="Update dataset labeling rule attributes",
-    response_model=LabelingRule,
-    response_model_exclude_none=True,
-)
-async def update_rule(
-    name: str,
-    query: str,
-    update: UpdateLabelingRule,
-    common_params: CommonTaskHandlerDependencies = Depends(),
-    service: TextClassificationService = Depends(
-        TextClassificationService.get_instance
-    ),
-    datasets: DatasetsService = Depends(DatasetsService.get_instance),
-    current_user: User = Security(auth.get_user, scopes=[]),
-) -> LabelingRule:
-
-    dataset = datasets.find_by_name(
-        user=current_user,
-        name=name,
-        task=TASK_TYPE,
-        workspace=common_params.workspace,
-        as_dataset_class=TasksFactory.get_task_dataset(TASK_TYPE),
-    )
-
-    rule = service.update_labeling_rule(
-        dataset,
-        rule_query=query,
-        labels=update.labels,
-        description=update.description,
-    )
-    return LabelingRule.parse_obj(rule)
-
-
-text_classification_dataset_settings.configure_router(router)
+router = configure_router()

--- a/src/argilla/server/apis/v0/handlers/text_classification_dataset_settings.py
+++ b/src/argilla/server/apis/v0/handlers/text_classification_dataset_settings.py
@@ -16,6 +16,7 @@ from typing import Type
 
 from fastapi import APIRouter, Body, Depends, Security
 
+from argilla.server.apis.v0.helpers import deprecate_endpoint
 from argilla.server.apis.v0.models.commons.params import (
     DATASET_NAME_PATH_PARAM,
     CommonTaskHandlerDependencies,
@@ -38,9 +39,12 @@ def configure_router(router: APIRouter):
 
     task = TaskType.text_classification
     base_endpoint = f"/{task}/{{name}}/settings"
+    new_base_endpoint = f"/{{name}}/{task}/settings"
 
-    @router.get(
+    @deprecate_endpoint(
         path=base_endpoint,
+        new_path=new_base_endpoint,
+        router_method=router.get,
         name=f"get_dataset_settings_for_{task}",
         operation_id=f"get_dataset_settings_for_{task}",
         description=f"Get the {task} dataset settings",
@@ -66,8 +70,10 @@ def configure_router(router: APIRouter):
         )
         return TextClassificationSettings.parse_obj(settings)
 
-    @router.put(
+    @deprecate_endpoint(
         path=base_endpoint,
+        new_path=new_base_endpoint,
+        router_method=router.put,
         name=f"save_dataset_settings_for_{task}",
         operation_id=f"save_dataset_settings_for_{task}",
         description=f"Save the {task} dataset settings",
@@ -101,8 +107,10 @@ def configure_router(router: APIRouter):
         )
         return TextClassificationSettings.parse_obj(settings)
 
-    @router.delete(
+    @deprecate_endpoint(
         path=base_endpoint,
+        new_path=new_base_endpoint,
+        router_method=router.delete,
         operation_id=f"delete_{task}_settings",
         name=f"delete_{task}_settings",
         description=f"Delete {task} dataset settings",

--- a/src/argilla/server/apis/v0/handlers/token_classification.py
+++ b/src/argilla/server/apis/v0/handlers/token_classification.py
@@ -19,19 +19,20 @@ from typing import Iterable, Optional
 from fastapi import APIRouter, Depends, Query, Security
 from fastapi.responses import StreamingResponse
 
-from argilla.server.apis.v0.handlers import token_classification_dataset_settings
+from argilla.server.apis.v0.handlers import (
+    metrics,
+    token_classification_dataset_settings,
+)
+from argilla.server.apis.v0.helpers import deprecate_endpoint
 from argilla.server.apis.v0.models.commons.model import BulkResponse
 from argilla.server.apis.v0.models.commons.params import (
     CommonTaskHandlerDependencies,
     RequestPagination,
 )
-from argilla.server.apis.v0.models.text_classification import (
-    TextClassificationDataset,
-    TextClassificationQuery,
-)
 from argilla.server.apis.v0.models.token_classification import (
     TokenClassificationAggregations,
     TokenClassificationBulkRequest,
+    TokenClassificationDataset,
     TokenClassificationQuery,
     TokenClassificationRecord,
     TokenClassificationSearchRequest,
@@ -46,237 +47,241 @@ from argilla.server.responses import StreamingResponseWithErrorHandling
 from argilla.server.security import auth
 from argilla.server.security.model import User
 from argilla.server.services.datasets import DatasetsService
-from argilla.server.services.tasks.text_classification.metrics import (
-    TextClassificationMetrics,
-)
-from argilla.server.services.tasks.text_classification.model import (
-    ServiceTextClassificationRecord,
-)
 from argilla.server.services.tasks.token_classification import (
     TokenClassificationService,
+)
+from argilla.server.services.tasks.token_classification.metrics import (
+    TokenClassificationMetrics,
 )
 from argilla.server.services.tasks.token_classification.model import (
     ServiceTokenClassificationQuery,
     ServiceTokenClassificationRecord,
 )
 
-TASK_TYPE = TaskType.token_classification
-BASE_ENDPOINT = "/{name}/" + TASK_TYPE
 
-TasksFactory.register_task(
-    task_type=TaskType.text_classification,
-    dataset_class=TextClassificationDataset,
-    query_request=TextClassificationQuery,
-    record_class=ServiceTextClassificationRecord,
-    metrics=TextClassificationMetrics,
-)
+def configure_router():
+    task_type = TaskType.token_classification
+    base_endpoint = f"/{{name}}/{task_type}"
+    new_base_endpoint = f"/{task_type}/{{name}}"
 
+    TasksFactory.register_task(
+        task_type=task_type,
+        dataset_class=TokenClassificationDataset,
+        query_request=TokenClassificationQuery,
+        record_class=ServiceTokenClassificationRecord,
+        metrics=TokenClassificationMetrics,
+    )
 
-router = APIRouter(tags=[TASK_TYPE], prefix="/datasets")
+    router = APIRouter(tags=[task_type], prefix="/datasets")
 
+    @router.post(
+        path=f"{base_endpoint}:bulk",
+        operation_id="bulk_records",
+        response_model=BulkResponse,
+        response_model_exclude_none=True,
+    )
+    async def bulk_records(
+        name: str,
+        bulk: TokenClassificationBulkRequest,
+        common_params: CommonTaskHandlerDependencies = Depends(),
+        service: TokenClassificationService = Depends(
+            TokenClassificationService.get_instance
+        ),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        validator: DatasetValidator = Depends(DatasetValidator.get_instance),
+        current_user: User = Security(auth.get_user, scopes=[]),
+    ) -> BulkResponse:
 
-@router.post(
-    BASE_ENDPOINT + ":bulk",
-    operation_id="bulk_records",
-    response_model=BulkResponse,
-    response_model_exclude_none=True,
-)
-async def bulk_records(
-    name: str,
-    bulk: TokenClassificationBulkRequest,
-    common_params: CommonTaskHandlerDependencies = Depends(),
-    service: TokenClassificationService = Depends(
-        TokenClassificationService.get_instance
-    ),
-    datasets: DatasetsService = Depends(DatasetsService.get_instance),
-    validator: DatasetValidator = Depends(DatasetValidator.get_instance),
-    current_user: User = Security(auth.get_user, scopes=[]),
-) -> BulkResponse:
+        task = task_type
+        owner = current_user.check_workspace(common_params.workspace)
+        try:
+            dataset = datasets.find_by_name(
+                current_user,
+                name=name,
+                task=task,
+                workspace=owner,
+                as_dataset_class=TasksFactory.get_task_dataset(task_type),
+            )
+            datasets.update(
+                user=current_user,
+                dataset=dataset,
+                tags=bulk.tags,
+                metadata=bulk.metadata,
+            )
+        except EntityNotFoundError:
+            dataset_class = TasksFactory.get_task_dataset(task)
+            dataset = dataset_class.parse_obj({**bulk.dict(), "name": name})
+            dataset.owner = owner
+            datasets.create_dataset(user=current_user, dataset=dataset)
 
-    task = TASK_TYPE
-    owner = current_user.check_workspace(common_params.workspace)
-    try:
-        dataset = datasets.find_by_name(
-            current_user,
-            name=name,
-            task=task,
-            workspace=owner,
-            as_dataset_class=TasksFactory.get_task_dataset(TASK_TYPE),
-        )
-        datasets.update(
+        records = [ServiceTokenClassificationRecord.parse_obj(r) for r in bulk.records]
+        # TODO(@frascuchon): validator can be applied in service layer
+        await validator.validate_dataset_records(
             user=current_user,
             dataset=dataset,
-            tags=bulk.tags,
-            metadata=bulk.metadata,
+            records=records,
         )
-    except EntityNotFoundError:
-        dataset_class = TasksFactory.get_task_dataset(task)
-        dataset = dataset_class.parse_obj({**bulk.dict(), "name": name})
-        dataset.owner = owner
-        datasets.create_dataset(user=current_user, dataset=dataset)
 
-    records = [ServiceTokenClassificationRecord.parse_obj(r) for r in bulk.records]
-    # TODO(@frascuchon): validator can be applied in service layer
-    await validator.validate_dataset_records(
-        user=current_user,
-        dataset=dataset,
-        records=records,
+        result = await service.add_records(
+            dataset=dataset,
+            records=records,
+        )
+        return BulkResponse(
+            dataset=name,
+            processed=result.processed,
+            failed=result.failed,
+        )
+
+    @router.post(
+        path=f"{base_endpoint}:search",
+        response_model=TokenClassificationSearchResults,
+        response_model_exclude_none=True,
+        operation_id="search_records",
     )
+    def search_records(
+        name: str,
+        search: TokenClassificationSearchRequest = None,
+        common_params: CommonTaskHandlerDependencies = Depends(),
+        include_metrics: bool = Query(
+            False, description="If enabled, return related record metrics"
+        ),
+        pagination: RequestPagination = Depends(),
+        service: TokenClassificationService = Depends(
+            TokenClassificationService.get_instance
+        ),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        current_user: User = Security(auth.get_user, scopes=[]),
+    ) -> TokenClassificationSearchResults:
 
-    result = await service.add_records(
-        dataset=dataset,
-        records=records,
-    )
-    return BulkResponse(
-        dataset=name,
-        processed=result.processed,
-        failed=result.failed,
-    )
+        search = search or TokenClassificationSearchRequest()
+        query = search.query or TokenClassificationQuery()
 
-
-@router.post(
-    BASE_ENDPOINT + ":search",
-    response_model=TokenClassificationSearchResults,
-    response_model_exclude_none=True,
-    operation_id="search_records",
-)
-def search_records(
-    name: str,
-    search: TokenClassificationSearchRequest = None,
-    common_params: CommonTaskHandlerDependencies = Depends(),
-    include_metrics: bool = Query(
-        False, description="If enabled, return related record metrics"
-    ),
-    pagination: RequestPagination = Depends(),
-    service: TokenClassificationService = Depends(
-        TokenClassificationService.get_instance
-    ),
-    datasets: DatasetsService = Depends(DatasetsService.get_instance),
-    current_user: User = Security(auth.get_user, scopes=[]),
-) -> TokenClassificationSearchResults:
-
-    search = search or TokenClassificationSearchRequest()
-    query = search.query or TokenClassificationQuery()
-
-    dataset = datasets.find_by_name(
-        user=current_user,
-        name=name,
-        task=TASK_TYPE,
-        workspace=common_params.workspace,
-        as_dataset_class=TasksFactory.get_task_dataset(TASK_TYPE),
-    )
-    results = service.search(
-        dataset=dataset,
-        query=ServiceTokenClassificationQuery.parse_obj(query),
-        sort_by=search.sort,
-        record_from=pagination.from_,
-        size=pagination.limit,
-        exclude_metrics=not include_metrics,
-    )
-
-    return TokenClassificationSearchResults(
-        total=results.total,
-        records=[TokenClassificationRecord.parse_obj(r) for r in results.records],
-        aggregations=TokenClassificationAggregations.parse_obj(results.metrics)
-        if results.metrics
-        else None,
-    )
-
-
-def scan_data_response(
-    data_stream: Iterable[TokenClassificationRecord],
-    chunk_size: int = 1000,
-    limit: Optional[int] = None,
-) -> StreamingResponseWithErrorHandling:
-    """Generate an textual stream data response for a dataset scan"""
-
-    async def stream_generator(stream):
-        """Converts dataset scan into a text stream"""
-
-        def grouper(n, iterable, fillvalue=None):
-            args = [iter(iterable)] * n
-            return itertools.zip_longest(fillvalue=fillvalue, *args)
-
-        if limit:
-            stream = takeuntil(stream, limit=limit)
-
-        for batch in grouper(
-            n=chunk_size,
-            iterable=stream,
-        ):
-            filtered_records = filter(lambda r: r is not None, batch)
-            yield "\n".join(
-                map(
-                    lambda r: r.json(by_alias=True, exclude_none=True), filtered_records
-                )
-            ) + "\n"
-
-    return StreamingResponseWithErrorHandling(
-        stream_generator(data_stream), media_type="application/json"
-    )
-
-
-@router.post(
-    BASE_ENDPOINT + "/data",
-    operation_id="stream_data",
-)
-async def stream_data(
-    name: str,
-    query: Optional[TokenClassificationQuery] = None,
-    common_params: CommonTaskHandlerDependencies = Depends(),
-    limit: Optional[int] = Query(None, description="Limit loaded records", gt=0),
-    service: TokenClassificationService = Depends(
-        TokenClassificationService.get_instance
-    ),
-    datasets: DatasetsService = Depends(DatasetsService.get_instance),
-    current_user: User = Security(auth.get_user, scopes=[]),
-    id_from: Optional[str] = None,
-) -> StreamingResponse:
-    """
-        Creates a data stream over dataset records
-
-    Parameters
-    ----------
-    name
-        The dataset name
-    query:
-        The stream data query
-    common_params:
-        Common query params
-    limit:
-        The load number of records limit. Optional
-    service:
-        The dataset records service
-    datasets:
-        The datasets service
-    current_user:
-        Request user
-    id_from:
-        If provided, read the samples after this record ID
-
-    """
-    query = query or TokenClassificationQuery()
-    dataset = datasets.find_by_name(
-        user=current_user,
-        name=name,
-        task=TASK_TYPE,
-        workspace=common_params.workspace,
-        as_dataset_class=TasksFactory.get_task_dataset(TASK_TYPE),
-    )
-    data_stream = map(
-        TokenClassificationRecord.parse_obj,
-        service.read_dataset(
+        dataset = datasets.find_by_name(
+            user=current_user,
+            name=name,
+            task=task_type,
+            workspace=common_params.workspace,
+            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+        )
+        results = service.search(
             dataset=dataset,
             query=ServiceTokenClassificationQuery.parse_obj(query),
-            id_from=id_from,
-            limit=limit,
+            sort_by=search.sort,
+            record_from=pagination.from_,
+            size=pagination.limit,
+            exclude_metrics=not include_metrics,
+        )
+
+        return TokenClassificationSearchResults(
+            total=results.total,
+            records=[TokenClassificationRecord.parse_obj(r) for r in results.records],
+            aggregations=TokenClassificationAggregations.parse_obj(results.metrics)
+            if results.metrics
+            else None,
+        )
+
+    def scan_data_response(
+        data_stream: Iterable[TokenClassificationRecord],
+        chunk_size: int = 1000,
+        limit: Optional[int] = None,
+    ) -> StreamingResponseWithErrorHandling:
+        """Generate an textual stream data response for a dataset scan"""
+
+        async def stream_generator(stream):
+            """Converts dataset scan into a text stream"""
+
+            def grouper(n, iterable, fillvalue=None):
+                args = [iter(iterable)] * n
+                return itertools.zip_longest(fillvalue=fillvalue, *args)
+
+            if limit:
+                stream = takeuntil(stream, limit=limit)
+
+            for batch in grouper(
+                n=chunk_size,
+                iterable=stream,
+            ):
+                filtered_records = filter(lambda r: r is not None, batch)
+                yield "\n".join(
+                    map(
+                        lambda r: r.json(by_alias=True, exclude_none=True),
+                        filtered_records,
+                    )
+                ) + "\n"
+
+        return StreamingResponseWithErrorHandling(
+            stream_generator(data_stream), media_type="application/json"
+        )
+
+    @router.post(
+        path=f"{base_endpoint}/data",
+        operation_id="stream_data",
+    )
+    async def stream_data(
+        name: str,
+        query: Optional[TokenClassificationQuery] = None,
+        common_params: CommonTaskHandlerDependencies = Depends(),
+        limit: Optional[int] = Query(None, description="Limit loaded records", gt=0),
+        service: TokenClassificationService = Depends(
+            TokenClassificationService.get_instance
         ),
+        datasets: DatasetsService = Depends(DatasetsService.get_instance),
+        current_user: User = Security(auth.get_user, scopes=[]),
+        id_from: Optional[str] = None,
+    ) -> StreamingResponse:
+        """
+            Creates a data stream over dataset records
+
+        Parameters
+        ----------
+        name
+            The dataset name
+        query:
+            The stream data query
+        common_params:
+            Common query params
+        limit:
+            The load number of records limit. Optional
+        service:
+            The dataset records service
+        datasets:
+            The datasets service
+        current_user:
+            Request user
+        id_from:
+            If provided, read the samples after this record ID
+
+        """
+        query = query or TokenClassificationQuery()
+        dataset = datasets.find_by_name(
+            user=current_user,
+            name=name,
+            task=task_type,
+            workspace=common_params.workspace,
+            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+        )
+        data_stream = map(
+            TokenClassificationRecord.parse_obj,
+            service.read_dataset(
+                dataset=dataset,
+                query=ServiceTokenClassificationQuery.parse_obj(query),
+                id_from=id_from,
+                limit=limit,
+            ),
+        )
+
+        return scan_data_response(
+            data_stream=data_stream,
+            limit=limit,
+        )
+
+    token_classification_dataset_settings.configure_router(router)
+    metrics.configure_router(
+        router,
+        cfg=TasksFactory.get_task_by_task_type(task_type),
     )
 
-    return scan_data_response(
-        data_stream=data_stream,
-        limit=limit,
-    )
+    return router
 
 
-token_classification_dataset_settings.configure_router(router)
+router = configure_router()

--- a/src/argilla/server/apis/v0/handlers/token_classification_dataset_settings.py
+++ b/src/argilla/server/apis/v0/handlers/token_classification_dataset_settings.py
@@ -16,6 +16,7 @@ from typing import Type
 
 from fastapi import APIRouter, Body, Depends, Security
 
+from argilla.server.apis.v0.helpers import deprecate_endpoint
 from argilla.server.apis.v0.models.commons.params import (
     DATASET_NAME_PATH_PARAM,
     CommonTaskHandlerDependencies,
@@ -37,9 +38,12 @@ __svc_settings_class__: Type[ServiceBaseDatasetSettings] = type(
 def configure_router(router: APIRouter):
     task = TaskType.token_classification
     base_endpoint = f"/{task}/{{name}}/settings"
+    new_base_endpoint = f"/{{name}}/{task}/settings"
 
-    @router.get(
+    @deprecate_endpoint(
         path=base_endpoint,
+        new_path=new_base_endpoint,
+        router_method=router.get,
         name=f"get_dataset_settings_for_{task}",
         operation_id=f"get_dataset_settings_for_{task}",
         description=f"Get the {task} dataset settings",
@@ -65,8 +69,10 @@ def configure_router(router: APIRouter):
         )
         return TokenClassificationSettings.parse_obj(settings)
 
-    @router.put(
+    @deprecate_endpoint(
         path=base_endpoint,
+        new_path=new_base_endpoint,
+        router_method=router.put,
         name=f"save_dataset_settings_for_{task}",
         operation_id=f"save_dataset_settings_for_{task}",
         description=f"Save the {task} dataset settings",
@@ -100,8 +106,10 @@ def configure_router(router: APIRouter):
         )
         return TokenClassificationSettings.parse_obj(settings)
 
-    @router.delete(
+    @deprecate_endpoint(
         path=base_endpoint,
+        new_path=new_base_endpoint,
+        router_method=router.delete,
         operation_id=f"delete_{task}_settings",
         name=f"delete_{task}_settings",
         description=f"Delete {task} dataset settings",

--- a/src/argilla/server/apis/v0/helpers.py
+++ b/src/argilla/server/apis/v0/helpers.py
@@ -1,0 +1,33 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Callable
+
+
+def deprecate_endpoint(
+    path: str, new_path: str, router_method: Callable, *args, **kwargs
+):
+    """
+    Helper decorator to deprecate a `path` endpoint adding the `new_path` endpoint.
+
+    Both `path` and `new_path` shares the same router method (get, post, patch,...) `router_method`
+    """
+
+    def decorator(func: Callable):
+        kwargs.pop("path", None)
+        kwargs.pop("deprecated", None)
+        router_method(path=path, *args, deprecated=True, **kwargs)(func)
+        router_method(path=new_path, *args, deprecated=False, **kwargs)(func)
+
+    return decorator

--- a/src/argilla/server/routes.py
+++ b/src/argilla/server/routes.py
@@ -20,11 +20,16 @@ set the required security dependencies if api security is enabled
 
 from fastapi import APIRouter
 
-from argilla.server.apis.v0.handlers import datasets as datasets
-from argilla.server.apis.v0.handlers import info as info
-from argilla.server.apis.v0.handlers import metrics as tasks
-from argilla.server.apis.v0.handlers import records_deletion as records_deletion
-from argilla.server.apis.v0.handlers import users as users
+from argilla.server.apis.v0.handlers import (
+    datasets,
+    info,
+    metrics,
+    records_deletion,
+    text2text,
+    text_classification,
+    token_classification,
+    users,
+)
 from argilla.server.errors.base_errors import __ALL__
 
 api_router = APIRouter(
@@ -38,7 +43,10 @@ for router in [
     users.router,
     datasets.router,
     info.router,
-    tasks.router,
+    metrics.router,
     records_deletion.router,
+    text_classification.router,
+    token_classification.router,
+    text2text.router,
 ]:
     api_router.include_router(router, dependencies=dependencies)


### PR DESCRIPTION
This PR includes changes to normalize the API path endpoints to 

```bash
/datasets/{name}/{task}/...
```

and marks the old ones

```bash
/dataset/{task}/{name}...
``` 

as deprecated

This change does not affect the API functionality

See: recognai/roadmap#22