### PR TITLE
Docs: Replace leftover `rubrix.apikey` with `argilla.apikey`

### DIFF
--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -127,7 +127,7 @@ class Argilla:
             api_url: Address of the REST API. If `None` (default) and the env variable ``ARGILLA_API_URL`` is not set,
                 it will default to `http://localhost:6900`.
             api_key: Authentification key for the REST API. If `None` (default) and the env variable ``ARGILLA_API_KEY``
-                is not set, it will default to `rubrix.apikey`.
+                is not set, it will default to `argilla.apikey`.
             workspace: The workspace to which records will be logged/loaded. If `None` (default) and the
                 env variable ``ARGILLA_WORKSPACE`` is not set, it will default to the private user workspace.
             timeout: Wait `timeout` seconds for the connection to timeout. Default: 60.


### PR DESCRIPTION
Related to #2254

# Description

Replace leftover `rubrix.apikey` with `argilla.apikey`, a la #2254.
Ignore the weird commit message artifacting, I always forget that I can't use ` in my commit messages on Windows.

**Type of change**

- [x] Documentation update

**How Has This Been Tested**
N/A

**Checklist**
- [x] I have merged the original branch into my forked branch

