### PR TITLE
Enhancement: Distinguish between error message and context in validation of spans

### DIFF
--- a/docs/_source/conf.py
+++ b/docs/_source/conf.py
@@ -149,7 +149,7 @@ if docs_version == "latest":
     branch = "main"
 else:
     branch = docs_version.replace("-", "/")
-    
+
 nbsphinx_prolog = (
     """
 .. raw:: html

--- a/src/argilla/utils/span_utils.py
+++ b/src/argilla/utils/span_utils.py
@@ -100,7 +100,7 @@ class SpanUtils:
                 context += self.text[max(char_start - 5, 0) : char_end + 5]
                 if char_end + 5 < len(self.text):
                     context += "..."
-                message = f"- [{span_str}] defined in {repr(context)}"
+                message = f"{span} - [{span_str}] defined in {repr(context)}"
 
                 misaligned_spans_errors.append(message)
 

--- a/src/argilla/utils/span_utils.py
+++ b/src/argilla/utils/span_utils.py
@@ -93,12 +93,14 @@ class SpanUtils:
                 self._start_to_token_idx.get(char_start),
                 self._end_to_token_idx.get(char_end),
             ):
-                message = f"- [{self.text[char_start:char_end]}] defined in "
+                span_str = self.text[char_start:char_end]
+                context = ""
                 if char_start - 5 > 0:
-                    message += "..."
-                message += self.text[max(char_start - 5, 0) : char_end + 5]
+                    context = "..."
+                context += self.text[max(char_start - 5, 0) : char_end + 5]
                 if char_end + 5 < len(self.text):
-                    message += "..."
+                    context += "..."
+                message = f"- [{span_str}] defined in {repr(context)}"
 
                 misaligned_spans_errors.append(message)
 

--- a/src/argilla/utils/span_utils.py
+++ b/src/argilla/utils/span_utils.py
@@ -94,14 +94,7 @@ class SpanUtils:
                 self._end_to_token_idx.get(char_end),
             ):
                 span_str = self.text[char_start:char_end]
-                context = ""
-                if char_start - 5 > 0:
-                    context = "..."
-                context += self.text[max(char_start - 5, 0) : char_end + 5]
-                if char_end + 5 < len(self.text):
-                    context += "..."
-                message = f"{span} - [{span_str}] defined in {repr(context)}"
-
+                message = f"{span} - {repr(span_str)}"
                 misaligned_spans_errors.append(message)
 
         if not_valid_spans_errors or misaligned_spans_errors:

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -625,8 +625,8 @@ def test_token_classification_spans(span, valid):
         with pytest.raises(
             ValueError,
             match="Following entity spans are not aligned with provided tokenization\n"
-            r"Spans:\n\('test', {}, {}\) - \[s\] defined in 'Esto es...'\n"
-            r"Tokens:\n\['Esto', 'es', 'una', 'prueba'\]".format(span[0], span[1]),
+            r"Spans:\n\('test', 1, 2\) - 's'\n"
+            r"Tokens:\n\['Esto', 'es', 'una', 'prueba'\]",
         ):
             ar.TokenClassificationRecord(
                 text=texto,

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -625,7 +625,7 @@ def test_token_classification_spans(span, valid):
         with pytest.raises(
             ValueError,
             match="Following entity spans are not aligned with provided tokenization\n"
-            r"Spans:\n- \[s\] defined in Esto es...\n"
+            r"Spans:\n- \[s\] defined in 'Esto es...'\n"
             r"Tokens:\n\['Esto', 'es', 'una', 'prueba'\]",
         ):
             ar.TokenClassificationRecord(

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -625,8 +625,8 @@ def test_token_classification_spans(span, valid):
         with pytest.raises(
             ValueError,
             match="Following entity spans are not aligned with provided tokenization\n"
-            r"Spans:\n- \[s\] defined in 'Esto es...'\n"
-            r"Tokens:\n\['Esto', 'es', 'una', 'prueba'\]",
+            r"Spans:\n\('test', {}, {}\) - \[s\] defined in 'Esto es...'\n"
+            r"Tokens:\n\['Esto', 'es', 'una', 'prueba'\]".format(span[0], span[1]),
         ):
             ar.TokenClassificationRecord(
                 text=texto,

--- a/tests/utils/test_span_utils.py
+++ b/tests/utils/test_span_utils.py
@@ -68,7 +68,7 @@ def test_validate_misaligned_spans():
     with pytest.raises(
         ValueError,
         match="Following entity spans are not aligned with provided tokenization\n"
-        r"Spans:\n- \[test \] defined in test this.\n"
+        r"Spans:\n- \[test \] defined in 'test this.'\n"
         r"Tokens:\n\['test', 'this', '.'\]",
     ):
         span_utils.validate([("mock", 0, 5)])
@@ -80,7 +80,7 @@ def test_validate_not_valid_and_misaligned_spans():
         ValueError,
         match=r"Following entity spans are not valid: \[\('mock', 2, 1\)\]\n"
         "Following entity spans are not aligned with provided tokenization\n"
-        r"Spans:\n- \[test \] defined in test this.\n"
+        r"Spans:\n- \[test \] defined in 'test this.'\n"
         r"Tokens:\n\['test', 'this', '.'\]",
     ):
         span_utils.validate([("mock", 2, 1), ("mock", 0, 5)])

--- a/tests/utils/test_span_utils.py
+++ b/tests/utils/test_span_utils.py
@@ -68,7 +68,7 @@ def test_validate_misaligned_spans():
     with pytest.raises(
         ValueError,
         match="Following entity spans are not aligned with provided tokenization\n"
-        r"Spans:\n- \[test \] defined in 'test this.'\n"
+        r"Spans:\n\('mock', 0, 5\) - \[test \] defined in 'test this.'\n"
         r"Tokens:\n\['test', 'this', '.'\]",
     ):
         span_utils.validate([("mock", 0, 5)])
@@ -80,7 +80,7 @@ def test_validate_not_valid_and_misaligned_spans():
         ValueError,
         match=r"Following entity spans are not valid: \[\('mock', 2, 1\)\]\n"
         "Following entity spans are not aligned with provided tokenization\n"
-        r"Spans:\n- \[test \] defined in 'test this.'\n"
+        r"Spans:\n\('mock', 0, 5\) - \[test \] defined in 'test this.'\n"
         r"Tokens:\n\['test', 'this', '.'\]",
     ):
         span_utils.validate([("mock", 2, 1), ("mock", 0, 5)])

--- a/tests/utils/test_span_utils.py
+++ b/tests/utils/test_span_utils.py
@@ -68,7 +68,7 @@ def test_validate_misaligned_spans():
     with pytest.raises(
         ValueError,
         match="Following entity spans are not aligned with provided tokenization\n"
-        r"Spans:\n\('mock', 0, 5\) - \[test \] defined in 'test this.'\n"
+        r"Spans:\n\('mock', 0, 5\) - 'test '\n"
         r"Tokens:\n\['test', 'this', '.'\]",
     ):
         span_utils.validate([("mock", 0, 5)])
@@ -80,7 +80,7 @@ def test_validate_not_valid_and_misaligned_spans():
         ValueError,
         match=r"Following entity spans are not valid: \[\('mock', 2, 1\)\]\n"
         "Following entity spans are not aligned with provided tokenization\n"
-        r"Spans:\n\('mock', 0, 5\) - \[test \] defined in 'test this.'\n"
+        r"Spans:\n\('mock', 0, 5\) - 'test '\n"
         r"Tokens:\n\['test', 'this', '.'\]",
     ):
         span_utils.validate([("mock", 2, 1), ("mock", 0, 5)])


### PR DESCRIPTION
# Description

I expanded slightly on the error message provided when providing spans that do not match the tokenization. 
Consider the following example script:
```python
import argilla as rg

record = rg.TokenClassificationRecord(
    text = "This is my text",
    tokens=["This", "is", "my", "text"],
    prediction=[("ORG", 0, 6), ("PER", 8, 14)],
)
```
The (truncated) output on the `develop` branch:
```
ValueError: Following entity spans are not aligned with provided tokenization
Spans:
- [This i] defined in This is my ...
- [my tex] defined in ...s is my text
Tokens:
['This', 'is', 'my', 'text']
```
The distinction between `defined in` and `This is` is unclear. I've worked on this.

The (truncated) output after this PR:
```
ValueError: Following entity spans are not aligned with provided tokenization
Spans:
- [This i] defined in 'This is my ...'
- [my tex] defined in '...s is my text'
Tokens:
['This', 'is', 'my', 'text']
```
Note the additional `'`. Note that the changes rely on `repr`, so if the snippet contains `'` itself, it uses `"` instead, e.g.:
```python
import argilla as rg

record = rg.TokenClassificationRecord(
    text = "This is Tom's text",
    tokens=["This", "is", "Tom", "'s", "text"],
    prediction=[("ORG", 0, 6), ("PER", 8, 16)],
)
```
```
ValueError: Following entity spans are not aligned with provided tokenization
Spans:
- [This i] defined in 'This is Tom...'
- [Tom's te] defined in "...s is Tom's text"
Tokens:
['This', 'is', 'Tom', "'s", 'text']
```

**Type of change**

- [x] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

Modified the relevant tests, ensured they worked.

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I added comments to my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

- Tom Aarsen