### PR TITLE
Add first iteration of workspace endpoints

### DIFF
--- a/src/argilla/server/alembic/versions/1769ee58fbb4_create_users_workspaces_table.py
+++ b/src/argilla/server/alembic/versions/1769ee58fbb4_create_users_workspaces_table.py
@@ -33,13 +33,9 @@ def upgrade() -> None:
     op.create_table(
         "users_workspaces",
         sa.Column("id", sa.Uuid, primary_key=True),
-        sa.Column("user_id", sa.Uuid, sa.ForeignKey("users.id"), nullable=False, index=True),
+        sa.Column("user_id", sa.Uuid, sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True),
         sa.Column(
-            "workspace_id",
-            sa.Uuid,
-            sa.ForeignKey("workspaces.id"),
-            nullable=False,
-            index=True,
+            "workspace_id", sa.Uuid, sa.ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False, index=True
         ),
         sa.UniqueConstraint("user_id", "workspace_id", name="user_id_workspace_id_uq"),
     )

--- a/src/argilla/server/apis/v0/handlers/workspaces.py
+++ b/src/argilla/server/apis/v0/handlers/workspaces.py
@@ -1,0 +1,107 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import List
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Security
+from pydantic import parse_obj_as
+from sqlalchemy.orm import Session
+
+from argilla.server.contexts import accounts
+from argilla.server.database import get_db
+from argilla.server.errors import EntityNotFoundError
+from argilla.server.security import auth
+from argilla.server.security.model import (
+    User,
+    UserWorkspaceCreate,
+    Workspace,
+    WorkspaceCreate,
+)
+
+router = APIRouter(tags=["workspaces"])
+
+
+@router.get("/workspaces", response_model=List[Workspace], response_model_exclude_none=True)
+def list_workspaces(*, db: Session = Depends(get_db), current_user: User = Security(auth.get_user, scopes=[])):
+    workspaces = accounts.list_workspaces(db)
+
+    return parse_obj_as(List[Workspace], workspaces)
+
+
+@router.post("/workspaces", response_model=Workspace, response_model_exclude_none=True)
+def create_workspace(
+    *,
+    db: Session = Depends(get_db),
+    workspace_create: WorkspaceCreate,
+    current_user: User = Security(auth.get_user, scopes=[]),
+):
+    workspace = accounts.create_workspace(db, workspace_create)
+
+    return Workspace.from_orm(workspace)
+
+
+@router.delete("/workspaces/{workspace_id}", response_model=Workspace, response_model_exclude_none=True)
+def delete_workspace(
+    *, db: Session = Depends(get_db), workspace_id: UUID, current_user: User = Security(auth.get_user, scopes=[])
+):
+    workspace = accounts.get_workspace_by_id(db, workspace_id)
+    if not workspace:
+        raise EntityNotFoundError(name=str(workspace_id), type=Workspace)
+
+    accounts.delete_workspace(db, workspace)
+
+    return Workspace.from_orm(workspace)
+
+
+@router.get("/workspaces/{workspace_id}/users", response_model=List[User], response_model_exclude_none=True)
+def list_workspace_users(
+    *, db: Session = Depends(get_db), workspace_id: UUID, current_user: User = Security(auth.get_user, scopes=[])
+):
+    workspace = accounts.get_workspace_by_id(db, workspace_id)
+    if not workspace:
+        raise EntityNotFoundError(name=str(workspace_id), type=Workspace)
+
+    return parse_obj_as(List[User], workspace.users)
+
+
+@router.post("/workspaces/{workspace_id}/users/{user_id}", response_model=User, response_model_exclude_none=True)
+def create_workspace_user(
+    *,
+    db: Session = Depends(get_db),
+    workspace_id: UUID,
+    user_id: UUID,
+    current_user: User = Security(auth.get_user, scopes=[]),
+):
+    user_workspace = accounts.create_user_workspace(db, UserWorkspaceCreate(user_id=user_id, workspace_id=workspace_id))
+
+    return User.from_orm(user_workspace.user)
+
+
+@router.delete("/workspaces/{workspace_id}/users/{user_id}", response_model=User, response_model_exclude_none=True)
+def delete_workspace_user(
+    *,
+    db: Session = Depends(get_db),
+    workspace_id: UUID,
+    user_id: UUID,
+    current_user: User = Security(auth.get_user, scopes=[]),
+):
+    user_workspace = accounts.get_user_workspace_by_user_id_and_workspace_id(db, user_id, workspace_id)
+    if not user_workspace:
+        raise EntityNotFoundError(name=str(user_id), type=User)
+
+    user = user_workspace.user
+    accounts.delete_user_workspace(db, user_workspace)
+
+    return User.from_orm(user)

