### PR TITLE
Add timestamps columns and fields to database models

### DIFF
--- a/src/argilla/server/alembic/versions/1769ee58fbb4_create_users_workspaces_table.py
+++ b/src/argilla/server/alembic/versions/1769ee58fbb4_create_users_workspaces_table.py
@@ -37,6 +37,8 @@ def upgrade() -> None:
         sa.Column(
             "workspace_id", sa.Uuid, sa.ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False, index=True
         ),
+        sa.Column("inserted_at", sa.DateTime, nullable=False),
+        sa.Column("updated_at", sa.DateTime, nullable=False),
         sa.UniqueConstraint("user_id", "workspace_id", name="user_id_workspace_id_uq"),
     )
 

--- a/src/argilla/server/alembic/versions/74694870197c_create_users_table.py
+++ b/src/argilla/server/alembic/versions/74694870197c_create_users_table.py
@@ -38,6 +38,8 @@ def upgrade() -> None:
         sa.Column("username", sa.String, nullable=False, unique=True, index=True),
         sa.Column("api_key", sa.Text, nullable=False, unique=True, index=True),
         sa.Column("password_hash", sa.Text, nullable=False),
+        sa.Column("inserted_at", sa.DateTime, nullable=False),
+        sa.Column("updated_at", sa.DateTime, nullable=False),
     )
 
 

--- a/src/argilla/server/alembic/versions/82a5a88a3fa5_create_workspaces_table.py
+++ b/src/argilla/server/alembic/versions/82a5a88a3fa5_create_workspaces_table.py
@@ -34,6 +34,8 @@ def upgrade() -> None:
         "workspaces",
         sa.Column("id", sa.Uuid, primary_key=True),
         sa.Column("name", sa.String, nullable=False),
+        sa.Column("inserted_at", sa.DateTime, nullable=False),
+        sa.Column("updated_at", sa.DateTime, nullable=False),
     )
 
 

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import secrets
+from datetime import datetime
 from typing import List, Optional
 from uuid import UUID, uuid4
 
@@ -28,12 +29,19 @@ def generate_user_api_key():
     return secrets.token_urlsafe(_USER_API_KEY_BYTES_LENGTH)
 
 
+def default_inserted_at(context):
+    return context.get_current_parameters()["inserted_at"]
+
+
 class UserWorkspace(Base):
     __tablename__ = "users_workspaces"
 
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
     user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"))
     workspace_id: Mapped[UUID] = mapped_column(ForeignKey("workspaces.id"))
+
+    inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
     user: Mapped["User"] = relationship()
     workspace: Mapped["Workspace"] = relationship()
@@ -44,6 +52,9 @@ class Workspace(Base):
 
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
     name: Mapped[str]
+
+    inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
     users: Mapped[List["User"]] = relationship(secondary="users_workspaces", back_populates="workspaces")
 
@@ -57,5 +68,8 @@ class User(Base):
     username: Mapped[str]
     api_key: Mapped[str] = mapped_column(Text, unique=True, default=generate_user_api_key)
     password_hash: Mapped[str] = mapped_column(Text)
+
+    inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
     workspaces: Mapped[List["Workspace"]] = relationship(secondary="users_workspaces", back_populates="users")

--- a/src/argilla/server/security/model.py
+++ b/src/argilla/server/security/model.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import re
+from datetime import datetime
 from typing import Any, List, Optional
 from uuid import UUID
 
@@ -40,6 +41,8 @@ class UserWorkspaceCreate(BaseModel):
 class Workspace(BaseModel):
     id: UUID
     name: str
+    inserted_at: datetime
+    updated_at: datetime
 
     class Config:
         orm_mode = True
@@ -85,6 +88,10 @@ class User(BaseModel):
     disabled: Optional[bool] = None
     api_key: str
     workspaces: Optional[List[str]] = None
+    # TODO: Adding inserted_at and updated_at is causing multiple errors so we are disabling them by now.
+    # Once that we refactor all the old code we should enable this again.
+    # inserted_at: datetime
+    # updated_at: datetime
 
     class Config:
         orm_mode = True


### PR DESCRIPTION
This PR include the following changes:
* Add `inserted_at` and `updated_at` columns to all database table migrations.
* Add `inserted_at` and `updated_at` fields to database models and Pydantic schemas.

Missing things:
* It was not possible to add `inserted_at`,  and `updated_at` fields to `User` Pydantic schema due to some errors in old code. We can fix this later.

Gotchas:
* In order to have the same exact values for `inserted_at` and `updated_at` when a record is inserted I have created a `default_inserted_at` function that get the context of the operation to extract the value of `inserted_at` and use it on `update_at`.
* I can see microseconds level date times inserted on SQLite so I guess we are covered on that sense (maybe we can check this once we test the changes with PostgreSQL).




