### PR TITLE
fix: Pass vector search k to metrics computation

### DIFF
--- a/src/argilla/server/daos/backend/search/model.py
+++ b/src/argilla/server/daos/backend/search/model.py
@@ -69,6 +69,11 @@ class BaseDatasetsQuery(BaseQuery):
 class VectorSearch(BaseModel):
     name: str
     value: List[float]
+    k: Optional[int] = Field(
+        default=None,
+        description="Number of elements to retrieve. "
+        "If not provided, the request size will be used instead",
+    )
 
 
 class BaseRecordsQuery(BaseQuery):

--- a/src/argilla/server/daos/backend/search/query_builder.py
+++ b/src/argilla/server/daos/backend/search/query_builder.py
@@ -231,7 +231,7 @@ class EsQueryBuilder:
                 es_query=es_query,
                 vector_field=self.get_vector_field_name(query.vector.name),
                 vector_value=query.vector.value,
-                top_k=size,
+                top_k=query.vector.k or size,
             )
 
         return es_query

--- a/src/argilla/server/services/search/service.py
+++ b/src/argilla/server/services/search/service.py
@@ -73,7 +73,7 @@ class SearchRecordsService:
 
         sort_config = sort_config or ServiceSortConfig()
         exclude_fields = ["metrics.*"] if exclude_metrics else None
-        if query.vector and not query.vector.k:
+        if query and query.vector and not query.vector.k:
             query.vector.k = size
         results = self.__dao__.search_records(
             dataset,

--- a/src/argilla/server/services/search/service.py
+++ b/src/argilla/server/services/search/service.py
@@ -73,6 +73,8 @@ class SearchRecordsService:
 
         sort_config = sort_config or ServiceSortConfig()
         exclude_fields = ["metrics.*"] if exclude_metrics else None
+        if query.vector and not query.vector.k:
+            query.vector.k = size
         results = self.__dao__.search_records(
             dataset,
             search=DaoRecordsSearch(


### PR DESCRIPTION
Metrics were computed with default k=5 when the semantic search is enabled. This PR adds the k parameter to metrics computation.