### PR TITLE
fix: Read statics with proper encoding

### DIFF
--- a/src/argilla/server/helpers.py
+++ b/src/argilla/server/helpers.py
@@ -16,7 +16,10 @@
 """
 Common helper functions
 """
+import logging
 from typing import Any, Dict, List, Optional
+
+_LOGGER = logging.getLogger("argilla.server")
 
 
 def unflatten_dict(
@@ -134,3 +137,22 @@ def remove_suffix(text: str, suffix: str):
     if text.endswith(suffix):
         return text[: -len(suffix)]
     return text
+
+
+def replace_string_in_file(
+    filename: str,
+    string: str,
+    replace_by: str,
+    encoding: str = "utf-8",
+):
+    """Read a file and replace an old value in file by a new one"""
+    # Safely read the input filename using 'with'
+    with open(filename, encoding=encoding) as f:
+        data = f.read()
+        if string not in data:
+            return
+
+    # Safely write the changed content, if found in the file
+    with open(filename, mode="w", encoding=encoding) as f:
+        data = data.replace(string, replace_by)
+        f.write(data)

--- a/src/argilla/server/server.py
+++ b/src/argilla/server/server.py
@@ -97,15 +97,17 @@ def configure_app_statics(app: FastAPI):
         BASE_URL_VAR_NAME = "@@baseUrl@@"
         temp_dir = tempfile.mkdtemp()
         new_folder = shutil.copytree(path_from, temp_dir + "/statics")
+        base_url = helpers.remove_suffix(settings.base_url, suffix="/")
         for extension in ["*.js", "*.html"]:
             for file in glob.glob(
                 f"{new_folder}/**/{extension}",
                 recursive=True,
             ):
-                with fileinput.FileInput(file, inplace=True, backup=".bak") as file:
-                    for line in file:
-                        base_url = helpers.remove_suffix(settings.base_url, "/")
-                        print(line.replace(BASE_URL_VAR_NAME, base_url), end="")
+                helpers.replace_string_in_file(
+                    file,
+                    string=BASE_URL_VAR_NAME,
+                    replace_by=base_url,
+                )
 
         return new_folder
 


### PR DESCRIPTION
# Description

This PR uses `utf-8` encoding to read static files for ur replacement.

Closes #2219 

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I added comments to my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
