### PR TITLE
Improve database sessions management

### DIFF
--- a/src/argilla/server/apis/v0/handlers/users.py
+++ b/src/argilla/server/apis/v0/handlers/users.py
@@ -13,14 +13,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from fastapi import APIRouter, Request, Security, Depends
+from fastapi import APIRouter, Depends, Request, Security
 from sqlalchemy.orm import Session
 
 from argilla.server.commons import telemetry
 from argilla.server.contexts import accounts
+from argilla.server.database import get_db
 from argilla.server.security import auth
 from argilla.server.security.model import User, UserCreate
-from argilla.server.database import get_db
 
 router = APIRouter(tags=["users"])
 
@@ -49,10 +49,7 @@ async def whoami(request: Request, current_user: User = Security(auth.get_user, 
 
 @router.post("/users", response_model=User, response_model_exclude_none=True)
 def create_user(
-    *,
-    db: Session = Depends(get_db),
-    user_create: UserCreate,
-    current_user: User = Security(auth.get_user, scopes=[])
+    *, db: Session = Depends(get_db), user_create: UserCreate, current_user: User = Security(auth.get_user, scopes=[])
 ):
     user = accounts.create_user(db, user_create)
 

--- a/src/argilla/server/apis/v0/handlers/users.py
+++ b/src/argilla/server/apis/v0/handlers/users.py
@@ -13,13 +13,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from fastapi import APIRouter, Request, Security
+from fastapi import APIRouter, Request, Security, Depends
+from sqlalchemy.orm import Session
 
-from argilla.server import models
 from argilla.server.commons import telemetry
 from argilla.server.contexts import accounts
 from argilla.server.security import auth
 from argilla.server.security.model import User, UserCreate
+from argilla.server.database import get_db
 
 router = APIRouter(tags=["users"])
 
@@ -47,7 +48,12 @@ async def whoami(request: Request, current_user: User = Security(auth.get_user, 
 
 
 @router.post("/users", response_model=User, response_model_exclude_none=True)
-def create_user(user_create: UserCreate, current_user: User = Security(auth.get_user, scopes=[])):
-    user = accounts.create_user(**dict(user_create))
+def create_user(
+    *,
+    db: Session = Depends(get_db),
+    user_create: UserCreate,
+    current_user: User = Security(auth.get_user, scopes=[])
+):
+    user = accounts.create_user(db, user_create)
 
     return User.from_orm(user)

--- a/src/argilla/server/contexts/accounts.py
+++ b/src/argilla/server/contexts/accounts.py
@@ -22,16 +22,12 @@ from sqlalchemy.orm import Session
 _CRYPT_CONTEXT = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
-def get_user_by_api_key(api_key: str):
-    session = SessionLocal()
-
-    return session.scalar(select(User).where(User.api_key == api_key))
+def get_user_by_username(db: Session, username: str):
+    return db.query(User).filter(User.username == username).first()
 
 
-def get_user_by_username(username):
-    session = SessionLocal()
-
-    return session.scalar(select(User).where(User.username == username))
+def get_user_by_api_key(db: Session, api_key: str):
+    return db.query(User).filter(User.api_key == api_key).first()
 
 
 def create_user(db: Session, user_create: UserCreate):
@@ -49,8 +45,8 @@ def create_user(db: Session, user_create: UserCreate):
     return user
 
 
-def authenticate_user(username, password):
-    user = get_user_by_username(username)
+def authenticate_user(db: Session, username: str, password: str):
+    user = get_user_by_username(db, username)
 
     if user and _CRYPT_CONTEXT.verify(password, user.password_hash):
         return user

--- a/src/argilla/server/contexts/accounts.py
+++ b/src/argilla/server/contexts/accounts.py
@@ -12,12 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from argilla.server.database import SessionLocal
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+
 from argilla.server.models import User
 from argilla.server.security.model import UserCreate
-from passlib.context import CryptContext
-from sqlalchemy import select
-from sqlalchemy.orm import Session
 
 _CRYPT_CONTEXT = CryptContext(schemes=["bcrypt"], deprecated="auto")
 

--- a/src/argilla/server/contexts/accounts.py
+++ b/src/argilla/server/contexts/accounts.py
@@ -12,11 +12,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from passlib.context import CryptContext
-from sqlalchemy.orm import Session
-
 from argilla.server.models import User
 from argilla.server.security.model import UserCreate
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
 
 _CRYPT_CONTEXT = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -34,7 +33,7 @@ def create_user(db: Session, user_create: UserCreate):
         first_name=user_create.first_name,
         last_name=user_create.last_name,
         username=user_create.username,
-        password_hash=_CRYPT_CONTEXT.hash(user_create.password)
+        password_hash=_CRYPT_CONTEXT.hash(user_create.password),
     )
 
     db.add(user)

--- a/src/argilla/server/database.py
+++ b/src/argilla/server/database.py
@@ -22,5 +22,13 @@ engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
+def get_db():
+    try:
+        db = SessionLocal()
+        yield db
+    finally:
+        db.close()
+
+
 class Base(DeclarativeBase):
     pass

--- a/src/argilla/server/security/auth_provider/local/provider.py
+++ b/src/argilla/server/security/auth_provider/local/provider.py
@@ -22,10 +22,11 @@ from fastapi.security import (
     OAuth2PasswordRequestForm,
     SecurityScopes,
 )
-from sqlalchemy.orm import Session
 from jose import JWTError, jwt
+from sqlalchemy.orm import Session
 
 from argilla.server.contexts import accounts
+from argilla.server.database import get_db
 from argilla.server.errors import InactiveUserError, UnauthorizedError
 from argilla.server.security.auth_provider.base import (
     AuthProvider,
@@ -34,7 +35,6 @@ from argilla.server.security.auth_provider.base import (
 )
 from argilla.server.security.auth_provider.local.users.service import UsersService
 from argilla.server.security.model import Token, User
-from argilla.server.database import get_db
 
 from .settings import Settings
 from .settings import settings as local_security

--- a/src/argilla/server/security/model.py
+++ b/src/argilla/server/security/model.py
@@ -39,9 +39,9 @@ class UserGetter(GetterDict):
 
 
 class UserCreate(BaseModel):
-    username: constr(regex=_USER_USERNAME_REGEX)
     first_name: str
     last_name: Optional[str]
+    username: constr(regex=_USER_USERNAME_REGEX)
     password: constr(min_length=_USER_PASSWORD_MIN_LENGTH)
 
 

--- a/src/argilla/server/seeds.py
+++ b/src/argilla/server/seeds.py
@@ -17,25 +17,22 @@ from argilla.server.models import User
 
 
 def development_seeds():
-    session = SessionLocal()
-
-    session.add_all(
-        [
-            User(
-                first_name="John",
-                last_name="Doe",
-                username="argilla",
-                password_hash="$2y$05$eaw.j2Kaw8s8vpscVIZMfuqSIX3OLmxA21WjtWicDdn0losQ91Hw.",
-                api_key="1234",
-            ),
-            User(
-                first_name="Tanya",
-                last_name="Franklin",
-                username="tanya",
-                password_hash="$2y$05$eaw.j2Kaw8s8vpscVIZMfuqSIX3OLmxA21WjtWicDdn0losQ91Hw.",
-                api_key="123456",
-            ),
-        ]
-    )
-
-    session.commit()
+    with SessionLocal() as session, session.begin():
+        session.add_all(
+            [
+                User(
+                    first_name="John",
+                    last_name="Doe",
+                    username="argilla",
+                    password_hash="$2y$05$eaw.j2Kaw8s8vpscVIZMfuqSIX3OLmxA21WjtWicDdn0losQ91Hw.",
+                    api_key="1234",
+                ),
+                User(
+                    first_name="Tanya",
+                    last_name="Franklin",
+                    username="tanya",
+                    password_hash="$2y$05$eaw.j2Kaw8s8vpscVIZMfuqSIX3OLmxA21WjtWicDdn0losQ91Hw.",
+                    api_key="123456",
+                ),
+            ]
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,8 +64,8 @@ def setup_database(engine):
 
 
 def seed_for_tests():
-    with SessionLocal() as db_session:
-        db_session.add_all(
+    with SessionLocal() as session, session.begin():
+        session.add_all(
             [
                 User(
                     first_name="Argilla",
@@ -87,8 +87,6 @@ def seed_for_tests():
                 ),
             ]
         )
-
-        db_session.commit()
 
 
 @pytest.fixture

--- a/tests/server/security/test_provider.py
+++ b/tests/server/security/test_provider.py
@@ -29,6 +29,7 @@ async def test_get_user_via_token(db_session):
     access_token = localAuth._create_access_token(username="argilla")
     user = await localAuth.get_user(
         security_scopes=security_Scopes,
+        db=db_session,
         token=access_token,
         api_key=None,
         old_api_key=None,
@@ -38,7 +39,7 @@ async def test_get_user_via_token(db_session):
 
 @pytest.mark.asyncio
 async def test_get_user_via_api_key(db_session):
-    user = await localAuth.get_user(security_scopes=security_Scopes, api_key=DEFAULT_API_KEY, token=None)
+    user = await localAuth.get_user(security_scopes=security_Scopes, db=db_session, api_key=DEFAULT_API_KEY, token=None)
     assert user.username == "argilla"
 
 
@@ -52,5 +53,5 @@ async def test_get_user_by_api_key():
 # Test for function fetch token
 def test_fetch_token_user(db_session):
     access_token = localAuth._create_access_token(username="argilla")
-    user = localAuth.fetch_token_user(token=access_token)
+    user = localAuth.fetch_token_user(db=db_session, token=access_token)
     assert user.username == "argilla"


### PR DESCRIPTION
Improve how database sessions are used in context and endpoints:
- Using a new `get_db` function yielding a `SessionLocal` instance and ensuring the session is closed.
- All endpoints that require it now depends on `get_db`.
- Accounts context functions now receive a `db` session argument.
- We have improved how `SessionLocal` is used on seeds functions.