### PR TITLE
feat(Client): relax client constraints for rules management

### DIFF
--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -622,6 +622,13 @@ class Argilla:
                 _LOGGER.warning(f"Cannot update rule {rule}: {ex}")
 
     def delete_dataset_labeling_rules(self, dataset: str, rules: List[LabelingRule]):
+        for rule in rules:
+                try:
+                    text_classification_api.delete_dataset_labeling_rule(
+                        self._client, name=dataset, rule=rule
+                    )
+                except Exception as ex:
+                    _LOGGER.warning(f"Cannot delete rule {rule}: {ex}")
         """Deletes the dataset labeling rules"""
         for rule in rules:
             text_classification_api.delete_dataset_labeling_rule(

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -597,6 +597,8 @@ class Argilla:
                 _LOGGER.warning(
                     f"Rule {rule} already exists. Please, update the rule instead."
                 )
+            except Exception as ex:
+                _LOGGER.warning(f"Cannot create rule {rule}: {ex}")
 
     def update_dataset_labeling_rules(
         self,
@@ -616,6 +618,8 @@ class Argilla:
                 text_classification_api.add_dataset_labeling_rule(
                     self._client, name=dataset, rule=rule
                 )
+            except Exception as ex:
+                _LOGGER.warning(f"Cannot update rule {rule}: {ex}")
 
     def delete_dataset_labeling_rules(self, dataset: str, rules: List[LabelingRule]):
         """Deletes the dataset labeling rules"""

--- a/tests/labeling/text_classification/test_rule.py
+++ b/tests/labeling/text_classification/test_rule.py
@@ -150,6 +150,33 @@ def test_call(monkeypatch, mocked_client, log_dataset):
     assert rule(records[1]) is None
 
 
+def test_add_duplicated_rule(
+    mocked_client,
+    log_dataset,
+):
+    rules = [
+        Rule(query="lab", label="DD"),
+        Rule(query="lab", label="EF"),
+    ]
+    add_rules(log_dataset, rules)
+    new_rules = load_rules(log_dataset)
+    assert len(new_rules) == 1, new_rules
+    assert new_rules[0].label == "DD" and new_rules[0].query == "lab"
+
+
+def test_create_rules_with_update(
+    mocked_client,
+    log_dataset,
+):
+    rules = [Rule(query="lab", label="DD"), Rule(query="ob", label="EF")]
+    update_rules(log_dataset, rules)
+
+    new_rules = load_rules(log_dataset)
+    assert [{"query": r.query, "label": r.label} for r in rules] == [
+        {"query": r.query, "label": r.label} for r in new_rules
+    ]
+
+
 def test_load_rules(mocked_client, log_dataset):
 
     mocked_client.post(


### PR DESCRIPTION
# Description

- When adding a new rule, just warn and ignore if already created
- When updating a rule, create it is not already created
- When deleting a rule, warn if something went wrong but no error raised

Closes #2048 

**Type of change**

Please delete options that are not relevant.

- [x] Enhancement

**Checklist**

- [x] I have merged the original branch into my forked branch
- [x] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I added comments to my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
