### PR TITLE
resolved prepare_for_training errors prior to release w.r.t. inputs f…

### DIFF
--- a/src/argilla/client/datasets.py
+++ b/src/argilla/client/datasets.py
@@ -15,6 +15,7 @@
 import functools
 import logging
 import random
+import uuid
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import pandas as pd
@@ -473,6 +474,9 @@ class DatasetBase:
         if isinstance(framework, str):
             framework = Framework(framework)
 
+        if test_size == 0:
+            test_size = None
+
         # prepare for training for the right method
         if framework is Framework.TRANSFORMERS:
             return self._prepare_for_training_with_transformers(
@@ -484,13 +488,12 @@ class DatasetBase:
                 " dataset for training with the spacy framework."
             )
         elif framework in [Framework.SPACY, Framework.SPARK_NLP]:
-            if train_size or test_size:
+            if train_size and test_size:
                 from sklearn.model_selection import train_test_split
 
                 records_train, records_test = train_test_split(
                     shuffled_records,
                     train_size=train_size,
-                    test_size=test_size,
                     shuffle=False,
                     random_state=seed,
                 )
@@ -861,11 +864,16 @@ class DatasetForTextClassification(DatasetBase):
         all_labels = self.__all_labels__()
 
         # Creating the DocBin object as in https://spacy.io/usage/training#training-data
+
         for record in records:
             if record.annotation is None:
                 continue
 
-            doc = nlp.make_doc(record.text)
+            if record.text is None:
+                text = ". ".join(record.inputs.values())
+            else:
+                text = record.text
+            doc = nlp.make_doc(text)
 
             cats = dict.fromkeys(all_labels, 0)
             for anno in record.annotation:
@@ -884,11 +892,18 @@ class DatasetForTextClassification(DatasetBase):
         else:
             label_name = "label"
 
-        spark_nlp_data = [
-            [record.id, record.text, record.annotation]
-            for record in records
-            if record.annotation is not None
-        ]
+        spark_nlp_data = []
+        for record in records:
+            if record.annotation is None:
+                continue
+            if record.id is None:
+                record.id = str(uuid.uuid4())
+            if record.text is None:
+                text = ". ".join(record.inputs.values())
+            else:
+                text = record.text
+
+            spark_nlp_data.append([record.id, text, record.annotation])
 
         return pd.DataFrame(spark_nlp_data, columns=["id", "text", label_name])
 
@@ -1111,6 +1126,9 @@ class DatasetForTokenClassification(DatasetBase):
     def _prepare_for_training_with_spark_nlp(
         self, records: List[Record]
     ) -> "pandas.DataFrame":
+        for record in records:
+            if record.id is None:
+                record.id = str(uuid.uuid4())
         iob_doc_data = [
             [
                 record.id,

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -270,10 +270,11 @@ class TestDatasetForTextClassification:
         records = request.getfixturevalue(records)
         expected_dataset = ar.DatasetForTextClassification(records)
 
+        expected_dataset.prepare_for_training(train_size=0.5)
         dataset_ds = expected_dataset.to_datasets()
 
         assert isinstance(dataset_ds, datasets.Dataset)
-        print(dataset_ds.column_names)
+
         assert dataset_ds.column_names == [
             "text",
             "inputs",


### PR DESCRIPTION
…ield and non-existent id for spark and non-existent

# Description

There were some specific issues regarding the prepare for training w.r.t. `inputs` vs `text` field, missing ids for spark-nlp.

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)


