### PR TITLE
Rename users_workspaces to workspaces_users

### DIFF
--- a/src/argilla/server/alembic/versions/1769ee58fbb4_create_workspaces_users_table.py
+++ b/src/argilla/server/alembic/versions/1769ee58fbb4_create_workspaces_users_table.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-"""create users_workspaces table
+"""create workspaces_users table
 
 Revision ID: 1769ee58fbb4
 Revises: 82a5a88a3fa5
@@ -31,17 +31,17 @@ depends_on = None
 
 def upgrade() -> None:
     op.create_table(
-        "users_workspaces",
+        "workspaces_users",
         sa.Column("id", sa.Uuid, primary_key=True),
-        sa.Column("user_id", sa.Uuid, sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True),
         sa.Column(
             "workspace_id", sa.Uuid, sa.ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False, index=True
         ),
+        sa.Column("user_id", sa.Uuid, sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True),
         sa.Column("inserted_at", sa.DateTime, nullable=False),
         sa.Column("updated_at", sa.DateTime, nullable=False),
-        sa.UniqueConstraint("user_id", "workspace_id", name="user_id_workspace_id_uq"),
+        sa.UniqueConstraint("workspace_id", "user_id", name="workspace_id_user_id_uq"),
     )
 
 
 def downgrade() -> None:
-    op.drop_table("users_workspaces")
+    op.drop_table("workspaces_users")

--- a/src/argilla/server/apis/v0/handlers/workspaces.py
+++ b/src/argilla/server/apis/v0/handlers/workspaces.py
@@ -25,9 +25,9 @@ from argilla.server.errors import EntityNotFoundError
 from argilla.server.security import auth
 from argilla.server.security.model import (
     User,
-    UserWorkspaceCreate,
     Workspace,
     WorkspaceCreate,
+    WorkspaceUserCreate,
 )
 
 router = APIRouter(tags=["workspaces"])
