### PR TITLE
refactor: Change the default api key to `argilla.apikey`

### DIFF
--- a/docs/_source/getting_started/installation/user_management.md
+++ b/docs/_source/getting_started/installation/user_management.md
@@ -53,9 +53,14 @@ By default, if you don't configure a `users.yml` file, your Argilla instance is 
 
 - username: `argilla`
 - password: `1234`
-- api_key: `rubrix.apikey`
+- api_key: `argilla.apikey`
 
 for security reasons we recommend changing at least the password and API key.
+
+:::{note}
+To connect to an old Argilla server using client `>=1.3.0`, you should specify the default user API key `rubrix.apikey`.
+Otherwise, connections will fail with an Unauthorized server error.
+:::
 
 ### Override default API key
 

--- a/src/argilla/_constants.py
+++ b/src/argilla/_constants.py
@@ -18,8 +18,11 @@ DEFAULT_MAX_KEYWORD_LENGTH = 128
 
 API_KEY_HEADER_NAME = "X-Argilla-Api-Key"
 WORKSPACE_HEADER_NAME = "X-Argilla-Workspace"
-DEFAULT_API_KEY = "rubrix.apikey"  # Keep the same api key for now
+DEFAULT_API_KEY = "argilla.apikey"  # Keep the same api key for now
 
+# TODO: This constant will be drop out with issue
+#  https://github.com/argilla-io/argilla/issues/2251 fix
+_OLD_DEFAULT_API_KEY = "rubrix.apikey"
 _OLD_API_KEY_HEADER_NAME = "X-Rubrix-Api-Key"
 _OLD_WORKSPACE_HEADER_NAME = "X-Rubrix-Workspace"
 

--- a/src/argilla/client/api.py
+++ b/src/argilla/client/api.py
@@ -81,7 +81,7 @@ def init(
         api_url: Address of the REST API. If `None` (default) and the env variable ``ARGILLA_API_URL`` is not set,
             it will default to `http://localhost:6900`.
         api_key: Authentification key for the REST API. If `None` (default) and the env variable ``ARGILLA_API_KEY``
-            is not set, it will default to `rubrix.apikey`.
+            is not set, it will default to `argilla.apikey`.
         workspace: The workspace to which records will be logged/loaded. If `None` (default) and the
             env variable ``ARGILLA_WORKSPACE`` is not set, it will default to the private user workspace.
         timeout: Wait `timeout` seconds for the connection to timeout. Default: 60.

--- a/src/argilla/server/security/auth_provider/local/users/dao.py
+++ b/src/argilla/server/security/auth_provider/local/users/dao.py
@@ -17,6 +17,7 @@ from typing import Dict, Iterable, Optional
 
 import yaml
 
+from argilla._constants import _OLD_DEFAULT_API_KEY, DEFAULT_API_KEY
 from argilla.server.security.auth_provider.local.settings import settings
 
 from .model import UserInDB
@@ -55,6 +56,12 @@ class UsersDAO:
 
     async def get_user_by_api_key(self, api_key: str) -> Optional[UserInDB]:
         """Find a user for a given api key"""
+
+        # TODO: This piece of code will be drop out with issue
+        #  https://github.com/argilla-io/argilla/issues/2251 fix
+        if api_key == _OLD_DEFAULT_API_KEY and _DEFAULT_USER.api_key == DEFAULT_API_KEY:
+            return _DEFAULT_USER
+
         for user in self.__users__.values():
             if api_key == user.api_key:
                 return user

--- a/tests/client/test_init.py
+++ b/tests/client/test_init.py
@@ -14,6 +14,7 @@
 
 from argilla import TextClassificationRecord
 from argilla.client import api
+from argilla.client.api import active_api
 
 
 def test_resource_leaking_with_several_init(mocked_client):
@@ -47,3 +48,14 @@ def test_init_with_extra_headers(mocked_client):
         assert (
             active_api.http_client.headers[key] == value
         ), f"{key}:{value} not in client headers"
+
+
+def test_init(mocked_client):
+    the_api = active_api()
+    user = the_api.http_client.get("/api/me")
+    assert user["username"] == "argilla"
+
+    api.init(api_key="rubrix.apikey")
+    the_api = active_api()
+    user = the_api.http_client.get("/api/me")
+    assert user["username"] == "argilla"


### PR DESCRIPTION


# Description

This PR adds code to change the default API key to `argilla.apikey`, with backward compatibility with old apikey.

Closes #2250 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Refactor (change restructuring the codebase without changing functionality)
- [x] Documentation update

**Checklist**

- [x] I have merged the original branch into my forked branch
- [x] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I added comments to my code
- [x] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
