### PR TITLE
perf: Optimize word cloud computation

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,6 +33,9 @@ services:
         hard: -1
     networks:
       - argilla
+    ports:
+      - "9200:9200"
+      - "9300:9300"
     volumes:
       - elasticdata:/usr/share/elasticsearch/data
 
@@ -40,7 +43,7 @@ services:
     image: docker.elastic.co/kibana/kibana:7.11.1
     container_name: kibana
     ports:
-      - 5601:5601
+      - "5601:5601"
     environment:
       ELASTICSEARCH_URL: http://elasticsearch:9200
       ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,8 +59,6 @@ server = [
     "luqum >= 0.11,< 0.13",
     # metrics
     "scikit-learn >= 0.24.2",
-    # Words cloud
-    "stopwordsiso ~= 0.6.1",
     # Statics server
     "aiofiles>=0.6,<22.2",
     "PyYAML~=5.4.1",

--- a/src/argilla/server/daos/backend/mappings/helpers.py
+++ b/src/argilla/server/daos/backend/mappings/helpers.py
@@ -14,13 +14,12 @@
 
 from typing import Any, Dict, List
 
+from argilla.server.daos.backend.mappings.stopwords import english
 from argilla.server.settings import settings
 
 EXTENDED_ANALYZER_REF = "extended_analyzer"
 
 MULTILINGUAL_STOP_ANALYZER_REF = "multilingual_stop_analyzer"
-
-DEFAULT_SUPPORTED_LANGUAGES = ["es", "en", "fr", "de"]  # TODO: env var configuration
 
 
 class mappings:
@@ -33,7 +32,7 @@ class mappings:
             "type": "keyword",
         }
         if enable_text_search:
-            text_field = mappings.text_field()
+            text_field = mappings.text_field(with_wordcloud=False)
             text_field_fields = text_field.pop("fields", {})
             mapping["fields"] = {"text": text_field, **text_field_fields}
         return mapping
@@ -53,50 +52,35 @@ class mappings:
         }
 
     @staticmethod
-    def words_text_field():
-        """Mappings config for old `word` field. Deprecated"""
-
-        default_analyzer = settings.default_es_search_analyzer
-        exact_analyzer = settings.exact_es_search_analyzer
-
-        if default_analyzer == "standard":
-            default_analyzer = MULTILINGUAL_STOP_ANALYZER_REF
-
-        if exact_analyzer == "whitespace":
-            exact_analyzer = EXTENDED_ANALYZER_REF
-
-        return {
-            "type": "text",
-            "fielddata": True,
-            "analyzer": default_analyzer,
-            "fields": {
-                "extended": {
-                    "type": "text",
-                    "analyzer": exact_analyzer,
-                }
-            },
-        }
-
-    @staticmethod
-    def text_field():
+    def text_field(with_wordcloud: bool = True):
         """Mappings config for textual field"""
         default_analyzer = settings.default_es_search_analyzer
         exact_analyzer = settings.exact_es_search_analyzer
 
