### PR TITLE
perf: Exclude heavy record fields on python metrics computation

### DIFF
--- a/src/argilla/server/daos/backend/client_adapters/base.py
+++ b/src/argilla/server/daos/backend/client_adapters/base.py
@@ -72,6 +72,7 @@ class IClientAdapter(metaclass=ABCMeta):
         enable_highlight: bool = False,
         sort: Optional[SortConfig] = None,
         include_fields: Optional[List[str]] = None,
+        exclude_fields: Optional[List[str]] = None,
         shuffle: bool = False,
     ) -> Iterable[Dict[str, Any]]:
         pass

--- a/src/argilla/server/daos/backend/client_adapters/opensearch.py
+++ b/src/argilla/server/daos/backend/client_adapters/opensearch.py
@@ -325,6 +325,7 @@ class OpenSearchClient(IClientAdapter):
         enable_highlight: bool = False,
         sort: Optional[SortConfig] = None,
         include_fields: Optional[List[str]] = None,
+        exclude_fields: Optional[List[str]] = None,
         shuffle: bool = False,
     ) -> Iterable[Dict[str, Any]]:
         size = size or 1000
@@ -337,6 +338,7 @@ class OpenSearchClient(IClientAdapter):
             sort=sort,
             id_from=id_from,
             include_fields=include_fields,
+            exclude_fields=exclude_fields,
             highlight=highlight,
             shuffle=shuffle,
         )

--- a/src/argilla/server/daos/backend/generic_elastic.py
+++ b/src/argilla/server/daos/backend/generic_elastic.py
@@ -219,6 +219,7 @@ class GenericElasticEngineBackend(LoggingMixin):
         limit: Optional[int] = None,
         shuffle: bool = False,
         include_fields: Optional[List[str]] = None,
+        exclude_fields: Optional[List[str]] = None,
     ) -> Iterable[Dict[str, Any]]:
         index = dataset_records_index(id)
 
@@ -229,6 +230,7 @@ class GenericElasticEngineBackend(LoggingMixin):
             id_from=id_from,
             fetch_once=shuffle,
             include_fields=include_fields,
+            exclude_fields=exclude_fields,
             enable_highlight=True,
             shuffle=shuffle,
         )

--- a/src/argilla/server/daos/records.py
+++ b/src/argilla/server/daos/records.py
@@ -186,6 +186,7 @@ class DatasetRecordsDAO:
         id_from: Optional[str] = None,
         shuffle: bool = False,
         include_fields: Optional[Set[str]] = None,
+        exclude_fields: Optional[Set[str]] = None,
     ) -> Iterable[Dict[str, Any]]:
         """
         Iterates over a dataset records
@@ -202,6 +203,8 @@ class DatasetRecordsDAO:
             From which ID should we start iterating
         include_fields:
             A set of record fields to retrieve. Wildcard are allowed
+        exclude_fields:
+            A set of record fields to exclude. Wildcard are allowed
 
         Returns
         -------
@@ -215,6 +218,7 @@ class DatasetRecordsDAO:
             id_from=id_from,
             shuffle=shuffle,
             include_fields=list(include_fields) if include_fields else None,
+            exclude_fields=list(exclude_fields) if exclude_fields else None,
         )
 
     async def delete_records_by_query(

--- a/src/argilla/server/services/metrics/service.py
+++ b/src/argilla/server/services/metrics/service.py
@@ -102,6 +102,11 @@ class MetricsService:
                 search=DaoRecordsSearch(query=query),
                 shuffle=metric.shuffle_records,
                 limit=metric.records_to_fetch,
+                exclude_fields={
+                    "vectors",
+                    "metrics",
+                    "metadata",
+                },  # Load records more efficiently
             )
             return metric.apply(map(record_class.parse_obj, records))
 


### PR DESCRIPTION
# Description

Exclude heavy record fields like `vectors` or `metrics` when computing a python-based metric.