### PR TITLE
Feat/2059 allow passing workspace as client parm for rglog or rgload

### DIFF
--- a/src/argilla/client/api.py
+++ b/src/argilla/client/api.py
@@ -109,6 +109,7 @@ def init(
 def log(
     records: Union[Record, Iterable[Record], Dataset],
     name: str,
+    workspace: Optional[str] = None,
     tags: Optional[Dict[str, str]] = None,
     metadata: Optional[Dict[str, Any]] = None,
     chunk_size: int = 500,
@@ -122,6 +123,8 @@ def log(
     Args:
         records: The record, an iterable of records, or a dataset to log.
         name: The dataset name.
+        workspace: The workspace to which records will be logged/loaded. If `None` (default) and the
+            env variable ``ARGILLA_WORKSPACE`` is not set, it will default to the private user workspace.
         tags: A dictionary of tags related to the dataset.
         metadata: A dictionary of extra info for the dataset.
         chunk_size: The chunk size for a data bulk.
@@ -150,6 +153,7 @@ def log(
     return ArgillaSingleton.get().log(
         records=records,
         name=name,
+        workspace=workspace,
         tags=tags,
         metadata=metadata,
         chunk_size=chunk_size,
@@ -161,6 +165,7 @@ def log(
 async def log_async(
     records: Union[Record, Iterable[Record], Dataset],
     name: str,
+    workspace: Optional[str] = None,
     tags: Optional[Dict[str, str]] = None,
     metadata: Optional[Dict[str, Any]] = None,
     chunk_size: int = 500,
@@ -171,6 +176,8 @@ async def log_async(
     Args:
         records: The record, an iterable of records, or a dataset to log.
         name: The dataset name.
+        workspace: The workspace to which records will be logged/loaded. If `None` (default) and the
+            env variable ``ARGILLA_WORKSPACE`` is not set, it will default to the private user workspace.
         tags: A dictionary of tags related to the dataset.
         metadata: A dictionary of extra info for the dataset.
         chunk_size: The chunk size for a data bulk.
@@ -192,6 +199,7 @@ async def log_async(
     return await ArgillaSingleton.get().log_async(
         records=records,
         name=name,
+        workspace=workspace,
         tags=tags,
         metadata=metadata,
         chunk_size=chunk_size,
@@ -201,6 +209,7 @@ async def log_async(
 
 def load(
     name: str,
+    workspace: Optional[str] = None,
     query: Optional[str] = None,
     vector: Optional[Tuple[str, List[float]]] = None,
     ids: Optional[List[Union[str, int]]] = None,
@@ -212,6 +221,8 @@ def load(
 
     Args:
         name: The dataset name.
+        workspace: The workspace to which records will be logged/loaded. If `None` (default) and the
+            env variable ``ARGILLA_WORKSPACE`` is not set, it will default to the private user workspace.
         query: An ElasticSearch query with the `query string
             syntax <https://argilla.readthedocs.io/en/stable/guides/queries.html>`_
         vector: Vector configuration for a semantic search
@@ -246,6 +257,7 @@ def load(
     """
     return ArgillaSingleton.get().load(
         name=name,
+        workspace=workspace,
         query=query,
         vector=vector,
         ids=ids,
@@ -280,22 +292,25 @@ def copy(
     )
 
 
-def delete(name: str):
+def delete(name: str, workspace: Optional[str] = None):
     """
     Deletes a dataset.
 
     Args:
         name: The dataset name.
+        workspace: The workspace to which records will be logged/loaded. If `None` (default) and the
+            env variable ``ARGILLA_WORKSPACE`` is not set, it will default to the private user workspace.
 
     Examples:
         >>> import argilla as rg
         >>> rg.delete(name="example-dataset")
     """
-    ArgillaSingleton.get().delete(name)
+    ArgillaSingleton.get().delete(name=name, workspace=workspace)
 
 
 def delete_records(
     name: str,
+    workspace: Optional[str] = None,
     query: Optional[str] = None,
     ids: Optional[List[Union[str, int]]] = None,
     discard_only: bool = False,
@@ -305,6 +320,8 @@ def delete_records(
 
     Args:
         name: The dataset name.
+        workspace: The workspace to which records will be logged/loaded. If `None` (default) and the
+            env variable ``ARGILLA_WORKSPACE`` is not set, it will default to the private user workspace.
         query: An ElasticSearch query with the `query string syntax
             <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
         ids: If provided, deletes dataset records with given ids.
@@ -329,6 +346,7 @@ def delete_records(
     """
     return ArgillaSingleton.get().delete_records(
         name=name,
+        workspace=workspace,
         query=query,
         ids=ids,
         discard_only=discard_only,

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -372,10 +372,10 @@ def test_log_load_with_workspace(mocked_client, monkeypatch, request, records, d
     records = request.getfixturevalue(records)
 
     api.log(records[0], name=dataset_names[0], workspace="booohh")
-    api.log(records[0], name=dataset_names[0], workspace="mock_workspace")
-    _ = api.load(dataset_names[0], workspace="mock_workspace")
+    api.log(records[0], name=dataset_names[0], workspace="argilla")
+    _ = api.load(dataset_names[0], workspace="argilla")
     ds = api.load(dataset_names[0], workspace="booohh")
-    api.delete(dataset_names[0], workspace="mock_workspace")
+    api.delete(dataset_names[0], workspace="argilla")
     api.delete_records(dataset_names[0], ids=[rec.id for rec in ds], workspace="booohh")
 
 

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -330,7 +330,7 @@ def test_general_log_load(mocked_client, monkeypatch, request, records, dataset_
     records = request.getfixturevalue(records)
 
     # log single records
-    api.log(records[0], name=dataset_names[0])
+    api.log(records[0], name=dataset_names[0], workspace=)
     dataset = api.load(dataset_names[0])
     records[0].metrics = dataset[0].metrics
     assert dataset[0] == records[0]
@@ -354,6 +354,30 @@ def test_general_log_load(mocked_client, monkeypatch, request, records, dataset_
         record.metrics = expected.metrics
         assert record == expected
 
+@pytest.mark.parametrize(
+    "records, dataset_class",
+    [
+        ("singlelabel_textclassification_records", rg.DatasetForTextClassification),
+    ],
+)
+def test_log_load_with_workspace(mocked_client, monkeypatch, request, records, dataset_class):
+    dataset_names = [
+        f"test_general_log_load_{dataset_class.__name__.lower()}_" + input_type
+        for input_type in ["single", "list", "dataset"]
+    ]
+    for name in dataset_names:
+        mocked_client.delete(f"/api/datasets/{name}")
+
+    records = request.getfixturevalue(records)
+
+    api.log(records[0], name=dataset_names[0], workspace="booohh")
+    api.log(records[0], name=dataset_names[0], workspace="mock_workspace")
+    _ = api.load(dataset_names[0], workspace="mock_workspace")
+    ds = api.load(dataset_names[0], workspace="booohh")
+    api.delete(dataset_names[0], workspace="mock_workspace")
+    api.delete_records(dataset_names[0], ids=[rec.id for rec in ds], workspace="booohh")
+
+
 
 def test_passing_wrong_iterable_data(mocked_client):
     dataset_name = "test_log_single_records"
@@ -371,6 +395,7 @@ def test_log_with_generator(mocked_client, monkeypatch):
             yield rg.TextClassificationRecord(id=i, inputs={"text": "The text data"})
 
     api.log(generator(), name=dataset_name)
+
 
 
 def test_create_ds_with_wrong_name(mocked_client):

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -371,12 +371,10 @@ def test_log_load_with_workspace(mocked_client, monkeypatch, request, records, d
 
     records = request.getfixturevalue(records)
 
-    api.log(records[0], name=dataset_names[0], workspace="booohh")
-    api.log(records[0], name=dataset_names[0], workspace="argilla")
-    _ = api.load(dataset_names[0], workspace="argilla")
-    ds = api.load(dataset_names[0], workspace="booohh")
+    api.log(records, name=dataset_names[0], workspace="argilla")
+    ds = api.load(dataset_names[0], workspace="argilla")
+    api.delete_records(dataset_names[0], ids=[rec.id for rec in ds][:1], workspace="argilla")
     api.delete(dataset_names[0], workspace="argilla")
-    api.delete_records(dataset_names[0], ids=[rec.id for rec in ds], workspace="booohh")
 
 
 def test_passing_wrong_iterable_data(mocked_client):

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -330,7 +330,7 @@ def test_general_log_load(mocked_client, monkeypatch, request, records, dataset_
     records = request.getfixturevalue(records)
 
     # log single records
-    api.log(records[0], name=dataset_names[0], workspace=)
+    api.log(records[0], name=dataset_names[0])
     dataset = api.load(dataset_names[0])
     records[0].metrics = dataset[0].metrics
     assert dataset[0] == records[0]
@@ -353,6 +353,7 @@ def test_general_log_load(mocked_client, monkeypatch, request, records, dataset_
     for record, expected in zip(dataset, records):
         record.metrics = expected.metrics
         assert record == expected
+
 
 @pytest.mark.parametrize(
     "records, dataset_class",
@@ -378,7 +379,6 @@ def test_log_load_with_workspace(mocked_client, monkeypatch, request, records, d
     api.delete_records(dataset_names[0], ids=[rec.id for rec in ds], workspace="booohh")
 
 
-
 def test_passing_wrong_iterable_data(mocked_client):
     dataset_name = "test_log_single_records"
     mocked_client.delete(f"/api/datasets/{dataset_name}")
@@ -395,7 +395,6 @@ def test_log_with_generator(mocked_client, monkeypatch):
             yield rg.TextClassificationRecord(id=i, inputs={"text": "The text data"})
 
     api.log(generator(), name=dataset_name)
-
 
 
 def test_create_ds_with_wrong_name(mocked_client):


### PR DESCRIPTION
# Description

 allow passing workspace as client parm for rglog or rgload. I also enabled this for `rg.delete` and `rg.delete_records`.

Closes #2059 
**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)


- [X] New feature (non-breaking change which adds functionality)
- [X] Refactor (change restructuring the codebase without changing functionality)
- [X] Improvement (change adding some improvement to an existing functionality)


**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [Test A](https://github.com/argilla-io/argilla/blob/b227b09a423dae8792e520ce4f9da3dcb5fb0d0d/tests/client/test_api.py#L364)


**Checklist**

- [X] I have merged the original branch into my forked branch

- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
