### PR TITLE
fix(Client): Stop using `ujson` for client actions

### DIFF
--- a/src/argilla/client/sdk/client.py
+++ b/src/argilla/client/sdk/client.py
@@ -16,17 +16,11 @@ import dataclasses
 import datetime
 import functools
 import inspect
+import json
 import uuid
-from urllib.parse import urlparse
-
-from pydantic import BaseModel
-
-try:
-    import ujson as json
-except ModuleNotFoundError:
-    import json
-
+from json import JSONEncoder
 from typing import Dict, Optional, TypeVar
+from urllib.parse import urlparse
 
 import httpx
 
@@ -77,7 +71,7 @@ class _AuthenticatedClient(_Client):
     token: str
 
 
-class _EnhancedJSONEncoder(json.JSONEncoder):
+class _EnhancedJSONEncoder(JSONEncoder):
     def default(self, o):
         if dataclasses.is_dataclass(o):
             return dataclasses.asdict(o)

--- a/src/argilla/server/daos/backend/generic_elastic.py
+++ b/src/argilla/server/daos/backend/generic_elastic.py
@@ -48,11 +48,6 @@ from argilla.server.errors import BadRequestError, EntityNotFoundError
 from argilla.server.errors.task_errors import MetadataLimitExceededError
 from argilla.server.settings import settings
 
-try:
-    import ujson as json
-except ModuleNotFoundError:
-    import json
-
 
 def dataset_records_index(dataset_id: str) -> str:
     index_mame_template = settings.dataset_records_index_name


### PR DESCRIPTION
# Description

`ujson` does not share the same API signature as `json` so, we cannot use it indifferently


**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I added comments to my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
