### PR TITLE
add repr method for Rule, Dataset.

### DIFF
--- a/src/argilla/client/datasets.py
+++ b/src/argilla/client/datasets.py
@@ -141,6 +141,12 @@ class DatasetBase:
     def __len__(self) -> int:
         return len(self._records)
 
+    def __repr__(self):
+        return repr(self.to_pandas())
+
+    def __str__(self):
+        return repr(self)
+
     @_requires_datasets
     def to_datasets(self) -> "datasets.Dataset":
         """Exports your records to a `datasets.Dataset`.
@@ -655,12 +661,6 @@ class DatasetForTextClassification(DatasetBase):
         return datasets.Dataset.from_dict(
             ds_dict, features=datasets.Features(feature_dict)
         )
-
-    def __repr__(self):
-        return repr(self.to_pandas())
-
-    def __str__(self):
-        return repr(self)
 
 
 class Framework(Enum):

--- a/src/argilla/client/datasets.py
+++ b/src/argilla/client/datasets.py
@@ -657,16 +657,7 @@ class DatasetForTextClassification(DatasetBase):
         )
 
     def __repr__(self):
-        header_string = (
-            f"{''.ljust(4)}\t{'text'.ljust(30)}\t{'annotation'}\t{'prediction'}"
-        )
-        repr_list = [
-            f"{str(i).ljust(4)}\t{rec.text[:30].ljust(30)}\t{str(rec.annotation).ljust(10)}\t{str(rec.prediction).ljust(10)}"
-            for i, rec in enumerate(self._records[:5])
-        ]
-        record_string = "\n".join(repr_list)
-        count_string = f"{len(self._records)} TextClassificationRecord records"
-        return "\n".join([header_string, record_string, "...", count_string])
+        return repr(self.to_pandas())
 
     def __str__(self):
         return repr(self)

--- a/src/argilla/client/datasets.py
+++ b/src/argilla/client/datasets.py
@@ -657,14 +657,20 @@ class DatasetForTextClassification(DatasetBase):
         )
 
     def __repr__(self):
-        header_string = f"{''.ljust(4)}\t{'text'.ljust(30)}\t{'annotation'}\t{'prediction'}"
-        repr_list = [f"{str(i).ljust(4)}\t{rec.text[:30].ljust(30)}\t{str(rec.annotation).ljust(10)}\t{str(rec.prediction).ljust(10)}" for i, rec in enumerate(self._records[:5])]
+        header_string = (
+            f"{''.ljust(4)}\t{'text'.ljust(30)}\t{'annotation'}\t{'prediction'}"
+        )
+        repr_list = [
+            f"{str(i).ljust(4)}\t{rec.text[:30].ljust(30)}\t{str(rec.annotation).ljust(10)}\t{str(rec.prediction).ljust(10)}"
+            for i, rec in enumerate(self._records[:5])
+        ]
         record_string = "\n".join(repr_list)
         count_string = f"{len(self._records)} TextClassificationRecord records"
-        return "\n".join([header_string, record_string,"...", count_string])
+        return "\n".join([header_string, record_string, "...", count_string])
 
     def __str__(self):
         return repr(self)
+
 
 class Framework(Enum):
     TRANSFORMERS = "transformers"

--- a/src/argilla/client/datasets.py
+++ b/src/argilla/client/datasets.py
@@ -656,6 +656,15 @@ class DatasetForTextClassification(DatasetBase):
             ds_dict, features=datasets.Features(feature_dict)
         )
 
+    def __repr__(self):
+        header_string = f"{''.ljust(4)}\t{'text'.ljust(30)}\t{'annotation'}\t{'prediction'}"
+        repr_list = [f"{str(i).ljust(4)}\t{rec.text[:30].ljust(30)}\t{str(rec.annotation).ljust(10)}\t{str(rec.prediction).ljust(10)}" for i, rec in enumerate(self._records[:5])]
+        record_string = "\n".join(repr_list)
+        count_string = f"{len(self._records)} TextClassificationRecord records"
+        return "\n".join([header_string, record_string,"...", count_string])
+
+    def __str__(self):
+        return repr(self)
 
 class Framework(Enum):
     TRANSFORMERS = "transformers"

--- a/src/argilla/labeling/text_classification/rule.py
+++ b/src/argilla/labeling/text_classification/rule.py
@@ -180,6 +180,7 @@ class Rule:
         """The rule string representation."""
         return repr(self)
 
+
 def add_rules(dataset: str, rules: List[Rule]):
     """Adds the rules to a given dataset
 

--- a/src/argilla/labeling/text_classification/rule.py
+++ b/src/argilla/labeling/text_classification/rule.py
@@ -172,6 +172,13 @@ class Rule:
         else:
             return self._label
 
+    def __repr__(self):
+        """The rule representation."""
+        return f"Rule(query='{self.query}', label='{self.label}', name='{self.name}')"
+
+    def __str__(self):
+        """The rule string representation."""
+        return repr(self)
 
 def add_rules(dataset: str, rules: List[Rule]):
     """Adds the rules to a given dataset


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Closes #2046 

**Type of change**

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

Please describe the tests that you ran to verify your changes. And ideally reference `tests`.
```
import argilla as rg
from argilla.labeling.text_classification.rule import Rule

plz = Rule(query="plz OR please", label="SPAM")
print(repr(plz))
>>> Rule(query='plz OR please', label='SPAM', name='plz OR please')


records = [
        rg.TextClassificationRecord(text="example"),
        rg.TextClassificationRecord(text="another example"),
        rg.TextClassificationRecord(text="another example another example another example another example another example another example"),
    ]
dataset = rg.DatasetForTextClassification(records=records)
print(dataset)
>>>
    	text                          	annotation	prediction
0   	example                       	None      	None      
1   	another example               	None      	None      
2   	another example another exampl	None      	None      
...
3 TextClassificationRecord records

```

**Checklist**

- [x] I have merged the original branch into my forked branch
- [x] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I added comments to my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