-        return {
+        mappings = {
             "type": "text",
             "analyzer": default_analyzer,
             "fields": {
-                "exact": {"type": "text", "analyzer": exact_analyzer},
-                "wordcloud": {
+                "exact": {
                     "type": "text",
-                    "analyzer": MULTILINGUAL_STOP_ANALYZER_REF,
-                    "fielddata": True,
+                    "analyzer": exact_analyzer,
                 },
             },
-            # TODO(@frascuchon): verify min es version that support meta fields
-            # "meta": {"experimental": "true"},
         }
+
+        if with_wordcloud:
+            mappings["fields"]["wordcloud"] = {
+                "type": "text",
+                "fielddata": True,
+                "fielddata_frequency_filter": {
+                    "min": 0.001,
+                    "max": 0.1,
+                    "min_segment_size": 500,
+                },
+                "analyzer": MULTILINGUAL_STOP_ANALYZER_REF,
+            }
+
+        return mappings
 
     @staticmethod
     def source(includes: List[str] = None, excludes: List[str] = None):
@@ -122,15 +106,45 @@ class mappings:
         return {"dynamic": True, "type": "object"}
 
 
-def multilingual_stop_analyzer(supported_langs: List[str] = None) -> Dict[str, Any]:
-    """Multilingual stop analyzer"""
-    from stopwordsiso import stopwords
-
-    supported_langs = supported_langs or DEFAULT_SUPPORTED_LANGUAGES
-    return {
-        "type": "stop",
-        "stopwords": [w for w in stopwords(supported_langs)],
+def configure_multilingual_stop_analyzer(
+    settings: Dict[str, Any],
+    supported_langs: List[str] = None,
+):
+    lang2elastic_stop = {
+        "en": english.STOPWORDS,
+        "es": "_spanish_",
+        "fr": "_french_",
+        "de": "_german_",
     }
+
+    supported_langs = supported_langs or [lang for lang in lang2elastic_stop]
+
+    def get_value_with_defaults(data: dict, key: str, default):
+        prop = data.get(key)
+        if prop is None:
+            data[key] = default
+        return data[key]
+
+    analysis = get_value_with_defaults(settings, "analysis", {})
+    filter = get_value_with_defaults(analysis, "filter", {})
+    analyzer = get_value_with_defaults(analysis, "analyzer", {})
+
+    filters = []
+    for lang in supported_langs:
+        stopwords = lang2elastic_stop.get(lang)
+        if stopwords:
+            filter[lang] = {
+                "type": "stop",
+                "stopwords": stopwords,
+            }
+            filters.append(lang)
+
+    analyzer[MULTILINGUAL_STOP_ANALYZER_REF] = {
+        "tokenizer": "lowercase",
+        "filter": filters,
+    }
+
+    return settings
 
 
 def extended_analyzer():
@@ -144,16 +158,18 @@ def extended_analyzer():
 
 def tasks_common_settings():
     """Common index settings"""
-    return {
+    es_settings = {
         "number_of_shards": settings.es_records_index_shards,
         "number_of_replicas": settings.es_records_index_replicas,
         "analysis": {
             "analyzer": {
-                MULTILINGUAL_STOP_ANALYZER_REF: multilingual_stop_analyzer(),
                 EXTENDED_ANALYZER_REF: extended_analyzer(),
             }
         },
     }
+
+    configure_multilingual_stop_analyzer(settings=es_settings)
+    return es_settings
 
 
 def dynamic_metrics_text():
@@ -190,7 +206,6 @@ def tasks_common_mappings():
         "dynamic": "strict",
         "properties": {
             "id": mappings.keyword_field(),
-            "words": mappings.words_text_field(),
             "text": mappings.text_field(),
             # TODO(@frascuchon): Enable prediction and annotation
             #  so we can build extra metrics based on these fields

--- a/src/argilla/server/daos/backend/mappings/stopwords/__init__.py
+++ b/src/argilla/server/daos/backend/mappings/stopwords/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/src/argilla/server/daos/backend/mappings/stopwords/english.py
+++ b/src/argilla/server/daos/backend/mappings/stopwords/english.py
@@ -1,0 +1,348 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+stopwords_data = """
+ | From https://snowballstem.org/algorithms/english/stop.txt
+ | This file is distributed under the BSD License.
+ | See https://snowballstem.org/license.html
+ | Also see https://opensource.org/licenses/bsd-license.html
+ |  - Encoding was converted to UTF-8.
+ |  - This notice was added.
+ |
+ | NOTE: To use this file with StopFilterFactory, you must specify format="snowball"
+
+ | An English stop word list. Comments begin with vertical bar. Each stop
+ | word is at the start of a line.
+
+ | Many of the forms below are quite rare (e.g. "yourselves") but included for
+ |  completeness.
+
+           | PRONOUNS FORMS
+             | 1st person sing
+
+i              | subject, always in upper case of course
+
+me             | object
+my             | possessive adjective
+               | the possessive pronoun `mine' is best suppressed, because of the
+               | sense of coal-mine etc.
+myself         | reflexive
+             | 1st person plural
+we             | subject
+
+| us           | object
+               | care is required here because US = United States. It is usually
+               | safe to remove it if it is in lower case.
+our            | possessive adjective
+ours           | possessive pronoun
+ourselves      | reflexive
+             | second person (archaic `thou' forms not included)
+you            | subject and object
+your           | possessive adjective
+yours          | possessive pronoun
+yourself       | reflexive (singular)
+yourselves     | reflexive (plural)
+             | third person singular
+he             | subject
+him            | object
+his            | possessive adjective and pronoun
+himself        | reflexive
+
+she            | subject
+her            | object and possessive adjective
+hers           | possessive pronoun
+herself        | reflexive
+
+it             | subject and object
+its            | possessive adjective
+itself         | reflexive
+             | third person plural
+they           | subject
+them           | object
+their          | possessive adjective
+theirs         | possessive pronoun
+themselves     | reflexive
+             | other forms (demonstratives, interrogatives)
+what
+which
+who
+whom
+this
+that
+these
+those
+
+            | VERB FORMS (using F.R. Palmer's nomenclature)
+             | BE
+am             | 1st person, present
+is             | -s form (3rd person, present)
+are            | present
+was            | 1st person, past
+were           | past
+be             | infinitive
+been           | past participle
+being          | -ing form
+             | HAVE
+have           | simple
+has            | -s form
+had            | past
+having         | -ing form
+             | DO
+do             | simple
+does           | -s form
+did            | past
+doing          | -ing form
+
+ | The forms below are, I believe, best omitted, because of the significant
+ | homonym forms:
+
+ |  He made a WILL
+ |  old tin CAN
+ |  merry month of MAY
+ |  a smell of MUST
+ |  fight the good fight with all thy MIGHT
+
+ | would, could, should, ought might however be included
+
+ |          | AUXILIARIES
+ |            | WILL
+ |will
+
+would
+
+ |            | SHALL
+ |shall
+
+should
+
+ |            | CAN
+ |can
+
+could
+
+ |            | MAY
+ |may
+ |might
+ |            | MUST
+ |must
+ |            | OUGHT
+
+ought
+
+           | COMPOUND FORMS, increasingly encountered nowadays in 'formal' writing
+              | pronoun + verb
+
+i'm
+you're
+he's
+she's
+it's
+we're
+they're
+i've
+you've
+we've
+they've
+i'd
+you'd
+he'd
+she'd
+we'd
+they'd
+i'll
+you'll
+he'll
+she'll
+we'll
+they'll
+
+              | verb + negation
+
+isn't
+aren't
+wasn't
+weren't
+hasn't
+haven't
+hadn't
+doesn't
+don't
+didn't
+
+              | auxiliary + negation
+
+won't
+wouldn't
+shan't
+shouldn't
+can't
+cannot
+couldn't
+mustn't
+
+             | miscellaneous forms
+
+let's
+that's
+who's
+what's
+here's
+there's
+when's
+where's
+why's
+how's
+
+              | rarer forms
+
+ | daren't needn't
+
+              | doubtful forms
+
+ | oughtn't mightn't
+
+           | ARTICLES
+a
+an
+the
+
+           | THE REST (Overlap among prepositions, conjunctions, adverbs etc is so
+           | high, that classification is pointless.)
+and
+but
+if
+or
+because
+as
+until
+while
+
+of
+at
+by
+for
+with
+about
+against
+between
+into
+through
+during
+before
+after
+above
+below
+to
+from
+up
+down
+in
+out
+on
+off
+over
+under
+
+again
+further
+then
+once
+
+here
+there
+when
+where
+why
+how
+
+all
+any
+both
+each
+few
+more
+most
+other
+some
+such
+
+no
+nor
+not
+only
+own
+same
+so
+than
+too
+very
+
+| Just for the record, the following words are among the commonest in English
+
+    | one
+    | every
+    | least
+    | less
+    | many
+    | now
+    | ever
+    | never
+    | say
+    | says
+    | said
+    | also
+    | get
+    | go
+    | goes
+    | just
+    | made
+    | make
+    | put
+    | see
+    | seen
+    | whether
+    | like
+    | well
+    | back
+    | even
+    | still
+    | way
+    | take
+    | since
+    | another
+    | however
+    | two
+    | three
+    | four
+    | five
+    | first
+    | second
+    | new
+    | old
+    | high
+    | long
+
+"""
+
+
+def read_stopwords(data: str):
+    stopwords = []
+    for line in data.split("\n"):
+        word = line.split("|")[0].strip()
+        if word:
+            stopwords.append(word)
+    return list(set(stopwords))
+
+
+STOPWORDS = read_stopwords(stopwords_data)

--- a/src/argilla/server/daos/backend/mappings/text2text.py
+++ b/src/argilla/server/daos/backend/mappings/text2text.py
@@ -20,7 +20,6 @@ def text2text_mappings():
     return {
         "_source": mappings.source(
             excludes=[
-                # "words", # Cannot be exclude since comment text_length metric  is computed using this source fields
                 "predicted",
                 "predicted_as",
                 "predicted_by",
@@ -32,7 +31,7 @@ def text2text_mappings():
         "properties": {
             "annotated_as": mappings.keyword_field(),
             "predicted_as": mappings.keyword_field(),
-            "text_predicted": mappings.words_text_field(),
-            "score": {"type": "float"},
+            "text_predicted": mappings.text_field(),
+            "score": mappings.decimal_field(),
         },
     }

--- a/src/argilla/server/daos/backend/mappings/text_classification.py
+++ b/src/argilla/server/daos/backend/mappings/text_classification.py
@@ -20,7 +20,6 @@ def text_classification_mappings():
     return {
         "_source": mappings.source(
             excludes=[
-                # "words", # Cannot be exclude since comment text_length metric  is computed using this source fields
                 "predicted",
                 "predicted_as",
                 "predicted_by",
@@ -46,6 +45,11 @@ def text_classification_mappings():
             "score": mappings.decimal_field(),
         },
         "dynamic_templates": [
-            {"inputs.*": {"path_match": "inputs.*", "mapping": mappings.text_field()}}
+            {
+                "inputs.*": {
+                    "path_match": "inputs.*",
+                    "mapping": mappings.text_field(),
+                }
+            }
         ],
     }

--- a/src/argilla/server/daos/backend/mappings/token_classification.py
+++ b/src/argilla/server/daos/backend/mappings/token_classification.py
@@ -68,7 +68,6 @@ def token_classification_mappings():
     return {
         "_source": mappings.source(
             excludes=[
-                # "words", # Cannot be exclude since comment text_length metric  is computed using this source fields
                 "predicted",
                 "predicted_as",
                 "predicted_by",

--- a/src/argilla/server/daos/backend/metrics/base.py
+++ b/src/argilla/server/daos/backend/metrics/base.py
@@ -197,13 +197,17 @@ class NestedHistogramAggregation(NestedPathElasticsearchMetric):
 class WordCloudAggregation(ElasticsearchMetric):
     default_field: str
 
+    DEFAULT_WORDCOUNT_SIZE = 80
+
     def _build_aggregation(
-        self, text_field: str = None, size: int = None
+        self,
+        text_field: str = None,
+        size: int = None,
     ) -> Dict[str, Any]:
         field = text_field or self.default_field
         terms_id = f"{self.id}_{field}" if text_field else self.id
         return TermsAggregation(id=terms_id, field=field,).aggregation_request(
-            size=size
+            size=size or self.DEFAULT_WORDCOUNT_SIZE
         )[terms_id]
 
 

--- a/src/argilla/server/services/tasks/text2text/models.py
+++ b/src/argilla/server/services/tasks/text2text/models.py
@@ -81,7 +81,6 @@ class ServiceText2TextRecord(ServiceBaseRecord[ServiceText2TextAnnotation]):
             "annotated_by": self.annotated_by,
             "predicted_by": self.predicted_by,
             "score": self.scores,
-            "words": self.all_text(),
         }
 
 

--- a/src/argilla/server/services/tasks/text_classification/model.py
+++ b/src/argilla/server/services/tasks/text_classification/model.py
@@ -329,7 +329,6 @@ class ServiceTextClassificationRecord(ServiceBaseRecord[TextClassificationAnnota
         words = self.all_text()
         return {
             **super().extended_fields(),
-            "words": words,
             "text": words,
         }
 

--- a/src/argilla/server/services/tasks/token_classification/model.py
+++ b/src/argilla/server/services/tasks/token_classification/model.py
@@ -99,7 +99,6 @@ class ServiceTokenClassificationRecord(
                 {"mention": mention, "entity": entity.label}
                 for mention, entity in self.annotated_mentions()
             ],
-            "words": self.all_text(),
         }
 
     def __init__(self, **data):

--- a/tests/server/text2text/test_api.py
+++ b/tests/server/text2text/test_api.py
@@ -75,7 +75,11 @@ def test_search_records(mocked_client):
         "predicted_by": {"test": 1},
         "predicted_text": {},
         "status": {"Default": 2},
-        "words": {"data": 2, "ånother": 1},
+        "words": {
+            "data": 2,
+            "text": 1,
+            "ånother": 1,
+        },
     }
 
 

--- a/tests/server/token_classification/test_api.py
+++ b/tests/server/token_classification/test_api.py
@@ -215,7 +215,7 @@ def test_create_records_for_token_classification(
         "predicted_by": {"test": 1},
         "predicted_mentions": {"TEST": {"This": 1}},
         "status": {"Default": 1},
-        "words": {},
+        "words": {"text": 1},
     }
 
     assert "This" in results.aggregations.predicted_mentions[entity_label]


### PR DESCRIPTION
# Description

Sometimes, for huge datasets, the word cloud metric can introduce some problems loading the dataset. This PR introduces a better way to compute it and avoid those situations.

Also:
- Remove stopwords-iso deps
- Create the multi-lingual stop analyzer using standard filters (All but English. See https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-stop-tokenfilter.html#analysis-stop-tokenfilter)
- Remove refs to unused field `words`

Refs #1757 

**Checklist**

- [x] I have merged the original branch into my forked branch
- [x] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I added comments to my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
