### PR TITLE
feat: The records in virtual scroll overlaps to Reference Record

### DIFF
--- a/frontend/components/commons/results/ResultsList.vue
+++ b/frontend/components/commons/results/ResultsList.vue
@@ -210,6 +210,7 @@ export default {
 <style lang="scss">
 .vue-recycle-scroller__item-wrapper {
   box-sizing: content-box;
+  z-index: 0;
 }
 
 .vue-recycle-scroller__item-view {


### PR DESCRIPTION
# Description

This PR includes z-index in virtual scroller to prevent the records in virtual scroll from overlapping to Reference Record

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**How Has This Been Tested**

Please describe the tests that you ran to verify your changes. And ideally reference `tests`.

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I added comments to my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
