### PR TITLE
fix: Remove extra html when text is not highlighted

### DIFF
--- a/frontend/plugins/highlight-search.js
+++ b/frontend/plugins/highlight-search.js
@@ -53,7 +53,7 @@ export default (context, inject) => {
 
   function replaceText(regex, text) {
     return htmlText(text).replace(regex, (matched) =>
-      htmlHighlightText(matched)
+      matched ? htmlHighlightText(matched) : matched
     );
   }
 


### PR DESCRIPTION
closes #1758

This PR removes extra html when text is not highlighted