@@ -95,9 +95,9 @@ def create_workspace_user(
     if not user:
         raise EntityNotFoundError(name=str(user_id), type=User)
 
-    user_workspace = accounts.create_user_workspace(db, UserWorkspaceCreate(user_id=user_id, workspace_id=workspace_id))
+    workspace_user = accounts.create_workspace_user(db, WorkspaceUserCreate(workspace_id=workspace_id, user_id=user_id))
 
-    return User.from_orm(user_workspace.user)
+    return User.from_orm(workspace_user.user)
 
 
 @router.delete("/workspaces/{workspace_id}/users/{user_id}", response_model=User, response_model_exclude_none=True)
@@ -108,11 +108,11 @@ def delete_workspace_user(
     user_id: UUID,
     current_user: User = Security(auth.get_user, scopes=[]),
 ):
-    user_workspace = accounts.get_user_workspace_by_user_id_and_workspace_id(db, user_id, workspace_id)
-    if not user_workspace:
+    workspace_user = accounts.get_workspace_user_by_workspace_id_and_user_id(db, workspace_id, user_id)
+    if not workspace_user:
         raise EntityNotFoundError(name=str(user_id), type=User)
 
-    user = user_workspace.user
-    accounts.delete_user_workspace(db, user_workspace)
+    user = workspace_user.user
+    accounts.delete_workspace_user(db, workspace_user)
 
     return User.from_orm(user)

--- a/src/argilla/server/contexts/accounts.py
+++ b/src/argilla/server/contexts/accounts.py
@@ -14,11 +14,11 @@
 
 from uuid import UUID
 
-from argilla.server.models import User, UserWorkspace, Workspace
+from argilla.server.models import User, Workspace, WorkspaceUser
 from argilla.server.security.model import (
     UserCreate,
-    UserWorkspaceCreate,
     WorkspaceCreate,
+    WorkspaceUserCreate,
 )
 from passlib.context import CryptContext
 from sqlalchemy.orm import Session
@@ -26,27 +26,28 @@ from sqlalchemy.orm import Session
 _CRYPT_CONTEXT = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
-def get_user_workspace_by_user_id_and_workspace_id(db: Session, user_id: UUID, workspace_id: UUID):
-    return db.query(UserWorkspace).filter_by(user_id=user_id, workspace_id=workspace_id).first()
+def get_workspace_user_by_workspace_id_and_user_id(db: Session, workspace_id: UUID, user_id: UUID):
+    return db.query(WorkspaceUser).filter_by(workspace_id=workspace_id, user_id=user_id).first()
 
 
-def create_user_workspace(db: Session, user_workspace_create: UserWorkspaceCreate):
-    user_workspace = UserWorkspace(
-        user_id=user_workspace_create.user_id, workspace_id=user_workspace_create.workspace_id
+def create_workspace_user(db: Session, workspace_user_create: WorkspaceUserCreate):
+    workspace_user = WorkspaceUser(
+        workspace_id=workspace_user_create.workspace_id,
+        user_id=workspace_user_create.user_id,
     )
 
-    db.add(user_workspace)
+    db.add(workspace_user)
     db.commit()
-    db.refresh(user_workspace)
+    db.refresh(workspace_user)
 
-    return user_workspace
+    return workspace_user
 
 
-def delete_user_workspace(db: Session, user_workspace: UserWorkspace):
-    db.delete(user_workspace)
+def delete_workspace_user(db: Session, workspace_user: WorkspaceUser):
+    db.delete(workspace_user)
     db.commit()
 
-    return user_workspace
+    return workspace_user
 
 
 def get_workspace_by_id(db: Session, workspace_id: UUID):

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -33,18 +33,18 @@ def default_inserted_at(context):
     return context.get_current_parameters()["inserted_at"]
 
 
-class UserWorkspace(Base):
-    __tablename__ = "users_workspaces"
+class WorkspaceUser(Base):
+    __tablename__ = "workspaces_users"
 
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
-    user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"))
     workspace_id: Mapped[UUID] = mapped_column(ForeignKey("workspaces.id"))
+    user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"))
 
     inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
-    user: Mapped["User"] = relationship(viewonly=True)
     workspace: Mapped["Workspace"] = relationship(viewonly=True)
+    user: Mapped["User"] = relationship(viewonly=True)
 
 
 class Workspace(Base):
@@ -57,7 +57,7 @@ class Workspace(Base):
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
     users: Mapped[List["User"]] = relationship(
-        secondary="users_workspaces", back_populates="workspaces", order_by=UserWorkspace.inserted_at.asc()
+        secondary="workspaces_users", back_populates="workspaces", order_by=WorkspaceUser.inserted_at.asc()
     )
 
 
@@ -75,5 +75,5 @@ class User(Base):
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
     workspaces: Mapped[List["Workspace"]] = relationship(
-        secondary="users_workspaces", back_populates="users", order_by=UserWorkspace.inserted_at.asc()
+        secondary="workspaces_users", back_populates="users", order_by=WorkspaceUser.inserted_at.asc()
     )

--- a/src/argilla/server/security/model.py
+++ b/src/argilla/server/security/model.py
@@ -34,7 +34,7 @@ _USER_USERNAME_REGEX = DATASET_NAME_REGEX_PATTERN
 WORKSPACE_NAME_PATTERN = re.compile(_WORKSPACE_NAME_REGEX)
 
 
-class UserWorkspaceCreate(BaseModel):
+class WorkspaceUserCreate(BaseModel):
     user_id: UUID
     workspace_id: UUID
 

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -47,7 +47,7 @@ from argilla.server.apis.v0.models.text_classification import (
     TextClassificationSearchResults,
 )
 from argilla.server.contexts import accounts
-from argilla.server.security.model import UserWorkspaceCreate, WorkspaceCreate
+from argilla.server.security.model import WorkspaceCreate, WorkspaceUserCreate
 from sqlalchemy.orm import Session
 
 from tests.helpers import SecuredClient
@@ -454,7 +454,7 @@ def test_dataset_copy_to_another_workspace(mocked_client, admin: User, db: Sessi
     new_workspace_name = "my-fun-workspace"
 
     workspace = accounts.create_workspace(db, WorkspaceCreate(name=new_workspace_name))
-    accounts.create_user_workspace(db, UserWorkspaceCreate(user_id=admin.id, workspace_id=workspace.id))
+    accounts.create_workspace_user(db, WorkspaceUserCreate(workspace_id=workspace.id, user_id=admin.id))
 
     mocked_client.delete(f"/api/datasets/{dataset_name}")
     mocked_client.delete(f"/api/datasets/{dataset_copy}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ from argilla.client.sdk.users import api as users_api
 from argilla.server.commons import telemetry
 from argilla.server.contexts import accounts
 from argilla.server.database import SessionLocal
-from argilla.server.models import User, UserWorkspace, Workspace
+from argilla.server.models import User, Workspace, WorkspaceUser
 from argilla.server.seeds import test_seeds
 
 try:
@@ -50,7 +50,7 @@ def db():
 
     session.query(User).delete()
     session.query(Workspace).delete()
-    session.query(UserWorkspace).delete()
+    session.query(WorkspaceUser).delete()
     session.commit()
 
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -14,7 +14,14 @@
 
 import factory
 from argilla.server.database import SessionLocal
-from argilla.server.models import User, UserWorkspace, Workspace
+from argilla.server.models import User, Workspace, WorkspaceUser
+
+
+class WorkspaceUserFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = WorkspaceUser
+        sqlalchemy_session = SessionLocal()
+        sqlalchemy_session_persistence = "commit"
 
 
 class WorkspaceFactory(factory.alchemy.SQLAlchemyModelFactory):
@@ -36,12 +43,3 @@ class UserFactory(factory.alchemy.SQLAlchemyModelFactory):
     username = factory.Sequence(lambda n: f"username-{n}")
     api_key = factory.Sequence(lambda n: f"api-key-{n}")
     password_hash = "$2y$05$eaw.j2Kaw8s8vpscVIZMfuqSIX3OLmxA21WjtWicDdn0losQ91Hw."
-
-
-class UserWorkspaceFactory(factory.alchemy.SQLAlchemyModelFactory):
-    class Meta:
-        model = UserWorkspace
-        sqlalchemy_session = SessionLocal()
-        sqlalchemy_session_persistence = "commit"
-
-    # TODO: Define relationships with user and workspace

--- a/tests/functional_tests/test_log_for_text_classification.py
+++ b/tests/functional_tests/test_log_for_text_classification.py
@@ -23,7 +23,7 @@ from argilla.client.sdk.commons.errors import (
 )
 from argilla.server.contexts import accounts
 from argilla.server.models import User
-from argilla.server.security.model import UserWorkspaceCreate, WorkspaceCreate
+from argilla.server.security.model import WorkspaceCreate, WorkspaceUserCreate
 from argilla.server.settings import settings
 from sqlalchemy.orm import Session
 
@@ -196,7 +196,7 @@ def test_log_data_in_several_workspaces(mocked_client: SecuredClient, admin: Use
     text = "This is a text"
 
     workspace = accounts.create_workspace(db, WorkspaceCreate(name=workspace_name))
-    accounts.create_user_workspace(db, UserWorkspaceCreate(user_id=admin.id, workspace_id=workspace.id))
+    accounts.create_workspace_user(db, WorkspaceUserCreate(workspace_id=workspace.id, user_id=admin.id))
 
     api = Argilla()
 


### PR DESCRIPTION
In this PR I'm redefining the order of the entities in `users_workspaces` table to `workspaces_users`. This will improve the semantics of our endpoints and make it more clear.

I have changed too the associated ORM models and Pydantic schemas to reflect this change.

Everything else should remain the same, behavior is not changing.

