### PR TITLE
Doc: remove checkpoint 'add new comments' from PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -28,7 +28,6 @@ Closes #<issue_number>
 - [ ] I added relevant documentation
 - [ ] follows the style guidelines of this project
 - [ ] I did a self-review of my code
-- [ ] I added comments to my code
 - [ ] I made corresponding changes to the documentation
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works


### PR DESCRIPTION
# Description
If a code needs comments, except in some particular cases, it's not clean code.
So maybe it's better to remove the line  `I added comments to my code` from the PR template.

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [x] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- N/A

**Checklist**

- N/A I have merged the original branch into my forked branch
- N/A I added relevant documentation
- N/A follows the style guidelines of this project
- N/A I did a self-review of my code
- N/A I added comments to my code
- N/A I made corresponding changes to the documentation
- N/A My changes generate no new warnings
- N/A I have added tests that prove my fix is effective or that my feature works
