### PR TITLE
refactor: Remove final slash for the list datasets endpoint

### DIFF
--- a/src/argilla/server/apis/v0/handlers/datasets.py
+++ b/src/argilla/server/apis/v0/handlers/datasets.py
@@ -17,6 +17,7 @@ from typing import List
 
 from fastapi import APIRouter, Body, Depends, Security
 
+from argilla.server.apis.v0.helpers import deprecate_endpoint
 from argilla.server.apis.v0.models.commons.params import CommonTaskHandlerDependencies
 from argilla.server.apis.v0.models.datasets import (
     CopyDatasetRequest,
@@ -33,8 +34,10 @@ from argilla.server.services.datasets import DatasetsService
 router = APIRouter(tags=["datasets"], prefix="/datasets")
 
 
-@router.get(
+@deprecate_endpoint(
     "/",
+    new_path="",
+    router_method=router.get,
     response_model=List[Dataset],
     response_model_exclude_none=True,
     operation_id="list_datasets",

--- a/src/argilla/server/apis/v0/helpers.py
+++ b/src/argilla/server/apis/v0/helpers.py
@@ -27,7 +27,24 @@ def deprecate_endpoint(
     def decorator(func: Callable):
         kwargs.pop("path", None)
         kwargs.pop("deprecated", None)
-        router_method(path=path, *args, deprecated=True, **kwargs)(func)
-        router_method(path=new_path, *args, deprecated=False, **kwargs)(func)
+        operation_id = kwargs.pop("operation_id", None)
+        operation_id_old = None
+        if operation_id:
+            operation_id_old = f"{operation_id}_old"
+
+        router_method(
+            path=path,
+            *args,
+            deprecated=True,
+            operation_id=operation_id_old,
+            **kwargs,
+        )(func)
+        router_method(
+            path=new_path,
+            *args,
+            deprecated=False,
+            operation_id=operation_id,
+            **kwargs,
+        )(func)
 
     return decorator


### PR DESCRIPTION
# Description

Just a minimal change to remove the final slash for the list datasets endpoint.

instead of 
```bash
GET /api/datsets/
```

you can access it as:
```bash
GET /api/datasets
```

The old endpoint is deprecated but not removed

**Type of change**

Please delete options that are not relevant.

- [x] Enhancement (more or less relevant improvement done to an existing feature or behavior)

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I added comments to my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