--- a/src/argilla/server/apis/v0/handlers/workspaces.py
+++ b/src/argilla/server/apis/v0/handlers/workspaces.py
@@ -52,7 +52,10 @@ def create_workspace(
     return Workspace.from_orm(workspace)
 
 
-@router.delete("/workspaces/{workspace_id}", response_model=Workspace, response_model_exclude_none=True)
+# TODO: We can't do workspaces deletions right now. Workspaces are associated with datasets and used on
+# ElasticSearch indexes. Once that we have datasets on the database and we can check if the workspace doesn't have
+# any dataset then we can delete them.
+# @router.delete("/workspaces/{workspace_id}", response_model=Workspace, response_model_exclude_none=True)
 def delete_workspace(
     *, db: Session = Depends(get_db), workspace_id: UUID, current_user: User = Security(auth.get_user, scopes=[])
 ):

--- a/src/argilla/server/contexts/accounts.py
+++ b/src/argilla/server/contexts/accounts.py
@@ -12,12 +12,73 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from argilla.server.models import User
-from argilla.server.security.model import UserCreate
+from uuid import UUID
+
+from argilla.server.models import User, UserWorkspace, Workspace
+from argilla.server.security.model import (
+    UserCreate,
+    UserWorkspaceCreate,
+    WorkspaceCreate,
+)
 from passlib.context import CryptContext
 from sqlalchemy.orm import Session
 
 _CRYPT_CONTEXT = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def get_user_workspace_by_user_id_and_workspace_id(db: Session, user_id: UUID, workspace_id: UUID):
+    return (
+        db.query(UserWorkspace)
+        .filter(
+            UserWorkspace.user_id == user_id,
+            UserWorkspace.workspace_id == workspace_id,
+        )
+        .first()
+    )
+
+
+def create_user_workspace(db: Session, user_workspace_create: UserWorkspaceCreate):
+    user_workspace = UserWorkspace(
+        user_id=user_workspace_create.user_id, workspace_id=user_workspace_create.workspace_id
+    )
+
+    db.add(user_workspace)
+    db.commit()
+    db.refresh(user_workspace)
+
+    return user_workspace
+
+
+def delete_user_workspace(db: Session, user_workspace: UserWorkspace):
+    db.delete(user_workspace)
+    db.commit()
+
+    return user_workspace
+
+
+def get_workspace_by_id(db: Session, workspace_id: UUID):
+    return db.query(Workspace).get(workspace_id)
+
+
+def list_workspaces(db: Session):
+    return db.query(Workspace).all()
+
+
+def create_workspace(db: Session, workspace_create: WorkspaceCreate):
+    workspace = Workspace(name=workspace_create.name)
+
+    db.add(workspace)
+    db.commit()
+    db.refresh(workspace)
+
+    return workspace
+
+
+def delete_workspace(db: Session, workspace: Workspace):
+    db.delete(workspace)
+    db.commit()
+
+    return workspace
 
 
 def get_user_by_username(db: Session, username: str):

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -35,6 +35,9 @@ class UserWorkspace(Base):
     user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"))
     workspace_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("workspaces.id"))
 
