### PR TITLE
opensearch docker compose file doesn't run

### DIFF
--- a/docker-compose.opensearch.yaml
+++ b/docker-compose.opensearch.yaml
@@ -30,7 +30,7 @@ services:
     expose:
       - "5601" # Expose port 5601 for web access to OpenSearch Dashboards
     environment:
-      DISABLE_SECURITY_DASHBOARDS_PLUGIN: true
+      DISABLE_SECURITY_DASHBOARDS_PLUGIN: 1
       OPENSEARCH_HOSTS: '["http://opensearch-node1:9200"]'
     networks:
       - argilla


### PR DESCRIPTION
Following error is raised:
```
ERROR: The Compose file './docker-compose.yaml' is invalid because:
services.opensearch-dashboards.environment.DISABLE_SECURITY_DASHBOARDS_PLUGIN contains true, which is an invalid type, it should be a string, number, or a null
```

<img width="994" alt="Screenshot 2023-01-18 at 14 42 09" src="https://user-images.githubusercontent.com/42403093/213200977-5089c23f-187b-4944-8c35-63bf76d9f8b2.png">



Changing `true` to 1 fixed the issue

# Description

Syntactic change to fix opensearch docker compose file

Closes #(issue_number)

**Type of change**

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**How Has This Been Tested**

Please describe the tests that you ran to verify your changes. And ideally reference `tests`.

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I added comments to my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
