### PR TITLE
docs: fixed typo errors for terminology section

### DIFF
--- a/docs/_source/getting_started/terminology.md
+++ b/docs/_source/getting_started/terminology.md
@@ -9,8 +9,8 @@ Specific features that are covered by internal `Argilla` functionalities.
 | Terminology | Description |
 | :--- | :--- |
 | Datasets       | Internal `Dataset` classes are lightweight containers for Argilla records.        |
-| Metrics       | Argilla `Metrics` enable you to perform fine-grained analyses of your models and training datasets.        |
-| Queries       | Argilla query functionalities based on the powerful `Elasticsearch` query string syntax.        |
+| Metrics       | Argilla `Metrics` enables you to perform fine-grained analysis of your models and training datasets.        |
+| Queries       | Argilla query functionalities are based on the powerful `Elasticsearch` query string syntax.        |
 
 
 ## MLOps Steps
@@ -28,11 +28,11 @@ All steps that we directly or in-directly cover within the `MLOps lifecycle`.
 
 Main task categories that we cover within the `NLP landscape`.
 
-| Terminology | Description |
-| :--- | :--- |
-| 📕📗 TextClassification      | Assigning predefined category labels to `texts`. This contains sub-taks like detecting sentiment, textual similarity, and multi-label classification. |
-| 🈴🈯️ TokenClassification      | Assigning predefined category labels to `words and phrases within texts` . This contains sub-taks like Named Entity Recognition (NER) and Part-Of-Speech Tagging (POS).      |
-| 👨🏽💬 TextGeneration       | Generating a `text` based on an input `text`.  This contains sub-taks like machine translation, and paraphrase generation. |
+| Terminology | Description                                                                                                                                                              |
+| :--- |:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 📕📗 TextClassification      | Assigning predefined category labels to `texts`. This contains sub-tasks like detecting sentiment, textual similarity, and multi-label classification.                   |
+| 🈴🈯️ TokenClassification      | Assigning predefined category labels to `words and phrases within texts` . This contains sub-tasks like Named Entity Recognition (NER) and Part-Of-Speech Tagging (POS). |
+| 👨🏽💬 TextGeneration       | Generating a `text` based on an input `text`.  This contains sub-tasks like machine translation, and paraphrase generation.                                              |
 
 ## Techniques
 


### PR DESCRIPTION
### Description
Fixed typo errors in the [terminology](https://docs.argilla.io/en/latest/getting_started/terminology.html) section of the document.

