### PR TITLE
fix: Change method for Doc creation by spacy.Language

### DIFF
--- a/src/argilla/client/datasets.py
+++ b/src/argilla/client/datasets.py
@@ -908,7 +908,7 @@ class DatasetForTokenClassification(DatasetBase):
             if record.annotation is None:
                 continue
 
-            doc = nlp(record.text)
+            doc = nlp.make_doc(record.text)
             entities = []
 
             for anno in record.annotation:


### PR DESCRIPTION
Fixes #1890

Whole pipeline should not be involved in Doc creating process when it is not necessary.

_Matthew's Honnibal_ (author of _spaCy_) answer on stackoverflow about `nlp(text)` vs `nlp.make_doc(text)`:
> https://stackoverflow.com/a/66094373/12277937
