### PR TITLE
fix: Update vue-virtual-scroller dependency version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
             # - --remove-header
 
 -   repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.10.0
     hooks:
     -   id: black
         additional_dependencies: ['click==8.0.4']

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@
 <p align="center">Data Labeling + Data Curation + Inference Store</p>
 <p align="center">Designed for MLOps & Feedback Loops</p>
 
-<iframe src="https://www.youtube.com/embed/jP3anvp7Rto" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="" width="100%" height="450" frameborder="0"></iframe>
+<iframe width="100%" height="450" src="https://www.youtube.com/embed/jP3anvp7Rto" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
 <br>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@
 <p align="center">Data Labeling + Data Curation + Inference Store</p>
 <p align="center">Designed for MLOps & Feedback Loops</p>
 
-<iframe width="100%" height="450" src="https://www.youtube.com/embed/jP3anvp7Rto" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
+https://user-images.githubusercontent.com/1107111/197567844-4370487d-fe44-441e-9a92-48e529713a15.mp4
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ https://user-images.githubusercontent.com/1107111/197567844-4370487d-fe44-441e-9
 <a  href="https://join.slack.com/t/rubrixworkspace/shared_invite/zt-whigkyjn-a3IUJLD7gDbTZ0rKlvcJ5g">
 <img src="https://img.shields.io/badge/JOIN US ON SLACK-4A154B?style=for-the-badge&logo=slack&logoColor=white" />
 </a>
+<a href="https://linkedin.com/company/argilla-io">
 <img src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" />
+</a>
+<a  href="https://twitter.com/argilla_io">
 <img src="https://img.shields.io/badge/Twitter-1DA1F2?style=for-the-badge&logo=twitter&logoColor=white" />
+</a>
 </p>
 
 <br>

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 <img  alt="CI"  src="https://img.shields.io/conda/vn/conda-forge/rubrix?logo=anaconda&style=flat&color=orange">
 </!a-->
 <img  alt="Codecov" src="https://img.shields.io/codecov/c/github/recognai/rubrix">
-<a href="https://pepy.tech/project/rubrix">
-<img  alt="CI"  src="https://static.pepy.tech/personalized-badge/rubrix?period=month&units=international_system&left_color=grey&right_color=blue&left_text=pypi%20downloads/month">
+<a href="https://pepy.tech/project/argilla">
+<img  alt="CI"  src="https://static.pepy.tech/personalized-badge/argilla?period=month&units=international_system&left_color=grey&right_color=blue&left_text=pypi%20downloads/month">
 </a>
 </p>
 
@@ -22,14 +22,7 @@
 <p align="center">Data Labeling + Data Curation + Inference Store</p>
 <p align="center">Designed for MLOps & Feedback Loops</p>
 
-
-
-https://user-images.githubusercontent.com/1107111/197567844-4370487d-fe44-441e-9a92-48e529713a15.mp4
-
-
-<!--https://user-images.githubusercontent.com/15979778/167146590-72d8f7b1-f94d-45a6-9896-1525cf949efe.mp4-->
-
-
+<iframe src="https://www.youtube.com/embed/jP3anvp7Rto" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="" width="100%" height="450" frameborder="0"></iframe>
 <br>
 
 <p align="center">
@@ -101,7 +94,7 @@ The simplest way is to use`Docker` by running:
 docker run -d --name es-for-argilla -p 9200:9200 -p 9300:9300 -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2
 
 ```
-> :information_source: **Check [the docs](https://rubrix.readthedocs.io/en/stable/getting_started/setup%26installation.html) for further options and configurations for Elasticsearch.**
+> :information_source: **Check [the docs](https://docs.argilla.io/en/latest/getting_started/quickstart.html) for further options and configurations for Elasticsearch.**
 
 Finally you can **launch the server**:
 
@@ -222,10 +215,10 @@ The training datasets created with Argilla are model agnostic.
 
 You can choose one of many amazing frameworks to train your model, like [transformers](https://huggingface.co/docs/transformers/), [spaCy](https://spacy.io/), [flair](https://github.com/flairNLP/flair) or [sklearn](https://scikit-learn.org).
 
-Check out our [cookbook](https://rubrix.readthedocs.io/en/stable/guides/cookbook.html) and our [tutorials](https://rubrix.readthedocs.io/en/stable) on how Argilla integrates with these frameworks.
+Check out our [deep deives](https://docs.argilla.io/en/latest/guides/guides.html) and our [tutorials](https://docs.argilla.io/en/latest/tutorials/tutorials.html) on how Argilla integrates with these frameworks.
 
 
-If you want to train a Hugging Face transformer or spaCy NER model, we provide a neat shortcut to [prepare your dataset for training](https://rubrix.readthedocs.io/en/stable/reference/python/python_client.html#rubrix.client.datasets.DatasetForTextClassification.prepare_for_training).
+If you want to train a Hugging Face transformer or spaCy NER model, we provide a neat shortcut to [prepare your dataset for training](https://docs.argilla.io/en/latest/guides/features/datasets.html#Prepare-dataset-for-training).
 ### Can Argilla share the Elasticsearch Instance/cluster?
 Yes, you can use the same Elasticsearch instance/cluster for Argilla and other applications.
 You only need to perform some configuration, check the Advanced installation guide in the docs.
@@ -242,8 +235,8 @@ curl -X PUT "localhost:9200/_cluster/settings?pretty" -H 'Content-Type: applicat
 
 ```
 ## Contributors
-<a  href="https://github.com/recognai/rubrix/graphs/contributors">
+<a  href="https://github.com/argilla-io/argilla/graphs/contributors">
 
-<img  src="https://contrib.rocks/image?repo=recognai/rubrix" />
+<img  src="https://contrib.rocks/image?repo=argilla-io/argilla" />
 
 </a>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <br>
 </h1>
 <p align="center">
-<a  href="https://pypi.org/project/rubrix/">
+<a  href="https://pypi.org/project/argilla/">
 <img  alt="CI"  src="https://img.shields.io/pypi/v/rubrix.svg?style=flat-square&logo=pypi&logoColor=white">
 </a>
 <!--a  href="https://anaconda.org/conda-forge/rubrix">

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   argilla:
-    image: argilla-io/argilla-server:latest
+    image: argilla/argilla-server:latest
     restart: unless-stopped
     ports:
       - "6900:80"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
     "vue-moment": "^4.1.0",
     "vue-svgicon": "^3.2.9",
     "vue-vega": "^1.0.0-alpha.13",
-    "vue-virtual-scroller": "^1.0.10"
+    "vue-virtual-scroller": "~1.0.10"
   },
   "devDependencies": {
     "@babel/core": "7.17.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argilla",
-  "version": "1.0.0",
+  "version": "1.1.0-dev0",
   "private": true,
   "eslintIgnore": [
     "node_modules/**/*",

--- a/src/argilla/_version.py
+++ b/src/argilla/_version.py
@@ -13,4 +13,4 @@
 #  limitations under the License.
 
 # coding: utf-8
-version = "1.0.0"
+version = "1.1.0-dev0"


### PR DESCRIPTION
This PR changes the vue-virtual-scroller version to avoid dependency problems in events during annotation

closes #1806
closes #1782