### PR TITLE
feat: Use <button> tag instead of <a> tag for sidebar buttons

### DIFF
--- a/frontend/assets/scss/abstract/mixins/_mixins.scss
+++ b/frontend/assets/scss/abstract/mixins/_mixins.scss
@@ -263,7 +263,6 @@
 }
 
 @mixin resetButtonStyles() {
-  display: flex;
   outline: none;
   border: none;
   background: none;

--- a/frontend/assets/scss/abstract/mixins/_mixins.scss
+++ b/frontend/assets/scss/abstract/mixins/_mixins.scss
@@ -261,3 +261,11 @@
   left: 50%;
   transform: translate(-50%, -50%);
 }
+
+@mixin resetButtonStyles() {
+  display: flex;
+  outline: none;
+  border: none;
+  background: none;
+  margin: auto;
+}

--- a/frontend/components/commons/sidebar/SidebarButton.vue
+++ b/frontend/components/commons/sidebar/SidebarButton.vue
@@ -59,11 +59,7 @@ export default {
 
 <style lang="scss" scoped>
 .sidebar-button {
-  display: flex;
-  outline: none;
-  border: none;
-  background: none;
-  margin: auto;
+  @include resetButtonStyles();
   &.mode {
     &:hover {
       .svg-icon {

--- a/frontend/components/commons/sidebar/SidebarButton.vue
+++ b/frontend/components/commons/sidebar/SidebarButton.vue
@@ -1,13 +1,12 @@
 <template>
-  <a
+  <button
     class="sidebar-button"
     :class="sidebarButtonClass"
-    href="#"
     :data-title="tooltip"
     @click="$emit('button-action', id)"
   >
     <svgicon :name="icon"></svgicon>
-  </a>
+  </button>
 </template>
 
 <script>
@@ -60,6 +59,11 @@ export default {
 
 <style lang="scss" scoped>
 .sidebar-button {
+  display: flex;
+  outline: none;
+  border: none;
+  background: none;
+  margin: auto;
   &.mode {
     &:hover {
       .svg-icon {

--- a/frontend/components/commons/sidebar/SidebarButton.vue
+++ b/frontend/components/commons/sidebar/SidebarButton.vue
@@ -60,6 +60,7 @@ export default {
 <style lang="scss" scoped>
 .sidebar-button {
   @include resetButtonStyles();
+  display: flex;
   &.mode {
     &:hover {
       .svg-icon {


### PR DESCRIPTION
# Description

This PR replaces the <a> tag with <button> to prevent changing the url without the new base_url and to make it more semantic

See #2138

**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**How Has This Been Tested**

Please describe the tests that you ran to verify your changes. And ideally reference `tests`.

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I added comments to my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
