### PR TITLE
fix: Remove "Help explain button" in Manage rule view

### DIFF
--- a/frontend/components/text-classifier/header/TextClassificationHeader.vue
+++ b/frontend/components/text-classifier/header/TextClassificationHeader.vue
@@ -63,7 +63,7 @@ export default {
       return this.dataset.isMultiLabel;
     },
     isRuleListView() {
-      return this.dataset.viewSettings.visibleRulesList;
+      return this.dataset.viewSettings?.visibleRulesList || false;
     },
     availableLabels() {
       const record = this.dataset.results.records[0];

--- a/frontend/components/text-classifier/header/TextClassificationHeader.vue
+++ b/frontend/components/text-classifier/header/TextClassificationHeader.vue
@@ -23,7 +23,10 @@
     >
       <records-counter :total="dataset.results.total"></records-counter>
     </filters-area>
-    <explain-help-info v-if="isExplainedRecord" :dataset="dataset" />
+    <explain-help-info
+      v-if="isExplainedRecord && !isRuleListView"
+      :dataset="dataset"
+    />
     <global-actions :dataset="dataset">
       <validate-discard-action
         :dataset="dataset"
@@ -58,6 +61,9 @@ export default {
     },
     isMultiLabel() {
       return this.dataset.isMultiLabel;
+    },
+    isRuleListView() {
+      return this.dataset.viewSettings.visibleRulesList;
     },
     availableLabels() {
       const record = this.dataset.results.records[0];

--- a/frontend/components/text-classifier/results/RecordExplain.vue
+++ b/frontend/components/text-classifier/results/RecordExplain.vue
@@ -41,6 +41,11 @@ export default {
       type: Array,
     },
   },
+  data() {
+    return {
+      colorSensitivity: 1 // color sensitivity (values from 1 to 4)
+    }
+  },
   computed: {
     predicted() {
       return this.record.predicted;
@@ -60,10 +65,8 @@ export default {
         let percent = Math.round(Math.abs(grad) * 100);
         if (percent !== 0) {
           /* eslint-disable no-mixed-operators */
-          const colorSensitivity = 1; // color sensitivity (values from 1 to 4)
-          const logNumber = 100 / Math.log10(100) ** colorSensitivity;
           percent = Math.round(
-            Math.log10(percent) ** colorSensitivity * logNumber
+            Math.log10(percent) ** this.colorSensitivity * this.logNumber
           );
         }
         return {
@@ -75,6 +78,9 @@ export default {
         };
       });
     },
+    logNumber() {
+      return 100 / Math.log10(100) ** this.colorSensitivity;
+    }
   },
   methods: {
     customClass(tokenItem) {

--- a/frontend/components/text-classifier/results/RecordExplain.vue
+++ b/frontend/components/text-classifier/results/RecordExplain.vue
@@ -43,8 +43,8 @@ export default {
   },
   data() {
     return {
-      colorSensitivity: 1 // color sensitivity (values from 1 to 4)
-    }
+      colorSensitivity: 1, // color sensitivity (values from 1 to 4)
+    };
   },
   computed: {
     predicted() {
@@ -80,7 +80,7 @@ export default {
     },
     logNumber() {
       return 100 / Math.log10(100) ** this.colorSensitivity;
-    }
+    },
   },
   methods: {
     customClass(tokenItem) {

--- a/frontend/components/text-classifier/results/RecordExplain.vue
+++ b/frontend/components/text-classifier/results/RecordExplain.vue
@@ -62,7 +62,9 @@ export default {
           /* eslint-disable no-mixed-operators */
           const colorSensitivity = 1; // color sensitivity (values from 1 to 4)
           const logNumber = 100 / Math.log10(100) ** colorSensitivity;
-          percent = Math.round(Math.log10(percent) ** colorSensitivity * logNumber);
+          percent = Math.round(
+            Math.log10(percent) ** colorSensitivity * logNumber
+          );
         }
         return {
           text: this.record.search_keywords


### PR DESCRIPTION
closes #1807

This PR removes the help explain button from the rules list view