### PR TITLE
chore(fix): Support multiple es versions but provide vectors support only with 8.x client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ server = [
     # Basic dependencies
     "fastapi >= 0.75,< 0.89",
     "opensearch-py >= 1.0,< 2.1",
-    "elasticsearch ~=8.5.0",
+    "elasticsearch >=7.11.0,< 8.6.0",
     "uvicorn[standard] >= 0.15.0,< 0.21.0",
     "smart-open",
     "brotli-asgi >= 1.1,< 1.3",

--- a/src/argilla/server/daos/backend/client_adapters/elasticsearch.py
+++ b/src/argilla/server/daos/backend/client_adapters/elasticsearch.py
@@ -13,25 +13,28 @@
 #  limitations under the License.
 
 import dataclasses
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, Optional, Tuple
 
-from elasticsearch import (
-    ApiError,
-    Elasticsearch,
-    ElasticsearchWarning,
-    NotFoundError,
-    RequestError,
-    helpers,
-)
+import elasticsearch
+from elasticsearch import Elasticsearch, NotFoundError, RequestError, helpers
+from packaging.version import parse
 
 from argilla.server.daos.backend.base import BackendErrorHandler
 from argilla.server.daos.backend.client_adapters.opensearch import OpenSearchClient
-from argilla.server.daos.backend.search.model import BaseQuery, SortConfig
 from argilla.server.daos.backend.search.query_builder import EsQueryBuilder
+
+ES_CLIENT_VERSION: str = elasticsearch.__versionstr__
+
+if parse(elasticsearch.__versionstr__) >= parse("8.0"):
+    from elasticsearch import ApiError, ElasticsearchWarning
+else:
+    from elasticsearch.exceptions import ElasticsearchException as ApiError
+    from elasticsearch.exceptions import ElasticsearchWarning
 
 
 @dataclasses.dataclass
 class ElasticsearchClient(OpenSearchClient):
+    ES_CLIENT_VERSION = ES_CLIENT_VERSION
     query_builder = EsQueryBuilder()
 
     def __post_init__(self):


### PR DESCRIPTION
Like previous argilla server versions, allow having an elasticsearch client installed (other than 8.5.x) and still launch the application.

The vector support won't be available for those clients and a message will be raised.