### PR TITLE
docs: Rephrase `to know more` into `to learn more` in Quickstart login page

### DIFF
--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -45,7 +45,7 @@
             target="_blank"
             >this guide</a
           >
-          to know more about usage and configuration options.
+          to learn more about usage and configuration options.
         </p>
         <base-button type="submit" class="form__button primary"
           >Enter</base-button


### PR DESCRIPTION
Hello!

# Description

This PR rephrases `to know more` into `to learn more` in the quickstart login page here:

![image](https://user-images.githubusercontent.com/37621491/217243809-250e4c94-74f8-4a48-bad6-0ad4312c9fea.png)

I believe that `learn` sounds better here, but I'm open to your thoughts.

Sidenote: Well done on the addition of the link. I think it'll help lots of users out.

**Type of change**

- [x] Documentation update

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I added comments to my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

