### PR TITLE
feat: better log error handling

### DIFF
--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -92,7 +92,7 @@ class _ArgillaLogAgent:
             dataset = kwargs["name"]
             records = kwargs["records"]
             _LOGGER.error(
-                f"\nCannot log in dataset '{dataset}'\n records '{str(records)[:100]}...'\n"
+                f"\nCannot log data in dataset '{dataset}'\n"
                 f"Error: {type(ex).__name__}\n"
                 f"Details: {ex}"
             )

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -90,7 +90,6 @@ class _ArgillaLogAgent:
             return await api.log_async(*args, **kwargs)
         except Exception as ex:
             dataset = kwargs["name"]
-            records = kwargs["records"]
             _LOGGER.error(
                 f"\nCannot log data in dataset '{dataset}'\n"
                 f"Error: {type(ex).__name__}\n"

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -89,9 +89,12 @@ class _ArgillaLogAgent:
         try:
             return await api.log_async(*args, **kwargs)
         except Exception as ex:
+            dataset = kwargs["name"]
+            records = kwargs["records"]
             _LOGGER.error(
-                f"Cannot log data {args, kwargs}\n"
-                f"Error of type {type(ex)}\n: {ex}. ({ex.args})"
+                f"\nCannot log in dataset '{dataset}'\n records '{str(records)[:100]}...'\n"
+                f"Error: {type(ex).__name__}\n"
+                f"Details: {ex}"
             )
             raise ex
 

--- a/src/argilla/client/sdk/commons/errors.py
+++ b/src/argilla/client/sdk/commons/errors.py
@@ -13,6 +13,8 @@
 #  limitations under the License.
 from typing import Any
 
+import httpx
+
 
 class BaseClientError(Exception):
     pass
@@ -46,6 +48,21 @@ class ApiCompatibilityError(BaseClientError):
         )
 
 
+class HttpResponseError(BaseClientError):
+    """Used for handle http errros other than defined in Argilla server"""
+
+    def __init__(self, response: httpx.Response):
+        self.status_code = response.status_code
+        self.detail = response.text
+
+    def __str__(self):
+        return (
+            "Received an HTTP error from server\n"
+            + f"Response status: {self.status_code}\n"
+            + f"Response content: {self.detail}\n"
+        )
+
+
 class ArApiResponseError(BaseClientError):
 
     HTTP_STATUS: int
@@ -60,8 +77,28 @@ class ArApiResponseError(BaseClientError):
         )
 
 
+class BadRequestApiError(ArApiResponseError):
+    HTTP_STATUS = 400
+
+
+class UnauthorizedApiError(ArApiResponseError):
+    HTTP_STATUS = 401
+
+
+class ForbiddenApiError(ArApiResponseError):
+    HTTP_STATUS = 403
+
+
 class NotFoundApiError(ArApiResponseError):
     HTTP_STATUS = 404
+
+
+class MethodNotAllowedApiError(ArApiResponseError):
+    HTTP_STATUS = 405
+
+
+class AlreadyExistsApiError(ArApiResponseError):
+    HTTP_STATUS = 409
 
 
 class ValidationApiError(ArApiResponseError):
@@ -86,26 +123,6 @@ class ValidationApiError(ArApiResponseError):
 
         # TODO: parse error details and match with client context
         super().__init__(**ctx, params=params)
-
-
-class BadRequestApiError(ArApiResponseError):
-    HTTP_STATUS = 400
-
-
-class UnauthorizedApiError(ArApiResponseError):
-    HTTP_STATUS = 401
-
-
-class ForbiddenApiError(ArApiResponseError):
-    HTTP_STATUS = 403
-
-
-class AlreadyExistsApiError(ArApiResponseError):
-    HTTP_STATUS = 409
-
-
-class MethodNotAllowedApiError(ArApiResponseError):
-    HTTP_STATUS = 405
 
 
 class GenericApiError(ArApiResponseError):

--- a/src/argilla/server/daos/backend/base.py
+++ b/src/argilla/server/daos/backend/base.py
@@ -39,8 +39,8 @@ class WrongLogDataError(Exception):
     """Error on logging data"""
 
     class Error(BaseModel):
