### PR TITLE
Use `rich` for logging, tracebacks, printing, progressbars

### DIFF
--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -46,6 +46,6 @@ dependencies:
       - spacy==3.1.0
       - https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.1.0/en_core_web_sm-3.1.0.tar.gz
       - transformers[torch]~=4.18.0
-      - loguru
+      - rich==13.0.1
       # install Argilla in editable mode
       - -e .[server,listeners]

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -43,8 +43,8 @@ dependencies:
       - pgmpy
       - plotly>=4.1.0
       - snorkel>=0.9.7
-      - spacy==3.1.0
-      - https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.1.0/en_core_web_sm-3.1.0.tar.gz
+      - spacy==3.5.0
+      - https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.5.0/en_core_web_sm-3.5.0.tar.gz
       - transformers[torch]~=4.18.0
       - rich==13.0.1
       # install Argilla in editable mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,11 +38,13 @@ dependencies = [
     "wrapt >= 1.13,< 1.15",
     # weaksupervision
     "numpy < 1.24.0",
+    # for progressbars
     "tqdm >= 4.27.0",
     # monitor background consumers
     "backoff",
-    "monotonic"
-
+    "monotonic",
+    # for logging, tracebacks, printing, progressbars
+    "rich <= 13.0.1"
 ]
 dynamic = ["version"]
 

--- a/src/argilla/__init__.py
+++ b/src/argilla/__init__.py
@@ -21,12 +21,18 @@ as well as in the `_import_structure` dictionary.
 import sys as _sys
 from typing import TYPE_CHECKING as _TYPE_CHECKING
 
-from rich.traceback import install as _install_rich
-
 from argilla.logging import configure_logging as _configure_logging
 
 from . import _version
 from .utils import LazyargillaModule as _LazyargillaModule
+
+try:
+    from rich.traceback import install as _install_rich
+
+    # Rely on `rich` for tracebacks
+    _install_rich()
+except ModuleNotFoundError:
+    pass
 
 __version__ = _version.version
 
@@ -117,6 +123,3 @@ _sys.modules[__name__] = _LazyargillaModule(
 )
 
 _configure_logging()
-
-# Rely on `rich` for tracebacks
-_install_rich()

--- a/src/argilla/__init__.py
+++ b/src/argilla/__init__.py
@@ -21,6 +21,8 @@ as well as in the `_import_structure` dictionary.
 import sys as _sys
 from typing import TYPE_CHECKING as _TYPE_CHECKING
 
+from rich.traceback import install as _install_rich
+
 from argilla.logging import configure_logging as _configure_logging
 
 from . import _version
@@ -115,3 +117,6 @@ _sys.modules[__name__] = _LazyargillaModule(
 )
 
 _configure_logging()
+
+# Rely on `rich` for tracebacks
+_install_rich()

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -20,7 +20,8 @@ import warnings
 from asyncio import Future
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
-from tqdm.auto import tqdm
+from rich import print as rprint
+from rich.progress import Progress
 
 from argilla._constants import (
     _OLD_WORKSPACE_HEADER_NAME,
@@ -376,25 +377,28 @@ class Argilla:
             )
 
         processed, failed = 0, 0
-        progress_bar = tqdm(total=len(records), disable=not verbose)
-        for i in range(0, len(records), chunk_size):
-            chunk = records[i : i + chunk_size]
-
-            response = await async_bulk(
-                client=self._client,
-                name=name,
-                json_body=bulk_class(
-                    tags=tags,
-                    metadata=metadata,
-                    records=[creation_class.from_client(r) for r in chunk],
-                ),
+        with Progress() as progress_bar:
+            task = progress_bar.add_task(
+                "Logging...", total=len(records), visible=verbose
             )
 
-            processed += response.parsed.processed
-            failed += response.parsed.failed
+            for i in range(0, len(records), chunk_size):
+                chunk = records[i : i + chunk_size]
 
-            progress_bar.update(len(chunk))
-        progress_bar.close()
+                response = await async_bulk(
+                    client=self._client,
+                    name=name,
+                    json_body=bulk_class(
+                        tags=tags,
+                        metadata=metadata,
+                        records=[creation_class.from_client(r) for r in chunk],
+                    ),
+                )
+
+                processed += response.parsed.processed
+                failed += response.parsed.failed
+
+                progress_bar.update(task, advance=len(chunk))
 
         # TODO: improve logging policy in library
         if verbose:
@@ -406,7 +410,7 @@ class Argilla:
                 not workspace
             ):  # Just for backward comp. with datasets with no workspaces
                 workspace = "-"
