### PR TITLE
fix(API): use query for es-metric computation

### DIFF
--- a/src/argilla/server/daos/backend/client_adapters/opensearch.py
+++ b/src/argilla/server/daos/backend/client_adapters/opensearch.py
@@ -240,6 +240,7 @@ class OpenSearchClient(IClientAdapter):
         with self.error_handling(index=index):
             es_query = self.query_builder.map_2_es_query(
                 schema=self.get_index_schema(index=index),
+                query=query,
             )
 
             results = {}

--- a/src/argilla/server/daos/backend/client_adapters/opensearch.py
+++ b/src/argilla/server/daos/backend/client_adapters/opensearch.py
@@ -121,16 +121,11 @@ class OpenSearchClient(IClientAdapter):
                 size=size,
             )
 
-            if "knn" in es_query["query"]:
-                self._check_vector_supported()
-
-            results = self.__client__.search(
+            results = self._es_search(
                 index=index,
-                body=es_query,
-                routing=routing,
-                track_total_hits=True,
-                rest_total_hits_as_int=True,
+                es_query=es_query,
                 size=size,
+                routing=routing,
             )
 
             return self._process_search_results(
@@ -246,11 +241,10 @@ class OpenSearchClient(IClientAdapter):
             results = {}
             for aggregation in aggregations:
                 es_query["aggs"] = aggregation
-                search = self.__client__.search(
+
+                search = self._es_search(
                     index=index,
-                    body=es_query,
-                    track_total_hits=True,
-                    rest_total_hits_as_int=True,
+                    es_query=es_query,
                     size=0,
                 )
 
@@ -782,3 +776,23 @@ class OpenSearchClient(IClientAdapter):
             data["search_keywords"] = keywords
 
         return data
+
+    def _es_search(
+        self,
+        index: str,
+        es_query: Dict[str, Any],
+        size: int,
+        routing: Optional[str] = None,
+    ):
+        if "knn" in es_query["query"]:
+            self._check_vector_supported()
+
+        results = self.__client__.search(
+            index=index,
+            body=es_query,
+            routing=routing,
+            track_total_hits=True,
+            rest_total_hits_as_int=True,
+            size=size,
+        )
+        return results

--- a/src/argilla/server/daos/backend/search/query_builder.py
+++ b/src/argilla/server/daos/backend/search/query_builder.py
@@ -371,7 +371,7 @@ class EsQueryBuilder:
             "num_candidates": num_candidates,  # TODO: parameterize
             "filter": es_query_filter,
         }
-        es_query.pop("sort")
+        es_query.pop("sort", None)
         del es_query["query"]
 
     def _setup_random_score(self, es_query: Dict[str, Any]):
@@ -404,7 +404,7 @@ class OpenSearchQueryBuilder(EsQueryBuilder):
                 "k": top_k,  # TODO: Input from query
             }
         }
-        es_query.pop("sort")
+        es_query.pop("sort", None)
         filter = es_query.pop("query")
         es_query.update(
             {

--- a/src/argilla/server/daos/records.py
+++ b/src/argilla/server/daos/records.py
@@ -167,7 +167,10 @@ class DatasetRecordsDAO:
             )
             if isinstance(total, dict):
                 total = total["value"]
-            return DaoRecordsSearchResults(total=total, records=records)
+            return DaoRecordsSearchResults(
+                total=total,
+                records=records,
+            )
         except ClosedIndexError:
             raise ClosedDatasetError(dataset.name)
         except IndexNotFoundError:

--- a/src/argilla/server/services/search/service.py
+++ b/src/argilla/server/services/search/service.py
@@ -75,7 +75,10 @@ class SearchRecordsService:
         exclude_fields = ["metrics.*"] if exclude_metrics else None
         results = self.__dao__.search_records(
             dataset,
-            search=DaoRecordsSearch(query=query, sort=sort_config),
+            search=DaoRecordsSearch(
+                query=query,
+                sort=sort_config,
+            ),
             size=size,
             record_from=record_from,
             exclude_fields=exclude_fields,

--- a/tests/server/text_classification/test_api.py
+++ b/tests/server/text_classification/test_api.py
@@ -48,7 +48,7 @@ def test_create_records_for_text_classification_with_multi_label(mocked_client):
                     "one_more": [{"a": 1, "b": 2}],
                 },
                 "prediction": {
-                    "agent": "test",
+                    "agent": "testA",
                     "labels": [
                         {"class": "Test", "score": 0.6},
                         {"class": "Mocking", "score": 0.7},
@@ -60,9 +60,12 @@ def test_create_records_for_text_classification_with_multi_label(mocked_client):
                 "id": 1,
                 "inputs": {"data": "my data"},
                 "multi_label": True,
-                "metadata": {"field_one": "another value one", "field_two": "value 2"},
+                "metadata": {
+                    "field_one": "another value one",
+                    "field_two": "value 2",
+                },
                 "prediction": {
-                    "agent": "test",
+                    "agent": "testB",
                     "labels": [
                         {"class": "Test", "score": 0.6},
                         {"class": "Mocking", "score": 0.7},
@@ -112,7 +115,8 @@ def test_create_records_for_text_classification_with_multi_label(mocked_client):
     assert response.status_code == 200, response.json()
 
     response = mocked_client.post(
-        f"/api/datasets/{dataset}/TextClassification:search", json={}
+        f"/api/datasets/{dataset}/TextClassification:search",
+        json={},
     )
 
     assert response.status_code == 200
@@ -120,6 +124,15 @@ def test_create_records_for_text_classification_with_multi_label(mocked_client):
     assert results.total == 2
     assert results.aggregations.predicted_as == {"Mocking": 2, "Test": 2}
     assert results.records[0].predicted is None
+
+    response = mocked_client.post(
+        f"/api/datasets/{dataset}/TextClassification:search",
+        json={"query": {"predicted_by": ["testA"]}},
+    )
+    assert response.status_code == 200, response.json()
+    results = TextClassificationSearchResults.parse_obj(response.json())
+    assert results.total == len(results.records) == 1
+    assert results.aggregations.predicted_by == {"testA": 1}
 
 
 def test_create_records_for_text_classification(mocked_client, telemetry_track_data):


### PR DESCRIPTION
# Description

Similarity search refactor introduced a fix when es-metric is computed, skipping query settings. This PR fix that problem

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
Included a new failing test case.

**Checklist**

- [x] I have merged the original branch into my forked branch
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I added comments to my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
