### PR TITLE
Refactor/remove inheritance for datasets

### DIFF
--- a/src/argilla/server/apis/v0/handlers/metrics.py
+++ b/src/argilla/server/apis/v0/handlers/metrics.py
@@ -81,7 +81,6 @@ def configure_router(router: APIRouter, cfg: TaskConfig):
             name=name,
             task=cfg.task,
             workspace=request_deps.workspace,
-            as_dataset_class=TasksFactory.get_task_dataset(cfg.task),
         )
 
         metrics = TasksFactory.get_task_metrics(dataset.task)
@@ -111,7 +110,6 @@ def configure_router(router: APIRouter, cfg: TaskConfig):
             name=name,
             task=cfg.task,
             workspace=request_deps.workspace,
-            as_dataset_class=TasksFactory.get_task_dataset(cfg.task),
         )
 
         metric_ = TasksFactory.find_task_metric(task=cfg.task, metric_id=metric)

--- a/src/argilla/server/apis/v0/handlers/text2text.py
+++ b/src/argilla/server/apis/v0/handlers/text2text.py
@@ -56,7 +56,6 @@ def configure_router():
 
     TasksFactory.register_task(
         task_type=TaskType.text2text,
-        dataset_class=ServiceBaseDataset,
         query_request=Text2TextQuery,
         record_class=ServiceText2TextRecord,
         metrics=Text2TextMetrics,

--- a/src/argilla/server/apis/v0/handlers/text2text.py
+++ b/src/argilla/server/apis/v0/handlers/text2text.py
@@ -27,7 +27,6 @@ from argilla.server.apis.v0.models.commons.params import (
 )
 from argilla.server.apis.v0.models.text2text import (
     Text2TextBulkRequest,
-    Text2TextDataset,
     Text2TextMetrics,
     Text2TextQuery,
     Text2TextRecord,
@@ -43,7 +42,7 @@ from argilla.server.responses import StreamingResponseWithErrorHandling
 from argilla.server.schemas.datasets import CreateDatasetRequest
 from argilla.server.security import auth
 from argilla.server.security.model import User
-from argilla.server.services.datasets import DatasetsService
+from argilla.server.services.datasets import DatasetsService, ServiceBaseDataset
 from argilla.server.services.tasks.text2text import Text2TextService
 from argilla.server.services.tasks.text2text.models import (
     ServiceText2TextQuery,
@@ -57,7 +56,7 @@ def configure_router():
 
     TasksFactory.register_task(
         task_type=TaskType.text2text,
-        dataset_class=Text2TextDataset,
+        dataset_class=ServiceBaseDataset,
         query_request=Text2TextQuery,
         record_class=ServiceText2TextRecord,
         metrics=Text2TextMetrics,
@@ -87,7 +86,6 @@ def configure_router():
                 name=name,
                 task=task,
                 workspace=workspace,
-                as_dataset_class=TasksFactory.get_task_dataset(task_type),
             )
             datasets.update(
                 user=current_user,
@@ -132,7 +130,6 @@ def configure_router():
             name=name,
             task=task_type,
             workspace=common_params.workspace,
-            as_dataset_class=TasksFactory.get_task_dataset(task_type),
         )
         result = service.search(
             dataset=dataset,
@@ -224,7 +221,6 @@ def configure_router():
             name=name,
             task=task_type,
             workspace=common_params.workspace,
-            as_dataset_class=TasksFactory.get_task_dataset(task_type),
         )
         data_stream = map(
             Text2TextRecord.parse_obj,

--- a/src/argilla/server/apis/v0/handlers/text_classification.py
+++ b/src/argilla/server/apis/v0/handlers/text_classification.py
@@ -103,7 +103,6 @@ def configure_router():
                 name=name,
                 task=task,
                 workspace=workspace,
-                as_dataset_class=TasksFactory.get_task_dataset(task_type),
             )
             dataset = datasets.update(
                 user=current_user,
@@ -181,7 +180,6 @@ def configure_router():
             name=name,
             task=task_type,
             workspace=common_params.workspace,
-            as_dataset_class=TasksFactory.get_task_dataset(task_type),
         )
         result = service.search(
             dataset=dataset,
@@ -274,7 +272,6 @@ def configure_router():
             name=name,
             task=task_type,
             workspace=common_params.workspace,
-            as_dataset_class=TasksFactory.get_task_dataset(task_type),
         )
 
         data_stream = map(
@@ -312,7 +309,7 @@ def configure_router():
             name=name,
             task=task_type,
             workspace=common_params.workspace,
-            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+            as_dataset_class=TextClassificationDataset,
         )
 
         return [LabelingRule.parse_obj(rule) for rule in service.list_labeling_rules(dataset)]
@@ -339,7 +336,7 @@ def configure_router():
             name=name,
             task=task_type,
             workspace=common_params.workspace,
-            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+            as_dataset_class=TextClassificationDataset,
         )
 
         rule = ServiceLabelingRule(
@@ -375,7 +372,6 @@ def configure_router():
             name=name,
             task=task_type,
             workspace=common_params.workspace,
-            as_dataset_class=TasksFactory.get_task_dataset(task_type),
         )
 
         return service.compute_labeling_rule(dataset, rule_query=query, labels=labels)
@@ -401,7 +397,7 @@ def configure_router():
             name=name,
             task=task_type,
             workspace=common_params.workspace,
-            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+            as_dataset_class=TextClassificationDataset,
         )
         metrics = service.compute_all_labeling_rules(dataset)
         return DatasetLabelingRulesMetricsSummary.parse_obj(metrics)
@@ -426,7 +422,7 @@ def configure_router():
             name=name,
             task=task_type,
             workspace=common_params.workspace,
-            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+            as_dataset_class=TextClassificationDataset,
         )
 
         service.delete_labeling_rule(dataset, rule_query=query)
