### PR TITLE
fix(Client): check url underscore only for hostnames

### DIFF
--- a/src/argilla/client/sdk/client.py
+++ b/src/argilla/client/sdk/client.py
@@ -17,6 +17,7 @@ import datetime
 import functools
 import inspect
 import uuid
+from urllib.parse import urlparse
 
 from pydantic import BaseModel
 
@@ -61,7 +62,9 @@ class _Client:
         self.base_url = self.base_url.strip()
         if self.base_url.endswith("/"):
             self.base_url = self.base_url[:-1]
-        if "_" in self.base_url and self.base_url.startswith("https://"):
+
+        url = urlparse(self.base_url)
+        if url.scheme == "https" and "_" in url.hostname:
             self.__httpx__ = None
             raise ValueError(
                 'Avoid using hostnames with underscores "_". For reference see:'
@@ -293,7 +296,11 @@ ResponseType = TypeVar("ResponseType")
 
 
 @dataclasses.dataclass
-class AuthenticatedClient(Client, _ClientCommonDefaults, _AuthenticatedClient):
+class AuthenticatedClient(
+    Client,
+    _ClientCommonDefaults,
+    _AuthenticatedClient,
+):
     """A Client which has been authenticated for use on secured endpoints"""
 
     def __hash__(self):

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -35,14 +35,17 @@ from argilla.client.sdk.token_classification.models import (
 from argilla.server.daos.backend.client_adapters.factory import ClientAdapterFactory
 from argilla.server.settings import settings
 
-client = ClientAdapterFactory.get(
-    hosts=settings.elasticsearch,
-    index_shards=settings.es_records_index_shards,
-    ssl_verify=settings.elasticsearch_ssl_verify,
-    ca_path=settings.elasticsearch_ca_path,
-)
+try:
+    client = ClientAdapterFactory.get(
+        hosts=settings.elasticsearch,
+        index_shards=settings.es_records_index_shards,
+        ssl_verify=settings.elasticsearch_ssl_verify,
+        ca_path=settings.elasticsearch_ca_path,
+    )
 
-SUPPORTED_VECTOR_SEARCH = client.vector_search_supported
+    SUPPORTED_VECTOR_SEARCH = client.vector_search_supported
+except Exception:
+    SUPPORTED_VECTOR_SEARCH = False
 
 
 @pytest.fixture(scope="session")

--- a/tests/client/sdk/commons/test_client.py
+++ b/tests/client/sdk/commons/test_client.py
@@ -1,0 +1,40 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+
+from argilla.client.sdk.client import Client
+
+
+@pytest.mark.parametrize(
+    ("url", "raises_error"),
+    [
+        ("https://wrong_hostname", True),
+        ("http://wrong_hostname_but_http", False),
+        ("https://good-hostname", False),
+        ("https://good-hostname/with_undescore_path", False),
+        ("https://space.orchestapp.io/pbp-service-argilla_6900", False),
+    ],
+)
+def test_wrong_hostname_values(
+    url: str,
+    raises_error: bool,
+):
+
+    if raises_error:
+        with pytest.raises(Exception):
+            Client(base_url=url)
+    else:
+        client = Client(base_url=url)
+        assert client


### PR DESCRIPTION
The current base URL check takes the whole URL instead of the hostname. This PR fixes it.