### PR TITLE
Replace Rubrix Docker link with updated Argilla one

### DIFF
--- a/docs/_source/getting_started/installation/configurations/user_management.md
+++ b/docs/_source/getting_started/installation/configurations/user_management.md
@@ -120,7 +120,7 @@ If everything went well, the configured users can now log in and their annotatio
 
 ### Using docker-compose
 
-Make sure you create the yaml file above in the same folder as your `docker-compose.yaml`. You can download the `docker-compose` from this [URL](https://raw.githubusercontent.com/argilla-io/argilla/develop/docker-compose.yaml):
+Make sure you create the yaml file above in the same folder as your `docker-compose.yaml`. You can download the `docker-compose` from this [URL](https://raw.githubusercontent.com/argilla-io/argilla/main/docker-compose.yaml):
 
 Then open the provided ``docker-compose.yaml`` and configure your Argilla instance as follows:
 

--- a/docs/_source/getting_started/installation/configurations/user_management.md
+++ b/docs/_source/getting_started/installation/configurations/user_management.md
@@ -120,7 +120,7 @@ If everything went well, the configured users can now log in and their annotatio
 
 ### Using docker-compose
 
-Make sure you create the yaml file above in the same folder as your `docker-compose.yaml`. You can download the `docker-compose` from this [URL](https://git.io/rb-docker):
+Make sure you create the yaml file above in the same folder as your `docker-compose.yaml`. You can download the `docker-compose` from this [URL](https://raw.githubusercontent.com/argilla-io/argilla/develop/docker-compose.yaml):
 
 Then open the provided ``docker-compose.yaml`` and configure your Argilla instance as follows:
 


### PR DESCRIPTION
Closes #2288

# Description

Replace [Rubrix Docker link](https://git.io/rb-docker) with [updated Argilla one](https://raw.githubusercontent.com/argilla-io/argilla/develop/docker-compose.yaml).

**Type of change**
- [x] Documentation update

**How Has This Been Tested**
N/A

**Checklist**

- [x] I have merged the original branch into my forked branch
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [X] My changes generate no new warnings

- Tom Aarsen