### PR TITLE
perf: Fix OpenSearch memory problems

### DIFF
--- a/opensearch.compose.yaml
+++ b/opensearch.compose.yaml
@@ -17,11 +17,14 @@ services:
         soft: -1
         hard: -1
     ports:
-      - 9200:9200
+      - "9200:9200"
     networks:
       - argilla
+    volumes:
+      - opensearch-data:/usr/share/opensearch/data
+
 networks:
   argilla:
     driver: bridge
 volumes:
-  opensearchdata:
+  opensearch-data:

--- a/src/argilla/server/daos/backend/client_adapters/factory.py
+++ b/src/argilla/server/daos/backend/client_adapters/factory.py
@@ -34,13 +34,12 @@ class ClientAdapterFactory:
         ca_path: str,
         retry_on_timeout: bool = True,
         max_retries: int = 5,
-        opensearch_enable_knn: bool = False,
     ) -> IClientAdapter:
 
         (
             client_class,
             support_vector_search,
-        ) = cls._resolve_client_class_with_vector_support(hosts, opensearch_enable_knn)
+        ) = cls._resolve_client_class_with_vector_support(hosts)
 
         return client_class(
             index_shards=index_shards,
@@ -58,7 +57,6 @@ class ClientAdapterFactory:
     def _resolve_client_class_with_vector_support(
         cls,
         hosts: str,
-        enable_for_opensearch: bool = False,
     ) -> Tuple[Type, bool]:
         version, distribution = cls._fetch_cluster_version_info(hosts)
 
@@ -66,7 +64,7 @@ class ClientAdapterFactory:
 
         if distribution == "elasticsearch" and parse("8.5") <= parse(version):
             client_class = ElasticsearchClient
-        elif distribution == "opensearch" and enable_for_opensearch:
+        elif distribution == "opensearch" and parse("2.2") <= parse(version):
             client_class = OpenSearchClient
         else:
             client_class = OpenSearchClient

--- a/src/argilla/server/daos/backend/client_adapters/opensearch.py
+++ b/src/argilla/server/daos/backend/client_adapters/opensearch.py
@@ -67,27 +67,13 @@ class OpenSearchClient(IClientAdapter):
 
         self.set_index_settings(
             index=index,
-            settings={
-                "index": {
-                    "knn": True,
-                    "knn.algo_param.ef_search": 128,  # Ignored when engine=lucene
-                }
-            },
+            settings={"index.knn": True},
         )
         vector_mappings = {}
         for vector_name, vector_dimension in vectors.items():
             index_mapping = {
                 "type": "knn_vector",
                 "dimension": vector_dimension,
-                "method": {
-                    "name": "hnsw",
-                    "space_type": "l2",
-                    "engine": "nmslib",
-                    "parameters": {
-                        "m": 16,
-                        "ef_construction": 128,
-                    },
-                },
             }
             vector_field = self.query_builder.get_vector_field_name(vector_name)
             vector_mappings[vector_field] = index_mapping

--- a/src/argilla/server/daos/backend/client_adapters/opensearch.py
+++ b/src/argilla/server/daos/backend/client_adapters/opensearch.py
@@ -67,13 +67,19 @@ class OpenSearchClient(IClientAdapter):
 
         self.set_index_settings(
             index=index,
-            settings={"index.knn": True},
+            settings={"index.knn": False},
         )
         vector_mappings = {}
         for vector_name, vector_dimension in vectors.items():
             index_mapping = {
                 "type": "knn_vector",
                 "dimension": vector_dimension,
+                "method": {
+                    "name": "hnsw",
+                    "engine": "lucene",
+                    "space_type": "l2",
+                    "parameters": {"m": 2, "ef_construction": 4},
+                },
             }
             vector_field = self.query_builder.get_vector_field_name(vector_name)
             vector_mappings[vector_field] = index_mapping

--- a/src/argilla/server/daos/backend/generic_elastic.py
+++ b/src/argilla/server/daos/backend/generic_elastic.py
@@ -91,7 +91,6 @@ class GenericElasticEngineBackend(LoggingMixin):
                     index_shards=settings.es_records_index_shards,
                     ssl_verify=settings.elasticsearch_ssl_verify,
                     ca_path=settings.elasticsearch_ca_path,
-                    opensearch_enable_knn=settings.opensearch_enable_knn,
                 ),
                 metrics={**ALL_METRICS},
                 mappings={

--- a/src/argilla/server/daos/backend/mappings/text2text.py
+++ b/src/argilla/server/daos/backend/mappings/text2text.py
@@ -20,7 +20,7 @@ def text2text_mappings():
     return {
         "_source": mappings.source(
             excludes=[
-                # "words", # Cannot be excluded since comment text_length metric  is computed using this source fields
+                "words",  # Cannot be excluded since comment text_length metric  is computed using this source fields
                 "predicted",
                 "predicted_as",
                 "predicted_by",
@@ -32,7 +32,6 @@ def text2text_mappings():
         "properties": {
             "annotated_as": mappings.keyword_field(),
             "predicted_as": mappings.keyword_field(),
-            "text_predicted": mappings.words_text_field(),
             "score": {"type": "float"},
         },
     }

--- a/src/argilla/server/services/metrics/models.py
+++ b/src/argilla/server/services/metrics/models.py
@@ -158,11 +158,11 @@ class CommonTasksMetrics(ServiceBaseTaskMetrics, Generic[ServiceRecord]):
             name="Record status distribution",
             description="The dataset record status distribution",
         ),
-        ServiceBaseMetric(
-            id="words_cloud",
-            name="Inputs words cloud",
-            description="The words cloud for dataset inputs",
-        ),
+        # ServiceBaseMetric(
+        #     id="words_cloud",
+        #     name="Inputs words cloud",
+        #     description="The words cloud for dataset inputs",
+        # ),
         ServiceBaseMetric(id="metadata", name="Metadata fields stats"),
         ServiceBaseMetric(
             id="predicted_by",

--- a/src/argilla/server/services/tasks/text2text/models.py
+++ b/src/argilla/server/services/tasks/text2text/models.py
@@ -81,7 +81,7 @@ class ServiceText2TextRecord(ServiceBaseRecord[ServiceText2TextAnnotation]):
             "annotated_by": self.annotated_by,
             "predicted_by": self.predicted_by,
             "score": self.scores,
-            "words": self.all_text(),
+            # "words": self.all_text(),
         }
 
 

--- a/src/argilla/server/services/tasks/text2text/service.py
+++ b/src/argilla/server/services/tasks/text2text/service.py
@@ -85,7 +85,7 @@ class Text2TextService:
         metrics = TasksFactory.find_task_metrics(
             dataset.task,
             metric_ids={
-                "words_cloud",
+                # "words_cloud",
                 "predicted_by",
                 "annotated_by",
                 "status_distribution",
@@ -108,7 +108,7 @@ class Text2TextService:
         )
 
         if results.metrics:
-            results.metrics["words"] = results.metrics["words_cloud"]
+            results.metrics["words"] = results.metrics.get("words_cloud", {})
             results.metrics["status"] = results.metrics["status_distribution"]
 
         return results

--- a/src/argilla/server/services/tasks/text_classification/model.py
+++ b/src/argilla/server/services/tasks/text_classification/model.py
@@ -329,7 +329,7 @@ class ServiceTextClassificationRecord(ServiceBaseRecord[TextClassificationAnnota
         words = self.all_text()
         return {
             **super().extended_fields(),
-            "words": words,
+            # "words": words,
             "text": words,
         }
 

--- a/src/argilla/server/services/tasks/text_classification/service.py
+++ b/src/argilla/server/services/tasks/text_classification/service.py
@@ -119,7 +119,7 @@ class TextClassificationService:
         metrics = TasksFactory.find_task_metrics(
             dataset.task,
             metric_ids={
-                "words_cloud",
+                # "words_cloud",
                 "predicted_by",
                 "predicted_as",
                 "annotated_by",
@@ -145,7 +145,7 @@ class TextClassificationService:
         )
 
         if results.metrics:
-            results.metrics["words"] = results.metrics["words_cloud"]
+            results.metrics["words"] = results.metrics.get("words_cloud", {})
             results.metrics["status"] = results.metrics["status_distribution"]
             results.metrics["predicted"] = results.metrics["error_distribution"]
             results.metrics["predicted"].pop("unknown", None)

--- a/src/argilla/server/services/tasks/token_classification/model.py
+++ b/src/argilla/server/services/tasks/token_classification/model.py
@@ -99,7 +99,7 @@ class ServiceTokenClassificationRecord(
                 {"mention": mention, "entity": entity.label}
                 for mention, entity in self.annotated_mentions()
             ],
-            "words": self.all_text(),
+            # "words": self.all_text(),
         }
 
     def __init__(self, **data):

--- a/src/argilla/server/services/tasks/token_classification/service.py
+++ b/src/argilla/server/services/tasks/token_classification/service.py
@@ -102,7 +102,7 @@ class TokenClassificationService:
         metrics = TasksFactory.find_task_metrics(
             dataset.task,
             metric_ids={
-                "words_cloud",
+                # "words_cloud",
                 "predicted_by",
                 "predicted_as",
                 "annotated_by",
@@ -128,7 +128,7 @@ class TokenClassificationService:
         )
 
         if results.metrics:
-            results.metrics["words"] = results.metrics["words_cloud"]
+            results.metrics["words"] = results.metrics.get("words_cloud", {})
             results.metrics["status"] = results.metrics["status_distribution"]
             results.metrics["predicted"] = results.metrics["error_distribution"]
             results.metrics["predicted"].pop("unknown", None)

--- a/src/argilla/server/settings.py
+++ b/src/argilla/server/settings.py
@@ -66,7 +66,7 @@ class ApiSettings(BaseSettings):
     cors_origins: List[str] = ["*"]
 
     # TODO: Document this variable
-    opensearch_enable_knn: bool = False
+    opensearch_enable_knn: bool = True
 
     docs_enabled: bool = True
 

--- a/src/argilla/server/settings.py
+++ b/src/argilla/server/settings.py
@@ -98,7 +98,7 @@ class ApiSettings(BaseSettings):
         " Values containing higher than this will be truncated",
     )
 
-    enable_telemetry: bool = False
+    enable_telemetry: bool = True
 
     telemetry_key: Optional[str] = None
 

--- a/src/argilla/server/settings.py
+++ b/src/argilla/server/settings.py
@@ -98,7 +98,7 @@ class ApiSettings(BaseSettings):
         " Values containing higher than this will be truncated",
     )
 
-    enable_telemetry: bool = True
+    enable_telemetry: bool = False
 
     telemetry_key: Optional[str] = None
 

--- a/src/argilla/server/settings.py
+++ b/src/argilla/server/settings.py
@@ -65,9 +65,6 @@ class ApiSettings(BaseSettings):
     elasticsearch_ca_path: Optional[str] = None
     cors_origins: List[str] = ["*"]
 
-    # TODO: Document this variable
-    opensearch_enable_knn: bool = True
-
     docs_enabled: bool = True
 
     namespace: str = Field(default=None, regex=r"^[a-z]+$")

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -177,7 +177,7 @@ def test_load_limits(mocked_client, supported_vector_search):
     create_some_data_for_text_classification(
         mocked_client,
         dataset,
-        50,
+        n=50,
         with_vectors=supported_vector_search,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,10 @@ def telemetry_track_data(mocker):
 
 
 @pytest.fixture
-def mocked_client(monkeypatch, telemetry_track_data) -> SecuredClient:
+def mocked_client(
+    monkeypatch,
+    telemetry_track_data,
+) -> SecuredClient:
 
     with TestClient(app, raise_server_exceptions=False) as _client:
         client_ = SecuredClient(_client)

--- a/tests/server/text2text/test_api.py
+++ b/tests/server/text2text/test_api.py
@@ -80,7 +80,7 @@ def test_search_records(mocked_client):
         "predicted_by": {"test": 1},
         "predicted_text": {},
         "status": {"Default": 2},
-        "words": {"data": 2, "ånother": 1},
+        "words": {},
     }
 
 

--- a/tests/server/text_classification/test_api.py
+++ b/tests/server/text_classification/test_api.py
@@ -274,7 +274,7 @@ def test_create_records_for_text_classification_vector_search(
         "predicted_as": {"Mocking": 3},
         "predicted_by": {"test": 3},
         "status": {"Default": 3},
-        "words": {"data": 3},
+        "words": {},
     }
 
     response = mocked_client.post(

--- a/tests/server/text_classification/test_api.py
+++ b/tests/server/text_classification/test_api.py
@@ -164,7 +164,8 @@ def test_create_records_for_text_classification(mocked_client, telemetry_track_d
     assert created_dataset.metadata == metadata
 
     response = mocked_client.post(
-        f"/api/datasets/{dataset}/TextClassification:search", json={}
+        f"/api/datasets/{dataset}/TextClassification:search",
+        json={},
     )
 
     assert response.status_code == 200
@@ -178,7 +179,7 @@ def test_create_records_for_text_classification(mocked_client, telemetry_track_d
         "predicted_as": {"Mocking": 1},
         "predicted_by": {"test": 1},
         "status": {"Default": 1},
-        "words": {"data": 1},
+        "words": {},
     }
 
     telemetry_track_data.assert_called_once()


### PR DESCRIPTION
- Using Lucene engine  implementation for vector search because of reasons (https://github.com/opensearch-project/OpenSearch/issues/3545). 

  => **This option is only available for OpenSearch >= 2.2**

- Remove word cloud computation and indexing with a multilingual analyzer (reduce the indexing resources). The better way to compute this word/term cloud will be using a list of provided tokens or tokenizer instead of our custom one.