### PR TITLE
fix(client): prevent python client response json parse error

### DIFF
--- a/src/argilla/client/sdk/_helpers.py
+++ b/src/argilla/client/sdk/_helpers.py
@@ -11,11 +11,12 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-from typing import Any, Dict, Type, TypeVar, Union
+from json import JSONDecodeError
+from typing import Any, Dict, Optional, Type, TypeVar, Union
 
 import httpx
 
+from argilla.client.sdk.commons.errors import WrongResponseError
 from argilla.client.sdk.commons.errors_handler import handle_response_error
 from argilla.client.sdk.commons.models import (
     ErrorMessage,
@@ -27,7 +28,7 @@ from argilla.client.sdk.commons.models import (
 def build_raw_response(
     response: httpx.Response,
 ) -> Response[Union[Dict[str, Any], ErrorMessage, HTTPValidationError]]:
-    return build_typed_response(response, response_type_class=dict)
+    return build_typed_response(response)
 
 
 ResponseType = TypeVar("ResponseType")
@@ -35,12 +36,11 @@ ResponseType = TypeVar("ResponseType")
 
 def build_typed_response(
     response: httpx.Response,
-    response_type_class: Type[ResponseType],
+    response_type_class: Optional[Type[ResponseType]] = None,
 ) -> Response[Union[ResponseType, ErrorMessage, HTTPValidationError]]:
-    parsed_response = response.json()
-
-    check_response_error(response, expected_response=response_type_class)
-    parsed_response = response_type_class(**parsed_response)
+    parsed_response = check_response(response, expected_response=response_type_class)
+    if response_type_class:
+        parsed_response = response_type_class(**parsed_response)
     return Response(
         status_code=response.status_code,
         content=response.content,
@@ -49,7 +49,22 @@ def build_typed_response(
     )
 
 
-def check_response_error(response: httpx.Response, **kwargs) -> bool:
-    if 200 <= response.status_code < 400:
-        return False
+def check_response(response: httpx.Response, **kwargs) -> Any:
+    if 200 <= response.status_code < 300:
+        try:
+            return response.json()
+        except JSONDecodeError:
+            raise WrongResponseError(
+                message="Cannot parse json data from response",
+                response=response.content,
+            )
+    if 300 <= response.status_code < 400:
+        message = (
+            f"Unexpected response {response.status_code} status. "
+            "Verify your client/server connection and retry the operation"
+        )
+        raise WrongResponseError(
+            message=message,
+            response=response.content,
+        )
     handle_response_error(response, **kwargs)

--- a/src/argilla/client/sdk/commons/errors.py
+++ b/src/argilla/client/sdk/commons/errors.py
@@ -11,10 +11,24 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from typing import Any
 
 
 class BaseClientError(Exception):
     pass
+
+
+class WrongResponseError(BaseClientError):
+    def __init__(self, message: str, response: Any):
+        self.message = message
+        self.response = response
+
+    def __str__(self):
+        return (
+            f"\nUnexpected response: {self.message}"
+            "\nResponse content:"
+            f"\n{self.response}"
+        )
 
 
 class ApiCompatibilityError(BaseClientError):

--- a/tests/client/sdk/commons/test_client.py
+++ b/tests/client/sdk/commons/test_client.py
@@ -14,6 +14,7 @@
 
 import pytest
 
+from argilla.client.api import active_api
 from argilla.client.sdk.client import Client
 
 
@@ -38,3 +39,10 @@ def test_wrong_hostname_values(
     else:
         client = Client(base_url=url)
         assert client
+
+
+def test_http_calls(mocked_client):
+
+    rb_api = active_api()
+    data = rb_api.http_client.get("/api/_info")
+    assert data.get("version"), data


### PR DESCRIPTION
Sometimes, responses contain non-parseable data, related to some misconfiguration or special environment settings (extra auth or proxy fine-tuning). In those cases, the response is not properly parsed and a wrong error is launched. This PR fixes this.