### PR TITLE
Fix broken `.pre-commit-config.yaml` configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,51 +1,49 @@
 repos:
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.4.0
-      hooks:
-          - id: check-yaml
-          - id: end-of-file-fixer
-            exclude_types: [text, jupyter]
-          - id: trailing-whitespace
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+        exclude_types: [text, jupyter]
+      - id: trailing-whitespace
 
--   repo: https://github.com/Lucas-C/pre-commit-hooks
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.4.2
     hooks:
-    -   id: insert-license
+      - id: insert-license
         name: "Insert license header in Python source files"
         files: \.py$
         args:
-            - --license-filepath
-            - src/license_header.txt
-            - --fuzzy-match-generates-todo
-            # - --remove-header
+          - --license-filepath
+          - src/license_header.txt
+          - --fuzzy-match-generates-todo
+          # - --remove-header
 
-    - repo: https://github.com/psf/black
-      rev: 22.12.0
-      hooks:
-          - id: black
-            additional_dependencies: ["click==8.0.4"]
-
-
--   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+  - repo: https://github.com/psf/black
+    rev: 22.12.0
     hooks:
-    -   id: isort
+      - id: black
+        additional_dependencies: ["click==8.0.4"]
 
-    - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-      rev: v9.4.0
-      hooks:
-          - id: commitlint
-            stages: [commit-msg]
-            additional_dependencies: ["@commitlint/config-conventional"]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.11.5
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.4.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ["@commitlint/config-conventional"]
 
 ci:
-    autofix_commit_msg: |
-        [pre-commit.ci] auto fixes from pre-commit.com hooks
-
-        for more information, see https://pre-commit.ci
-    autofix_prs: true
-    autoupdate_branch: ""
-    autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
-    autoupdate_schedule: weekly
-    skip: []
-    submodules: false
+  autofix_commit_msg: |
+    [pre-commit.ci] auto fixes from pre-commit.com hooks
+    for more information, see https://pre-commit.ci
+  autofix_prs: true
+  autoupdate_branch: ""
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
+  autoupdate_schedule: weekly
+  skip: []
+  submodules: false


### PR DESCRIPTION
Closes #2284

Hello!

## Pull Request overview
1. Fix broken `.pre-commit-config.yaml` configuration by reverting the changes to the file from e53c2018c6ae781f35845e07c8806ca68acea7fc.
2. Decrement `isort` version from 5.12.0 to 5.11.5, as the former no longer supports Python 3.7.

## Details
I ran the [`Prettier`](https://prettier.io/) formatter on the file as it stood before e53c2018c6ae781f35845e07c8806ca68acea7fc to normalize the structure of the file. YAML can be pretty specific, so it's best not to update the formatting manually too often.

Sadly, the `pre-commit` auto-update functionality will soon update the `isort` version back to 5.12.0+. I'm sure there are some better solutions, but I would be more than okay with stopping the autoupdates until we move to Python 3.8+. After all, there's only ~4 months left of Python 3.7 before modules really stop supporting it.

## After these changes
Whereas before a configuration error was thrown (see #2284), this is now the output of `pre-commit run` with no changes:
```python
check yaml...........................................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
trim trailing whitespace.............................(no files to check)Skipped
Insert license header in Python source files.........(no files to check)Skipped
black................................................(no files to check)Skipped
isort................................................(no files to check)Skipped
```

- Tom Aarsen