### PR TITLE
Docs: Remove cut-off sentence in docs codeblock

### DIFF
--- a/docs/_source/getting_started/installation/user_management.md
+++ b/docs/_source/getting_started/installation/user_management.md
@@ -110,7 +110,7 @@ To configure your Argilla instance for various users, you just need to create a 
   workspaces: ['client_projects'] # access to her user workspace and the client_projects workspace
 - username: user3
   hashed_password: <generated-hashed-password> # See the previous section above
-  api_key: "ThisIsTheUser2APIKEY" # this user can access all workspaces (including
+  api_key: "ThisIsTheUser2APIKEY" # this user can access all workspaces
 - ...
 ```
 


### PR DESCRIPTION
# Description

Remove the cutoff sentence in the first codeblock in this link:
https://docs.argilla.io/en/latest/getting_started/installation/configurations/user_management.html#add-new-users-and-workspaces

Alternatively, we can try to go for the original intention of the sentence, which was probably something along the lines of:
> (including private/default ones)
However, I'm not sure whether that is indeed the case (anymore).

**Type of change**

- [x] Documentation update

**How Has This Been Tested**
N/A

**Checklist**
- [X] I have merged the original branch into my forked branch
