### PR TITLE
fix: Avoid closing the score filter when dragging the slider

### DIFF
--- a/frontend/components/commons/header/filters/FilterDropdown.vue
+++ b/frontend/components/commons/header/filters/FilterDropdown.vue
@@ -18,7 +18,10 @@
 <template>
   <div
     ref="dropdownMenu"
-    v-click-outside="onClickOutside"
+    v-click-outside="{
+      events: ['mousedown'],
+      handler: onClickOutside,
+    }"
     :class="[
       'dropdown',
       colorType === 'grey' ? '--grey' : '',

--- a/frontend/components/commons/header/filters/FiltersList.vue
+++ b/frontend/components/commons/header/filters/FiltersList.vue
@@ -250,7 +250,7 @@ export default {
   },
   methods: {
     onClickOutside() {
-      this.initialVisibleGroup = undefined;
+      this.initialVisibleGroup = null;
     },
     itemsAppliedOnGroup(group) {
       if (group === "Sort") {
@@ -264,7 +264,7 @@ export default {
     },
     selectGroup(group) {
       if (this.initialVisibleGroup === group) {
-        this.initialVisibleGroup = undefined;
+        this.initialVisibleGroup =  null;
       } else {
         this.initialVisibleGroup = group;
       }

--- a/frontend/components/commons/header/filters/FiltersList.vue
+++ b/frontend/components/commons/header/filters/FiltersList.vue
@@ -16,7 +16,13 @@
   -->
 
 <template>
-  <div v-click-outside="close" class="filters">
+  <div
+    v-click-outside="{
+      events: ['mousedown'],
+      handler: onClickOutside,
+    }"
+    class="filters"
+  >
     <div class="filters__list">
       <div v-for="group in groups" :key="group" class="filters__list__item">
         <p
@@ -243,7 +249,7 @@ export default {
     },
   },
   methods: {
-    close() {
+    onClickOutside() {
       this.initialVisibleGroup = undefined;
     },
     itemsAppliedOnGroup(group) {

--- a/frontend/components/commons/header/filters/FiltersList.vue
+++ b/frontend/components/commons/header/filters/FiltersList.vue
@@ -19,7 +19,7 @@
   <div
     v-click-outside="{
       events: ['mousedown'],
-      handler: onClickOutside,
+      handler: close,
     }"
     class="filters"
   >
@@ -249,7 +249,7 @@ export default {
     },
   },
   methods: {
-    onClickOutside() {
+    close() {
       this.initialVisibleGroup = null;
     },
     itemsAppliedOnGroup(group) {


### PR DESCRIPTION
This PR fixes the score filter selection, avoiding closing the score filter when dragging the slider outside of the filter content

see #1802
closes #1876