@@ -453,7 +449,7 @@ def configure_router():
             name=name,
             task=task_type,
             workspace=common_params.workspace,
-            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+            as_dataset_class=TextClassificationDataset,
         )
         rule = service.find_labeling_rule(dataset, rule_query=query)
         return LabelingRule.parse_obj(rule)
@@ -481,7 +477,7 @@ def configure_router():
             name=name,
             task=task_type,
             workspace=common_params.workspace,
-            as_dataset_class=TasksFactory.get_task_dataset(task_type),
+            as_dataset_class=TextClassificationDataset,
         )
 
         rule = service.update_labeling_rule(

--- a/src/argilla/server/apis/v0/handlers/token_classification.py
+++ b/src/argilla/server/apis/v0/handlers/token_classification.py
@@ -65,7 +65,6 @@ def configure_router():
 
     TasksFactory.register_task(
         task_type=task_type,
-        dataset_class=ServiceBaseDataset,
         query_request=TokenClassificationQuery,
         record_class=ServiceTokenClassificationRecord,
         metrics=TokenClassificationMetrics,

--- a/src/argilla/server/apis/v0/handlers/token_classification.py
+++ b/src/argilla/server/apis/v0/handlers/token_classification.py
@@ -31,7 +31,6 @@ from argilla.server.apis.v0.models.commons.params import (
 from argilla.server.apis.v0.models.token_classification import (
     TokenClassificationAggregations,
     TokenClassificationBulkRequest,
-    TokenClassificationDataset,
     TokenClassificationQuery,
     TokenClassificationRecord,
     TokenClassificationSearchRequest,
@@ -46,7 +45,7 @@ from argilla.server.responses import StreamingResponseWithErrorHandling
 from argilla.server.schemas.datasets import CreateDatasetRequest
 from argilla.server.security import auth
 from argilla.server.security.model import User
-from argilla.server.services.datasets import DatasetsService
+from argilla.server.services.datasets import DatasetsService, ServiceBaseDataset
 from argilla.server.services.tasks.token_classification import (
     TokenClassificationService,
 )
@@ -66,7 +65,7 @@ def configure_router():
 
     TasksFactory.register_task(
         task_type=task_type,
-        dataset_class=TokenClassificationDataset,
+        dataset_class=ServiceBaseDataset,
         query_request=TokenClassificationQuery,
         record_class=ServiceTokenClassificationRecord,
         metrics=TokenClassificationMetrics,
@@ -97,7 +96,6 @@ def configure_router():
                 name=name,
                 task=task,
                 workspace=workspace,
-                as_dataset_class=TasksFactory.get_task_dataset(task_type),
             )
             datasets.update(
                 user=current_user,
@@ -154,7 +152,6 @@ def configure_router():
             name=name,
             task=task_type,
             workspace=common_params.workspace,
-            as_dataset_class=TasksFactory.get_task_dataset(task_type),
         )
         results = service.search(
             dataset=dataset,
@@ -246,7 +243,6 @@ def configure_router():
             name=name,
             task=task_type,
             workspace=common_params.workspace,
-            as_dataset_class=TasksFactory.get_task_dataset(task_type),
         )
         data_stream = map(
             TokenClassificationRecord.parse_obj,

--- a/src/argilla/server/apis/v0/models/text2text.py
+++ b/src/argilla/server/apis/v0/models/text2text.py
@@ -32,7 +32,6 @@ from argilla.server.services.search.model import (
     ServiceBaseRecordsQuery,
     ServiceBaseSearchResultsAggregations,
 )
-from argilla.server.services.tasks.text2text.models import ServiceText2TextDataset
 
 
 class Text2TextPrediction(BaseModel):
@@ -72,10 +71,6 @@ class Text2TextSearchAggregations(ServiceBaseSearchResultsAggregations):
 
 
 class Text2TextSearchResults(BaseSearchResults[Text2TextRecord, Text2TextSearchAggregations]):
-    pass
-
-
-class Text2TextDataset(ServiceText2TextDataset):
     pass
 
 

--- a/src/argilla/server/apis/v0/models/token_classification.py
+++ b/src/argilla/server/apis/v0/models/token_classification.py
@@ -32,9 +32,6 @@ from argilla.server.services.search.model import (
 from argilla.server.services.tasks.token_classification.model import (
     ServiceTokenClassificationAnnotation as _TokenClassificationAnnotation,
 )
-from argilla.server.services.tasks.token_classification.model import (
-    ServiceTokenClassificationDataset,
-)
 
 
 class TokenClassificationAnnotation(_TokenClassificationAnnotation):
@@ -87,8 +84,4 @@ class TokenClassificationAggregations(ServiceBaseSearchResultsAggregations):
 
 
 class TokenClassificationSearchResults(BaseSearchResults[TokenClassificationRecord, TokenClassificationAggregations]):
-    pass
-
-
-class TokenClassificationDataset(ServiceTokenClassificationDataset):
     pass

--- a/src/argilla/server/commons/config.py
+++ b/src/argilla/server/commons/config.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel
 
 from argilla.server.commons.models import TaskType
 from argilla.server.errors import EntityNotFoundError, WrongTaskError
-from argilla.server.services.datasets import ServiceDataset
+from argilla.server.services.datasets import ServiceBaseDataset, ServiceDataset
 from argilla.server.services.metrics import ServiceBaseMetric
 from argilla.server.services.metrics.models import ServiceBaseTaskMetrics
 from argilla.server.services.search.model import ServiceRecordsQuery
@@ -40,14 +40,14 @@ class TasksFactory:
     def register_task(
         cls,
         task_type: TaskType,
-        dataset_class: Type[ServiceDataset],
         query_request: Type[ServiceRecordsQuery],
         record_class: Type[ServiceRecord],
+        dataset_class: Optional[Type[ServiceDataset]] = None,
         metrics: Optional[Type[ServiceBaseTaskMetrics]] = None,
     ):
         cls.__REGISTERED_TASKS__[task_type] = TaskConfig(
             task=task_type,
-            dataset=dataset_class,
+            dataset=dataset_class or ServiceBaseDataset,
             query=query_request,
             record=record_class,
             metrics=metrics,

--- a/src/argilla/server/services/datasets.py
+++ b/src/argilla/server/services/datasets.py
@@ -153,6 +153,8 @@ class DatasetsService:
         copy_dataset.name = copy_name
         copy_dataset.workspace = dataset_workspace
 
+        date_now = datetime.utcnow()
+
         copy_dataset.created_at = date_now
         copy_dataset.last_updated = date_now
         copy_dataset.tags = {**copy_dataset.tags, **(copy_tags or {})}

--- a/src/argilla/server/services/tasks/text2text/models.py
+++ b/src/argilla/server/services/tasks/text2text/models.py
@@ -76,7 +76,3 @@ class ServiceText2TextRecord(ServiceBaseRecord[ServiceText2TextAnnotation]):
 class ServiceText2TextQuery(ServiceBaseRecordsQuery):
     score: Optional[ServiceScoreRange] = Field(default=None)
     predicted: Optional[PredictionStatus] = Field(default=None, nullable=True)
-
-
-class ServiceText2TextDataset(ServiceBaseDataset):
-    task: TaskType = Field(default=TaskType.text2text, const=True)

--- a/src/argilla/server/services/tasks/text2text/service.py
+++ b/src/argilla/server/services/tasks/text2text/service.py
@@ -18,6 +18,7 @@ from typing import Iterable, List, Optional
 from fastapi import Depends
 
 from argilla.server.commons.config import TasksFactory
+from argilla.server.services.datasets import ServiceDataset
 from argilla.server.services.search.model import (
     ServiceSearchResults,
     ServiceSortableField,
@@ -27,7 +28,6 @@ from argilla.server.services.search.service import SearchRecordsService
 from argilla.server.services.storage.service import RecordsStorageService
 from argilla.server.services.tasks.commons import BulkResponse
 from argilla.server.services.tasks.text2text.models import (
-    ServiceText2TextDataset,
     ServiceText2TextQuery,
     ServiceText2TextRecord,
 )
@@ -61,7 +61,7 @@ class Text2TextService:
 
     async def add_records(
         self,
-        dataset: ServiceText2TextDataset,
+        dataset: ServiceDataset,
         records: List[ServiceText2TextRecord],
     ):
         failed = await self.__storage__.store_records(
@@ -73,7 +73,7 @@ class Text2TextService:
 
     def search(
         self,
-        dataset: ServiceText2TextDataset,
+        dataset: ServiceDataset,
         query: ServiceText2TextQuery,
         sort_by: List[ServiceSortableField],
         record_from: int = 0,
@@ -113,7 +113,7 @@ class Text2TextService:
 
     def read_dataset(
         self,
-        dataset: ServiceText2TextDataset,
+        dataset: ServiceDataset,
         query: Optional[ServiceText2TextQuery] = None,
         id_from: Optional[str] = None,
         limit: int = 1000,

--- a/src/argilla/server/services/tasks/text_classification/model.py
+++ b/src/argilla/server/services/tasks/text_classification/model.py
@@ -64,7 +64,7 @@ class ServiceLabelingRule(BaseModel):
 
 
 class ServiceTextClassificationDataset(ServiceBaseDataset):
-    task: TaskType = Field(default=TaskType.text_classification, const=True)
+    task: TaskType = Field(default=TaskType.text_classification)
     rules: List[ServiceLabelingRule] = Field(default_factory=list)
 
 

--- a/src/argilla/server/services/tasks/token_classification/model.py
+++ b/src/argilla/server/services/tasks/token_classification/model.py
@@ -205,8 +205,3 @@ class ServiceTokenClassificationQuery(ServiceBaseRecordsQuery):
     annotated_as: List[str] = Field(default_factory=list)
     score: Optional[ServiceScoreRange] = Field(default=None)
     predicted: Optional[PredictionStatus] = Field(default=None, nullable=True)
-
-
-class ServiceTokenClassificationDataset(ServiceBaseDataset):
-    task: TaskType = Field(default=TaskType.token_classification, const=True)
-    pass

--- a/src/argilla/server/services/tasks/token_classification/service.py
+++ b/src/argilla/server/services/tasks/token_classification/service.py
@@ -19,12 +19,12 @@ from fastapi import Depends
 
 from argilla.server.commons.config import TasksFactory
 from argilla.server.daos.backend.search.model import SortableField
+from argilla.server.services.datasets import ServiceBaseDataset
 from argilla.server.services.search.model import ServiceSearchResults, ServiceSortConfig
 from argilla.server.services.search.service import SearchRecordsService
 from argilla.server.services.storage.service import RecordsStorageService
 from argilla.server.services.tasks.commons import BulkResponse
 from argilla.server.services.tasks.token_classification.model import (
-    ServiceTokenClassificationDataset,
     ServiceTokenClassificationQuery,
     ServiceTokenClassificationRecord,
 )
@@ -58,7 +58,7 @@ class TokenClassificationService:
 
     async def add_records(
         self,
-        dataset: ServiceTokenClassificationDataset,
+        dataset: ServiceBaseDataset,
         records: List[ServiceTokenClassificationRecord],
     ):
         failed = await self.__storage__.store_records(
@@ -70,7 +70,7 @@ class TokenClassificationService:
 
     def search(
         self,
-        dataset: ServiceTokenClassificationDataset,
+        dataset: ServiceBaseDataset,
         query: ServiceTokenClassificationQuery,
         sort_by: List[SortableField],
         record_from: int = 0,
@@ -138,7 +138,7 @@ class TokenClassificationService:
 
     def read_dataset(
         self,
-        dataset: ServiceTokenClassificationDataset,
+        dataset: ServiceBaseDataset,
         query: ServiceTokenClassificationQuery,
         id_from: Optional[str] = None,
         limit: int = 1000,


### PR DESCRIPTION
- Using common dataset class when possible
- Keep dataset inheritance only for text-classification (for now, `rules` are there) 
- Remove dataset classes for token and text2text 