### PR TITLE
Refactor: Add `require_version` function and `requires_version` decorator

### DIFF
--- a/src/argilla/client/datasets.py
+++ b/src/argilla/client/datasets.py
@@ -28,7 +28,7 @@ from argilla.client.models import (
     TokenClassificationRecord,
 )
 from argilla.client.sdk.datasets.models import TaskType
-from argilla.utils.dependency import require_version, requires_datasets, requires_spacy
+from argilla.utils.dependency import require_version, requires_version
 from argilla.utils.span_utils import SpanUtils
 
 if TYPE_CHECKING:
@@ -119,7 +119,7 @@ class DatasetBase:
     def __str__(self):
         return repr(self)
 
-    @requires_datasets
+    @requires_version("datasets>1.17.0")
     def to_datasets(self) -> "datasets.Dataset":
         """Exports your records to a `datasets.Dataset`.
 
@@ -462,7 +462,7 @@ class DatasetBase:
         else:
             raise NotImplementedError(f"Framework {framework} is not supported. Choose from:" f" {list(Framework)}")
 
-    @requires_spacy
+    @requires_version("spacy")
     def _prepare_for_training_with_spacy(
         self, **kwargs
     ) -> Union["spacy.token.DocBin", Tuple["spacy.token.DocBin", "spacy.token.DocBin"]]:
@@ -477,7 +477,7 @@ class DatasetBase:
 
         raise NotImplementedError
 
-    @requires_datasets
+    @requires_version("datasets>1.17.0")
     def _prepare_for_training_with_transformers(self, **kwargs) -> "datasets.Dataset":
         """Prepares the dataset for training using the "transformers" framework.
 
@@ -490,7 +490,7 @@ class DatasetBase:
 
         raise NotImplementedError
 
-    @requires_datasets
+    @requires_version("datasets>1.17.0")
     def _prepare_for_training_with_spark_nlp(self, **kwargs) -> "datasets.Dataset":
         """Prepares the dataset for training using the "spark-nlp" framework.
 
@@ -559,7 +559,7 @@ class DatasetForTextClassification(DatasetBase):
         super().__init__(records=records)
 
     @classmethod
-    @requires_datasets
+    @requires_version("datasets>1.17.0")
     def from_datasets(
         cls,
         dataset: "datasets.Dataset",
@@ -710,7 +710,7 @@ class DatasetForTextClassification(DatasetBase):
     def _from_pandas(cls, dataframe: pd.DataFrame) -> "DatasetForTextClassification":
         return cls([TextClassificationRecord(**row) for row in dataframe.to_dict("records")])
 
-    @requires_datasets
+    @requires_version("datasets>1.17.0")
     def _prepare_for_training_with_transformers(
         self,
         train_size: Optional[float] = None,
@@ -770,7 +770,7 @@ class DatasetForTextClassification(DatasetBase):
 
         return ds
 
-    @requires_spacy
+    @requires_version("spacy")
     def _prepare_for_training_with_spacy(self, nlp: "spacy.Language", records: List[Record]) -> "spacy.tokens.DocBin":
         from spacy.tokens import DocBin
 
@@ -869,7 +869,7 @@ class DatasetForTokenClassification(DatasetBase):
         return parent_fields + ["tags"]  # compute annotation from tags
 
     @classmethod
-    @requires_datasets
+    @requires_version("datasets>1.17.0")
     def from_datasets(
         cls,
         dataset: "datasets.Dataset",
@@ -947,7 +947,7 @@ class DatasetForTokenClassification(DatasetBase):
     ) -> "DatasetForTokenClassification":
         return super().from_pandas(dataframe)
 
-    @requires_datasets
+    @requires_version("datasets>1.17.0")
     def _prepare_for_training_with_transformers(
         self,
         train_size: Optional[float] = None,
@@ -986,7 +986,7 @@ class DatasetForTokenClassification(DatasetBase):
 
         return ds
 
-    @requires_spacy
+    @requires_version("spacy")
     def _prepare_for_training_with_spacy(self, nlp: "spacy.Language", records: List[Record]) -> "spacy.tokens.DocBin":
         from spacy.tokens import DocBin
 
@@ -1127,7 +1127,7 @@ class DatasetForText2Text(DatasetBase):
         super().__init__(records=records)
 
     @classmethod
-    @requires_datasets
+    @requires_version("datasets>1.17.0")
     def from_datasets(
         cls,
         dataset: "datasets.Dataset",
@@ -1230,7 +1230,7 @@ class DatasetForText2Text(DatasetBase):
     def _from_pandas(cls, dataframe: pd.DataFrame) -> "DatasetForText2Text":
         return cls([Text2TextRecord(**row) for row in dataframe.to_dict("records")])
 
-    @requires_datasets
+    @requires_version("datasets>1.17.0")
     def prepare_for_training(self, **kwargs) -> "datasets.Dataset":
         """Prepares the dataset for training.
 

