### PR TITLE
Fix wrong method name when user is not found on authenticate_user function

### DIFF
--- a/src/argilla/server/contexts/accounts.py
+++ b/src/argilla/server/contexts/accounts.py
@@ -127,4 +127,4 @@ def authenticate_user(db: Session, username: str, password: str):
     elif user:
         return
     else:
-        _CRYPT_CONTEXT.verify_dummy()
+        _CRYPT_CONTEXT.dummy_verify()

--- a/src/argilla/server/server.py
+++ b/src/argilla/server/server.py
@@ -38,7 +38,11 @@ from argilla.server.daos.backend import GenericElasticEngineBackend
 from argilla.server.daos.backend.base import GenericSearchError
 from argilla.server.daos.datasets import DatasetsDAO
 from argilla.server.daos.records import DatasetRecordsDAO
-from argilla.server.errors import APIErrorHandler, EntityNotFoundError
+from argilla.server.errors import (
+    APIErrorHandler,
+    EntityNotFoundError,
+    UnauthorizedError,
+)
 from argilla.server.routes import api_router
 from argilla.server.security import auth
 from argilla.server.settings import settings
@@ -65,6 +69,7 @@ def configure_api_exceptions(api: FastAPI):
     """Configures fastapi exception handlers"""
     api.exception_handler(EntityNotFoundError)(APIErrorHandler.common_exception_handler)
     api.exception_handler(Exception)(APIErrorHandler.common_exception_handler)
+    api.exception_handler(UnauthorizedError)(APIErrorHandler.common_exception_handler)
     api.exception_handler(RequestValidationError)(APIErrorHandler.common_exception_handler)
 
 

--- a/tests/server/api/v0/test_security_token.py
+++ b/tests/server/api/v0/test_security_token.py
@@ -1,0 +1,51 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from argilla.server.models import User
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+
+def test_create_security_token(client: TestClient, admin: User):
+    response = client.post("/api/security/token", data={"username": admin.username, "password": "1234"})
+
+    assert response.status_code == 200
+
+    response_body = response.json()
+    assert response_body["access_token"]
+    assert response_body["token_type"] == "bearer"
+
+
+def test_create_security_token_with_empty_username(client: TestClient):
+    response = client.post("/api/security/token", data={"username": "", "password": "1234"})
+
+    assert response.status_code == 422
+
+
+def test_create_security_token_with_empty_password(client: TestClient, admin: User):
+    response = client.post("/api/security/token", data={"username": admin.username, "password": ""})
+
+    assert response.status_code == 422
+
+
+def test_create_security_token_with_invalid_username(client: TestClient):
+    response = client.post("/api/security/token", data={"username": "invalid", "password": "1234"})
+
+    assert response.status_code == 401
+
+
+def test_create_security_token_with_invalid_password(client: TestClient, admin: User):
+    response = client.post("/api/security/token", data={"username": admin.username, "password": "invalid"})
+
+    assert response.status_code == 401


### PR DESCRIPTION
A small fix for a wrong method name used when user is not found on `authenticate_user`.

Waiting for changes on test settings to be merged so we can write some new tests for this one.