### PR TITLE
chore: Adapt tests utils to httpx version variability

### DIFF
--- a/tests/functional_tests/test_log_for_token_classification.py
+++ b/tests/functional_tests/test_log_for_token_classification.py
@@ -517,7 +517,7 @@ def test_search_keywords(mocked_client):
     from datasets import load_dataset
 
     # TODO(@frascuchon): Move dataset to new organization
-    dataset_ds = load_dataset("rubrix/gutenberg_spacy-ner", split="train")
+    dataset_ds = load_dataset("argilla/gutenberg_spacy-ner", split="train")
     dataset_rb = argilla.read_datasets(dataset_ds, task="TokenClassification")
 
     argilla.delete(dataset)

--- a/tests/server/datasets/test_api.py
+++ b/tests/server/datasets/test_api.py
@@ -247,7 +247,8 @@ def test_delete_records(mocked_client):
         ],
     )
     response = mocked_client.delete(
-        f"/api/datasets/{dataset_name}/data", json={"ids": [1]}
+        f"/api/datasets/{dataset_name}/data",
+        json={"ids": [1]},
     )
     assert response.status_code == 200
     assert response.json() == {"matched": 1, "processed": 1}


### PR DESCRIPTION
# Description

Just supports several httpx versions for test helpers. Mainly:

- Uses httpx.request ("DELETE",...) instead of `httpx.delete` to pass json data properly 
- Detect `stream` method and use it instead of `stream=True` parameter for GET and POST


**Checklist**

- [x] I have merged the original branch into my forked branch
- [x] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I added comments to my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
