### PR TITLE
Add validation for manage settings by admins

### DIFF
--- a/src/argilla/server/apis/v0/handlers/text_classification_dataset_settings.py
+++ b/src/argilla/server/apis/v0/handlers/text_classification_dataset_settings.py
@@ -22,6 +22,7 @@ from argilla.server.apis.v0.models.commons.params import (
     CommonTaskHandlerDependencies,
 )
 from argilla.server.apis.v0.models.dataset_settings import TextClassificationSettings
+from argilla.server.apis.v0.validators.commons import validate_is_super_user
 from argilla.server.apis.v0.validators.text_classification import DatasetValidator
 from argilla.server.commons.models import TaskType
 from argilla.server.security import auth
@@ -118,6 +119,10 @@ def configure_router(router: APIRouter):
             task=task,
             workspace=ws_params.workspace,
         )
+        validate_is_super_user(
+            user, message=f"Cannot delete settings for dataset {found_ds.id}. Only admins can apply this change"
+        )
+
         await datasets.delete_settings(
             user=user,
             dataset=found_ds,

--- a/src/argilla/server/apis/v0/handlers/token_classification_dataset_settings.py
+++ b/src/argilla/server/apis/v0/handlers/token_classification_dataset_settings.py
@@ -22,6 +22,7 @@ from argilla.server.apis.v0.models.commons.params import (
     CommonTaskHandlerDependencies,
 )
 from argilla.server.apis.v0.models.dataset_settings import TokenClassificationSettings
+from argilla.server.apis.v0.validators.commons import validate_is_super_user
 from argilla.server.apis.v0.validators.token_classification import DatasetValidator
 from argilla.server.commons.models import TaskType
 from argilla.server.security import auth
@@ -117,6 +118,9 @@ def configure_router(router: APIRouter):
             name=name,
             task=task,
             workspace=ws_params.workspace,
+        )
+        validate_is_super_user(
+            user, message=f"Cannot delete settings for dataset {found_ds.id}. Only admins can apply this change"
         )
         await datasets.delete_settings(
             user=user,

--- a/src/argilla/server/apis/v0/validators/commons.py
+++ b/src/argilla/server/apis/v0/validators/commons.py
@@ -1,0 +1,22 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from argilla.server.errors import ForbiddenOperationError
+from argilla.server.security.model import User
+
+
+def validate_is_super_user(user: User, message: str = None):
+    """Common validation to ensure the current user is a admin/superuser"""
+    if not user.is_superuser():
+        raise ForbiddenOperationError(message or "Only admin users can apply this change")

--- a/src/argilla/server/apis/v0/validators/text_classification.py
+++ b/src/argilla/server/apis/v0/validators/text_classification.py
@@ -18,8 +18,13 @@ from fastapi import Depends
 
 from argilla.server.apis.v0.models.dataset_settings import TextClassificationSettings
 from argilla.server.apis.v0.models.datasets import Dataset
+from argilla.server.apis.v0.validators.commons import validate_is_super_user
 from argilla.server.commons.models import TaskType
-from argilla.server.errors import BadRequestError, EntityNotFoundError
+from argilla.server.errors import (
+    BadRequestError,
+    EntityNotFoundError,
+    ForbiddenOperationError,
+)
 from argilla.server.security.model import User
 from argilla.server.services.datasets import DatasetsService, ServiceBaseDatasetSettings
 from argilla.server.services.tasks.text_classification.metrics import DatasetLabels
@@ -55,6 +60,9 @@ class DatasetValidator:
         return cls._INSTANCE
 
     async def validate_dataset_settings(self, user: User, dataset: Dataset, settings: TextClassificationSettings):
+        validate_is_super_user(
+            user, message=f"Cannot save settings for dataset {dataset.id}. Only admins can apply this change"
+        )
         if settings and settings.label_schema:
             results = self.__metrics__.summarize_metric(
                 dataset=dataset,

--- a/src/argilla/server/apis/v0/validators/token_classification.py
+++ b/src/argilla/server/apis/v0/validators/token_classification.py
@@ -18,6 +18,7 @@ from fastapi import Depends
 
 from argilla.server.apis.v0.models.dataset_settings import TokenClassificationSettings
 from argilla.server.apis.v0.models.datasets import Dataset
+from argilla.server.apis.v0.validators.commons import validate_is_super_user
 from argilla.server.commons.models import TaskType
 from argilla.server.errors import BadRequestError, EntityNotFoundError
 from argilla.server.security.model import User
@@ -56,6 +57,9 @@ class DatasetValidator:
         return cls._INSTANCE
 
     async def validate_dataset_settings(self, user: User, dataset: Dataset, settings: TokenClassificationSettings):
+        validate_is_super_user(
+            user, message=f"Cannot save settings for dataset {dataset.id}. Only admins can apply this change"
+        )
         if settings and settings.label_schema:
             results = self.__metrics__.summarize_metric(
                 dataset=dataset,


### PR DESCRIPTION
Adding extra custom validation allow only admin/superuser dataset settings management.

If for example, a non-admin user tries to upgrade/update label schema, this validation will return a 403 response.