-        error: str
-        caused_by: Any
+        reason: str = None
+        caused_by: Any = None
 
     def __init__(self, errors: List[Error]):
         self.errors = errors
@@ -91,7 +91,7 @@ class BackendErrorHandler(ABC):
                 except bulk_error as ex:
                     errors = [
                         WrongLogDataError.Error(
-                            error=error_info.get("cause"),
+                            reason=error_info.get("reason"),
                             caused_by=error_info.get("caused_by"),
                         )
                         for error in ex.errors

--- a/src/argilla/server/daos/backend/client_adapters/elasticsearch.py
+++ b/src/argilla/server/daos/backend/client_adapters/elasticsearch.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, Iterable, Optional, Tuple
 
 import elasticsearch
 from elasticsearch import Elasticsearch, NotFoundError, RequestError, helpers
+from elasticsearch.helpers import BulkIndexError
 from packaging.version import parse
 
 from argilla.server.daos.backend.base import BackendErrorHandler
@@ -42,6 +43,7 @@ class ElasticsearchClient(OpenSearchClient):
         self.error_handling = BackendErrorHandler(
             WarningIgnore=ElasticsearchWarning,
             RequestError=RequestError,
+            BulkError=BulkIndexError,
             NotFoundError=NotFoundError,
             GenericApiError=ApiError,
         )

--- a/src/argilla/server/daos/backend/client_adapters/opensearch.py
+++ b/src/argilla/server/daos/backend/client_adapters/opensearch.py
@@ -22,6 +22,7 @@ from opensearchpy.exceptions import (
     OpenSearchWarning,
     RequestError,
 )
+from opensearchpy.helpers import BulkIndexError
 
 from argilla.server.daos.backend import query_helpers
 from argilla.server.daos.backend.base import BackendErrorHandler, IndexNotFoundError
@@ -53,6 +54,7 @@ class OpenSearchClient(IClientAdapter):
         self.error_handling = BackendErrorHandler(
             WarningIgnore=OpenSearchWarning,
             RequestError=RequestError,
+            BulkError=BulkIndexError,
             NotFoundError=NotFoundError,
             GenericApiError=OpenSearchException,
         )

--- a/src/argilla/server/errors/base_errors.py
+++ b/src/argilla/server/errors/base_errors.py
@@ -113,6 +113,12 @@ class BadRequestError(ServerError):
         self.message = detail
 
 
+class BulkDataError(BadRequestError):
+    def __init__(self, detail: str, errors: Any):
+        super().__init__(detail)
+        self.errors = errors
+
+
 class InactiveUserError(ServerError):
     """Inactive user error"""
 

--- a/src/argilla/server/errors/base_errors.py
+++ b/src/argilla/server/errors/base_errors.py
@@ -114,6 +114,8 @@ class BadRequestError(ServerError):
 
 
 class BulkDataError(BadRequestError):
+    """Error on bulk data"""
+
     def __init__(self, detail: str, errors: Any):
         super().__init__(detail)
         self.errors = errors

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -35,6 +35,7 @@ from argilla.client.sdk.commons.errors import (
     BaseClientError,
     ForbiddenApiError,
     GenericApiError,
+    HttpResponseError,
     InputValueError,
     NotFoundApiError,
     UnauthorizedApiError,
@@ -299,6 +300,7 @@ def test_log_background_with_error(
         (404, NotFoundApiError),
         (422, ValidationApiError),
         (500, GenericApiError),
+        (413, HttpResponseError),
     ],
 )
 def test_delete_with_errors(mocked_client, monkeypatch, status, error_type):


### PR DESCRIPTION
# Description

This PR adds code to better error parsing for bulk index errors, and other HTTP errors in general:

- For bulk errors, return the reason and the causes of the errors for each failed record in the bulk.
- Reduce args info when an error is raised from a `rg.log`
- Parse HTTP status codes and responses other than those defined by the Argilla server.

Closes #2005 

**Type of change**

Please delete options that are not relevant.

- [x] Improvement

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I added comments to my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
