### PR TITLE
Improve field constraints for some Pydantic schemas

### DIFF
--- a/src/argilla/server/security/model.py
+++ b/src/argilla/server/security/model.py
@@ -51,7 +51,7 @@ class Workspace(BaseModel):
 
 
 class WorkspaceCreate(BaseModel):
-    name: str = Field(regex=_WORKSPACE_NAME_REGEX, min_length=1)
+    name: constr(regex=_WORKSPACE_NAME_REGEX, min_length=1)
 
 
 class UserGetter(GetterDict):
@@ -65,10 +65,10 @@ class UserGetter(GetterDict):
 
 
 class UserCreate(BaseModel):
-    first_name: str = Field(min_length=1)
-    last_name: Optional[str] = Field(min_length=1)
-    username: str = Field(regex=_USER_USERNAME_REGEX, min_length=1)
-    password: str = Field(min_length=_USER_PASSWORD_MIN_LENGTH, max_length=_USER_PASSWORD_MAX_LENGTH)
+    first_name: constr(min_length=1, strip_whitespace=True)
+    last_name: Optional[constr(min_length=1, strip_whitespace=True)]
+    username: constr(regex=_USER_USERNAME_REGEX, min_length=1)
+    password: constr(min_length=_USER_PASSWORD_MIN_LENGTH, max_length=_USER_PASSWORD_MAX_LENGTH)
 
 
 class UserGetter(GetterDict):

--- a/src/argilla/server/security/model.py
+++ b/src/argilla/server/security/model.py
@@ -29,6 +29,7 @@ _WORKSPACE_NAME_REGEX = r"^[a-zA-Z0-9][a-zA-Z0-9_\-]*$"
 _EMAIL_REGEX_PATTERN = r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}"
 
 _USER_PASSWORD_MIN_LENGTH = 8
+_USER_PASSWORD_MAX_LENGTH = 100
 _USER_USERNAME_REGEX = DATASET_NAME_REGEX_PATTERN
 
 WORKSPACE_NAME_PATTERN = re.compile(_WORKSPACE_NAME_REGEX)
@@ -50,7 +51,7 @@ class Workspace(BaseModel):
 
 
 class WorkspaceCreate(BaseModel):
-    name: constr(regex=_WORKSPACE_NAME_REGEX)
+    name: str = Field(regex=_WORKSPACE_NAME_REGEX, min_length=1)
 
 
 class UserGetter(GetterDict):
@@ -64,10 +65,10 @@ class UserGetter(GetterDict):
 
 
 class UserCreate(BaseModel):
-    first_name: str
-    last_name: Optional[str]
-    username: constr(regex=_USER_USERNAME_REGEX)
-    password: constr(min_length=_USER_PASSWORD_MIN_LENGTH)
+    first_name: str = Field(min_length=1)
+    last_name: Optional[str] = Field(min_length=1)
+    username: str = Field(regex=_USER_USERNAME_REGEX, min_length=1)
+    password: str = Field(min_length=_USER_PASSWORD_MIN_LENGTH, max_length=_USER_PASSWORD_MAX_LENGTH)
 
 
 class UserGetter(GetterDict):

--- a/tests/server/api/v0/test_users.py
+++ b/tests/server/api/v0/test_users.py
@@ -80,11 +80,17 @@ def test_create_user_without_authentication(client: TestClient, db: Session):
     assert db.query(User).count() == 1
 
 
-# TODO: We need to review all the models because of this.
-# More info here: https://github.com/pydantic/pydantic/issues/1626
-@pytest.mark.skip(reason="pydantic allows empty strings for non optional fields")
-def test_create_user_with_invalid_firstname(client: TestClient, db: Session, admin_auth_header: dict):
+def test_create_user_with_invalid_min_length_first_name(client: TestClient, db: Session, admin_auth_header: dict):
     user = {"first_name": "", "username": "username", "password": "12345678"}
+
+    response = client.post("/api/users", headers=admin_auth_header, json=user)
+
+    assert response.status_code == 422
+    assert db.query(User).count() == 1
+
+
+def test_create_user_with_invalid_min_length_last_name(client: TestClient, db: Session, admin_auth_header: dict):
+    user = {"first_name": "first-name", "last_name": "", "username": "username", "password": "12345678"}
 
     response = client.post("/api/users", headers=admin_auth_header, json=user)
 
@@ -101,8 +107,17 @@ def test_create_user_with_invalid_username(client: TestClient, db: Session, admi
     assert db.query(User).count() == 1
 
 
-def test_create_user_with_invalid_password(client: TestClient, db: Session, admin_auth_header: dict):
+def test_create_user_with_invalid_min_password_length(client: TestClient, db: Session, admin_auth_header: dict):
     user = {"first_name": "first-name", "username": "username", "password": "1234"}
+
+    response = client.post("/api/users", headers=admin_auth_header, json=user)
+
+    assert response.status_code == 422
+    assert db.query(User).count() == 1
+
+
+def test_create_user_with_invalid_max_password_length(client: TestClient, db: Session, admin_auth_header: dict):
+    user = {"first_name": "first-name", "username": "username", "password": "p" * 101}
 
     response = client.post("/api/users", headers=admin_auth_header, json=user)
 

--- a/tests/server/api/v0/test_workspaces.py
+++ b/tests/server/api/v0/test_workspaces.py
@@ -58,7 +58,7 @@ def test_create_workspace_without_authentication(client: TestClient, db: Session
     assert db.query(Workspace).count() == 0
 
 
-def test_create_workspace_with_empty_name(client: TestClient, db: Session, admin_auth_header: dict):
+def test_create_workspace_with_invalid_min_length_name(client: TestClient, db: Session, admin_auth_header: dict):
     response = client.post("/api/workspaces", headers=admin_auth_header, json={"name": ""})
 
     assert response.status_code == 422


### PR DESCRIPTION
We found that Pydantic schema string fields allow empty strings by default, being the field optional or not.

More info about that here: https://github.com/pydantic/pydantic/issues/1626

With this behavior we can finish with empty strings used in fields like `user.first_name`, `user.last_name` and others. Something that can have a bad impact in our application.

I have explored different solutions, like defining a common validation or a custom field type. At the end I think the most simple solution is to be explicit and define the constraint that we want for the fields. In this case `min_length=1` when necessary.

Additional changes:
* Added new max length constraint for `user.password` field.
* Notice how I have changed `constr` for `str = Field(...)`. If I'm not wrong looks like they are similar but `Field` is used to generate a validation response when errors are found.