### PR TITLE
chore: Replace old recognai emails with argilla ones

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-contact@recogn.ai.
+contact@argilla.io.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,10 @@ keywords = [
     "mlops"
 ]
 authors = [
-    {name = "recognai", email = "contact@recogn.ai"}
+    {name = "argilla", email = "contact@argilla.io"}
 ]
 maintainers = [
-    {name = "recognai", email = "contact@recogn.ai"}
+    {name = "argilla", email = "contact@argilla.io"}
 ]
 dependencies = [
     # Client

--- a/tests/server/security/test_model.py
+++ b/tests/server/security/test_model.py
@@ -18,7 +18,7 @@ from argilla.server.security.model import User
 from pydantic import ValidationError
 
 
-@pytest.mark.parametrize("email", ["my@email.com", "infra@recogn.ai"])
+@pytest.mark.parametrize("email", ["my@email.com", "infra@argilla.io"])
 def test_valid_mail(email):
     user = User(username="user", email=email)
     assert user.email == email


### PR DESCRIPTION
# Description

Replace old `recogn.ai` emails with `argilla.io` ones.

This will improve [argilla Pypi package page](https://pypi.org/project/argilla/) showing the correct contact emails.

We still have a reference to `recogn.ai` on this JS model file: https://github.com/argilla-io/argilla/blob/develop/frontend/models/Dataset.js#L22

Please @frascuchon and @keithCuniah can you confirm if that JS code can be safely changed and how?