### PR TITLE
Enhancement: Also validate records on assignment of variables

### DIFF
--- a/src/argilla/client/models.py
+++ b/src/argilla/client/models.py
@@ -121,7 +121,9 @@ class _Validators(BaseModel):
         return values
 
     class Config:
+        # https://docs.pydantic.dev/usage/model_config/#options
         extra = "forbid"
+        validate_assignment = True
 
 
 class BulkResponse(BaseModel):

--- a/tests/client/test_models.py
+++ b/tests/client/test_models.py
@@ -306,3 +306,24 @@ def test_nat_to_none_to_datetime():
 def test_text2text_prediction_validator(prediction, expected):
     record = Text2TextRecord(text="mock", prediction=prediction)
     assert record.prediction == expected
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        TextClassificationRecord(text="This is a test"),
+        TokenClassificationRecord(
+            text="This is a test", tokens="This is a test".split()
+        ),
+        Text2TextRecord(text="This is a test"),
+    ],
+)
+def test_record_validation_on_assignment(record):
+    with pytest.raises(ValidationError):
+        record.prediction = "rubbish"
+
+    with pytest.raises(ValidationError):
+        record.annotation = [("rubbish",)]
+
+    with pytest.raises(ValidationError):
+        record.vectors = "rubbish"


### PR DESCRIPTION
Closes #2257

Hello!

## Pull Request overview
* Add `validate_assignment = True` to the `pydantic` Config to also apply validation on assignment e.g. via `record.prediction = ...`.
* Add tests to ensure the correct behaviour.

## What was wrong?
See #2257 for details on the issue. The core issue is that the following script would fail with a server-side error on `rg.log`:
```python
import argilla as rg

record = rg.TextClassificationRecord(
    text="Hello world, this is me!",
    prediction=[("LABEL1", 0.8), ("LABEL2", 0.2)],
    annotation="LABEL1",
    multi_label=False,
)
rg.log(record, "test_item_assignment")
record.prediction = "rubbish"
rg.log(record, "test_item_assignment")
```
<details><summary>Click to see failure logs using the develop branch</summary>

```
023-02-14 11:19:40.794 | ERROR    | argilla.client.client:__log_internal__:103 - 
Cannot log data in dataset 'test_item_assignment'
Error: ValueError
Details: not enough values to unpack (expected 2, got 1)
Traceback (most recent call last):
  File "c:/code/argilla/demo_2257.py", line 13, in <module>
    rg.log(record, "test_item_assignment")
  File "C:\code\argilla\src\argilla\client\api.py", line 157, in log
    background=background,
  File "C:\code\argilla\src\argilla\client\client.py", line 305, in log
    return future.result()
  File "C:\Users\tom\.conda\envs\argilla\lib\concurrent\futures\_base.py", line 435, in result
    return self.__get_result()
  File "C:\Users\tom\.conda\envs\argilla\lib\concurrent\futures\_base.py", line 384, in __get_result
    raise self._exception
  File "C:\code\argilla\src\argilla\client\client.py", line 107, in __log_internal__
    raise ex
  File "C:\code\argilla\src\argilla\client\client.py", line 99, in __log_internal__
    return await api.log_async(*args, **kwargs)
  File "C:\code\argilla\src\argilla\client\client.py", line 389, in log_async
    records=[creation_class.from_client(r) for r in chunk],
  File "C:\code\argilla\src\argilla\client\client.py", line 389, in <listcomp>
    records=[creation_class.from_client(r) for r in chunk],
  File "C:\code\argilla\src\argilla\client\sdk\text_classification\models.py", line 65, in from_client
    for label, score in record.prediction
  File "C:\code\argilla\src\argilla\client\sdk\text_classification\models.py", line 64, in <listcomp>
    ClassPrediction(**{"class": label, "score": score})
ValueError: not enough values to unpack (expected 2, got 1)
  0%|                                                                                                                                                     | 0/1 [00:00<?, ?it/s]
```
</details>
This is unnecessary, as we can create a client-side error using our validators, too.

## The fix
The fix is as simple as instructing `pydantic` to also trigger the validation on assignment, e.g. on `record.prediction = ...`.

## Relevant documentation
See `validate_assignment` in https://docs.pydantic.dev/usage/model_config/#options.

## After the fix
Using the same script as before, the error now becomes:
```
Traceback (most recent call last):
  File "c:/code/argilla/demo_2257.py", line 11, in <module>
    record.prediction = "rubbish"
  File "C:\code\argilla\src\argilla\client\models.py", line 280, in __setattr__
    super().__setattr__(name, value)
  File "pydantic\main.py", line 445, in pydantic.main.BaseModel.__setattr__
pydantic.error_wrappers.ValidationError: 1 validation error for TextClassificationRecord
prediction
  value is not a valid list (type=type_error.list)
```
Which triggers directly on the assignment rather than only when the record is logged.

---

**Type of change**

- [x] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

All existing tests passed with my changes. Beyond that, I added some new tests of my own. These tests fail on the `develop` branch, but pass on this branch. This is because previously it was allowed to perform `record.prediction = "rubbish"` as no validation was executed on it.

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I added comments to my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

---

- Tom Aarsen