-            print(
+            rprint(
                 f"{processed} records logged to"
                 f" {self._client.base_url}/datasets/{workspace}/{name}"
             )

--- a/src/argilla/logging.py
+++ b/src/argilla/logging.py
@@ -18,10 +18,13 @@ This module centralizes all configuration and logging management
 """
 
 import logging
-from logging import Logger
+from logging import Logger, StreamHandler
 from typing import Type
 
-from rich.logging import RichHandler
+try:
+    from rich.logging import RichHandler as ArgillaHandler
+except ModuleNotFoundError:
+    ArgillaHandler = StreamHandler
 
 
 def full_qualified_class_name(_class: Type) -> str:
@@ -59,7 +62,7 @@ class LoggingMixin:
 
 def configure_logging():
     """Normalizes logging configuration for argilla and its dependencies"""
-    handler = RichHandler()
+    handler = ArgillaHandler()
 
     # See the note here: https://docs.python.org/3/library/logging.html#logging.Logger.propagate
     # We only attach our handler to the root logger and let propagation take care of the rest

--- a/src/argilla/logging.py
+++ b/src/argilla/logging.py
@@ -21,10 +21,7 @@ import logging
 from logging import Logger
 from typing import Type
 
-try:
-    from loguru import logger
-except ModuleNotFoundError:
-    logger = None
+from rich.logging import RichHandler
 
 
 def full_qualified_class_name(_class: Type) -> str:
@@ -60,64 +57,10 @@ class LoggingMixin:
         return self.__logger__
 
 
-class LoguruLoggerHandler(logging.Handler):
-    """This logging handler enables an easy way to use loguru fo all built-in logger traces"""
-
-    __LOGLEVEL_MAPPING__ = {
-        50: "CRITICAL",
-        40: "ERROR",
-        30: "WARNING",
-        20: "INFO",
-        10: "DEBUG",
-        0: "NOTSET",
-    }
-
-    @property
-    def is_available(self) -> bool:
-        """Return True if handler can tackle log records. False otherwise"""
-        return logger is not None
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        if not self.is_available:
-            self.emit = lambda record: None
-
-    def emit(self, record: logging.LogRecord):
-        try:
-            level = logger.level(record.levelname).name
-        except AttributeError:
-            level = self.__LOGLEVEL_MAPPING__[record.levelno]
-
-        frame, depth = logging.currentframe(), 2
-        while frame.f_code.co_filename == logging.__file__:
-            frame = frame.f_back
-            depth += 1
-
-        log = logger.bind(request_id="argilla")
-        log.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
-
-
 def configure_logging():
     """Normalizes logging configuration for argilla and its dependencies"""
-    intercept_handler = LoguruLoggerHandler()
-    if not intercept_handler.is_available:
-        return
+    handler = RichHandler()
 
-    logging.basicConfig(handlers=[intercept_handler], level=logging.WARNING)
-    for name in logging.root.manager.loggerDict:
-        logger_ = logging.getLogger(name)
-        logger_.handlers = []
-
-    for name in [
-        "uvicorn",
-        "uvicorn.lifespan",
-        "uvicorn.error",
-        "uvicorn.access",
-        "fastapi",
-        "argilla",
-        "argilla.server",
-    ]:
-        logger_ = logging.getLogger(name)
-        logger_.propagate = False
-        logger_.handlers = [intercept_handler]
+    # See the note here: https://docs.python.org/3/library/logging.html#logging.Logger.propagate
+    # We only attach our handler to the root logger and let propagation take care of the rest
+    logging.basicConfig(handlers=[handler], level=logging.WARNING)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,15 +15,10 @@
 import httpx
 import pytest
 from _pytest.logging import LogCaptureFixture
-from argilla.client.sdk.users import api as users_api
-from argilla.server.commons import telemetry
-
-try:
-    from loguru import logger
-except ModuleNotFoundError:
-    logger = None
 from argilla import app
 from argilla.client.api import active_api
+from argilla.client.sdk.users import api as users_api
+from argilla.server.commons import telemetry
 from starlette.testclient import TestClient
 
 from .helpers import SecuredClient
@@ -68,13 +63,3 @@ def mocked_client(
         monkeypatch.setattr(rb_api._client, "__httpx__", client_)
 
         yield client_
-
-
-@pytest.fixture
-def caplog(caplog: LogCaptureFixture):
-    if not logger:
-        yield caplog
-    else:
-        handler_id = logger.add(caplog.handler, format="{message}")
-        yield caplog
-        logger.remove(handler_id)

--- a/tests/labeling/text_classification/test_label_errors.py
+++ b/tests/labeling/text_classification/test_label_errors.py
@@ -17,6 +17,7 @@ import sys
 import argilla as ar
 import cleanlab
 import pytest
+from _pytest.logging import LogCaptureFixture
 from argilla.labeling.text_classification import find_label_errors
 from argilla.labeling.text_classification.label_errors import (
     MissingPredictionError,
@@ -76,7 +77,7 @@ def test_no_records():
         find_label_errors(records)
 
 
-def test_multi_label_warning(caplog):
+def test_multi_label_warning(caplog: LogCaptureFixture):
     record = ar.TextClassificationRecord(
         text="test",
         prediction=[("mock", 0.0), ("mock2", 0.0)],

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -16,7 +16,7 @@
 import logging
 import sys
 
-from argilla.logging import RichHandler
+from argilla.logging import ArgillaHandler
 from argilla.utils import LazyargillaModule
 
 
@@ -25,7 +25,7 @@ def test_lazy_module():
 
 
 def test_configure_logging_call():
-    # Ensure that the root logger uses the RichHandler,
+    # Ensure that the root logger uses the ArgillaHandler (RichHandler if rich is installed),
     # whereas the other loggers do not have handlers
-    assert isinstance(logging.getLogger().handlers[0], RichHandler)
+    assert isinstance(logging.getLogger().handlers[0], ArgillaHandler)
     assert len(logging.getLogger("argilla").handlers) == 0

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -16,7 +16,7 @@
 import logging
 import sys
 
-from argilla.logging import LoguruLoggerHandler
+from argilla.logging import RichHandler
 from argilla.utils import LazyargillaModule
 
 
@@ -25,4 +25,7 @@ def test_lazy_module():
 
 
 def test_configure_logging_call():
-    assert isinstance(logging.getLogger("argilla").handlers[0], LoguruLoggerHandler)
+    # Ensure that the root logger uses the RichHandler,
+    # whereas the other loggers do not have handlers
+    assert isinstance(logging.getLogger().handlers[0], RichHandler)
+    assert len(logging.getLogger("argilla").handlers) == 0

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 import logging
 
-from argilla.logging import LoggingMixin, LoguruLoggerHandler
+from argilla.logging import LoggingMixin, RichHandler
 
 
 class LoggingForTest(LoggingMixin):
@@ -50,8 +50,8 @@ def test_logging_mixin_without_breaking_constructors():
 
 
 def test_logging_handler(mocker):
-    mocker.patch.object(LoguruLoggerHandler, "emit", autospec=True)
-    handler = LoguruLoggerHandler()
+    mocker.patch.object(RichHandler, "emit", autospec=True)
+    handler = RichHandler()
 
     logger = logging.getLogger(__name__)
     logger.handlers = [handler]

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 import logging
 
-from argilla.logging import LoggingMixin, RichHandler
+from argilla.logging import ArgillaHandler, LoggingMixin
 
 
 class LoggingForTest(LoggingMixin):
@@ -50,8 +50,8 @@ def test_logging_mixin_without_breaking_constructors():
 
 
 def test_logging_handler(mocker):
-    mocker.patch.object(RichHandler, "emit", autospec=True)
-    handler = RichHandler()
+    mocker.patch.object(ArgillaHandler, "emit", autospec=True)
+    handler = ArgillaHandler()
 
     logger = logging.getLogger(__name__)
     logger.handlers = [handler]


### PR DESCRIPTION
Closes #1843

Hello!

## Pull Request overview
* Use [`rich`](https://github.com/Textualize/rich) for logging, tracebacks, printing and progressbars.
* Add `rich` as a dependency.
* Remove `loguru` as a dependency and remove all mentions of it in the codebase.
* Simplify logging configuration according to the logging documentation.
* Update logging tests.

## Before & After
[`rich`](https://github.com/Textualize/rich) is a large Python library for very colorful formatting in the terminal. Most importantly (in my opinion), it improves the readability of logs and tracebacks. Let's go over some before-and-afters:
<details><summary>Printing, Logging & Progressbars</summary>

### Before:
![image](https://user-images.githubusercontent.com/37621491/219089678-e57906d3-568d-480e-88a4-9240397f5229.png)

### After:
![image](https://user-images.githubusercontent.com/37621491/219089826-646d57a6-7e5b-426f-9ab1-d6d6317ec885.png)

Note that for the logs, the repeated information on the left side is removed. Beyond that, the file location from which the log originates is moved to the right side. Beyond that, the progressbar has been updated, ahd the URL in the printed output has been highlighted automatically.

</details>

<details><summary>Tracebacks</summary>

### Before:
![image](https://user-images.githubusercontent.com/37621491/219090868-42cfe128-fd98-47ec-9d38-6f6f52a21373.png)

### After:
![image](https://user-images.githubusercontent.com/37621491/219090903-86f1fe11-d509-440d-8a6a-2833c344707b.png)

---

### Before:
![image](https://user-images.githubusercontent.com/37621491/219091343-96bae874-a673-4281-80c5-caebb67e348e.png)

### After:
![image](https://user-images.githubusercontent.com/37621491/219091193-d4cb1f64-11a7-4783-a9b2-0aec1abb8eb7.png)

---

### Before
![image](https://user-images.githubusercontent.com/37621491/219091791-aa8969a1-e0c1-4708-a23d-38d22c2406f2.png)

### After
![image](https://user-images.githubusercontent.com/37621491/219091878-e24c1f6b-83fa-4fed-9705-ede522faee82.png)

</details>

## Notes
Note that there are some changes in the logging configuration. Most of all, it has been simplified according to the note from [here](https://docs.python.org/3/library/logging.html#logging.Logger.propagate). In my changes, I only attach our handler to the root logger and let propagation take care of the rest.

Beyond that, I've set `rich` to 13.0.1 as newer versions experience a StopIteration error like discussed [here](https://github.com/Textualize/rich/issues/2800#issuecomment-1428764064).

I've replaced `tqdm` with `rich` Progressbar when logging. However, I've kept the `tqdm` progressbar for the [Weak Labeling](https://github.com/argilla-io/argilla/blob/develop/src/argilla/labeling/text_classification/weak_labels.py) for now. 

One difference between the old situation and now is that all of the logs are displayed during `pytest` under "live log call" (so, including expected errors), while earlier only warnings were shown.

## What to review?
Please do the following when reviewing:
1. Ensuring that `rich` is correctly set to be installed whenever someone installs `argilla`. I always set my dependencies explicitly in setup.py like [here](https://github.com/nltk/nltk/blob/develop/setup.py#L115) or [here](https://github.com/huggingface/setfit/blob/78851287535305ef32f789c7a87004628172b5b6/setup.py#L47-L48), but the one for `argilla` is [empty](https://github.com/argilla-io/argilla/blob/develop/setup.py), and `pyproject.toml` is used instead. I'd like for someone to look this over.
2. Fetch this branch and run some arbitrary code. Load some data, log some data, crash some programs, and get an idea of the changes. Especially changes to loggers and tracebacks can be a bit personal, so I'd like to get people on board with this. Otherwise we can scrap it or find a compromise. After all, this is also a design PR.
3. Please have a look at my discussion points below.

## Discussion
`rich` is quite configurable, so there's some changes that we can make still.
1. The `RichHandler` logging handler can be modified to e.g. include rich tracebacks in their logs as discussed [here](https://rich.readthedocs.io/en/latest/logging.html#handle-exceptions). Are we interested in this?
2. The `rich` traceback handler can be set up to include local variables in its traceback:
    <details><summary>Click to see a rich traceback with local variables</summary>

    ![image](https://user-images.githubusercontent.com/37621491/219096029-796b57ee-2f1b-485f-af35-c3effd44200b.png)
    </details>
    Are we interested in this? I think this is a bit overkill in my opinion.
3. We can suppress frames from certain Python modules to exclude them from the rich tracebacks. Are we interested in this?
4. The default rich traceback shows a maximum of 100 frames, which is a *lot*. Are we interested in reducing this to only show the first and last X?
5. The progress bar doesn't automatically stretch to fill the full available width, while `tqdm` does. If we want, we can set `expand=True` and it'll also expand to the entire width. Are we interested in this?
6. The progress "bar" does not need to be a bar, we can also use e.g. a spinner animation. See some more info [here](https://rich.readthedocs.io/en/latest/progress.html#columns). Are we interested in this?

---

**Type of change**

- [x] Refactor (change restructuring the codebase without changing functionality)

**How Has This Been Tested**

I've updated the tests according to my changes.

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I added comments to my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

- Tom Aarsen