--- a/src/argilla/client/datasets.py
+++ b/src/argilla/client/datasets.py
@@ -12,14 +12,12 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import functools
 import logging
 import random
 import uuid
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 import pandas as pd
-from pkg_resources import parse_version
 
 from argilla.client.models import (
     Framework,
@@ -30,6 +28,7 @@ from argilla.client.models import (
     TokenClassificationRecord,
 )
 from argilla.client.sdk.datasets.models import TaskType
+from argilla.utils.dependency import require_version, requires_datasets, requires_spacy
 from argilla.utils.span_utils import SpanUtils
 
 if TYPE_CHECKING:
@@ -38,42 +37,6 @@ if TYPE_CHECKING:
     import spacy
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _requires_datasets(func):
-    @functools.wraps(func)
-    def check_if_datasets_installed(*args, **kwargs):
-        try:
-            import datasets
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError(
-                f"'datasets' must be installed to use `{func.__name__}`! You can"
-                " install 'datasets' with the command: `pip install datasets>1.17.0`"
-            )
-        if not (parse_version(datasets.__version__) > parse_version("1.17.0")):
-            raise ModuleNotFoundError(
-                "Version >1.17.0 of 'datasets' must be installed to use `to_datasets`!"
-                " You can update 'datasets' with the command: `pip install -U"
-                " datasets>1.17.0`"
-            )
-        return func(*args, **kwargs)
-
-    return check_if_datasets_installed
-
-
-def _requires_spacy(func):
-    @functools.wraps(func)
-    def check_if_spacy_installed(*args, **kwargs):
-        try:
-            import spacy  # noqa: F401
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError(
-                f"'spacy' must be installed to use `{func.__name__}`"
-                "You can install 'spacy' with the command: `pip install spacy`"
-            )
-        return func(*args, **kwargs)
-
-    return check_if_spacy_installed
 
 
 class DatasetBase:
@@ -156,7 +119,7 @@ class DatasetBase:
     def __str__(self):
         return repr(self)
 
-    @_requires_datasets
+    @requires_datasets
     def to_datasets(self) -> "datasets.Dataset":
         """Exports your records to a `datasets.Dataset`.
 
@@ -473,6 +436,7 @@ class DatasetBase:
             )
         elif framework in [Framework.SPACY, Framework.SPARK_NLP]:
             if train_size and test_size:
+                require_version("scikit-learn")
                 from sklearn.model_selection import train_test_split
 
                 records_train, records_test = train_test_split(
@@ -498,7 +462,7 @@ class DatasetBase:
         else:
             raise NotImplementedError(f"Framework {framework} is not supported. Choose from:" f" {list(Framework)}")
 
-    @_requires_spacy
+    @requires_spacy
     def _prepare_for_training_with_spacy(
         self, **kwargs
     ) -> Union["spacy.token.DocBin", Tuple["spacy.token.DocBin", "spacy.token.DocBin"]]:
@@ -513,7 +477,7 @@ class DatasetBase:
 
         raise NotImplementedError
 
-    @_requires_datasets
+    @requires_datasets
     def _prepare_for_training_with_transformers(self, **kwargs) -> "datasets.Dataset":
         """Prepares the dataset for training using the "transformers" framework.
 
@@ -526,7 +490,7 @@ class DatasetBase:
 
         raise NotImplementedError
 
-    @_requires_datasets
+    @requires_datasets
     def _prepare_for_training_with_spark_nlp(self, **kwargs) -> "datasets.Dataset":
         """Prepares the dataset for training using the "spark-nlp" framework.
 
@@ -595,6 +559,7 @@ class DatasetForTextClassification(DatasetBase):
         super().__init__(records=records)
 
     @classmethod
+    @requires_datasets
     def from_datasets(
         cls,
         dataset: "datasets.Dataset",
@@ -745,7 +710,7 @@ class DatasetForTextClassification(DatasetBase):
     def _from_pandas(cls, dataframe: pd.DataFrame) -> "DatasetForTextClassification":
         return cls([TextClassificationRecord(**row) for row in dataframe.to_dict("records")])
 
-    @_requires_datasets
+    @requires_datasets
     def _prepare_for_training_with_transformers(
         self,
         train_size: Optional[float] = None,
@@ -784,6 +749,7 @@ class DatasetForTextClassification(DatasetBase):
         ds = datasets.Dataset.from_dict(ds_dict, features=datasets.Features(feature_dict))
 
         if self._records[0].multi_label:
+            require_version("scikit-learn")
             from sklearn.preprocessing import MultiLabelBinarizer
 
             labels = [rec["label"] for rec in ds]
@@ -804,7 +770,7 @@ class DatasetForTextClassification(DatasetBase):
 
         return ds
 
-    @_requires_spacy
+    @requires_spacy
     def _prepare_for_training_with_spacy(self, nlp: "spacy.Language", records: List[Record]) -> "spacy.tokens.DocBin":
         from spacy.tokens import DocBin
 
@@ -903,6 +869,7 @@ class DatasetForTokenClassification(DatasetBase):
         return parent_fields + ["tags"]  # compute annotation from tags
 
     @classmethod
+    @requires_datasets
     def from_datasets(
         cls,
         dataset: "datasets.Dataset",
@@ -980,7 +947,7 @@ class DatasetForTokenClassification(DatasetBase):
     ) -> "DatasetForTokenClassification":
         return super().from_pandas(dataframe)
 
-    @_requires_datasets
+    @requires_datasets
     def _prepare_for_training_with_transformers(
         self,
         train_size: Optional[float] = None,
@@ -1019,7 +986,7 @@ class DatasetForTokenClassification(DatasetBase):
 
         return ds
 
-    @_requires_spacy
+    @requires_spacy
     def _prepare_for_training_with_spacy(self, nlp: "spacy.Language", records: List[Record]) -> "spacy.tokens.DocBin":
         from spacy.tokens import DocBin
 
@@ -1160,6 +1127,7 @@ class DatasetForText2Text(DatasetBase):
         super().__init__(records=records)
 
     @classmethod
+    @requires_datasets
     def from_datasets(
         cls,
         dataset: "datasets.Dataset",
@@ -1262,7 +1230,7 @@ class DatasetForText2Text(DatasetBase):
     def _from_pandas(cls, dataframe: pd.DataFrame) -> "DatasetForText2Text":
         return cls([Text2TextRecord(**row) for row in dataframe.to_dict("records")])
 
-    @_requires_datasets
+    @requires_datasets
     def prepare_for_training(self, **kwargs) -> "datasets.Dataset":
         """Prepares the dataset for training.
 

--- a/src/argilla/labeling/text_classification/label_models.py
+++ b/src/argilla/labeling/text_classification/label_models.py
@@ -21,7 +21,7 @@ import numpy as np
 
 from argilla import DatasetForTextClassification, TextClassificationRecord
 from argilla.labeling.text_classification.weak_labels import WeakLabels, WeakMultiLabels
-from argilla.utils.dependency import requires_sklearn, requires_version
+from argilla.utils.dependency import requires_version
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -311,7 +311,7 @@ class MajorityVoter(LabelModel):
 
         return records_with_prediction
 
-    @requires_sklearn
+    @requires_version("scikit-learn")
     def score(
         self,
         tie_break_policy: Union[TieBreakPolicy, str] = "abstain",
@@ -606,7 +606,7 @@ class Snorkel(LabelModel):
 
         return DatasetForTextClassification(records_with_prediction)
 
-    @requires_sklearn
+    @requires_version("scikit-learn")
     def score(
         self,
         tie_break_policy: Union[TieBreakPolicy, str] = "abstain",
@@ -876,7 +876,7 @@ class FlyingSquid(LabelModel):
 
         return probas
 
-    @requires_sklearn
+    @requires_version("scikit-learn")
     def score(
         self,
         tie_break_policy: Union[TieBreakPolicy, str] = "abstain",

--- a/src/argilla/labeling/text_classification/label_models.py
+++ b/src/argilla/labeling/text_classification/label_models.py
@@ -21,6 +21,7 @@ import numpy as np
 
 from argilla import DatasetForTextClassification, TextClassificationRecord
 from argilla.labeling.text_classification.weak_labels import WeakLabels, WeakMultiLabels
+from argilla.utils.dependency import requires_sklearn, requires_version
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -310,6 +311,7 @@ class MajorityVoter(LabelModel):
 
         return records_with_prediction
 
+    @requires_sklearn
     def score(
         self,
         tie_break_policy: Union[TieBreakPolicy, str] = "abstain",
@@ -344,13 +346,6 @@ class MajorityVoter(LabelModel):
         Raises:
             MissingAnnotationError: If the ``weak_labels`` do not contain annotated records.
         """
-        try:
-            import sklearn  # noqa: F401
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError(
-                "'sklearn' must be installed to compute the metrics! "
-                "You can install 'sklearn' with the command: `pip install scikit-learn`"
-            )
         from sklearn.metrics import classification_report
 
         wl_matrix = self._weak_labels.matrix(has_annotation=True)
@@ -443,6 +438,7 @@ class MajorityVoter(LabelModel):
         return annotation, prediction
 
 
+@requires_version("snorkel")
 class Snorkel(LabelModel):
     """The label model by `Snorkel <https://github.com/snorkel-team/snorkel/>`__.
 
@@ -463,15 +459,7 @@ class Snorkel(LabelModel):
     """
 
     def __init__(self, weak_labels: WeakLabels, verbose: bool = True, device: str = "cpu"):
-        try:
-            import snorkel  # noqa: F401
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError(
-                "'snorkel' must be installed to use the `Snorkel` label model! "
-                "You can install 'snorkel' with the command: `pip install snorkel`"
-            )
-        else:
-            from snorkel.labeling.model import LabelModel as SnorkelLabelModel
+        from snorkel.labeling.model import LabelModel as SnorkelLabelModel
 
         super().__init__(weak_labels)
 
@@ -618,6 +606,7 @@ class Snorkel(LabelModel):
 
         return DatasetForTextClassification(records_with_prediction)
 
+    @requires_sklearn
     def score(
         self,
         tie_break_policy: Union[TieBreakPolicy, str] = "abstain",
@@ -689,6 +678,8 @@ class Snorkel(LabelModel):
         )
 
 
+@requires_version("flyingsquid")
+@requires_version("pgmpy")
 class FlyingSquid(LabelModel):
     """The label model by `FlyingSquid <https://github.com/HazyResearch/flyingsquid>`__.
 
@@ -708,19 +699,9 @@ class FlyingSquid(LabelModel):
     """
 
     def __init__(self, weak_labels: WeakLabels, **kwargs):
-        try:
-            import flyingsquid  # noqa: F401
-            import pgmpy  # noqa: F401
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError(
-                "'flyingsquid' must be installed to use the `FlyingSquid` label model!"
-                " You can install 'flyingsquid' with the command: `pip install pgmpy"
-                " flyingsquid`"
-            )
-        else:
-            from flyingsquid.label_model import LabelModel as FlyingSquidLabelModel
+        from flyingsquid.label_model import LabelModel as FlyingSquidLabelModel
 
-            self._FlyingSquidLabelModel = FlyingSquidLabelModel
+        self._FlyingSquidLabelModel = FlyingSquidLabelModel
 
         super().__init__(weak_labels)
 
@@ -895,6 +876,7 @@ class FlyingSquid(LabelModel):
 
         return probas
 
+    @requires_sklearn
     def score(
         self,
         tie_break_policy: Union[TieBreakPolicy, str] = "abstain",
@@ -932,13 +914,6 @@ class FlyingSquid(LabelModel):
             NotFittedError: If the label model was still not fitted.
             MissingAnnotationError: If the ``weak_labels`` do not contain annotated records.
         """
-        try:
-            import sklearn  # noqa: F401
-        except ModuleNotFoundError:
-            raise ModuleNotFoundError(
-                "'sklearn' must be installed to compute the metrics! "
-                "You can install 'sklearn' with the command: `pip install scikit-learn`"
-            )
         from sklearn.metrics import classification_report
 
         if isinstance(tie_break_policy, str):

--- a/src/argilla/monitoring/asgi.py
+++ b/src/argilla/monitoring/asgi.py
@@ -18,26 +18,19 @@ import logging
 import re
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from argilla.monitoring.base import BaseMonitor
-
-try:
-    import starlette  # noqa: F401
-except ModuleNotFoundError:
-    raise ModuleNotFoundError(
-        "'starlette' must be installed to use the middleware feature! "
-        "You can install 'starlette' with the command: `pip install starlette>=0.13.0`"
-    )
-else:
-    from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
-    from starlette.requests import Request
-    from starlette.responses import JSONResponse, Response, StreamingResponse
-    from starlette.types import Message, Receive
-
 from argilla.client.models import (
     Record,
     TextClassificationRecord,
     TokenClassificationRecord,
 )
+from argilla.monitoring.base import BaseMonitor
+from argilla.utils.dependency import require_version
+
+require_version("starlette>=0.13.0")
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+from starlette.types import Message, Receive
 
 _logger = logging.getLogger(__name__)
 _default_tokenization_pattern = re.compile(r"\W+")

--- a/src/argilla/server/services/tasks/text_classification/metrics.py
+++ b/src/argilla/server/services/tasks/text_classification/metrics.py
@@ -22,7 +22,7 @@ from argilla.server.services.search.model import ServiceRecordsQuery
 from argilla.server.services.tasks.text_classification.model import (
     ServiceTextClassificationRecord,
 )
-from argilla.utils.dependency import requires_sklearn
+from argilla.utils.dependency import requires_version
 
 
 class F1Metric(ServicePythonMetric):
@@ -37,7 +37,7 @@ class F1Metric(ServicePythonMetric):
 
     multi_label: bool = False
 
-    @requires_sklearn
+    @requires_version("scikit-learn")
     def apply(self, records: Iterable[ServiceTextClassificationRecord]) -> Any:
         from sklearn.metrics import precision_recall_fscore_support
 

--- a/src/argilla/server/services/tasks/text_classification/metrics.py
+++ b/src/argilla/server/services/tasks/text_classification/metrics.py
@@ -15,8 +15,6 @@
 from typing import Any, ClassVar, Dict, Iterable, List
 
 from pydantic import Field
-from sklearn.metrics import precision_recall_fscore_support
-from sklearn.preprocessing import MultiLabelBinarizer
 
 from argilla.server.services.metrics import ServiceBaseMetric, ServicePythonMetric
 from argilla.server.services.metrics.models import CommonTasksMetrics
@@ -24,6 +22,7 @@ from argilla.server.services.search.model import ServiceRecordsQuery
 from argilla.server.services.tasks.text_classification.model import (
     ServiceTextClassificationRecord,
 )
+from argilla.utils.dependency import requires_sklearn
 
 
 class F1Metric(ServicePythonMetric):
@@ -38,7 +37,10 @@ class F1Metric(ServicePythonMetric):
 
     multi_label: bool = False
 
+    @requires_sklearn
     def apply(self, records: Iterable[ServiceTextClassificationRecord]) -> Any:
+        from sklearn.metrics import precision_recall_fscore_support
+
         filtered_records = list(filter(lambda r: r.predicted is not None, records))
         # TODO: This must be precomputed with using a global dataset metric
         ds_labels = {label for record in filtered_records for label in record.annotated_as + record.predicted_as}
@@ -61,6 +63,8 @@ class F1Metric(ServicePythonMetric):
                 y_pred.append([labels_mapping[label] for label in predictions])
 
         if self.multi_label:
+            from sklearn.preprocessing import MultiLabelBinarizer
+
             mlb = MultiLabelBinarizer(classes=list(labels_mapping.values()))
             y_true = mlb.fit_transform(y_true)
             y_pred = mlb.fit_transform(y_pred)

--- a/src/argilla/utils/dependency.py
+++ b/src/argilla/utils/dependency.py
@@ -54,7 +54,7 @@ def _compare_versions(
     if not ops[op](version.parse(got_version), version.parse(want_version)):
         raise ImportError(
             f"{requirement} must be installed{f' to use `{func_name}`' if func_name else ''}, but found {package}=={got_version}."
-            f" You can install '{package}' with the command: `pip install -U {requirement}`"
+            f" You can install a supported version of '{package}' with this command: `pip install -U {requirement}`"
         )
 
 
@@ -112,7 +112,7 @@ def require_version(requirement: str, func_name: Optional[str] = None) -> None:
     except importlib_metadata.PackageNotFoundError:
         raise ModuleNotFoundError(
             f"'{package}' must be installed{f' to use `{func_name}`' if func_name else ''}! You can"
-            f" install '{package}' with the command: `pip install {requirement}`"
+            f" install '{package}' with this command: `pip install {requirement}`"
         )
 
     # check that the right version is installed if version number or a range was provided

--- a/src/argilla/utils/dependency.py
+++ b/src/argilla/utils/dependency.py
@@ -148,22 +148,4 @@ def requires_version(requirement):
     return functools.partial(requires_decorator, requirement)
 
 
-def requires_datasets(func):
-    """Decorator requiring that `datasets` is installed with version `>1.17.0`.
-    Shorthand for `requires_version("datasets>1.17.0")`"""
-    return requires_decorator("datasets>1.17.0", func)
-
-
-def requires_spacy(func):
-    """Decorator requiring that `spacy` is installed.
-    Shorthand for `requires_version("spacy")`"""
-    return requires_decorator("spacy", func)
-
-
-def requires_sklearn(func):
-    """Decorator requiring that `scikit-learn` is installed and can be imported as `sklearn`.
-    Shorthand for `requires_version("scikit-learn")`"""
-    return requires_decorator("scikit-learn", func)
-
-
-__all__ = ["requires_datasets", "requires_spacy", "requires_sklearn", "requires_version", "require_version"]
+__all__ = ["requires_version", "require_version"]

--- a/src/argilla/utils/dependency.py
+++ b/src/argilla/utils/dependency.py
@@ -1,0 +1,169 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import functools
+import operator
+import re
+import sys
+from typing import Optional
+
+from packaging import version
+
+# This file was adapted from Hugging Face's wonderful transformers module
+
+# The package importlib_metadata is in a different place, depending on the python version.
+if sys.version_info < (3, 8):
+    import importlib_metadata
+else:
+    import importlib.metadata as importlib_metadata
+
+ops = {
+    "<": operator.lt,
+    "<=": operator.le,
+    "==": operator.eq,
+    "!=": operator.ne,
+    ">=": operator.ge,
+    ">": operator.gt,
+}
+
+
+def _compare_versions(
+    op: str,
+    got_version: Optional[str],
+    want_version: Optional[str],
+    requirement: str,
+    package: str,
+    func_name: Optional[str],
+):
+    if got_version is None or want_version is None:
+        raise ValueError(
+            f"Unable to compare versions for {requirement}: need={want_version} found={got_version}. This is unusual. Consider"
+            f" reinstalling {package}."
+        )
+    if not ops[op](version.parse(got_version), version.parse(want_version)):
+        raise ImportError(
+            f"{requirement} must be installed{f' to use `{func_name}`' if func_name else ''}, but found {package}=={got_version}."
+            f" You can install '{package}' with the command: `pip install -U {requirement}`"
+        )
+
+
+def require_version(requirement: str, func_name: Optional[str] = None) -> None:
+    """
+    Perform a runtime check of the dependency versions, using the exact same syntax used by pip.
+    The installed module version comes from the *site-packages* dir via *importlib_metadata*.
+
+    Args:
+        requirement (`str`): pip style definition, e.g.,  "tokenizers==0.9.4", "tqdm>=4.27", "numpy"
+        func_name (`str`, *optional*): what suggestion to print in case of requirements not being met
+
+    Example:
+    ```python
+    require_version("pandas>1.1.2")
+    require_version("datasets>1.17.0", "from_datasets")
+    ```
+    """
+
+    # non-versioned check
+    if re.match(r"^[\w_\-\d]+$", requirement):
+        package, op, want_version = requirement, None, None
+    else:
+        match = re.findall(r"^([^!=<>\s]+)([\s!=<>]{1,2}.+)", requirement)
+        if not match:
+            raise ValueError(
+                "requirement needs to be in the pip package format, .e.g., package_a==1.23, or package_b>=1.23, but"
+                f" got {requirement!r}."
+            )
+        package, want_full = match[0]
+        want_range = want_full.split(",")  # there could be multiple requirements
+        wanted = {}
+        for w in want_range:
+            match = re.findall(r"^([\s!=<>]{1,2})(.+)", w)
+            if not match:
+                raise ValueError(
+                    "requirement needs to be in the pip package format, .e.g., package_a==1.23, or package_b>=1.23,"
+                    f" but got {requirement!r}."
+                )
+            op, want_version = match[0]
+            wanted[op] = want_version
+            if op not in ops:
+                raise ValueError(f"{requirement}: need one of {list(ops.keys())}, but got {op!r}.")
+
+    # special case
+    if package == "python":
+        got_version = ".".join([str(x) for x in sys.version_info[:3]])
+        for op, want_version in wanted.items():
+            _compare_versions(op, got_version, want_version, requirement, package, func_name=func_name)
+        return
+
+    # check if any version is installed
+    try:
+        got_version = importlib_metadata.version(package)
+    except importlib_metadata.PackageNotFoundError:
+        raise ModuleNotFoundError(
+            f"'{package}' must be installed{f' to use `{func_name}`' if func_name else ''}! You can"
+            f" install '{package}' with the command: `pip install {requirement}`"
+        )
+
+    # check that the right version is installed if version number or a range was provided
+    if want_version is not None:
+        for op, want_version in wanted.items():
+            _compare_versions(op, got_version, want_version, requirement, package, func_name=func_name)
+
+
+def requires_decorator(requirement, func):
+    @functools.wraps(func)
+    def check_if_installed(*args, **kwargs):
+        require_version(requirement, func.__name__)
+        return func(*args, **kwargs)
+
+    return check_if_installed
+
+
+def requires_version(requirement):
+    """Decorator variant of `require_version`.
+    Perform a runtime check of the dependency versions, using the exact same syntax used by pip.
+    The installed module version comes from the *site-packages* dir via *importlib_metadata*.
+
+    Args:
+        requirement (`str`): pip style definition, e.g.,  "tokenizers==0.9.4", "tqdm>=4.27", "numpy"
+
+    Example:
+    ```python
+    @requires_version("datasets>1.17.0")
+    def from_datasets(self, ...):
+        ...
+    ```
+    """
+    return functools.partial(requires_decorator, requirement)
+
+
+def requires_datasets(func):
+    """Decorator requiring that `datasets` is installed with version `>1.17.0`.
+    Shorthand for `requires_version("datasets>1.17.0")`"""
+    return requires_decorator("datasets>1.17.0", func)
+
+
+def requires_spacy(func):
+    """Decorator requiring that `spacy` is installed.
+    Shorthand for `requires_version("spacy")`"""
+    return requires_decorator("spacy", func)
+
+
+def requires_sklearn(func):
+    """Decorator requiring that `scikit-learn` is installed and can be imported as `sklearn`.
+    Shorthand for `requires_version("scikit-learn")`"""
+    return requires_decorator("scikit-learn", func)
+
+
+__all__ = ["requires_datasets", "requires_spacy", "requires_sklearn", "requires_version", "require_version"]

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -157,14 +157,8 @@ class TestDatasetBase:
 
     def test_datasets_not_installed(self, monkeypatch):
         monkeypatch.setattr("argilla.client.datasets.DatasetBase._RECORD_TYPE", "mock")
-        monkeypatch.setitem(sys.modules, "datasets", None)
+        monkeypatch.setattr(sys, "meta_path", [], raising=False)
         with pytest.raises(ModuleNotFoundError, match="pip install datasets>1.17.0"):
-            DatasetBase().to_datasets()
-
-    def test_datasets_wrong_version(self, monkeypatch):
-        monkeypatch.setattr("argilla.client.datasets.DatasetBase._RECORD_TYPE", "mock")
-        monkeypatch.setattr("datasets.__version__", "1.16.0")
-        with pytest.raises(ModuleNotFoundError, match="pip install -U datasets>1.17.0"):
             DatasetBase().to_datasets()
 
     def test_iter_len_getitem(self, monkeypatch, singlelabel_textclassification_records):

--- a/tests/labeling/text_classification/test_label_errors.py
+++ b/tests/labeling/text_classification/test_label_errors.py
@@ -56,7 +56,7 @@ def test_sort_by_enum():
 
 
 def test_not_installed(monkeypatch):
-    monkeypatch.setitem(sys.modules, "cleanlab", None)
+    monkeypatch.setattr(sys, "meta_path", [], raising=False)
     with pytest.raises(ModuleNotFoundError, match="pip install cleanlab"):
         find_label_errors(None)
 

--- a/tests/utils/test_dependency.py
+++ b/tests/utils/test_dependency.py
@@ -83,7 +83,7 @@ class TestDependencyRequirements:
         # This method should fail, as our dependencies require a higher version of datasets
         with pytest.raises(
             ImportError,
-            match=f"but found datasets==.*?You can install 'datasets' with the command: `pip install -U datasets<1.0.0`",
+            match=f"but found datasets==.*?You can install a supported version of 'datasets' with this command: `pip install -U datasets<1.0.0`",
         ):
             test_inner()
 

--- a/tests/utils/test_dependency.py
+++ b/tests/utils/test_dependency.py
@@ -18,9 +18,6 @@ import sys
 import pytest
 from argilla.utils.dependency import (
     require_version,
-    requires_datasets,
-    requires_sklearn,
-    requires_spacy,
     requires_version,
 )
 
@@ -29,9 +26,9 @@ class TestDependencyRequirements:
     @pytest.mark.parametrize(
         ("decorator", "package_name", "import_name", "version"),
         [
-            (requires_datasets, "datasets", "datasets", ">1.17.0"),
-            (requires_spacy, "spacy", "spacy", ""),
-            (requires_sklearn, "scikit-learn", "sklearn", ""),
+            (requires_version("datasets>1.17.0"), "datasets", "datasets", ">1.17.0"),
+            (requires_version("spacy"), "spacy", "spacy", ""),
+            (requires_version("scikit-learn"), "scikit-learn", "sklearn", ""),
             (requires_version("faiss"), "faiss", "faiss", ""),
         ],
     )
@@ -60,9 +57,9 @@ class TestDependencyRequirements:
     @pytest.mark.parametrize(
         ("decorator"),
         [
-            requires_datasets,
-            requires_spacy,
-            requires_sklearn,
+            requires_version("datasets>1.17.0"),
+            requires_version("spacy"),
+            requires_version("scikit-learn"),
         ],
     )
     def test_installed_dependency_decorator(self, decorator):

--- a/tests/utils/test_dependency.py
+++ b/tests/utils/test_dependency.py
@@ -1,0 +1,110 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import importlib
+import sys
+
+import pytest
+from argilla.utils.dependency import (
+    require_version,
+    requires_datasets,
+    requires_sklearn,
+    requires_spacy,
+    requires_version,
+)
+
+
+class TestDependencyRequirements:
+    @pytest.mark.parametrize(
+        ("decorator", "package_name", "import_name", "version"),
+        [
+            (requires_datasets, "datasets", "datasets", ">1.17.0"),
+            (requires_spacy, "spacy", "spacy", ""),
+            (requires_sklearn, "scikit-learn", "sklearn", ""),
+            (requires_version("faiss"), "faiss", "faiss", ""),
+        ],
+    )
+    def test_missing_dependency_decorator(
+        self, monkeypatch: pytest.MonkeyPatch, decorator, package_name: str, import_name: str, version: str
+    ):
+        monkeypatch.setitem(sys.modules, import_name, None)
+        monkeypatch.setattr(sys, "meta_path", [], raising=False)
+
+        # Ensure that the package indeed cannot be imported due to the monkeypatch
+        with pytest.raises(ModuleNotFoundError):
+            importlib.import_module(import_name)
+
+        @decorator
+        def test_inner():
+            pass
+
+        requirement = package_name + version
+        # Verify that the decorator does its work and shows the desired output with `pip install ...`
+        with pytest.raises(
+            ModuleNotFoundError,
+            match=f"'{package_name}' must be installed to use `test_inner`!.*?`pip install {requirement}`",
+        ):
+            test_inner()
+
+    @pytest.mark.parametrize(
+        ("decorator"),
+        [
+            requires_datasets,
+            requires_spacy,
+            requires_sklearn,
+        ],
+    )
+    def test_installed_dependency_decorator(self, decorator):
+        # Ensure that the decorated function can be called just fine if the dependencies are installed,
+        # which they should be for these tests
+
+        @decorator
+        def test_inner():
+            return True
+
+        assert test_inner()
+
+    def test_installed_dependency_but_incorrect_version(self):
+        def test_inner():
+            require_version("datasets<1.0.0")
+            return True
+
+        # This method should fail, as our dependencies require a higher version of datasets
+        with pytest.raises(
+            ImportError,
+            match=f"but found datasets==.*?You can install 'datasets' with the command: `pip install -U datasets<1.0.0`",
+        ):
+            test_inner()
+
+    def test_require_version_failures(self):
+        # This operation is not supported
+        with pytest.raises(ValueError):
+            require_version("datasets~=1.0.0")
+
+        # Add some unsupported tokens, e.g. " "
+        with pytest.raises(ValueError):
+            require_version(" datasets")
+
+        # Add unsupported operation in second requirement version
+        with pytest.raises(ValueError):
+            require_version("datasets>1.0.0,~1.17.0")
+
+    def test_special_python_case(self):
+        require_version("python>3.6")
+
+    def test_multiple_version_requirements(self):
+        # This is equivalent to just datasets>1.17.0, but we expect it to work still
+        require_version("datasets>1.0.0,>1.8.0,>1.17.0")
+        # A more common example (designed not to break eventually):
+        require_version("datasets>1.17.0,<1000.0.0")


### PR DESCRIPTION
Closes #2367

Hello!

## Pull Request overview
* Implementation for `require_version` based on the transformer module.
* Implementation for `requires_version`, a decorator that wraps `require_version`
  * `requires_datasets`, `requires_spacy` and `requires_sklearn` as shorthands for `requires_version` for specific modules.
* Removed `try-except ModuleNotFoundError` throughout the project for e.g. `cleanlab`, `snorkel`, `flyingsquid`, `pgmpy`, `starlette` and replaced them with `requires_version` decorators.
* Added tests to accompany the additions
* Modified existing tests

## Details
I have added `require_version` which ought to be used like:
```python
...
if train_size and test_size:
    require_version("scikit-learn")
    from sklearn.model_selection import train_test_split
    ...
```

And also `requires_version`:
```python
...
@requires_version("cleanlab")
def find_label_errors(
    records: Union[List[TextClassificationRecord], DatasetForTextClassification],
    ...
```
and some shorthands, e.g.:
```python
...

@requires_datasets
def to_datasets() -> "datasets.Dataset":
    """Exports your records to a `datasets.Dataset`.
    ...
```

When `require_version` is called, or when a function/method wrapped with `requires_...` is called, [`importlib.metadata`](https://docs.python.org/3/library/importlib.metadata.html) is used to see if the package is installed, and at which version. This is the recommended approach for collecting version information, i.e. recommended over the less efficient `pkg_resources`.

### Advanced usage
We can set version requirements using this approach:
```python
require_version("datasets>1.17.0")
# or
@requires_version("datasets>1.17.0")
def ...
```
And not just one, we can set multiple:
```python
require_version("datasets>1.17.0,<2.0.0")
# or
@requires_version("datasets>1.17.0,<2.0.0")
def ...
```
We can also specify Python versions for certain functions/methods/sections of code:
```python
require_version("python>3.7")
# or
@requires_version("python>3.7")
def ...
```

### Missing & outdated dependencies
Consider the following example:
```python
from argilla.utils.dependency import requires_datasets

@requires_datasets
def foo():
    pass

foo()
```
When executed without `datasets` installed, the following exception is thrown:
```
ModuleNotFoundError: 'datasets' must be installed to use `foo`! You can install 'datasets' with this command: `pip install datasets>1.17.0`
```
Alternatively, if I install `datasets==1.16.0` and run it again, I get this exception:
```
ImportError: datasets>1.17.0 must be installed to use `foo`, but found datasets==1.16.0. You can install a supported version of 'datasets' with this command: `pip install -U datasets>1.17.0`
```

### Notes
I had to update various tests that contained the following snippet:
```python
monkeypatch.setitem(sys.modules, "datasets", None)
with pytest.raises(ModuleNotFoundError):
    ...
```
The reasoning is that although `import datasets` would fail in this case, the `require_version` function is not fooled by this monkeypatch as it reads directly from files in `sys.meta_path`. As a result, `require_version` still recognises that the module is installed. That way, it becomes a bit harder to pretend that a module is not installed. An alternative that I went with is clearing out `sys.meta_path`, which means that nothing can be imported after the monkeypatch.

One other tiny note: the following snippet also stopped working.
```
monkeypatch.setattr(FlyingSquid, "_predict", mock_predict)
```
This is because `FlyingSquid` is now decorated by `requires_version`, and this seems to have broken the `monkeypatch.setattr`. As a result, I now perform the `monkeypatch.setattr` on the class instance instead of the class.

I want to reiterate that everything from this section only affects the tests: the behaviour in practice works well.

Lastly, the tests result in a 97% coverage on the new file.

---

**Type of change**

- [x] Refactor (change restructuring the codebase without changing functionality)

**How Has This Been Tested**

The introduction of various tests under `tests/utils/test_dependency.py` and through updating tests throughout the project.
I also ran some test cases manually.

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I added comments to my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

---

I'm open to feedback, as always.

cc: @davidberenstein1957 @dvsrepo due to the discussion in #2367

- Tom Aarsen