### PR TITLE
Refactor: Replace "ar" with "rg" in test imports

### DIFF
--- a/docs/_source/conf.py
+++ b/docs/_source/conf.py
@@ -33,9 +33,9 @@
 import os
 
 try:
-    import argilla as ar
+    import argilla as rg
 
-    version_ = ar.__version__
+    version_ = rg.__version__
 except ModuleNotFoundError:
     version_ = os.environ["VERSION"]
 

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -16,7 +16,7 @@ import datetime
 from typing import List
 
 import argilla
-import argilla as ar
+import argilla as rg
 import pytest
 from argilla.client.sdk.datasets.models import TaskType
 from argilla.client.sdk.text2text.models import (
@@ -76,9 +76,9 @@ def gutenberg_spacy_ner(mocked_client):
 @pytest.fixture(scope="session")
 def singlelabel_textclassification_records(
     request,
-) -> List[ar.TextClassificationRecord]:
+) -> List[rg.TextClassificationRecord]:
     return [
-        ar.TextClassificationRecord(
+        rg.TextClassificationRecord(
             inputs={"text": "mock", "context": "mock"},
             prediction=[("a", 0.5), ("b", 0.5)],
             prediction_agent="mock_pagent",
@@ -87,27 +87,27 @@ def singlelabel_textclassification_records(
             id=1,
             event_timestamp=datetime.datetime(2000, 1, 1),
             metadata={"mock_metadata": "mock"},
-            explanation={"text": [ar.TokenAttributions(token="mock", attributions={"a": 0.1, "b": 0.5})]},
+            explanation={"text": [rg.TokenAttributions(token="mock", attributions={"a": 0.1, "b": 0.5})]},
             status="Validated",
         ),
-        ar.TextClassificationRecord(
+        rg.TextClassificationRecord(
             inputs={"text": "mock2", "context": "mock2"},
             prediction=[("a", 0.5), ("b", 0.2)],
             prediction_agent="mock2_pagent",
             id=2,
             event_timestamp=datetime.datetime(2000, 2, 1),
             metadata={"mock2_metadata": "mock2"},
-            explanation={"text": [ar.TokenAttributions(token="mock2", attributions={"a": 0.7, "b": 0.2})]},
+            explanation={"text": [rg.TokenAttributions(token="mock2", attributions={"a": 0.7, "b": 0.2})]},
             status="Default",
         ),
-        ar.TextClassificationRecord(
+        rg.TextClassificationRecord(
             inputs={"text": "mock2", "context": "mock2"},
             prediction=[("a", 0.5), ("b", 0.2)],
             prediction_agent="mock2_pagent",
             id=3,
             status="Discarded",
         ),
-        ar.TextClassificationRecord(
+        rg.TextClassificationRecord(
             inputs={"text": "mock3", "context": "mock3"},
             annotation="a",
             annotation_agent="mock_aagent",
@@ -115,7 +115,7 @@ def singlelabel_textclassification_records(
             event_timestamp=datetime.datetime(2000, 3, 1),
             metadata={"mock_metadata": "mock"},
         ),
-        ar.TextClassificationRecord(
+        rg.TextClassificationRecord(
             text="mock",
             id="b",
             status="Default",
@@ -149,9 +149,9 @@ def log_singlelabel_textclassification_records(
 
 
 @pytest.fixture(scope="session")
-def multilabel_textclassification_records(request) -> List[ar.TextClassificationRecord]:
+def multilabel_textclassification_records(request) -> List[rg.TextClassificationRecord]:
     return [
-        ar.TextClassificationRecord(
+        rg.TextClassificationRecord(
             inputs={"text": "mock", "context": "mock"},
             prediction=[("a", 0.6), ("b", 0.4)],
             prediction_agent="mock_pagent",
@@ -161,10 +161,10 @@ def multilabel_textclassification_records(request) -> List[ar.TextClassification
             id=1,
             event_timestamp=datetime.datetime(2000, 1, 1),
             metadata={"mock_metadata": "mock"},
-            explanation={"text": [ar.TokenAttributions(token="mock", attributions={"a": 0.1, "b": 0.5})]},
+            explanation={"text": [rg.TokenAttributions(token="mock", attributions={"a": 0.1, "b": 0.5})]},
             status="Validated",
         ),
-        ar.TextClassificationRecord(
+        rg.TextClassificationRecord(
             inputs={"text": "mock2", "context": "mock2"},
             prediction=[("a", 0.5), ("b", 0.2)],
             prediction_agent="mock2_pagent",
@@ -172,10 +172,10 @@ def multilabel_textclassification_records(request) -> List[ar.TextClassification
             id=2,
             event_timestamp=datetime.datetime(2000, 2, 1),
             metadata={"mock2_metadata": "mock2"},
-            explanation={"text": [ar.TokenAttributions(token="mock2", attributions={"a": 0.7, "b": 0.2})]},
+            explanation={"text": [rg.TokenAttributions(token="mock2", attributions={"a": 0.7, "b": 0.2})]},
             status="Default",
         ),
-        ar.TextClassificationRecord(
+        rg.TextClassificationRecord(
             inputs={"text": "mock2", "context": "mock2"},
             prediction=[("a", 0.5), ("b", 0.2)],
             prediction_agent="mock2_pagent",
@@ -183,7 +183,7 @@ def multilabel_textclassification_records(request) -> List[ar.TextClassification
             id=3,
             status="Discarded",
         ),
-        ar.TextClassificationRecord(
+        rg.TextClassificationRecord(
             inputs={"text": "mock3", "context": "mock3"},
             annotation=["a"],
             annotation_agent="mock_aagent",
@@ -193,7 +193,7 @@ def multilabel_textclassification_records(request) -> List[ar.TextClassification
             metadata={"mock_metadata": "mock"},
             metrics={},
         ),
-        ar.TextClassificationRecord(
+        rg.TextClassificationRecord(
             text="mock",
             multi_label=True,
             id="b",
@@ -229,9 +229,9 @@ def log_multilabel_textclassification_records(
 
 
 @pytest.fixture(scope="session")
-def tokenclassification_records(request) -> List[ar.TokenClassificationRecord]:
+def tokenclassification_records(request) -> List[rg.TokenClassificationRecord]:
     return [
-        ar.TokenClassificationRecord(
+        rg.TokenClassificationRecord(
             text="This is an example",
             tokens=["This", "is", "an", "example"],
             prediction=[("a", 5, 7), ("b", 11, 18)],
@@ -243,7 +243,7 @@ def tokenclassification_records(request) -> List[ar.TokenClassificationRecord]:
             metadata={"mock_metadata": "mock"},
             status="Validated",
         ),
-        ar.TokenClassificationRecord(
+        rg.TokenClassificationRecord(
             text="This is a second example",
             tokens=["This", "is", "a", "second", "example"],
             prediction=[("a", 5, 7), ("b", 8, 9)],
@@ -252,7 +252,7 @@ def tokenclassification_records(request) -> List[ar.TokenClassificationRecord]:
             event_timestamp=datetime.datetime(2000, 1, 1),
             metadata={"mock_metadata": "mock"},
         ),
-        ar.TokenClassificationRecord(
+        rg.TokenClassificationRecord(
             text="This is a secondd example",
             tokens=["This", "is", "a", "secondd", "example"],
             prediction=[("a", 5, 7), ("b", 8, 9, 0.5)],
@@ -260,7 +260,7 @@ def tokenclassification_records(request) -> List[ar.TokenClassificationRecord]:
             id=3,
             status="Default",
         ),
-        ar.TokenClassificationRecord(
+        rg.TokenClassificationRecord(
             text="This is a third example",
             tokens=["This", "is", "a", "third", "example"],
             annotation=[("a", 0, 4), ("b", 16, 23)],
@@ -270,7 +270,7 @@ def tokenclassification_records(request) -> List[ar.TokenClassificationRecord]:
             metadata={"mock_metadata": "mock"},
             metrics={},
         ),
-        ar.TokenClassificationRecord(
+        rg.TokenClassificationRecord(
             text="This is a third example",
             tokens=["This", "is", "a", "third", "example"],
             id="b",
@@ -303,9 +303,9 @@ def log_tokenclassification_records(
 
 
 @pytest.fixture(scope="session")
-def text2text_records(request) -> List[ar.Text2TextRecord]:
+def text2text_records(request) -> List[rg.Text2TextRecord]:
     return [
-        ar.Text2TextRecord(
+        rg.Text2TextRecord(
             text="This is an example",
             prediction=["Das ist ein Beispiel", "Esto es un ejemplo"],
             prediction_agent="mock_pagent",
@@ -316,7 +316,7 @@ def text2text_records(request) -> List[ar.Text2TextRecord]:
             metadata={"mock_metadata": "mock"},
             status="Validated",
         ),
-        ar.Text2TextRecord(
+        rg.Text2TextRecord(
             text="This is a one and a half example",
             prediction=[("Das ist ein Beispiell", 0.9), ("Esto es un ejemploo", 0.1)],
             prediction_agent="mock_pagent",
@@ -324,7 +324,7 @@ def text2text_records(request) -> List[ar.Text2TextRecord]:
             event_timestamp=datetime.datetime(2000, 1, 1),
             metadata={"mock_metadata": "mock"},
         ),
-        ar.Text2TextRecord(
+        rg.Text2TextRecord(
             text="This is a second example",
             prediction=["Esto es un ejemplooo", ("Das ist ein Beispielll", 0.9)],
             prediction_agent="mock_pagent",
@@ -333,7 +333,7 @@ def text2text_records(request) -> List[ar.Text2TextRecord]:
             metadata={"mock_metadata": "mock"},
             metrics={},
         ),
-        ar.Text2TextRecord(
+        rg.Text2TextRecord(
             text="This is a third example",
             annotation="C'est une très bonne baguette",
             annotation_agent="mock_pagent",
@@ -342,7 +342,7 @@ def text2text_records(request) -> List[ar.Text2TextRecord]:
             metadata={"mock_metadata": "mock"},
             metrics={},
         ),
-        ar.Text2TextRecord(
+        rg.Text2TextRecord(
             text="This is a forth example",
             id="b",
             status="Discarded",

--- a/tests/client/sdk/conftest.py
+++ b/tests/client/sdk/conftest.py
@@ -16,7 +16,7 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List
 
-import argilla as ar
+import argilla as rg
 import pytest
 from argilla._constants import DEFAULT_API_KEY
 from argilla.client.sdk.client import AuthenticatedClient
@@ -142,9 +142,9 @@ def sdk_client(mocked_client, monkeypatch):
 
 @pytest.fixture
 def bulk_textclass_data():
-    explanation = {"text": [ar.TokenAttributions(token="test", attributions={"test": 0.5})]}
+    explanation = {"text": [rg.TokenAttributions(token="test", attributions={"test": 0.5})]}
     records = [
-        ar.TextClassificationRecord(
+        rg.TextClassificationRecord(
             text="test",
             prediction=[("test", 0.5)],
             prediction_agent="agent",
@@ -170,7 +170,7 @@ def bulk_textclass_data():
 @pytest.fixture
 def bulk_text2text_data():
     records = [
-        ar.Text2TextRecord(
+        rg.Text2TextRecord(
             text="test",
             prediction=[("prueba", 0.5), ("intento", 0.5)],
             prediction_agent="agent",
@@ -194,7 +194,7 @@ def bulk_text2text_data():
 @pytest.fixture
 def bulk_tokenclass_data():
     records = [
-        ar.TokenClassificationRecord(
+        rg.TokenClassificationRecord(
             text="a raw text",
             tokens=["a", "raw", "text"],
             prediction=[("test", 2, 5, 0.9)],

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -17,7 +17,7 @@ import datetime
 from time import sleep
 from typing import Any, Iterable
 
-import argilla as ar
+import argilla as rg
 import datasets
 import httpx
 import pandas as pd
@@ -161,7 +161,7 @@ def test_log_something(monkeypatch, mocked_client):
 
     response = api.log(
         name=dataset_name,
-        records=ar.TextClassificationRecord(inputs={"text": "This is a test"}),
+        records=rg.TextClassificationRecord(inputs={"text": "This is a test"}),
     )
 
     assert response.processed == 1
@@ -199,7 +199,7 @@ def test_load_limits(mocked_client, supported_vector_search):
 def test_log_records_with_too_long_text(mocked_client):
     dataset_name = "test_log_records_with_too_long_text"
     mocked_client.delete(f"/api/datasets/{dataset_name}")
-    item = ar.TextClassificationRecord(inputs={"text": "This is a toooooo long text\n" * 10000})
+    item = rg.TextClassificationRecord(inputs={"text": "This is a toooooo long text\n" * 10000})
 
     api.log([item], name=dataset_name)
 
@@ -215,7 +215,7 @@ def test_log_without_name(mocked_client):
         match="Empty dataset name has been passed as argument.",
     ):
         api.log(
-            ar.TextClassificationRecord(inputs={"text": "This is a single record. Only this. No more."}),
+            rg.TextClassificationRecord(inputs={"text": "This is a single record. Only this. No more."}),
             name=None,
         )
 
@@ -236,7 +236,7 @@ def test_log_background(mocked_client):
     # Log in the background, and extract the future
     sample_text = "Sample text for testing"
     future = api.log(
-        ar.TextClassificationRecord(text=sample_text),
+        rg.TextClassificationRecord(text=sample_text),
         name=dataset_name,
         background=True,
     )
@@ -272,7 +272,7 @@ def test_log_background_with_error(
     monkeypatch.setattr(httpx.AsyncClient, "post", raise_http_error)
 
     future = api.log(
-        ar.TextClassificationRecord(text=sample_text),
+        rg.TextClassificationRecord(text=sample_text),
         name=dataset_name,
         background=True,
     )
@@ -313,10 +313,10 @@ def test_delete_with_errors(mocked_client, monkeypatch, status, error_type):
 @pytest.mark.parametrize(
     "records, dataset_class",
     [
-        ("singlelabel_textclassification_records", ar.DatasetForTextClassification),
-        ("multilabel_textclassification_records", ar.DatasetForTextClassification),
-        ("tokenclassification_records", ar.DatasetForTokenClassification),
-        ("text2text_records", ar.DatasetForText2Text),
+        ("singlelabel_textclassification_records", rg.DatasetForTextClassification),
+        ("multilabel_textclassification_records", rg.DatasetForTextClassification),
+        ("tokenclassification_records", rg.DatasetForTokenClassification),
+        ("text2text_records", rg.DatasetForText2Text),
     ],
 )
 def test_general_log_load(mocked_client, monkeypatch, request, records, dataset_class):
@@ -366,9 +366,9 @@ def test_log_with_generator(mocked_client, monkeypatch):
     dataset_name = "test_log_with_generator"
     mocked_client.delete(f"/api/datasets/{dataset_name}")
 
-    def generator(items: int = 10) -> Iterable[ar.TextClassificationRecord]:
+    def generator(items: int = 10) -> Iterable[rg.TextClassificationRecord]:
         for i in range(0, items):
-            yield ar.TextClassificationRecord(id=i, inputs={"text": "The text data"})
+            yield rg.TextClassificationRecord(id=i, inputs={"text": "The text data"})
 
     api.log(generator(), name=dataset_name)
 
@@ -378,7 +378,7 @@ def test_create_ds_with_wrong_name(mocked_client):
 
     with pytest.raises(InputValueError):
         api.log(
-            ar.TextClassificationRecord(
+            rg.TextClassificationRecord(
                 inputs={"text": "The text data"},
             ),
             name=dataset_name,
@@ -390,7 +390,7 @@ def test_delete_dataset(mocked_client):
     mocked_client.delete(f"/api/datasets/{dataset_name}")
 
     api.log(
-        ar.TextClassificationRecord(
+        rg.TextClassificationRecord(
             id=0,
             inputs={"text": "The text data"},
             annotation_agent="test",
@@ -422,7 +422,7 @@ def test_dataset_copy(mocked_client):
     mocked_client.delete(f"/api/datasets/{dataset_copy}")
     mocked_client.delete(f"/api/datasets/{dataset}")
 
-    record = ar.TextClassificationRecord(
+    record = rg.TextClassificationRecord(
         id=0,
         text="This is the record input",
         annotation_agent="test",
@@ -458,7 +458,7 @@ def test_dataset_copy_to_another_workspace(mocked_client):
         mocked_client.delete(f"/api/datasets/{dataset_copy}?workspace={new_workspace}")
 
         api.log(
-            ar.TextClassificationRecord(
+            rg.TextClassificationRecord(
                 id=0,
                 text="This is the record input",
                 annotation_agent="test",
@@ -485,7 +485,7 @@ def test_update_record(mocked_client):
     mocked_client.delete(f"/api/datasets/{dataset}")
 
     expected_inputs = ["This is a text"]
-    record = ar.TextClassificationRecord(
+    record = rg.TextClassificationRecord(
         id=0,
         inputs=expected_inputs,
         annotation_agent="test",
@@ -502,7 +502,7 @@ def test_update_record(mocked_client):
     assert len(records) == 1
     assert records[0]["annotation"] == "T"
     # This record will replace the old one
-    record = ar.TextClassificationRecord(
+    record = rg.TextClassificationRecord(
         id=0,
         inputs=expected_inputs,
     )
@@ -526,7 +526,7 @@ def test_text_classifier_with_inputs_list(mocked_client):
 
     expected_inputs = ["A", "List", "of", "values"]
     api.log(
-        ar.TextClassificationRecord(
+        rg.TextClassificationRecord(
             id=0,
             inputs=expected_inputs,
             annotation_agent="test",
@@ -589,8 +589,8 @@ def test_load_as_pandas(mocked_client, supported_vector_search):
     )
 
     records = api.load(name=dataset)
-    assert isinstance(records, ar.DatasetForTextClassification)
-    assert isinstance(records[0], ar.TextClassificationRecord)
+    assert isinstance(records, rg.DatasetForTextClassification)
+    assert isinstance(records[0], rg.TextClassificationRecord)
 
     if supported_vector_search:
         for record in records:
@@ -609,7 +609,7 @@ def test_load_as_pandas(mocked_client, supported_vector_search):
 def test_token_classification_spans(span, valid):
     texto = "Esto es una prueba"
     if valid:
-        ar.TokenClassificationRecord(
+        rg.TokenClassificationRecord(
             text=texto,
             tokens=texto.split(),
             prediction=[("test", *span)],
@@ -621,7 +621,7 @@ def test_token_classification_spans(span, valid):
             r"Spans:\n\('test', 1, 2\) - 's'\n"
             r"Tokens:\n\['Esto', 'es', 'una', 'prueba'\]",
         ):
-            ar.TokenClassificationRecord(
+            rg.TokenClassificationRecord(
                 text=texto,
                 tokens=texto.split(),
                 prediction=[("test", *span)],
@@ -633,7 +633,7 @@ def test_load_text2text(mocked_client, supported_vector_search):
 
     records = []
     for i in range(0, 2):
-        record = ar.Text2TextRecord(
+        record = rg.Text2TextRecord(
             text="test text",
             prediction=["test prediction"],
             annotation="test annotation",
@@ -680,7 +680,7 @@ def test_client_workspace(mocked_client):
 
 def test_load_sort(mocked_client):
     records = [
-        ar.TextClassificationRecord(
+        rg.TextClassificationRecord(
             text="test text",
             id=i,
         )

--- a/tests/client/test_client_errors.py
+++ b/tests/client/test_client_errors.py
@@ -18,6 +18,6 @@ from argilla.client.sdk.commons.errors import UnauthorizedApiError
 
 def test_unauthorized_response_error(mocked_client):
     with pytest.raises(UnauthorizedApiError, match="Could not validate credentials"):
-        import argilla as ar
+        import argilla as rg
 
-        ar.init(api_key="wrong-api-key")
+        rg.init(api_key="wrong-api-key")

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -17,7 +17,7 @@ import os
 import sys
 from time import sleep
 
-import argilla as ar
+import argilla as rg
 import datasets
 import pandas as pd
 import pytest
@@ -62,7 +62,7 @@ class TestDatasetBase:
 
         with pytest.raises(WrongRecordTypeError, match="but you provided Text2TextRecord"):
             DatasetBase(
-                records=[ar.Text2TextRecord(text="test")],
+                records=[rg.Text2TextRecord(text="test")],
             )
 
         with pytest.raises(
@@ -71,8 +71,8 @@ class TestDatasetBase:
         ):
             DatasetBase(
                 records=[
-                    ar.TextClassificationRecord(text="test"),
-                    ar.Text2TextRecord(text="test"),
+                    rg.TextClassificationRecord(text="test"),
+                    rg.Text2TextRecord(text="test"),
                 ],
             )
 
@@ -183,7 +183,7 @@ class TestDatasetBase:
             [rec.copy(deep=True) for rec in singlelabel_textclassification_records],
         )
 
-        record = ar.TextClassificationRecord(text="mock")
+        record = rg.TextClassificationRecord(text="mock")
         dataset[0] = record
 
         assert dataset._records[0] is record
@@ -199,7 +199,7 @@ class TestDatasetBase:
                 " .*TextClassificationRecord.* but you provided .*Text2TextRecord.*"
             ),
         ):
-            dataset[0] = ar.Text2TextRecord(text="mock")
+            dataset[0] = rg.Text2TextRecord(text="mock")
 
     def test_prepare_for_training_train_test_splits(self, monkeypatch, singlelabel_textclassification_records):
         monkeypatch.setattr("argilla.client.datasets.DatasetBase._RECORD_TYPE", TextClassificationRecord)
@@ -223,8 +223,8 @@ class TestDatasetBase:
 
 class TestDatasetForTextClassification:
     def test_init(self, singlelabel_textclassification_records):
-        ds = ar.DatasetForTextClassification(singlelabel_textclassification_records)
-        assert ds._RECORD_TYPE == ar.TextClassificationRecord
+        ds = rg.DatasetForTextClassification(singlelabel_textclassification_records)
+        assert ds._RECORD_TYPE == rg.TextClassificationRecord
         assert ds._records == singlelabel_textclassification_records
 
     @pytest.mark.parametrize(
@@ -236,7 +236,7 @@ class TestDatasetForTextClassification:
     )
     def test_to_from_datasets(self, records, request):
         records = request.getfixturevalue(records)
-        expected_dataset = ar.DatasetForTextClassification(records)
+        expected_dataset = rg.DatasetForTextClassification(records)
 
         expected_dataset.prepare_for_training(train_size=0.5)
         dataset_ds = expected_dataset.to_datasets()
@@ -266,24 +266,24 @@ class TestDatasetForTextClassification:
             }
         ]
 
-        dataset = ar.DatasetForTextClassification.from_datasets(dataset_ds)
+        dataset = rg.DatasetForTextClassification.from_datasets(dataset_ds)
 
-        assert isinstance(dataset, ar.DatasetForTextClassification)
+        assert isinstance(dataset, rg.DatasetForTextClassification)
         _compare_datasets(dataset, expected_dataset)
 
         missing_optional_cols = datasets.Dataset.from_dict({"inputs": ["mock"]})
-        rec = ar.DatasetForTextClassification.from_datasets(missing_optional_cols)[0]
+        rec = rg.DatasetForTextClassification.from_datasets(missing_optional_cols)[0]
         assert rec.inputs == {"text": "mock"}
 
     def test_from_to_datasets_id(self):
-        dataset_rb = ar.DatasetForTextClassification([ar.TextClassificationRecord(text="mock")])
+        dataset_rb = rg.DatasetForTextClassification([rg.TextClassificationRecord(text="mock")])
         dataset_ds = dataset_rb.to_datasets()
         assert dataset_ds["id"] == [None]
 
-        assert ar.read_datasets(dataset_ds, task="TextClassification")[0].id is None
+        assert rg.read_datasets(dataset_ds, task="TextClassification")[0].id is None
 
     def test_datasets_empty_metadata(self):
-        dataset = ar.DatasetForTextClassification([ar.TextClassificationRecord(text="mock")])
+        dataset = rg.DatasetForTextClassification([rg.TextClassificationRecord(text="mock")])
         assert dataset.to_datasets()["metadata"] == [None]
 
     @pytest.mark.parametrize(
@@ -295,16 +295,16 @@ class TestDatasetForTextClassification:
     )
     def test_to_from_pandas(self, records, request):
         records = request.getfixturevalue(records)
-        expected_dataset = ar.DatasetForTextClassification(records)
+        expected_dataset = rg.DatasetForTextClassification(records)
 
         dataset_df = expected_dataset.to_pandas()
 
         assert isinstance(dataset_df, pd.DataFrame)
         assert list(dataset_df.columns) == list(expected_dataset[0].__fields__.keys())
 
-        dataset = ar.DatasetForTextClassification.from_pandas(dataset_df)
+        dataset = rg.DatasetForTextClassification.from_pandas(dataset_df)
 
-        assert isinstance(dataset, ar.DatasetForTextClassification)
+        assert isinstance(dataset, rg.DatasetForTextClassification)
         for rec, expected in zip(dataset, expected_dataset):
             assert rec == expected
 
@@ -323,7 +323,7 @@ class TestDatasetForTextClassification:
         records = request.getfixturevalue(name)
         # TODO(@frascuchon): move dataset to new organization
         dataset_name = f"rubrix/_test_text_classification_records-{name}"
-        dataset_ds = ar.DatasetForTextClassification(records).to_datasets()
+        dataset_ds = rg.DatasetForTextClassification(records).to_datasets()
         _push_to_hub_with_retries(dataset_ds, repo_id=dataset_name, token=_HF_HUB_ACCESS_TOKEN, private=True)
         sleep(1)
         dataset_ds = datasets.load_dataset(
@@ -344,7 +344,7 @@ class TestDatasetForTextClassification:
     def test_prepare_for_training(self, request, records):
         records = request.getfixturevalue(records)
 
-        ds = ar.DatasetForTextClassification(records)
+        ds = rg.DatasetForTextClassification(records)
         train = ds.prepare_for_training()
 
         if not ds[0].multi_label:
@@ -381,14 +381,14 @@ class TestDatasetForTextClassification:
             use_auth_token=_HF_HUB_ACCESS_TOKEN,
         )
 
-        rb_ds = ar.DatasetForTextClassification.from_datasets(
+        rb_ds = rg.DatasetForTextClassification.from_datasets(
             ds,
             inputs="id",
             annotation="labels",
         )
         assert rb_ds[0].inputs == {"id": "eecwqtt"}
 
-        rb_ds = ar.DatasetForTextClassification.from_datasets(
+        rb_ds = rg.DatasetForTextClassification.from_datasets(
             ds,
             text="text",
             annotation="labels",
@@ -422,7 +422,7 @@ class TestDatasetForTextClassification:
             use_auth_token=_HF_HUB_ACCESS_TOKEN,
         )
 
-        rb_ds = ar.DatasetForTextClassification.from_datasets(
+        rb_ds = rg.DatasetForTextClassification.from_datasets(
             ds, text="review", annotation="star", metadata=["package_name", "date"]
         )
 
@@ -453,19 +453,19 @@ class TestDatasetForTextClassification:
                 }
             ),
         )
-        dataset_rb = ar.DatasetForTextClassification.from_datasets(dataset_ds, annotation="label")
+        dataset_rb = rg.DatasetForTextClassification.from_datasets(dataset_ds, annotation="label")
 
         assert [rec.annotation for rec in dataset_rb] == ["HAM", None]
 
 
 class TestDatasetForTokenClassification:
     def test_init(self, tokenclassification_records):
-        ds = ar.DatasetForTokenClassification(tokenclassification_records)
-        assert ds._RECORD_TYPE == ar.TokenClassificationRecord
+        ds = rg.DatasetForTokenClassification(tokenclassification_records)
+        assert ds._RECORD_TYPE == rg.TokenClassificationRecord
         assert ds._records == tokenclassification_records
 
     def test_to_from_datasets(self, tokenclassification_records):
-        expected_dataset = ar.DatasetForTokenClassification(tokenclassification_records)
+        expected_dataset = rg.DatasetForTokenClassification(tokenclassification_records)
 
         dataset_ds = expected_dataset.to_datasets()
 
@@ -502,42 +502,42 @@ class TestDatasetForTokenClassification:
             }
         ]
 
-        dataset = ar.DatasetForTokenClassification.from_datasets(dataset_ds)
+        dataset = rg.DatasetForTokenClassification.from_datasets(dataset_ds)
 
-        assert isinstance(dataset, ar.DatasetForTokenClassification)
+        assert isinstance(dataset, rg.DatasetForTokenClassification)
         _compare_datasets(dataset, expected_dataset)
 
         missing_optional_cols = datasets.Dataset.from_dict({"text": ["mock"], "tokens": [["mock"]]})
-        rec = ar.DatasetForTokenClassification.from_datasets(missing_optional_cols)[0]
+        rec = rg.DatasetForTokenClassification.from_datasets(missing_optional_cols)[0]
         assert rec.text == "mock" and rec.tokens == ["mock"]
 
     def test_from_to_datasets_id(self):
-        dataset_rb = ar.DatasetForTokenClassification([ar.TokenClassificationRecord(text="mock", tokens=["mock"])])
+        dataset_rb = rg.DatasetForTokenClassification([rg.TokenClassificationRecord(text="mock", tokens=["mock"])])
         dataset_ds = dataset_rb.to_datasets()
         assert dataset_ds["id"] == [None]
 
-        assert ar.read_datasets(dataset_ds, task="TokenClassification")[0].id is None
+        assert rg.read_datasets(dataset_ds, task="TokenClassification")[0].id is None
 
     def test_prepare_for_training_empty(self):
-        dataset = ar.DatasetForTokenClassification([ar.TokenClassificationRecord(text="mock", tokens=["mock"])])
+        dataset = rg.DatasetForTokenClassification([rg.TokenClassificationRecord(text="mock", tokens=["mock"])])
         with pytest.raises(AssertionError):
             dataset.prepare_for_training()
 
     def test_datasets_empty_metadata(self):
-        dataset = ar.DatasetForTokenClassification([ar.TokenClassificationRecord(text="mock", tokens=["mock"])])
+        dataset = rg.DatasetForTokenClassification([rg.TokenClassificationRecord(text="mock", tokens=["mock"])])
         assert dataset.to_datasets()["metadata"] == [None]
 
     def test_to_from_pandas(self, tokenclassification_records):
-        expected_dataset = ar.DatasetForTokenClassification(tokenclassification_records)
+        expected_dataset = rg.DatasetForTokenClassification(tokenclassification_records)
 
         dataset_df = expected_dataset.to_pandas()
 
         assert isinstance(dataset_df, pd.DataFrame)
         assert list(dataset_df.columns) == list(expected_dataset[0].__fields__.keys())
 
-        dataset = ar.DatasetForTokenClassification.from_pandas(dataset_df)
+        dataset = rg.DatasetForTokenClassification.from_pandas(dataset_df)
 
-        assert isinstance(dataset, ar.DatasetForTokenClassification)
+        assert isinstance(dataset, rg.DatasetForTokenClassification)
         for rec, expected in zip(dataset, expected_dataset):
             assert rec == expected
 
@@ -546,7 +546,7 @@ class TestDatasetForTokenClassification:
         reason="You need a HF Hub access token to test the push_to_hub feature",
     )
     def test_push_to_hub(self, tokenclassification_records):
-        dataset_ds = ar.DatasetForTokenClassification(tokenclassification_records).to_datasets()
+        dataset_ds = rg.DatasetForTokenClassification(tokenclassification_records).to_datasets()
         _push_to_hub_with_retries(
             dataset_ds,
             # TODO(@frascuchon): Move dataset to the new org
@@ -575,7 +575,7 @@ class TestDatasetForTokenClassification:
             use_auth_token=_HF_HUB_ACCESS_TOKEN,
             split="train",
         )
-        rb_dataset: DatasetForTokenClassification = ar.read_datasets(ner_dataset, task="TokenClassification")
+        rb_dataset: DatasetForTokenClassification = rg.read_datasets(ner_dataset, task="TokenClassification")
         for r in rb_dataset:
             r.annotation = [(label, start, end) for label, start, end, _ in r.prediction]
 
@@ -603,7 +603,7 @@ class TestDatasetForTokenClassification:
             use_auth_token=_HF_HUB_ACCESS_TOKEN,
             split="train",
         )
-        rb_dataset: DatasetForTokenClassification = ar.read_datasets(ner_dataset, task="TokenClassification")
+        rb_dataset: DatasetForTokenClassification = rg.read_datasets(ner_dataset, task="TokenClassification")
         for r in rb_dataset:
             r.annotation = [(label, start, end) for label, start, end, _ in r.prediction]
 
@@ -628,7 +628,7 @@ class TestDatasetForTokenClassification:
             use_auth_token=_HF_HUB_ACCESS_TOKEN,
             split="train",
         )
-        rb_dataset: DatasetForTokenClassification = ar.read_datasets(ner_dataset, task="TokenClassification")
+        rb_dataset: DatasetForTokenClassification = rg.read_datasets(ner_dataset, task="TokenClassification")
         for r in rb_dataset:
             r.annotation = [(label, start, end) for label, start, end, _ in r.prediction]
 
@@ -691,7 +691,7 @@ class TestDatasetForTokenClassification:
             use_auth_token=_HF_HUB_ACCESS_TOKEN,
         )
 
-        rb_ds = ar.DatasetForTokenClassification.from_datasets(ds, tags="ner_tags", metadata=["spans"])
+        rb_ds = rg.DatasetForTokenClassification.from_datasets(ds, tags="ner_tags", metadata=["spans"])
 
         again_the_ds = rb_ds.to_datasets()
         assert again_the_ds.column_names == [
@@ -710,7 +710,7 @@ class TestDatasetForTokenClassification:
 
     def test_from_datasets_with_empty_tokens(self, caplog):
         dataset_ds = datasets.Dataset.from_dict({"empty_tokens": [["mock"], []]})
-        dataset_rb = ar.DatasetForTokenClassification.from_datasets(dataset_ds, tokens="empty_tokens")
+        dataset_rb = rg.DatasetForTokenClassification.from_datasets(dataset_ds, tokens="empty_tokens")
 
         assert caplog.record_tuples[0][1] == 30
         assert caplog.record_tuples[0][2] == "Ignoring row with no tokens."
@@ -721,12 +721,12 @@ class TestDatasetForTokenClassification:
 
 class TestDatasetForText2Text:
     def test_init(self, text2text_records):
-        ds = ar.DatasetForText2Text(text2text_records)
-        assert ds._RECORD_TYPE == ar.Text2TextRecord
+        ds = rg.DatasetForText2Text(text2text_records)
+        assert ds._RECORD_TYPE == rg.Text2TextRecord
         assert ds._records == text2text_records
 
     def test_to_from_datasets(self, text2text_records):
-        expected_dataset = ar.DatasetForText2Text(text2text_records)
+        expected_dataset = rg.DatasetForText2Text(text2text_records)
 
         dataset_ds = expected_dataset.to_datasets()
 
@@ -751,43 +751,43 @@ class TestDatasetForText2Text:
             }
         ]
 
-        dataset = ar.DatasetForText2Text.from_datasets(dataset_ds)
+        dataset = rg.DatasetForText2Text.from_datasets(dataset_ds)
 
-        assert isinstance(dataset, ar.DatasetForText2Text)
+        assert isinstance(dataset, rg.DatasetForText2Text)
         _compare_datasets(dataset, expected_dataset)
 
         missing_optional_cols = datasets.Dataset.from_dict({"text": ["mock"]})
-        rec = ar.DatasetForText2Text.from_datasets(missing_optional_cols)[0]
+        rec = rg.DatasetForText2Text.from_datasets(missing_optional_cols)[0]
         assert rec.text == "mock"
 
         # alternative format for the predictions
         ds = datasets.Dataset.from_dict({"text": ["example"], "prediction": [["ejemplo"]]})
-        rec = ar.DatasetForText2Text.from_datasets(ds)[0]
+        rec = rg.DatasetForText2Text.from_datasets(ds)[0]
         assert rec.prediction[0][0] == "ejemplo"
         assert rec.prediction[0][1] == pytest.approx(1.0)
 
     def test_from_to_datasets_id(self):
-        dataset_rb = ar.DatasetForText2Text([ar.Text2TextRecord(text="mock")])
+        dataset_rb = rg.DatasetForText2Text([rg.Text2TextRecord(text="mock")])
         dataset_ds = dataset_rb.to_datasets()
         assert dataset_ds["id"] == [None]
 
-        assert ar.read_datasets(dataset_ds, task="Text2Text")[0].id is None
+        assert rg.read_datasets(dataset_ds, task="Text2Text")[0].id is None
 
     def test_datasets_empty_metadata(self):
-        dataset = ar.DatasetForText2Text([ar.Text2TextRecord(text="mock")])
+        dataset = rg.DatasetForText2Text([rg.Text2TextRecord(text="mock")])
         assert dataset.to_datasets()["metadata"] == [None]
 
     def test_to_from_pandas(self, text2text_records):
-        expected_dataset = ar.DatasetForText2Text(text2text_records)
+        expected_dataset = rg.DatasetForText2Text(text2text_records)
 
         dataset_df = expected_dataset.to_pandas()
 
         assert isinstance(dataset_df, pd.DataFrame)
         assert list(dataset_df.columns) == list(expected_dataset[0].__fields__.keys())
 
-        dataset = ar.DatasetForText2Text.from_pandas(dataset_df)
+        dataset = rg.DatasetForText2Text.from_pandas(dataset_df)
 
-        assert isinstance(dataset, ar.DatasetForText2Text)
+        assert isinstance(dataset, rg.DatasetForText2Text)
         for rec, expected in zip(dataset, expected_dataset):
             assert rec == expected
 
@@ -796,7 +796,7 @@ class TestDatasetForText2Text:
         reason="You need a HF Hub access token to test the push_to_hub feature",
     )
     def test_push_to_hub(self, text2text_records):
-        dataset_ds = ar.DatasetForText2Text(text2text_records).to_datasets()
+        dataset_ds = rg.DatasetForText2Text(text2text_records).to_datasets()
         _push_to_hub_with_retries(
             dataset_ds,
             # TODO(@frascuchon): Move dataset to the new org
@@ -824,7 +824,7 @@ class TestDatasetForText2Text:
             use_auth_token=_HF_HUB_ACCESS_TOKEN,
         )
 
-        rb_ds = ar.DatasetForText2Text.from_datasets(ds, text="description", annotation="abstract")
+        rb_ds = rg.DatasetForText2Text.from_datasets(ds, text="description", annotation="abstract")
 
         again_the_ds = rb_ds.to_datasets()
         assert again_the_ds.column_names == [
@@ -864,7 +864,7 @@ def test_read_pandas(monkeypatch, task, dataset_class):
 
     monkeypatch.setattr(f"argilla.client.datasets.{dataset_class}.from_pandas", mock_from_pandas)
 
-    assert ar.read_pandas("mock", task) == "mock"
+    assert rg.read_pandas("mock", task) == "mock"
 
 
 @pytest.mark.parametrize(
@@ -881,4 +881,4 @@ def test_read_datasets(monkeypatch, task, dataset_class):
 
     monkeypatch.setattr(f"argilla.client.datasets.{dataset_class}.from_datasets", mock_from_datasets)
 
-    assert ar.read_datasets("mock", task) == "mock"
+    assert rg.read_datasets("mock", task) == "mock"

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import argilla as ar
+import argilla as rg
 import pytest
 from argilla import TextClassificationSettings, TokenClassificationSettings
 from argilla.client import api
@@ -34,8 +34,8 @@ from argilla.client.sdk.commons.errors import ForbiddenApiError
 )
 def test_settings_workflow(mocked_client, settings_, wrong_settings):
     dataset = "test-dataset"
-    ar.delete(dataset)
-    ar.configure_dataset(dataset, settings=settings_)
+    rg.delete(dataset)
+    rg.configure_dataset(dataset, settings=settings_)
 
     current_api = api.active_api()
     datasets_api = current_api.datasets
@@ -44,13 +44,13 @@ def test_settings_workflow(mocked_client, settings_, wrong_settings):
     assert found_settings == settings_
 
     settings_.label_schema = {"LALALA"}
-    ar.configure_dataset(dataset, settings_)
+    rg.configure_dataset(dataset, settings_)
 
     found_settings = datasets_api.load_settings(dataset)
     assert found_settings == settings_
 
     with pytest.raises(ValueError, match="Task type mismatch"):
-        ar.configure_dataset(dataset, wrong_settings)
+        rg.configure_dataset(dataset, wrong_settings)
 
 
 def test_list_dataset(mocked_client):
@@ -66,10 +66,10 @@ def test_list_dataset(mocked_client):
 def test_delete_dataset_by_non_creator(mocked_client):
     try:
         dataset = "test_delete_dataset_by_non_creator"
-        ar.delete(dataset)
-        ar.configure_dataset(dataset, settings=TextClassificationSettings(label_schema={"A", "B", "C"}))
+        rg.delete(dataset)
+        rg.configure_dataset(dataset, settings=TextClassificationSettings(label_schema={"A", "B", "C"}))
         mocked_client.change_current_user("mock-user")
         with pytest.raises(ForbiddenApiError):
-            ar.delete(dataset)
+            rg.delete(dataset)
     finally:
         mocked_client.reset_default_user()

--- a/tests/functional_tests/datasets/helpers.py
+++ b/tests/functional_tests/datasets/helpers.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import argilla as ar
+import argilla as rg
 from argilla import Text2TextRecord, TextClassificationRecord, TokenClassificationRecord
 from argilla.server.commons.models import TaskType
 
@@ -38,7 +38,7 @@ def create_dataset(task: TaskType):
         )
 
     dataset = "test_dataset"
-    ar.delete(dataset)
+    rg.delete(dataset)
 
     if task == TaskType.text_classification:
         record_builder = text_class
@@ -49,7 +49,7 @@ def create_dataset(task: TaskType):
 
     records = [record_builder(i) for i in range(0, 50)]
 
-    ar.log(
+    rg.log(
         name=dataset,
         records=records,
     )

--- a/tests/functional_tests/datasets/test_delete_records_from_datasets.py
+++ b/tests/functional_tests/datasets/test_delete_records_from_datasets.py
@@ -20,45 +20,45 @@ from argilla.client.sdk.commons.errors import ForbiddenApiError
 
 def test_delete_records_from_dataset(mocked_client):
     dataset = "test_delete_records_from_dataset"
-    import argilla as ar
+    import argilla as rg
 
-    ar.delete(dataset)
-    ar.log(
+    rg.delete(dataset)
+    rg.log(
         name=dataset,
         records=[
-            ar.TextClassificationRecord(id=i, text="This is the text", metadata=dict(idx=i)) for i in range(0, 50)
+            rg.TextClassificationRecord(id=i, text="This is the text", metadata=dict(idx=i)) for i in range(0, 50)
         ],
     )
 
-    matched, processed = ar.delete_records(name=dataset, ids=[10], discard_only=True)
+    matched, processed = rg.delete_records(name=dataset, ids=[10], discard_only=True)
     assert matched, processed == (1, 1)
 
-    ds = ar.load(name=dataset)
+    ds = rg.load(name=dataset)
     assert len(ds) == 50
 
     time.sleep(1)
-    matched, processed = ar.delete_records(name=dataset, query="id:10", discard_only=False)
+    matched, processed = rg.delete_records(name=dataset, query="id:10", discard_only=False)
     assert matched, processed == (1, 1)
 
     time.sleep(1)
-    ds = ar.load(name=dataset)
+    ds = rg.load(name=dataset)
     assert len(ds) == 49
 
 
 def test_delete_records_without_permission(mocked_client):
     dataset = "test_delete_records_without_permission"
-    import argilla as ar
+    import argilla as rg
 
-    ar.delete(dataset)
-    ar.log(
+    rg.delete(dataset)
+    rg.log(
         name=dataset,
         records=[
-            ar.TextClassificationRecord(id=i, text="This is the text", metadata=dict(idx=i)) for i in range(0, 50)
+            rg.TextClassificationRecord(id=i, text="This is the text", metadata=dict(idx=i)) for i in range(0, 50)
         ],
     )
     try:
         mocked_client.change_current_user("mock-user")
-        matched, processed = ar.delete_records(
+        matched, processed = rg.delete_records(
             name=dataset,
             ids=[10],
             discard_only=True,
@@ -66,14 +66,14 @@ def test_delete_records_without_permission(mocked_client):
         assert matched, processed == (1, 1)
 
         with pytest.raises(ForbiddenApiError):
-            ar.delete_records(
+            rg.delete_records(
                 name=dataset,
                 query="id:10",
                 discard_only=False,
                 discard_when_forbidden=False,
             )
 
-        matched, processed = ar.delete_records(
+        matched, processed = rg.delete_records(
             name=dataset,
             query="id:10",
             discard_only=False,
@@ -86,13 +86,13 @@ def test_delete_records_without_permission(mocked_client):
 
 def test_delete_records_with_unmatched_records(mocked_client):
     dataset = "test_delete_records_with_unmatched_records"
-    import argilla as ar
+    import argilla as rg
 
-    ar.delete(dataset)
-    ar.log(
+    rg.delete(dataset)
+    rg.log(
         name=dataset,
         records=[
-            ar.TextClassificationRecord(
+            rg.TextClassificationRecord(
                 id=i,
                 text="This is the text",
                 metadata=dict(idx=i),
@@ -101,5 +101,5 @@ def test_delete_records_with_unmatched_records(mocked_client):
         ],
     )
 
-    matched, processed = ar.delete_records(dataset, ids=["you-wont-find-me-here"])
+    matched, processed = rg.delete_records(dataset, ids=["you-wont-find-me-here"])
     assert (matched, processed) == (0, 0)

--- a/tests/functional_tests/test_log_for_text_classification.py
+++ b/tests/functional_tests/test_log_for_text_classification.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import argilla as ar
+import argilla as rg
 import pytest
 from argilla.client.sdk.commons.errors import (
     BadRequestApiError,
@@ -29,14 +29,14 @@ def test_log_records_with_multi_and_single_label_task(mocked_client):
     dataset = "test_log_records_with_multi_and_single_label_task"
     expected_inputs = ["This is a text"]
 
-    ar.delete(dataset)
+    rg.delete(dataset)
     records = [
-        ar.TextClassificationRecord(
+        rg.TextClassificationRecord(
             id=0,
             inputs=expected_inputs,
             multi_label=False,
         ),
-        ar.TextClassificationRecord(
+        rg.TextClassificationRecord(
             id=1,
             inputs=expected_inputs,
             multi_label=True,
@@ -44,30 +44,30 @@ def test_log_records_with_multi_and_single_label_task(mocked_client):
     ]
 
     with pytest.raises(ValidationApiError):
-        ar.log(
+        rg.log(
             records,
             name=dataset,
         )
 
-    ar.log(records[0], name=dataset)
+    rg.log(records[0], name=dataset)
     with pytest.raises(Exception):
-        ar.log(records[1], name=dataset)
+        rg.log(records[1], name=dataset)
 
 
 def test_delete_and_create_for_different_task(mocked_client):
     dataset = "test_delete_and_create_for_different_task"
     text = "This is a text"
 
-    ar.delete(dataset)
-    ar.log(ar.TextClassificationRecord(id=0, inputs=text), name=dataset)
-    ar.load(dataset)
+    rg.delete(dataset)
+    rg.log(rg.TextClassificationRecord(id=0, inputs=text), name=dataset)
+    rg.load(dataset)
 
-    ar.delete(dataset)
-    ar.log(
-        ar.TokenClassificationRecord(id=0, text=text, tokens=text.split(" ")),
+    rg.delete(dataset)
+    rg.log(
+        rg.TokenClassificationRecord(id=0, text=text, tokens=text.split(" ")),
         name=dataset,
     )
-    ar.load(dataset)
+    rg.load(dataset)
 
 
 @pytest.mark.skipif(
@@ -81,34 +81,34 @@ def test_similarity_search_in_python_client(
     text = "This is a text"
     vectors = {"my_bert": [1, 2, 3, 4]}
 
-    ar.delete(dataset)
-    ar.log(
-        ar.TextClassificationRecord(
+    rg.delete(dataset)
+    rg.log(
+        rg.TextClassificationRecord(
             id=0,
             inputs=text,
             vectors=vectors,
         ),
         name=dataset,
     )
-    ds = ar.load(dataset, vector=("my_bert", [1, 1, 1, 1]))
+    ds = rg.load(dataset, vector=("my_bert", [1, 1, 1, 1]))
     assert len(ds) == 1
 
-    ar.log(
-        ar.TextClassificationRecord(
+    rg.log(
+        rg.TextClassificationRecord(
             id=1,
             inputs=text,
             vectors={"my_bert_2": [1, 2, 3, 4]},
         ),
         name=dataset,
     )
-    ds = ar.load(dataset, vector=("my_bert_2", [1, 1, 1, 1]))
+    ds = rg.load(dataset, vector=("my_bert_2", [1, 1, 1, 1]))
     assert len(ds) == 1
     with pytest.raises(
         BadRequestApiError,
         match="Cannot create more than 5 kind of vectors per dataset",
     ):
-        ar.log(
-            ar.TextClassificationRecord(
+        rg.log(
+            rg.TextClassificationRecord(
                 id=3,
                 inputs=text,
                 vectors={
@@ -132,10 +132,10 @@ def test_log_data_with_vectors_and_update_ok(
 ):
     dataset = "test_log_data_with_vectors_and_update_ok"
     text = "This is a text"
-    ar.delete(dataset)
+    rg.delete(dataset)
 
     records = [
-        ar.TextClassificationRecord(
+        rg.TextClassificationRecord(
             id=i,
             inputs=text,
             vectors={"text": [i] * 5},
@@ -143,11 +143,11 @@ def test_log_data_with_vectors_and_update_ok(
         for i in range(1, 10)
     ]
 
-    ar.log(
+    rg.log(
         records=records,
         name=dataset,
     )
-    ds = ar.load(
+    ds = rg.load(
         dataset,
         vector=(
             "text",
@@ -169,17 +169,17 @@ def test_log_data_with_vectors_and_update_ko(mocked_client: SecuredClient):
     text = "This is a text"
     vectors = {"my_bert": [1, 2, 3, 4]}
 
-    ar.delete(dataset)
-    ar.log(
-        ar.TextClassificationRecord(id=0, inputs=text, vectors=vectors),
+    rg.delete(dataset)
+    rg.log(
+        rg.TextClassificationRecord(id=0, inputs=text, vectors=vectors),
         name=dataset,
     )
-    ar.load(dataset)
+    rg.load(dataset)
 
     updated_vectors = {"my_bert": [2, 3, 5]}
     with pytest.raises(GenericApiError):
-        ar.log(
-            ar.TextClassificationRecord(id=0, text=text, vectors=updated_vectors),
+        rg.log(
+            rg.TextClassificationRecord(id=0, text=text, vectors=updated_vectors),
             name=dataset,
         )
 
@@ -191,21 +191,21 @@ def test_log_data_in_several_workspaces(mocked_client: SecuredClient):
 
     mocked_client.add_workspaces_to_argilla_user([workspace])
 
-    curr_ws = ar.get_workspace()
+    curr_ws = rg.get_workspace()
     for ws in [curr_ws, workspace]:
-        ar.set_workspace(ws)
-        ar.delete(dataset)
+        rg.set_workspace(ws)
+        rg.delete(dataset)
 
-    ar.set_workspace(curr_ws)
-    ar.log(ar.TextClassificationRecord(id=0, inputs=text), name=dataset)
+    rg.set_workspace(curr_ws)
+    rg.log(rg.TextClassificationRecord(id=0, inputs=text), name=dataset)
 
-    ar.set_workspace(workspace)
-    ar.log(ar.TextClassificationRecord(id=1, inputs=text), name=dataset)
-    ds = ar.load(dataset)
+    rg.set_workspace(workspace)
+    rg.log(rg.TextClassificationRecord(id=1, inputs=text), name=dataset)
+    ds = rg.load(dataset)
     assert len(ds) == 1
 
-    ar.set_workspace(curr_ws)
-    ds = ar.load(dataset)
+    rg.set_workspace(curr_ws)
+    ds = rg.load(dataset)
     assert len(ds) == 1
 
 
@@ -214,12 +214,12 @@ def test_search_keywords(mocked_client):
     from datasets import load_dataset
 
     dataset_ds = load_dataset("Recognai/sentiment-banking", split="train")
-    dataset_rb = ar.read_datasets(dataset_ds, task="TextClassification")
+    dataset_rb = rg.read_datasets(dataset_ds, task="TextClassification")
 
-    ar.delete(dataset)
-    ar.log(name=dataset, records=dataset_rb)
+    rg.delete(dataset)
+    rg.log(name=dataset, records=dataset_rb)
 
-    ds = ar.load(dataset, query="lim*")
+    ds = rg.load(dataset, query="lim*")
     df = ds.to_pandas()
     assert not df.empty
     assert "search_keywords" in df.columns
@@ -236,16 +236,16 @@ def test_search_keywords(mocked_client):
 def test_log_records_with_empty_metadata_list(mocked_client):
     dataset = "test_log_records_with_empty_metadata_list"
 
-    ar.delete(dataset)
+    rg.delete(dataset)
     expected_records = [
-        ar.TextClassificationRecord(text="The input text", metadata={"emptyList": []}),
-        ar.TextClassificationRecord(text="The input text", metadata={"emptyTuple": ()}),
-        ar.TextClassificationRecord(text="The input text", metadata={"emptyDict": {}}),
-        ar.TextClassificationRecord(text="The input text", metadata={"none": None}),
+        rg.TextClassificationRecord(text="The input text", metadata={"emptyList": []}),
+        rg.TextClassificationRecord(text="The input text", metadata={"emptyTuple": ()}),
+        rg.TextClassificationRecord(text="The input text", metadata={"emptyDict": {}}),
+        rg.TextClassificationRecord(text="The input text", metadata={"none": None}),
     ]
-    ar.log(expected_records, name=dataset)
+    rg.log(expected_records, name=dataset)
 
-    df = ar.load(dataset)
+    df = rg.load(dataset)
     df = df.to_pandas()
     assert len(df) == len(expected_records)
 
@@ -256,67 +256,67 @@ def test_log_records_with_empty_metadata_list(mocked_client):
 def test_logging_with_metadata_limits_exceeded(mocked_client):
     dataset = "test_logging_with_metadata_limits_exceeded"
 
-    ar.delete(dataset)
+    rg.delete(dataset)
 
-    expected_record = ar.TextClassificationRecord(
+    expected_record = rg.TextClassificationRecord(
         text="The input text",
         metadata={k: f"this is a string {k}" for k in range(0, settings.metadata_fields_limit + 1)},
     )
     with pytest.raises(BadRequestApiError):
-        ar.log(expected_record, name=dataset)
+        rg.log(expected_record, name=dataset)
 
     expected_record.metadata = {k: f"This is a string {k}" for k in range(0, settings.metadata_fields_limit)}
     # Dataset creation with data
-    ar.log(expected_record, name=dataset)
+    rg.log(expected_record, name=dataset)
     # This call will check already included fields
-    ar.log(expected_record, name=dataset)
+    rg.log(expected_record, name=dataset)
 
     expected_record.metadata["new_key"] = "value"
     with pytest.raises(BadRequestApiError):
-        ar.log(expected_record, name=dataset)
+        rg.log(expected_record, name=dataset)
 
 
 def test_log_with_other_task(mocked_client):
     dataset = "test_log_with_other_task"
 
-    ar.delete(dataset)
-    record = ar.TextClassificationRecord(
+    rg.delete(dataset)
+    record = rg.TextClassificationRecord(
         text="The input text",
     )
-    ar.log(record, name=dataset)
+    rg.log(record, name=dataset)
 
     with pytest.raises(BadRequestApiError):
-        ar.log(
-            ar.TokenClassificationRecord(text="The text", tokens=["The", "text"]),
+        rg.log(
+            rg.TokenClassificationRecord(text="The text", tokens=["The", "text"]),
             name=dataset,
         )
 
 
 def test_dynamics_metadata(mocked_client):
     dataset = "test_dynamics_metadata"
-    ar.log(
-        ar.TextClassificationRecord(text="This is a text", metadata={"a": "value"}),
+    rg.log(
+        rg.TextClassificationRecord(text="This is a text", metadata={"a": "value"}),
         name=dataset,
     )
 
-    ar.log(
-        ar.TextClassificationRecord(text="Another text", metadata={"b": "value"}),
+    rg.log(
+        rg.TextClassificationRecord(text="Another text", metadata={"b": "value"}),
         name=dataset,
     )
 
 
 def test_log_with_bulk_error(mocked_client):
     dataset = "test_log_with_bulk_error"
-    ar.delete(dataset)
+    rg.delete(dataset)
     try:
-        ar.log(
+        rg.log(
             [
-                ar.TextClassificationRecord(
+                rg.TextClassificationRecord(
                     id=0,
                     text="This is an special text",
                     metadata={"key": 1},
                 ),
-                ar.TextClassificationRecord(
+                rg.TextClassificationRecord(
                     id=1,
                     text="This is an special text",
                     metadata={"key": "wrong-value"},

--- a/tests/labeling/text_classification/test_label_errors.py
+++ b/tests/labeling/text_classification/test_label_errors.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 import sys
 
-import argilla as ar
+import argilla as rg
 import cleanlab
 import pytest
 from _pytest.logging import LogCaptureFixture
@@ -32,7 +32,7 @@ from pkg_resources import parse_version
 def records(request):
     if request.param:
         return [
-            ar.TextClassificationRecord(text="test", annotation=anot, prediction=pred, multi_label=True, id=i)
+            rg.TextClassificationRecord(text="test", annotation=anot, prediction=pred, multi_label=True, id=i)
             for i, anot, pred in zip(
                 range(2 * 6),
                 [["bad"], ["bad", "good"]] * 6,
@@ -41,7 +41,7 @@ def records(request):
         ]
 
     return [
-        ar.TextClassificationRecord(text="test", annotation=anot, prediction=pred, id=i)
+        rg.TextClassificationRecord(text="test", annotation=anot, prediction=pred, id=i)
         for i, anot, pred in zip(
             range(2 * 6),
             ["good", "bad"] * 6,
@@ -63,8 +63,8 @@ def test_not_installed(monkeypatch):
 
 def test_no_records():
     records = [
-        ar.TextClassificationRecord(text="test", prediction=[("mock", 0.0)]),
-        ar.TextClassificationRecord(text="test", annotation="test"),
+        rg.TextClassificationRecord(text="test", prediction=[("mock", 0.0)]),
+        rg.TextClassificationRecord(text="test", annotation="test"),
     ]
 
     with pytest.raises(NoRecordsError, match="none of your records have a prediction AND annotation"):
@@ -72,7 +72,7 @@ def test_no_records():
 
 
 def test_multi_label_warning(caplog: LogCaptureFixture):
-    record = ar.TextClassificationRecord(
+    record = rg.TextClassificationRecord(
         text="test",
         prediction=[("mock", 0.0), ("mock2", 0.0)],
         annotation=["mock", "mock2"],
@@ -112,7 +112,7 @@ def test_sort_by(monkeypatch, sort_by, expected):
             mock_find_label_issues,
         )
 
-    record = ar.TextClassificationRecord(text="mock", prediction=[("mock", 0.1)], annotation="mock")
+    record = rg.TextClassificationRecord(text="mock", prediction=[("mock", 0.1)], annotation="mock")
     find_label_errors(records=[record], sort_by=sort_by)
 
 
@@ -191,14 +191,14 @@ def test_construct_s_and_psx(records):
 
 
 def test_missing_predictions():
-    records = [ar.TextClassificationRecord(text="test", annotation="mock", prediction=[("mock2", 0.1)])]
+    records = [rg.TextClassificationRecord(text="test", annotation="mock", prediction=[("mock2", 0.1)])]
     with pytest.raises(
         MissingPredictionError,
         match="It seems predictions are missing for the label 'mock'",
     ):
         _construct_s_and_psx(records)
 
-    records.append(ar.TextClassificationRecord(text="test", annotation="mock", prediction=[("mock", 0.1)]))
+    records.append(rg.TextClassificationRecord(text="test", annotation="mock", prediction=[("mock", 0.1)]))
     with pytest.raises(
         MissingPredictionError,
         match="It seems a prediction for 'mock' is missing in the following record",
@@ -210,13 +210,13 @@ def test_missing_predictions():
 def dataset(mocked_client, records):
     dataset = "dataset_for_label_errors"
 
-    ar.log(records, name=dataset)
+    rg.log(records, name=dataset)
 
     yield dataset
-    ar.delete(dataset)
+    rg.delete(dataset)
 
 
 def test_find_label_errors_integration(dataset):
-    records = ar.load(dataset)
+    records = rg.load(dataset)
     recs = find_label_errors(records)
     assert [rec.id for rec in recs] == list(range(0, 11, 2)) + list(range(1, 12, 2))

--- a/tests/labeling/text_classification/test_rule.py
+++ b/tests/labeling/text_classification/test_rule.py
@@ -252,7 +252,7 @@ def test_update_rules(mocked_client, log_dataset):
 
 
 def test_copy_dataset_with_rules(mocked_client, log_dataset):
-    import argilla as ar
+    import argilla as rg
 
     rule = Rule(query="a query", label="LALA")
     delete_rule_silently(mocked_client, log_dataset, rule)
@@ -263,8 +263,8 @@ def test_copy_dataset_with_rules(mocked_client, log_dataset):
     )
 
     copied_dataset = f"{log_dataset}_copy"
-    ar.delete(copied_dataset)
-    ar.copy(log_dataset, name_of_copy=copied_dataset)
+    rg.delete(copied_dataset)
+    rg.copy(log_dataset, name_of_copy=copied_dataset)
 
     assert [{"q": r.query, "l": r.label} for r in load_rules(copied_dataset)] == [
         {"q": r.query, "l": r.label} for r in load_rules(log_dataset)

--- a/tests/listeners/test_listener.py
+++ b/tests/listeners/test_listener.py
@@ -15,7 +15,7 @@
 import time
 from typing import List
 
-import argilla as ar
+import argilla as rg
 import pytest
 from argilla import RGListenerContext, listener
 from argilla.client.models import Record
@@ -40,7 +40,7 @@ def condition_check_params(search):
     ],
 )
 def test_listener_with_parameters(mocked_client, dataset, query, metrics, condition, query_params):
-    ar.delete(dataset)
+    rg.delete(dataset)
 
     class TestListener:
         executed = False
@@ -78,7 +78,7 @@ def test_listener_with_parameters(mocked_client, dataset, query, metrics, condit
 
     time.sleep(1.5)
     assert test.action.is_running()
-    ar.log(ar.TextClassificationRecord(text="This is a text"), name=dataset)
+    rg.log(rg.TextClassificationRecord(text="This is a text"), name=dataset)
 
     with pytest.raises(ValueError):
         test.action.start()

--- a/tests/metrics/test_common_metrics.py
+++ b/tests/metrics/test_common_metrics.py
@@ -13,7 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import argilla
-import argilla as ar
+import argilla as rg
 import pytest
 from argilla.metrics.commons import keywords, records_status, text_length
 
@@ -40,17 +40,17 @@ def gutenberg_spacy_ner(mocked_client):
 def test_status_distribution(mocked_client):
     dataset = "test_status_distribution"
 
-    ar.delete(dataset)
+    rg.delete(dataset)
 
-    ar.log(
+    rg.log(
         [
-            ar.TextClassificationRecord(
+            rg.TextClassificationRecord(
                 id=1,
                 inputs={"text": "my first example"},
                 prediction=[("spam", 0.8), ("ham", 0.2)],
                 annotation=["spam"],
             ),
-            ar.TextClassificationRecord(
+            rg.TextClassificationRecord(
                 id=2,
                 inputs={"text": "my second example"},
                 prediction=[("ham", 0.8), ("spam", 0.2)],
@@ -70,24 +70,24 @@ def test_status_distribution(mocked_client):
 def test_text_length(mocked_client):
     dataset = "test_text_length"
 
-    ar.delete(dataset)
+    rg.delete(dataset)
 
-    ar.log(
+    rg.log(
         [
-            ar.TextClassificationRecord(
+            rg.TextClassificationRecord(
                 id=1,
                 inputs={"text": "my first example"},
                 prediction=[("spam", 0.8), ("ham", 0.2)],
                 annotation=["spam"],
             ),
-            ar.TextClassificationRecord(
+            rg.TextClassificationRecord(
                 id=2,
                 inputs={"text": "my second example"},
                 prediction=[("ham", 0.8), ("spam", 0.2)],
                 annotation=["ham"],
                 status="Default",
             ),
-            ar.TextClassificationRecord(
+            rg.TextClassificationRecord(
                 id=3,
                 inputs={"text": "simple text"},
                 prediction=[("ham", 0.8), ("spam", 0.2)],

--- a/tests/metrics/test_text_classification.py
+++ b/tests/metrics/test_text_classification.py
@@ -12,7 +12,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import argilla as ar
+import argilla as rg
 from argilla import TextClassificationRecord
 from argilla.client import api
 from argilla.metrics.text_classification import f1, f1_multilabel
@@ -21,15 +21,15 @@ from argilla.metrics.text_classification import f1, f1_multilabel
 def test_metrics_for_text_classification(mocked_client):
     dataset = "test_metrics_for_text_classification"
 
-    ar.log(
+    rg.log(
         [
-            ar.TextClassificationRecord(
+            rg.TextClassificationRecord(
                 id=1,
                 text="my first argilla example",
                 prediction=[("spam", 0.8), ("ham", 0.2)],
                 annotation=["spam"],
             ),
-            ar.TextClassificationRecord(
+            rg.TextClassificationRecord(
                 id=2,
                 inputs={"text": "my first argilla example"},
                 prediction=[("ham", 0.8), ("spam", 0.2)],
@@ -81,13 +81,13 @@ def test_metrics_for_text_classification(mocked_client):
 def test_f1_without_results(mocked_client):
     dataset = "test_f1_without_results"
 
-    ar.log(
+    rg.log(
         [
-            ar.TextClassificationRecord(
+            rg.TextClassificationRecord(
                 id=1,
                 text="my first argilla example",
             ),
-            ar.TextClassificationRecord(
+            rg.TextClassificationRecord(
                 id=2,
                 inputs={"text": "my first argilla example"},
             ),
@@ -133,7 +133,7 @@ def test_dataset_labels_metric(mocked_client):
             for i in range(2000, 3000)
         ]
     )
-    ar.log(
+    rg.log(
         name=dataset,
         records=records,
     )

--- a/tests/metrics/test_token_classification.py
+++ b/tests/metrics/test_token_classification.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 import argilla
-import argilla as ar
+import argilla as rg
 import pytest
 from argilla.metrics import entity_consistency
 from argilla.metrics.token_classification import (
@@ -35,30 +35,30 @@ def log_some_data(dataset: str):
     argilla.delete(dataset)
     text = "My first great example \n"
     tokens = text.split(" ")
-    ar.log(
+    rg.log(
         [
-            ar.TokenClassificationRecord(
+            rg.TokenClassificationRecord(
                 id=1,
                 text=text,
                 tokens=tokens,
                 prediction=[("CARDINAL", 3, 8)],
                 annotation=[("CARDINAL", 3, 8)],
             ),
-            ar.TokenClassificationRecord(
+            rg.TokenClassificationRecord(
                 id=2,
                 text=text,
                 tokens=tokens,
                 prediction=[("CARDINAL", 3, 8)],
                 annotation=[("CARDINAL", 3, 8)],
             ),
-            ar.TokenClassificationRecord(
+            rg.TokenClassificationRecord(
                 id=3,
                 text=text,
                 tokens=tokens,
                 prediction=[("NUMBER", 3, 8)],
                 annotation=[("NUMBER", 3, 8)],
             ),
-            ar.TokenClassificationRecord(
+            rg.TokenClassificationRecord(
                 id=4,
                 text=text,
                 tokens=tokens,
@@ -72,10 +72,10 @@ def log_some_data(dataset: str):
 
 def test_search_by_nested_metric(mocked_client):
     dataset = "test_search_by_nested_metric"
-    ar.delete(dataset)
+    rg.delete(dataset)
     log_some_data(dataset)
 
-    df = ar.load(dataset, query="metrics.predicted.mentions.capitalness: LOWER")
+    df = rg.load(dataset, query="metrics.predicted.mentions.capitalness: LOWER")
     assert len(df) > 0
 
 
@@ -286,12 +286,12 @@ def validate_mentions(
 )
 def test_metrics_without_data(mocked_client, metric, expected_results, monkeypatch):
     dataset = "test_metrics_without_data"
-    ar.delete(dataset)
+    rg.delete(dataset)
 
     text = "M"
     tokens = text.split(" ")
-    ar.log(
-        ar.TokenClassificationRecord(
+    rg.log(
+        rg.TokenClassificationRecord(
             id=1,
             text=text,
             tokens=tokens,
@@ -309,8 +309,8 @@ def test_metrics_for_text_classification(mocked_client):
     dataset = "test_metrics_for_token_classification"
 
     text = "test the f1 metric of the token classification task"
-    ar.log(
-        ar.TokenClassificationRecord(
+    rg.log(
+        rg.TokenClassificationRecord(
             id=1,
             text=text,
             tokens=text.split(),

--- a/tests/monitoring/test_flair_monitoring.py
+++ b/tests/monitoring/test_flair_monitoring.py
@@ -15,18 +15,18 @@ from time import sleep
 
 
 def test_flair_monitoring(mocked_client, monkeypatch):
-    import argilla as ar
+    import argilla as rg
     from flair.data import Sentence
     from flair.models import SequenceTagger
 
     dataset = "test_flair_monitoring"
     model = "flair/ner-english"
 
-    ar.delete(dataset)
+    rg.delete(dataset)
 
     # load tagger
     tagger = SequenceTagger.load(model)
-    tagger = ar.monitor(
+    tagger = rg.monitor(
         tagger,
         dataset=dataset,
         sample_rate=1.0,
@@ -42,7 +42,7 @@ def test_flair_monitoring(mocked_client, monkeypatch):
 
     sleep(1)  # wait for the consumer time
     detected_labels = sentence.get_labels("ner")
-    records = ar.load(dataset)
+    records = rg.load(dataset)
     assert len(records) == 1
 
     record = records[0]

--- a/tests/monitoring/test_spacy_monitoring.py
+++ b/tests/monitoring/test_spacy_monitoring.py
@@ -15,17 +15,17 @@
 import random
 from time import sleep
 
-import argilla as ar
+import argilla as rg
 
 
 def test_spacy_ner_monitor(monkeypatch, mocked_client):
     dataset = "spacy-dataset"
-    ar.delete(dataset)
+    rg.delete(dataset)
 
     import spacy
 
     nlp = spacy.load("en_core_web_sm")
-    nlp = ar.monitor(
+    nlp = rg.monitor(
         nlp,
         dataset=dataset,
         sample_rate=0.5,
@@ -38,26 +38,26 @@ def test_spacy_ner_monitor(monkeypatch, mocked_client):
         nlp("Paris is my favourite city")
 
     sleep(1)  # wait for the consumer time
-    df = ar.load(dataset)
+    df = rg.load(dataset)
     df = df.to_pandas()
     assert len(df) == 11
     # assert 10 - std < len(df) < 10 + std
     assert df.text.unique().tolist() == ["Paris is my favourite city"]
 
-    ar.delete(dataset)
+    rg.delete(dataset)
     list(nlp.pipe(["This is a text"] * 20))
 
     sleep(1)  # wait for the consumer time
-    df = ar.load(dataset)
+    df = rg.load(dataset)
     df = df.to_pandas()
     assert len(df) == 6
     assert df.text.unique().tolist() == ["This is a text"]
 
-    ar.delete(dataset)
+    rg.delete(dataset)
     list(nlp.pipe([("This is a text", {"meta": "data"})] * 20, as_tuples=True))
 
     sleep(1)  # wait for the consumer time
-    df = ar.load(dataset)
+    df = rg.load(dataset)
     df = df.to_pandas()
     assert len(df) == 14
     for metadata in df.metadata.values.tolist():

--- a/tests/server/text_classification/test_api_settings.py
+++ b/tests/server/text_classification/test_api_settings.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import argilla as ar
+import argilla as rg
 from argilla.server.commons.models import TaskType
 
 
@@ -23,7 +23,7 @@ def create_dataset(client, name: str):
 
 def test_create_dataset_settings(mocked_client):
     name = "test_create_dataset_settings"
-    ar.delete(name)
+    rg.delete(name)
     create_dataset(mocked_client, name)
 
     response = create_settings(mocked_client, name)
@@ -44,7 +44,7 @@ def create_settings(mocked_client, name):
 
 def test_get_dataset_settings_not_found(mocked_client):
     name = "test_get_dataset_settings"
-    ar.delete(name)
+    rg.delete(name)
     create_dataset(mocked_client, name)
 
     response = fetch_settings(mocked_client, name)
@@ -53,7 +53,7 @@ def test_get_dataset_settings_not_found(mocked_client):
 
 def test_delete_settings(mocked_client):
     name = "test_delete_settings"
-    ar.delete(name)
+    rg.delete(name)
 
     create_dataset(mocked_client, name)
     assert create_settings(mocked_client, name).status_code == 200
@@ -65,7 +65,7 @@ def test_delete_settings(mocked_client):
 
 def test_validate_settings_when_logging_data(mocked_client):
     name = "test_validate_settings_when_logging_data"
-    ar.delete(name)
+    rg.delete(name)
 
     create_dataset(mocked_client, name)
     assert create_settings(mocked_client, name).status_code == 200
@@ -88,7 +88,7 @@ def test_validate_settings_when_logging_data(mocked_client):
 def test_validate_settings_after_logging(mocked_client):
     name = "test_validate_settings_after_logging"
 
-    ar.delete(name)
+    rg.delete(name)
     response = log_some_data(mocked_client, name)
     assert response.status_code == 200
 

--- a/tests/server/token_classification/test_api_settings.py
+++ b/tests/server/token_classification/test_api_settings.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import argilla as ar
+import argilla as rg
 from argilla.server.commons.models import TaskType
 
 
@@ -23,7 +23,7 @@ def create_dataset(client, name: str):
 
 def test_create_dataset_settings(mocked_client):
     name = "test_create_dataset_settings"
-    ar.delete(name)
+    rg.delete(name)
     create_dataset(mocked_client, name)
 
     response = create_settings(mocked_client, name)
@@ -44,7 +44,7 @@ def create_settings(mocked_client, name):
 
 def test_get_dataset_settings_not_found(mocked_client):
     name = "test_get_dataset_settings"
-    ar.delete(name)
+    rg.delete(name)
     create_dataset(mocked_client, name)
 
     response = fetch_settings(mocked_client, name)
@@ -53,7 +53,7 @@ def test_get_dataset_settings_not_found(mocked_client):
 
 def test_delete_settings(mocked_client):
     name = "test_delete_settings"
-    ar.delete(name)
+    rg.delete(name)
 
     create_dataset(mocked_client, name)
     assert create_settings(mocked_client, name).status_code == 200
@@ -65,7 +65,7 @@ def test_delete_settings(mocked_client):
 
 def test_validate_settings_when_logging_data(mocked_client):
     name = "test_validate_settings_when_logging_data"
-    ar.delete(name)
+    rg.delete(name)
 
     create_dataset(mocked_client, name)
     assert create_settings(mocked_client, name).status_code == 200
@@ -110,7 +110,7 @@ def log_some_data(mocked_client, name):
 
 def test_validate_settings_after_logging(mocked_client):
     name = "test_validate_settings_after_logging"
-    ar.delete(name)
+    rg.delete(name)
     response = log_some_data(mocked_client, name)
     assert response.status_code == 200
 


### PR DESCRIPTION
Hello!

# Description

As discussed in Slack, I've replaced "ar" with "rg" as the shorthand import in the tests. Long live project-wide "find-and-replace" functionality.

**Type of change**

- [x] Refactor (change restructuring the codebase without changing functionality)

**How Has This Been Tested**

Running the test suite.

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

---

- Tom Aarsen