### PR TITLE
Change tests configuration to allow testing with new endpoints using database

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -97,6 +97,7 @@ jobs:
         if: steps.filter.outputs.python_code == 'true'
         run: |
           pip install -e ".[server,listeners]"
+          alembic upgrade head
           pytest --cov=argilla --cov-report=xml
           pip install "spacy<3.0" && python -m spacy download en_core_web_sm
           pytest tests/monitoring/test_spacy_monitoring.py
@@ -183,6 +184,7 @@ jobs:
         if: steps.filter.outputs.python_code == 'true'
         run: |
           pip install -e ".[server,listeners]"
+          alembic upgrade head
           pytest --cov=argilla --cov-report=xml
           pip install "spacy<3.0" && python -m spacy download en_core_web_sm
           pytest tests/monitoring/test_spacy_monitoring.py

--- a/src/argilla/server/seeds.py
+++ b/src/argilla/server/seeds.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from argilla._constants import DEFAULT_API_KEY
 from argilla.server.database import SessionLocal
 from argilla.server.models import User, Workspace
 
@@ -35,6 +36,21 @@ def development_seeds():
                     username="tanya",
                     password_hash="$2y$05$eaw.j2Kaw8s8vpscVIZMfuqSIX3OLmxA21WjtWicDdn0losQ91Hw.",
                     api_key="123456",
+                ),
+            ]
+        )
+
+
+def test_seeds():
+    with SessionLocal() as session, session.begin():
+        session.add_all(
+            [
+                User(
+                    first_name="John",
+                    last_name="Doe",
+                    username="argilla",
+                    password_hash="$2y$05$eaw.j2Kaw8s8vpscVIZMfuqSIX3OLmxA21WjtWicDdn0losQ91Hw.",
+                    api_key=DEFAULT_API_KEY,
                 ),
             ]
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from argilla._constants import API_KEY_HEADER_NAME, DEFAULT_API_KEY
 from argilla.client.client import Argilla
 from argilla.client.sdk.users import api as users_api
 from argilla.server.commons import telemetry
+from argilla.server.contexts import accounts
 from argilla.server.database import SessionLocal
 from argilla.server.models import User, Workspace
 from argilla.server.seeds import test_seeds
@@ -55,6 +56,11 @@ def db():
     session.query(User).delete()
     session.query(Workspace).delete()
     session.commit()
+
+
+@pytest.fixture(scope="function")
+def admin(db):
+    return accounts.get_user_by_api_key(db, DEFAULT_API_KEY)
 
 
 @pytest.fixture

--- a/tests/server/api/v0/test_workspaces.py
+++ b/tests/server/api/v0/test_workspaces.py
@@ -1,0 +1,30 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from argilla.server.contexts import accounts
+from argilla.server.security.model import WorkspaceCreate
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+
+def test_list_workspaces(client: TestClient, api_key_header: dict, db: Session):
+    accounts.create_workspace(db, WorkspaceCreate(name="workspace-a"))
+    accounts.create_workspace(db, WorkspaceCreate(name="workspace-b"))
+
+    response = client.get("/api/workspaces", headers=api_key_header)
+
+    workspaces = response.json()
+
+    assert response.status_code == 200
+    assert list(map(lambda ws: ws["name"], workspaces)) == ["workspace-a", "workspace-b"]

--- a/tests/server/security/test_provider.py
+++ b/tests/server/security/test_provider.py
@@ -18,6 +18,7 @@ from argilla.server.security.auth_provider.local.provider import (
     create_local_auth_provider,
 )
 from fastapi.security import SecurityScopes
+from sqlalchemy.orm import Session
 
 localAuth = create_local_auth_provider()
 security_Scopes = SecurityScopes
@@ -25,11 +26,11 @@ security_Scopes = SecurityScopes
 
 # Tests for function get_user via token and api key
 @pytest.mark.asyncio
-async def test_get_user_via_token(db_session):
+async def test_get_user_via_token(db: Session):
     access_token = localAuth._create_access_token(username="argilla")
     user = await localAuth.get_user(
         security_scopes=security_Scopes,
-        db=db_session,
+        db=db,
         token=access_token,
         api_key=None,
         old_api_key=None,
@@ -38,8 +39,8 @@ async def test_get_user_via_token(db_session):
 
 
 @pytest.mark.asyncio
-async def test_get_user_via_api_key(db_session):
-    user = await localAuth.get_user(security_scopes=security_Scopes, db=db_session, api_key=DEFAULT_API_KEY, token=None)
+async def test_get_user_via_api_key(db: Session):
+    user = await localAuth.get_user(security_scopes=security_Scopes, db=db, api_key=DEFAULT_API_KEY, token=None)
     assert user.username == "argilla"
 
 
@@ -51,7 +52,7 @@ async def test_get_user_by_api_key():
 
 
 # Test for function fetch token
-def test_fetch_token_user(db_session):
+def test_fetch_token_user(db: Session):
     access_token = localAuth._create_access_token(username="argilla")
-    user = localAuth.fetch_token_user(db=db_session, token=access_token)
+    user = localAuth.fetch_token_user(db=db, token=access_token)
     assert user.username == "argilla"


### PR DESCRIPTION
In this PR we are making changes on how tests are configured to be used with the database:
* Moved test seeds to a new `test_seeds` function at `argilla.server.seeds` package.
* One the new `test_seeds` function we are defining a default "argilla" user. In the future `test_seeds` should only have proper seeds necessary for the application to work normally and users and other stuff should be added as test fixtures.
* We didn't find a proper way to use transactions and rollback changes in every unit test and allow endpoints access the same data so we are truncating all the database tables after every unit test execution.
* We added a test for one of the new workspaces endpoint that interact with the database so we can check that everything is working as expected.
* Now our GitHub actions run (alembic) database migrations in the tests section.