### PR TITLE
feat: Keep previous pagination size after remove similarity filter

### DIFF
--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -232,9 +232,9 @@ async function _callSearchApi({ dataset, query, sort, size, from = 0 }) {
     query_text: newQueryText,
     vector: vector
       ? {
-        name: vector_name,
-        value: vector_values,
-      }
+          name: vector_name,
+          value: vector_values,
+        }
       : null,
   };
 
@@ -270,8 +270,8 @@ const queryTextCurryFactory = (queryText1) => (queryText2) =>
   queryText2 === undefined
     ? queryText1
     : queryTextCurryFactory(
-      `${queryText1} ${queryText1.length ? "AND" : ""} ${queryText2}`.trim()
-    );
+        `${queryText1} ${queryText1.length ? "AND" : ""} ${queryText2}`.trim()
+      );
 
 async function _querySearch({ dataset, query, sort, size }) {
   const save = size == 0 ? false : true;
@@ -466,26 +466,26 @@ async function _updateTaskDataset({ dataset, data }) {
 }
 
 async function _updatePagination({ id, size, page }) {
-  const updatedSize = getSizeRecords(size);
+  //const updatedSize = getSizeRecords(size);
   const pagination = await Pagination.update({
     where: id,
-    data: { size: updatedSize, page },
+    data: { size, page },
   });
 
   return pagination;
 }
 
-const getSizeRecords = (size) => {
-  const isWeakLabelingView = $nuxt.$route.query.viewMode === "labelling-rules";
-  const isSimilaritySearch = $nuxt.$route.query.vectorId;
-  const sizeIfSimilaritySearchisActivate = 50;
-  const updatedSize =
-    !isWeakLabelingView && isSimilaritySearch
-      ? sizeIfSimilaritySearchisActivate
-      : size;
+// const getSizeRecords = (size) => {
+//   const isWeakLabelingView = $nuxt.$route.query.viewMode === "labelling-rules";
+//   const isSimilaritySearch = $nuxt.$route.query.vectorId;
+//   const sizeIfSimilaritySearchisActivate = 50;
+//   const updatedSize =
+//     !isWeakLabelingView && isSimilaritySearch
+//       ? sizeIfSimilaritySearchisActivate
+//       : size;
 
-  return updatedSize;
-};
+//   return updatedSize;
+// };
 
 const getters = {
   findByName: () => (name) => {

--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -466,7 +466,6 @@ async function _updateTaskDataset({ dataset, data }) {
 }
 
 async function _updatePagination({ id, size, page }) {
-  //const updatedSize = getSizeRecords(size);
   const pagination = await Pagination.update({
     where: id,
     data: { size, page },
@@ -474,18 +473,6 @@ async function _updatePagination({ id, size, page }) {
 
   return pagination;
 }
-
-// const getSizeRecords = (size) => {
-//   const isWeakLabelingView = $nuxt.$route.query.viewMode === "labelling-rules";
-//   const isSimilaritySearch = $nuxt.$route.query.vectorId;
-//   const sizeIfSimilaritySearchisActivate = 50;
-//   const updatedSize =
-//     !isWeakLabelingView && isSimilaritySearch
-//       ? sizeIfSimilaritySearchisActivate
-//       : size;
-
-//   return updatedSize;
-// };
 
 const getters = {
   findByName: () => (name) => {

--- a/frontend/models/Dataset.js
+++ b/frontend/models/Dataset.js
@@ -79,11 +79,7 @@ class ObservationDataset extends Model {
   }
 
   get visibleRecords() {
-    if (this.viewSettings.pagination.disabledPagination) {
-      return this.results.records;
-    } else {
-      return this.results.records.slice(0, this.viewSettings.pagination.size);
-    }
+    return this.results.records;
   }
 
   static fields() {

--- a/frontend/models/Dataset.js
+++ b/frontend/models/Dataset.js
@@ -79,7 +79,11 @@ class ObservationDataset extends Model {
   }
 
   get visibleRecords() {
-    return this.results.records.slice(0, this.viewSettings.pagination.size);
+    if (this.viewSettings.pagination.disabledPagination) {
+      return this.results.records;
+    } else {
+      return this.results.records.slice(0, this.viewSettings.pagination.size);
+    }
   }
 
   static fields() {

--- a/frontend/models/DatasetViewSettings.js
+++ b/frontend/models/DatasetViewSettings.js
@@ -28,7 +28,6 @@ class Pagination extends Model {
       pageSizeOptions: this.attr([1, 10, 20, 50, 100]),
       maxRecordsLimit: this.number(10000),
       disabledShortCutPagination: this.boolean(false),
-      disabledPagination: this.boolean(false),
     };
   }
 
@@ -70,14 +69,6 @@ export default class DatasetViewSettings extends Model {
       where: this.$id,
       data: {
         visibleRulesList: false,
-      },
-    });
-  }
-  async disablePagination(value) {
-    return await Pagination.update({
-      where: this.$id,
-      data: {
-        disabledPagination: value,
       },
     });
   }

--- a/frontend/models/DatasetViewSettings.js
+++ b/frontend/models/DatasetViewSettings.js
@@ -28,6 +28,7 @@ class Pagination extends Model {
       pageSizeOptions: this.attr([1, 10, 20, 50, 100]),
       maxRecordsLimit: this.number(10000),
       disabledShortCutPagination: this.boolean(false),
+      disabledPagination: this.boolean(false),
     };
   }
 
@@ -72,7 +73,14 @@ export default class DatasetViewSettings extends Model {
       },
     });
   }
-
+  async disablePagination(value) {
+    return await Pagination.update({
+      where: this.$id,
+      data: {
+        disabledPagination: value,
+      },
+    });
+  }
   async disableShortCutPagination(value) {
     return await Pagination.update({
       where: this.$id,

--- a/frontend/pages/datasets/_workspace/_dataset/index.vue
+++ b/frontend/pages/datasets/_workspace/_dataset/index.vue
@@ -63,8 +63,8 @@ export default {
     // 4. If we have a vector filter, apply a search
     if (this.referenceRecordId) {
       await this.searchRecords({ query: this.dataset.query });
+      await this.disablePagination(true);
     }
-
   },
   computed: {
     ...mapGetters({
@@ -113,7 +113,7 @@ export default {
       return this.dataset && this.dataset.viewSettings.viewMode === "annotate";
     },
     isReferenceRecord() {
-      const value = VectorModel.query().where("is_active", true).first()
+      const value = VectorModel.query().where("is_active", true).first();
       return !!value;
     },
   },
@@ -160,6 +160,7 @@ export default {
       if (!vector) {
         // Update url query params
         this.updateUrlParamsWithVectorInfo(null);
+        await this.disablePagination(false);
       } else {
         const { vectorId } = vector;
         // 1. Fetch record reference data
@@ -169,8 +170,10 @@ export default {
           where: vectorId,
           data: { is_active: true },
         });
-        // 4. Update url query params
+        // 3. Update url query params
         this.updateUrlParamsWithVectorInfo(vectorData);
+        // 4. Disable pagination
+        await this.disablePagination(true);
       }
     },
     async activateVectorAndRecorByUrlQueryParams() {
@@ -252,6 +255,9 @@ export default {
         );
       }
     },
+    async disablePagination(value) {
+      await this.dataset.viewSettings.disablePagination(value);
+    }
   },
 };
 </script>

--- a/frontend/pages/datasets/_workspace/_dataset/index.vue
+++ b/frontend/pages/datasets/_workspace/_dataset/index.vue
@@ -63,7 +63,6 @@ export default {
     // 4. If we have a vector filter, apply a search
     if (this.referenceRecordId) {
       await this.searchRecords({ query: this.dataset.query });
-      await this.disablePagination(true);
     }
   },
   computed: {
@@ -160,7 +159,6 @@ export default {
       if (!vector) {
         // Update url query params
         this.updateUrlParamsWithVectorInfo(null);
-        await this.disablePagination(false);
       } else {
         const { vectorId } = vector;
         // 1. Fetch record reference data
@@ -172,8 +170,6 @@ export default {
         });
         // 3. Update url query params
         this.updateUrlParamsWithVectorInfo(vectorData);
-        // 4. Disable pagination
-        await this.disablePagination(true);
       }
     },
     async activateVectorAndRecorByUrlQueryParams() {
@@ -255,9 +251,6 @@ export default {
         );
       }
     },
-    async disablePagination(value) {
-      await this.dataset.viewSettings.disablePagination(value);
-    }
   },
 };
 </script>


### PR DESCRIPTION
# Description

This PR allows to disable pagination for similarity search keeping the previous pagination size

**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**How Has This Been Tested**

Please describe the tests that you ran to verify your changes. And ideally reference `tests`.

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I added comments to my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
