### PR TITLE
Add unique constraint to workspaces name column

### DIFF
--- a/src/argilla/server/alembic/versions/82a5a88a3fa5_create_workspaces_table.py
+++ b/src/argilla/server/alembic/versions/82a5a88a3fa5_create_workspaces_table.py
@@ -33,7 +33,7 @@ def upgrade() -> None:
     op.create_table(
         "workspaces",
         sa.Column("id", sa.Uuid, primary_key=True),
-        sa.Column("name", sa.String, nullable=False),
+        sa.Column("name", sa.String, nullable=False, unique=True, index=True),
         sa.Column("inserted_at", sa.DateTime, nullable=False),
         sa.Column("updated_at", sa.DateTime, nullable=False),
     )

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -51,7 +51,7 @@ class Workspace(Base):
     __tablename__ = "workspaces"
 
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
-    name: Mapped[str]
+    name: Mapped[str] = mapped_column(unique=True)
 
     inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
@@ -65,7 +65,7 @@ class User(Base):
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
     first_name: Mapped[str]
     last_name: Mapped[Optional[str]]
-    username: Mapped[str]
+    username: Mapped[str] = mapped_column(unique=True)
     api_key: Mapped[str] = mapped_column(Text, unique=True, default=generate_user_api_key)
     password_hash: Mapped[str] = mapped_column(Text)
 


### PR DESCRIPTION
This PR add an unique constraint to column `name` on `workspaces` table.

This restriction is necessary right now because we are using workspaces name inside elastic-search indexes and it's not possible to have duplications. In the future we will have information about elastic indexes in the database (using ids) so we can rethink is the uniqueness is necessary.

I have added a missing `mapped_column(unique=True)` for `username` field on `User` model too.