### PR TITLE
docs: Link key features (#1805)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ https://user-images.githubusercontent.com/1107111/197567844-4370487d-fe44-441e-9
 ### Monitoring
 
 - Close the gap between production data and data collection activities
-- Auto-monitoring for [major NLP libraries and pipelines](https://docs.argilla.io/en/latest/tutorials/libraries/libraries.html) (spaCy, Hugging Face, FlairNLP)
+- [Auto-monitoring](https://docs.argilla.io/en/latest/guides/steps/3_deploying.html) for [major NLP libraries and pipelines](https://docs.argilla.io/en/latest/tutorials/libraries/libraries.html) (spaCy, Hugging Face, FlairNLP)
 - [ASGI middleware](https://docs.argilla.io/en/latest/tutorials/notebooks/deploying-texttokenclassification-fastapi.html) for HTTP endpoints
 - Argilla Metrics to understand data and model issues, [like entity consistency for NER models](https://docs.argilla.io/en/latest/guides/steps/4_monitoring.html)
 - Integrated with Kibana for custom dashboards
@@ -184,7 +184,6 @@ Argilla is useful if you want to:
 ### What do I need to start using Argilla?
 You need to have a running instance of Elasticsearch and install the Argilla Python library.
 The library is used to read and write data into Argilla.
-To get started we highly recommend using Jupyter Notebooks so you might want to install Jupyter Lab or use Jupiter support for VS Code for example.
 
 ### How can I "upload" data into Argilla?
 Currently, the only way to upload data into Argilla is by using the Python library.
@@ -216,7 +215,7 @@ The training datasets created with Argilla are model agnostic.
 
 You can choose one of many amazing frameworks to train your model, like [transformers](https://huggingface.co/docs/transformers/), [spaCy](https://spacy.io/), [flair](https://github.com/flairNLP/flair) or [sklearn](https://scikit-learn.org).
 
-Check out our [deep deives](https://docs.argilla.io/en/latest/guides/guides.html) and our [tutorials](https://docs.argilla.io/en/latest/tutorials/tutorials.html) on how Argilla integrates with these frameworks.
+Check out our [deep dives](https://docs.argilla.io/en/latest/guides/guides.html) and our [tutorials](https://docs.argilla.io/en/latest/tutorials/tutorials.html) on how Argilla integrates with these frameworks.
 
 
 If you want to train a Hugging Face transformer or spaCy NER model, we provide a neat shortcut to [prepare your dataset for training](https://docs.argilla.io/en/latest/guides/features/datasets.html#Prepare-dataset-for-training).

--- a/README.md
+++ b/README.md
@@ -55,25 +55,25 @@ https://user-images.githubusercontent.com/1107111/197567844-4370487d-fe44-441e-9
 
 ### Advanced NLP labeling
 
-- Programmatic labeling using Weak Supervision. Built-in label models (Snorkel, Flyingsquid)
-- Bulk-labeling and search-driven annotation
-- Iterate on training data with any pre-trained model or library
+- Programmatic labeling using [weak supervision](https://docs.argilla.io/en/latest/guides/techniques/weak_supervision.html). Built-in label models (Snorkel, Flyingsquid)
+- [Bulk-labeling](https://docs.argilla.io/en/latest/reference/webapp/features.html#bulk-annotate) and [search-driven annotation](https://docs.argilla.io/en/latest/guides/features/queries.html)
+- Iterate on training data with any [pre-trained model](https://docs.argilla.io/en/latest/tutorials/libraries/huggingface.html) or [library](https://docs.argilla.io/en/latest/tutorials/libraries/libraries.html)
 - Efficiently review and refine annotations in the UI and with Python
-- Use Argilla built-in metrics and methods for finding label and data errors (e.g., cleanlab)
-- Simple integration with active learning workflows
+- Use Argilla built-in metrics and methods for [finding label and data errors (e.g., cleanlab)](https://docs.argilla.io/en/latest/tutorials/notebooks/monitoring-textclassification-cleanlab-explainability.html)
+- Simple integration with [active learning workflows](https://docs.argilla.io/en/latest/tutorials/techniques/active_learning.html)
 
 ### Monitoring
 
 - Close the gap between production data and data collection activities
-- Auto-monitoring for major NLP libraries and pipelines (spaCy, Hugging Face, FlairNLP)
-- ASGI middleware for HTTP endpoints
-- Argilla Metrics to understand data and model issues, like entity consistency for NER models
+- Auto-monitoring for [major NLP libraries and pipelines](https://docs.argilla.io/en/latest/tutorials/libraries/libraries.html) (spaCy, Hugging Face, FlairNLP)
+- [ASGI middleware](https://docs.argilla.io/en/latest/tutorials/notebooks/deploying-texttokenclassification-fastapi.html) for HTTP endpoints
+- Argilla Metrics to understand data and model issues, [like entity consistency for NER models](https://docs.argilla.io/en/latest/guides/steps/4_monitoring.html)
 - Integrated with Kibana for custom dashboards
 
 ### Team workspaces
 
 - Bring different users and roles into the NLP data and model lifecycles
-- Organize data collection, review and monitoring into different workspaces
+- Organize data collection, review and monitoring into different [workspaces](https://docs.argilla.io/en/latest/getting_started/installation/user_management.html#workspace)
 - Manage workspace access for different users
 
 ## Quickstart


### PR DESCRIPTION
I have linked all concepts that I could relate to some part of the docs. Moreover, I changed the captialization of "Weak Supervision" to "weak supervision" as it seemed more consistent with the rest of the README.md (e.g., active learning, data collection, ...).

Out of scope but related:
Do you plan to keep multiple versions of the documents online? If so it might be better to change all documentation links (not only the new ones) to a fixed version. 