### PR TITLE
fix(Client): formatting caused offset in prediction

### DIFF
--- a/frontend/components/token-classifier/results/TextSpanStatic.vue
+++ b/frontend/components/token-classifier/results/TextSpanStatic.vue
@@ -27,8 +27,8 @@
       :datasetName="datasetName"
       :record="record"
     />
-    <template v-else v-for="t in token.tokens">{{ t.text }}</template>
-    <template>{{ token.charsBetweenTokens }}</template>
+    <template v-else v-for="t in token.tokens">{{ t.text }}</template
+    ><template>{{ token.charsBetweenTokens }}</template>
   </span>
 </template>
 


### PR DESCRIPTION
# Description
The formatting cause an offset in the prediction. This is due of formatting
![image](https://user-images.githubusercontent.com/88380932/214285264-13190838-3458-4fb6-a9ac-ced64247ac4e.png)

**Type of change**

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**How Has This Been Tested**

Please describe the tests that you ran to verify your changes. And ideally reference `tests`.

- [x] Token Classification

**Checklist**

- [x] I have merged the original branch into my forked branch
- N/A I added relevant documentation
- N/A follows the style guidelines of this project
- N/A I did a self-review of my code
- N/A I added comments to my code
- N/A I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- N/A I have added tests that prove my fix is effective or that my feature works
