### PR TITLE
fix: Update vue-virtual-scroller dependency version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
     "vue-moment": "^4.1.0",
     "vue-svgicon": "^3.2.9",
     "vue-vega": "^1.0.0-alpha.13",
-    "vue-virtual-scroller": "^1.0.10"
+    "vue-virtual-scroller": "~1.0.10"
   },
   "devDependencies": {
     "@babel/core": "7.17.2",


### PR DESCRIPTION
This PR changes the vue-virtual-scroller version to avoid dependency problems in events during annotation

closes #1806
closes #1782
closes #1816
closes #1724