### PR TITLE
View Docs link in frontend header `users.vue`

### DIFF
--- a/frontend/components/commons/header/user/user.vue
+++ b/frontend/components/commons/header/user/user.vue
@@ -8,7 +8,7 @@
       <p class="user__mail">{{ user.email }}</p>
       <a
         class="user__link"
-        href="https://docs.rubrix.ml/en/stable/"
+        href="https://docs.argilla.io/en/latest/"
         target="_blank"
       >
         <svgicon width="16" height="16" name="external"></svgicon> View docs


### PR DESCRIPTION
Hi I just noticed that the "View Docs" link in the header of the Argilla's frontend interface currently leads to the old Rubrix documentation. 

Proposal to change `https://docs.rubrix.ml/en/stable/` to `https://docs.argilla.io/en/latest/`