### PR TITLE
chore(fix): Scroll to first result after query

### DIFF
--- a/frontend/components/commons/results/ResultsList.vue
+++ b/frontend/components/commons/results/ResultsList.vue
@@ -26,6 +26,7 @@
           :items="visibleRecords"
           :min-item-size="550"
           :buffer="200"
+          :key="showLoader"
         >
           <template #before>
             <slot name="results-header" />
@@ -169,7 +170,6 @@ export default {
       this.selectedRecord = undefined;
     },
     async onPagination(page, size) {
-      document.getElementById("scroll").scrollTop = 0;
       await this.paginate({
         dataset: this.dataset,
         page: page,


### PR DESCRIPTION
# Description

This PR removes the old logic and use loading status to refresh the virtual scroll position after query

**Type of change**

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**How Has This Been Tested**

Please describe the tests that you ran to verify your changes. And ideally reference `tests`.

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I added comments to my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
