### PR TITLE
Deprecate `chunk_size` in favor of `batch_size` for `rg.log`

### DIFF
--- a/src/argilla/client/api.py
+++ b/src/argilla/client/api.py
@@ -111,9 +111,10 @@ def log(
     name: str,
     tags: Optional[Dict[str, str]] = None,
     metadata: Optional[Dict[str, Any]] = None,
-    chunk_size: int = 500,
+    batch_size: int = 500,
     verbose: bool = True,
     background: bool = False,
+    chunk_size: Optional[int] = None,
 ) -> Union[BulkResponse, Future]:
     """Logs Records to argilla.
 
@@ -124,10 +125,11 @@ def log(
         name: The dataset name.
         tags: A dictionary of tags related to the dataset.
         metadata: A dictionary of extra info for the dataset.
-        chunk_size: The chunk size for a data bulk.
+        batch_size: The batch size for a data bulk.
         verbose: If True, shows a progress bar and prints out a quick summary at the end.
         background: If True, we will NOT wait for the logging process to finish and return an ``asyncio.Future``
             object. You probably want to set ``verbose`` to False in that case.
+        chunk_size: DEPRECATED! Use `batch_size` instead.
 
     Returns:
         Summary of the response from the REST API.
@@ -152,9 +154,10 @@ def log(
         name=name,
         tags=tags,
         metadata=metadata,
-        chunk_size=chunk_size,
+        batch_size=batch_size,
         verbose=verbose,
         background=background,
+        chunk_size=chunk_size,
     )
 
 
@@ -163,8 +166,9 @@ async def log_async(
     name: str,
     tags: Optional[Dict[str, str]] = None,
     metadata: Optional[Dict[str, Any]] = None,
-    chunk_size: int = 500,
+    batch_size: int = 500,
     verbose: bool = True,
+    chunk_size: Optional[int] = None,
 ) -> BulkResponse:
     """Logs Records to argilla with asyncio.
 
@@ -173,8 +177,9 @@ async def log_async(
         name: The dataset name.
         tags: A dictionary of tags related to the dataset.
         metadata: A dictionary of extra info for the dataset.
-        chunk_size: The chunk size for a data bulk.
+        batch_size: The batch size for a data bulk.
         verbose: If True, shows a progress bar and prints out a quick summary at the end.
+        chunk_size: DEPRECATED! Use `batch_size` instead.
 
     Returns:
         Summary of the response from the REST API
@@ -194,8 +199,9 @@ async def log_async(
         name=name,
         tags=tags,
         metadata=metadata,
-        chunk_size=chunk_size,
+        batch_size=batch_size,
         verbose=verbose,
+        chunk_size=chunk_size,
     )
 
 

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -236,6 +236,15 @@ def test_log_deprecated_chunk_size(mocked_client):
         api.log(records=[record], name=dataset_name, chunk_size=100)
 
 
+def test_large_batch_size_warning(mocked_client, caplog: pytest.LogCaptureFixture):
+    dataset_name = "test_large_batch_size_warning"
+    mocked_client.delete(f"/api/datasets/{dataset_name}")
+    record = rg.TextClassificationRecord(text="My text")
+    api.log(records=[record], name=dataset_name, batch_size=10000)
+    assert len(caplog.record_tuples) == 1
+    assert "batch size is noticeably large" in caplog.record_tuples[0][2]
+
+
 def test_log_background(mocked_client):
     """Verify that logs can be delayed via the background parameter."""
     dataset_name = "test_log_background"

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -228,6 +228,14 @@ def test_log_passing_empty_records_list(mocked_client):
         api.log(records=[], name="ds")
 
 
+def test_log_deprecated_chunk_size(mocked_client):
+    dataset_name = "test_log_deprecated_chunk_size"
+    mocked_client.delete(f"/api/datasets/{dataset_name}")
+    record = rg.TextClassificationRecord(text="My text")
+    with pytest.warns(FutureWarning, match="`chunk_size`.*`batch_size`"):
+        api.log(records=[record], name=dataset_name, chunk_size=100)
+
+
 def test_log_background(mocked_client):
     """Verify that logs can be delayed via the background parameter."""
     dataset_name = "test_log_background"


### PR DESCRIPTION
Closes #2453

## Pull Request overview
* Deprecate `chunk_size` in favor of `batch_size` in `rg.log`:
  * Move `chunk_size` to the end of all related signatures.
  * Set `chunk_size` default to None and update the typing accordingly.
  * Introduce `batch_size` in the old position in the signature.
  * Update docstrings accordingly.
  * Introduce a `FutureWarning` if `chunk_size` is used.
* Introduce test showing that `rg.log(..., chunk_size=100)` indeed throws a warning.
* Update a warning to no longer include a newline and a lot of spaces (see first comment of this PR)

## Details
Note that this deprecation is non-breaking: Code that uses `chunk_size` will still work, as `batch_size = chunk_size` after a FutureWarning is given, if `chunk_size` is not `None`.

## Discussion
* Should I use a FutureWarning? Or a DeprecationWarning? Or a PendingDeprecationWarning? The last two make sense, but they are [ignored by default](https://docs.python.org/3/library/warnings.html#default-warning-filter), I'm afraid. 
* Is the deprecation message in the format that we like?

---

**Type of change**
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

I introduced a test, and ran all tests.

**Checklist**

- [x] I have merged the original branch into my forked branch
- [x] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

---

- Tom Aarsen