### PR TITLE
Tests will link users to workspaces when needed

### DIFF
--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -449,7 +449,7 @@ def test_dataset_copy(mocked_client):
         api.copy(dataset, name_of_copy=dataset_copy, workspace=other_workspace)
 
 
-def test_dataset_copy_to_another_workspace(mocked_client, admin: User, db: Session):
+def test_dataset_copy_to_another_workspace(mocked_client, admin: User, db: Session, admin_auth_header: dict):
     dataset_name = "test_dataset_copy_to_another_workspace"
     dataset_copy = "new_dataset"
     new_workspace_name = "my-fun-workspace"
@@ -457,11 +457,11 @@ def test_dataset_copy_to_another_workspace(mocked_client, admin: User, db: Sessi
     workspace = accounts.create_workspace(db, WorkspaceCreate(name=new_workspace_name))
     accounts.create_workspace_user(db, WorkspaceUserCreate(workspace_id=workspace.id, user_id=admin.id))
 
-    mocked_client.delete(f"/api/datasets/{dataset_name}")
-    mocked_client.delete(f"/api/datasets/{dataset_copy}")
-    mocked_client.delete(f"/api/datasets/{dataset_copy}?workspace={new_workspace_name}")
+    mocked_client.delete(f"/api/datasets/{dataset_name}", headers=admin_auth_header)
+    mocked_client.delete(f"/api/datasets/{dataset_copy}", headers=admin_auth_header)
+    mocked_client.delete(f"/api/datasets/{dataset_copy}?workspace={new_workspace_name}", headers=admin_auth_header)
 
-    api = Argilla()
+    api = Argilla(api_key=admin.api_key)
 
     api.log(
         rg.TextClassificationRecord(

--- a/tests/functional_tests/datasets/test_delete_records_from_datasets.py
+++ b/tests/functional_tests/datasets/test_delete_records_from_datasets.py
@@ -19,6 +19,8 @@ import pytest
 from argilla.client.client import Argilla
 from argilla.client.sdk.commons.errors import ForbiddenApiError
 
+from tests.factories import WorkspaceUserFactory
+
 
 def test_delete_records_from_dataset(mocked_client):
     dataset = "test_delete_records_from_dataset"
@@ -47,8 +49,11 @@ def test_delete_records_from_dataset(mocked_client):
     assert len(ds) == 49
 
 
-def test_delete_records_without_permission(mocked_client, mock_user):
+def test_delete_records_without_permission(mocked_client, argilla_user, mock_user):
     dataset = "test_delete_records_without_permission"
+
+    for workspace in argilla_user.workspaces:
+        WorkspaceUserFactory.create(workspace_id=workspace.id, user_id=mock_user.id)
 
     argilla_client = Argilla()
 

--- a/tests/functional_tests/test_log_for_text_classification.py
+++ b/tests/functional_tests/test_log_for_text_classification.py
@@ -198,7 +198,7 @@ def test_log_data_in_several_workspaces(mocked_client: SecuredClient, admin: Use
     workspace = accounts.create_workspace(db, WorkspaceCreate(name=workspace_name))
     accounts.create_workspace_user(db, WorkspaceUserCreate(workspace_id=workspace.id, user_id=admin.id))
 
-    api = Argilla()
+    api = Argilla(api_key=admin.api_key)
 
     current_workspace = api.get_workspace()
     for ws in [current_workspace, workspace_name]:

--- a/tests/server/datasets/test_api.py
+++ b/tests/server/datasets/test_api.py
@@ -20,6 +20,7 @@ from argilla.server.apis.v0.models.text_classification import (
 )
 from argilla.server.commons.models import TaskType
 
+from tests.factories import WorkspaceUserFactory
 from tests.helpers import SecuredClient
 
 
@@ -236,9 +237,12 @@ def create_mock_dataset(client, dataset, records=[]):
     )
 
 
-def test_delete_records(mocked_client, mock_user):
+def test_delete_records(mocked_client, argilla_user, mock_user):
     dataset_name = "test_delete_records"
     delete_dataset(mocked_client, dataset_name)
+
+    for workspace in argilla_user.workspaces:
+        WorkspaceUserFactory.create(workspace_id=workspace.id, user_id=mock_user.id)
 
     create_mock_dataset(
         mocked_client,


### PR DESCRIPTION
Failing tests were trying to launch actions using a workspace linked to the `argilla` user. Now, those tests will create this link explicitly.