### PR TITLE
fix: Compute predicted properly for token classification [NEEDS_DATA_UPGRADE]

### DIFF
--- a/src/argilla/server/services/tasks/token_classification/model.py
+++ b/src/argilla/server/services/tasks/token_classification/model.py
@@ -145,11 +145,21 @@ class ServiceTokenClassificationRecord(
     @property
     def predicted(self) -> Optional[PredictionStatus]:
         if self.annotation and self.prediction:
-            return (
-                PredictionStatus.OK
-                if self.annotation.entities == self.prediction.entities
-                else PredictionStatus.KO
-            )
+
+            annotated_entities = self.annotation.entities
+            predicted_entities = self.prediction.entities
+            if len(annotated_entities) != len(predicted_entities):
+                return PredictionStatus.KO
+
+            for ann, pred in zip(annotated_entities, predicted_entities):
+                if (
+                    ann.start != pred.start
+                    or ann.end != pred.end
+                    or ann.label != pred.label
+                ):
+                    return PredictionStatus.KO
+
+            return PredictionStatus.OK
         return None
 
     @property

--- a/tests/server/token_classification/test_model.py
+++ b/tests/server/token_classification/test_model.py
@@ -335,3 +335,48 @@ def test_whitespace_in_tokens():
     record = ServiceTokenClassificationRecord.parse_obj(record)
     assert record
     assert record.tokens == ["every", "four", "(", "4", ")", " "]
+
+
+def test_predicted_ok_ko_computation():
+
+    text = "A text with some empty spaces that could bring not cleanly annotated spans"
+    record = ServiceTokenClassificationRecord(
+        text=text,
+        tokens=text.split(),
+        prediction=TokenClassificationAnnotation(
+            agent="pred.test",
+            entities=[
+                EntitySpan(
+                    start=0,
+                    end=6,
+                    label="VERB",
+                ),
+                EntitySpan(
+                    start=47,
+                    end=68,
+                    label="VERB",
+                    score=0.5,
+                ),
+            ],
+        ),
+        annotation=TokenClassificationAnnotation(
+            agent="test",
+            entities=[
+                EntitySpan(
+                    start=0,
+                    end=6,
+                    label="VERB",
+                ),
+                EntitySpan(
+                    start=47,
+                    end=68,
+                    label="VERB",
+                ),
+            ],
+        ),
+    )
+
+    assert record.predicted == PredictionStatus.OK
+
+    record.annotation.entities = record.annotation.entities[1:]
+    assert record.predicted == PredictionStatus.KO


### PR DESCRIPTION
This PR fixes the way predicted ok/ko info is computed for token classification records.

To apply this fix to already created datasets, you must first re-log records. Otherwise, stored info won't be updated.

Closes #1955 