+    user: Mapped["User"] = relationship()
+    workspace: Mapped["Workspace"] = relationship()
+
 
 class Workspace(Base):
     __tablename__ = "workspaces"

--- a/src/argilla/server/routes.py
+++ b/src/argilla/server/routes.py
@@ -31,6 +31,7 @@ from argilla.server.apis.v0.handlers import (
     text_classification,
     token_classification,
     users,
+    workspaces,
 )
 from argilla.server.errors.base_errors import __ALL__
 
@@ -41,6 +42,7 @@ dependencies = []
 
 for router in [
     users.router,
+    workspaces.router,
     datasets.router,
     info.router,
     metrics.router,

--- a/src/argilla/server/security/model.py
+++ b/src/argilla/server/security/model.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 import re
 from typing import Any, List, Optional
+from uuid import UUID
 
 from pydantic import BaseModel, Field, constr, validator
 from pydantic.utils import GetterDict
@@ -21,11 +22,31 @@ from pydantic.utils import GetterDict
 from argilla._constants import DATASET_NAME_REGEX_PATTERN
 from argilla.server.errors import EntityNotFoundError
 
-WORKSPACE_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_\-]*$")
+_WORKSPACE_NAME_REGEX = r"^[a-zA-Z0-9][a-zA-Z0-9_\-]*$"
+
 _EMAIL_REGEX_PATTERN = r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}"
 
 _USER_PASSWORD_MIN_LENGTH = 8
 _USER_USERNAME_REGEX = DATASET_NAME_REGEX_PATTERN
+
+WORKSPACE_NAME_PATTERN = re.compile(_WORKSPACE_NAME_REGEX)
+
+
+class UserWorkspaceCreate(BaseModel):
+    user_id: UUID
+    workspace_id: UUID
+
+
+class Workspace(BaseModel):
+    id: UUID
+    name: str
+
+    class Config:
+        orm_mode = True
+
+
+class WorkspaceCreate(BaseModel):
+    name: constr(regex=_WORKSPACE_NAME_REGEX)
 
 
 class UserGetter(GetterDict):

--- a/src/argilla/server/seeds.py
+++ b/src/argilla/server/seeds.py
@@ -13,13 +13,15 @@
 #  limitations under the License.
 
 from argilla.server.database import SessionLocal
-from argilla.server.models import User
+from argilla.server.models import User, Workspace
 
 
 def development_seeds():
     with SessionLocal() as session, session.begin():
         session.add_all(
             [
+                Workspace(name="workspace-1"),
+                Workspace(name="workspace-2"),
                 User(
                     first_name="John",
                     last_name="Doe",


### PR DESCRIPTION
This PR includes the first iteration for the new workspaces API.

The included endpoints allow to:
- `GET /api/workspaces`: list workspaces.
- `POST /api/workspaces`: create a new workspace.
- `DELETE /api/workspaces/:workspace_id`: delete a workspace.
- `GET /api/workspaces/:workspace_id/users`: list users members of the workspace. 
- `POST /api/workspaces/:workspace_id/users/:user_id`: add a new user as member of the workspace.
- `DELETE /api/workspace/:workspace_id/users/:user_id`: remove/delete a user as member of the workspace.

It also includes changes to `users_workspaces` table migration adding on delete cascade. With this change once a record on `users` or `workspaces` table is deleted we are deleting the associated `users_workspaces` record too.

There are some missing things that are not included and we will fix later:
- When deleting workspaces we are not checking if they have associated datasets or not.
- Pagination (we need to discuss the response format for this).
- Some missing errors that are not managed yet (for example conflict error when an user is already member of a workspace and you are trying to create it).
- Timestamps (`inserted_at`, `udpdated_at` columns).
- Tests (we want to do some improvements to our testing suite first).

@frascuchon tell me if you want to discuss some of these missing points.
