### PR TITLE
feat: Allow sort records by event_timestamp or last_updated fields

### DIFF
--- a/frontend/components/commons/header/filters/FiltersList.vue
+++ b/frontend/components/commons/header/filters/FiltersList.vue
@@ -299,11 +299,11 @@ export default {
       this.$emit("applySortBy", sortList);
       this.close();
     },
-    sortByDateFilter(id, name) {
+    sortByDateFilter(id, name, group = "Sort") {
       return {
-        id: id,
+        id,
         key: id,
-        group: "Sort",
+        group: group,
         name: name,
         disabled: this.recordPropertyHasValue(id),
       };

--- a/frontend/components/commons/header/filters/FiltersList.vue
+++ b/frontend/components/commons/header/filters/FiltersList.vue
@@ -235,6 +235,22 @@ export default {
             a.key.toLowerCase() > b.key.toLowerCase() ? 1 : -1
           )) ||
         [];
+      const dateFields = [
+        {
+          id: "last_updated",
+          key: "last_updated",
+          group: "Sort",
+          name: "Last updated",
+          disabled: this.recordPropertyHasValue("last_updated"),
+        },
+        {
+          id: "event_timestamp",
+          key: "event_timestamp",
+          group: "Sort",
+          name: "Event timestamp",
+          disabled: this.recordPropertyHasValue("event_timestamp"),
+        },
+      ].filter(({ disabled }) => !disabled);
       const uncoveredByRules = {
         id: "uncovered_by_rules",
         key: "uncovered_by_rules",
@@ -243,9 +259,14 @@ export default {
         options: [true, false],
         selected:
           this.dataset.query.uncovered_by_rules &&
-          this.dataset.query.uncovered_by_rules.length > 0,
+          this.dataset.query.uncovered_by_rules?.length > 0,
       };
-      return [...filters, ...sortedMetadataFilters, uncoveredByRules];
+      return [
+        ...filters,
+        ...dateFields,
+        ...sortedMetadataFilters,,
+        uncoveredByRules,
+      ];
     },
   },
   methods: {
@@ -264,7 +285,7 @@ export default {
     },
     selectGroup(group) {
       if (this.initialVisibleGroup === group) {
-        this.initialVisibleGroup =  null;
+        this.initialVisibleGroup = null;
       } else {
         this.initialVisibleGroup = group;
       }
@@ -289,6 +310,11 @@ export default {
     onSortBy(sortList) {
       this.$emit("applySortBy", sortList);
       this.close();
+    },
+    recordPropertyHasValue(prop) {
+      return (
+        !this.dataset.results.records.some((record) => record[prop]) || false
+      );
     },
   },
 };

--- a/frontend/components/commons/header/filters/FiltersList.vue
+++ b/frontend/components/commons/header/filters/FiltersList.vue
@@ -303,8 +303,8 @@ export default {
       return {
         id,
         key: id,
-        group: group,
-        name: name,
+        group,
+        name,
         disabled: this.recordPropertyHasValue(id),
       };
     },

--- a/frontend/components/commons/header/filters/FiltersList.vue
+++ b/frontend/components/commons/header/filters/FiltersList.vue
@@ -236,20 +236,8 @@ export default {
           )) ||
         [];
       const dateFields = [
-        {
-          id: "last_updated",
-          key: "last_updated",
-          group: "Sort",
-          name: "Last updated",
-          disabled: this.recordPropertyHasValue("last_updated"),
-        },
-        {
-          id: "event_timestamp",
-          key: "event_timestamp",
-          group: "Sort",
-          name: "Event timestamp",
-          disabled: this.recordPropertyHasValue("event_timestamp"),
-        },
+        this.sortByDateFilter("last_updated", "Last Updated"),
+        this.sortByDateFilter("event_timestamp", "Event Timestamp"),
       ].filter(({ disabled }) => !disabled);
       const uncoveredByRules = {
         id: "uncovered_by_rules",
@@ -310,6 +298,15 @@ export default {
     onSortBy(sortList) {
       this.$emit("applySortBy", sortList);
       this.close();
+    },
+    sortByDateFilter(id, name) {
+      return {
+        id: id,
+        key: id,
+        group: "Sort",
+        name: name,
+        disabled: this.recordPropertyHasValue(id),
+      };
     },
     recordPropertyHasValue(prop) {
       return (

--- a/frontend/components/commons/header/filters/FiltersList.vue
+++ b/frontend/components/commons/header/filters/FiltersList.vue
@@ -264,7 +264,7 @@ export default {
       return [
         ...filters,
         ...dateFields,
-        ...sortedMetadataFilters,,
+        ...sortedMetadataFilters,
         uncoveredByRules,
       ];
     },

--- a/frontend/models/Common.js
+++ b/frontend/models/Common.js
@@ -31,6 +31,7 @@ class BaseRecord {
     status,
     selected,
     event_timestamp,
+    last_updated,
     search_keywords,
   }) {
     this.id = id;
@@ -40,6 +41,7 @@ class BaseRecord {
     this.status = status;
     this.selected = selected || false;
     this.event_timestamp = event_timestamp;
+    this.last_updated = last_updated;
     this.search_keywords = search_keywords || [];
   }
 


### PR DESCRIPTION
closes #1835

This PR includes the fields event_timestamp and last_updated in the sort filter allowing to sort records by these values