### PR TITLE
Expose `batch_size` parameter for `rg.load`

### DIFF
--- a/src/argilla/client/api.py
+++ b/src/argilla/client/api.py
@@ -206,6 +206,7 @@ def load(
     ids: Optional[List[Union[str, int]]] = None,
     limit: Optional[int] = None,
     id_from: Optional[str] = None,
+    batch_size: Optional[int] = None,
     as_pandas=None,
 ) -> Dataset:
     """Loads a argilla dataset.
@@ -220,6 +221,8 @@ def load(
         id_from: If provided, starts gathering the records starting from that Record.
             As the Records returned with the load method are sorted by ID, ´id_from´
             can be used to load using batches.
+        batch_size: If provided, load `batch_size` samples per request. A lower batch
+            size may help avoid timeouts.
         as_pandas: DEPRECATED! To get a pandas DataFrame do
             ``rg.load('my_dataset').to_pandas()``.
 
@@ -251,6 +254,7 @@ def load(
         ids=ids,
         limit=limit,
         id_from=id_from,
+        batch_size=batch_size,
         as_pandas=as_pandas,
     )
 

--- a/src/argilla/client/api.py
+++ b/src/argilla/client/api.py
@@ -206,7 +206,7 @@ def load(
     ids: Optional[List[Union[str, int]]] = None,
     limit: Optional[int] = None,
     id_from: Optional[str] = None,
-    batch_size: Optional[int] = None,
+    batch_size: int = 250,
     as_pandas=None,
 ) -> Dataset:
     """Loads a argilla dataset.

--- a/src/argilla/client/apis/datasets.py
+++ b/src/argilla/client/apis/datasets.py
@@ -155,6 +155,7 @@ class Datasets(AbstractApi):
         projection: Optional[Set[str]] = None,
         limit: Optional[int] = None,
         id_from: Optional[str] = None,
+        batch_size: Optional[int] = None,
         **query,
     ) -> Iterable[dict]:
         """
@@ -169,6 +170,8 @@ class Datasets(AbstractApi):
             id_from: If provided, starts gathering the records starting from that Record.
                 As the Records returned with the load method are sorted by ID, ´id_from´
                 can be used to load using batches.
+            batch_size: If provided, load `batch_size` samples per request. A lower batch
+                size may help avoid timeouts.
 
         Returns:
             An iterable of raw object containing per-record info
@@ -177,7 +180,7 @@ class Datasets(AbstractApi):
         if limit and limit < 0:
             raise ValueError("The scan limit must be non-negative.")
 
-        batch_size = self.DEFAULT_SCAN_SIZE
+        batch_size = batch_size or self.DEFAULT_SCAN_SIZE
         limit = limit if limit else math.inf
         url = f"{self._API_PREFIX}/{name}/records/:search?limit={{limit}}"
         query = self._parse_query(query=query)

--- a/src/argilla/client/apis/datasets.py
+++ b/src/argilla/client/apis/datasets.py
@@ -102,8 +102,6 @@ class Datasets(AbstractApi):
 
     __SETTINGS_MIN_API_VERSION__ = "0.15"
 
-    DEFAULT_SCAN_SIZE = 250
-
     class _DatasetApiModel(BaseModel):
         name: str
         task: TaskType
@@ -155,7 +153,7 @@ class Datasets(AbstractApi):
         projection: Optional[Set[str]] = None,
         limit: Optional[int] = None,
         id_from: Optional[str] = None,
-        batch_size: Optional[int] = None,
+        batch_size: int = 250,
         **query,
     ) -> Iterable[dict]:
         """
@@ -180,7 +178,6 @@ class Datasets(AbstractApi):
         if limit and limit < 0:
             raise ValueError("The scan limit must be non-negative.")
 
-        batch_size = batch_size or self.DEFAULT_SCAN_SIZE
         limit = limit if limit else math.inf
         url = f"{self._API_PREFIX}/{name}/records/:search?limit={{limit}}"
         query = self._parse_query(query=query)

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -439,7 +439,7 @@ class Argilla:
         ids: Optional[List[Union[str, int]]] = None,
         limit: Optional[int] = None,
         id_from: Optional[str] = None,
-        batch_size: Optional[int] = None,
+        batch_size: int = 250,
         as_pandas=None,
     ) -> Dataset:
         """Loads a argilla dataset.
@@ -669,7 +669,7 @@ class Argilla:
         ids: Optional[List[Union[str, int]]] = None,
         limit: Optional[int] = None,
         id_from: Optional[str] = None,
-        batch_size: Optional[int] = None,
+        batch_size: int = 250,
     ) -> Dataset:
         dataset = self.datasets.find_by_name(name=name)
         task = dataset.task

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -439,6 +439,7 @@ class Argilla:
         ids: Optional[List[Union[str, int]]] = None,
         limit: Optional[int] = None,
         id_from: Optional[str] = None,
+        batch_size: Optional[int] = None,
         as_pandas=None,
     ) -> Dataset:
         """Loads a argilla dataset.
@@ -481,6 +482,7 @@ class Argilla:
                 ids=ids,
                 limit=limit,
                 id_from=id_from,
+                batch_size=batch_size,
             )
         except ApiCompatibilityError as err:  # Api backward compatibility
             from argilla import __version__ as version
@@ -495,6 +497,13 @@ class Argilla:
                 f"`pip install argilla=={err.api_version}`",
                 category=UserWarning,
             )
+            if batch_size is not None:
+                warnings.warn(
+                    message="The `batch_size` parameter is not supported"
+                    f" on server version {err.api_version}. Consider"
+                    f" updating your server version to {version} to"
+                    " take advantage of this functionality."
+                )
 
             return self._load_records_old_fashion(
                 name=name,
@@ -660,6 +669,7 @@ class Argilla:
         ids: Optional[List[Union[str, int]]] = None,
         limit: Optional[int] = None,
         id_from: Optional[str] = None,
+        batch_size: Optional[int] = None,
     ) -> Dataset:
         dataset = self.datasets.find_by_name(name=name)
         task = dataset.task
@@ -707,6 +717,7 @@ class Argilla:
             projection={"*"},
             limit=limit,
             id_from=id_from,
+            batch_size=batch_size,
             # Query
             query_text=query,
             ids=ids,

--- a/src/argilla/server/apis/v0/handlers/records_search.py
+++ b/src/argilla/server/apis/v0/handlers/records_search.py
@@ -57,7 +57,7 @@ def configure_router(router: APIRouter):
         limit: int = Query(
             default=100,
             gte=0,
-            le=500,
+            le=1000,
             description="Number of records to retrieve",
         ),
         request_deps: CommonTaskHandlerDependencies = Depends(),


### PR DESCRIPTION
Closes #2454 

Hello!

## Pull Request overview
* Extend my previous work to expose a `batch_size` parameter to `rg.load` (and `rg.scan`, `_load_records_new_fashion`).
  * Update the docstrings for the public methods.
  * The actual implementation is very simple due to my earlier work in #2434:
    * `batch_size = self.DEFAULT_SCAN_SIZE` -> `batch_size = batch_size or self.DEFAULT_SCAN_SIZE`
* Add an (untested!) warning if `batch_size` is supplied with an old server version.
  * (We don't have compatibility tests for old server versions)
* I've simplified `test_scan_efficient_limiting` with `batch_size` rather than using a mocker to update `DEFAULT_SCAN_SIZE`.
  * I've also extended this test to test `rg.load` in addition to `active_api().datasets.scan`.

## Note
Unlike previously discussed with @davidberenstein1957, I have *not* added a warning like so:
https://github.com/argilla-io/argilla/blob/f5834a5408051bf1fa60d42aede6b325dc07fdbd/src/argilla/client/client.py#L338-L343
The server limits the maximum batch size to 500 for loading, so there is no need to have a warning when using a batch size of over 5000.

## Discussion
1. Should I include in the docstring that the default batch size is 250? That would be "hardcoded" into the docs, so if we ever change the default (`self.DEFAULT_SCAN_SIZE`), then we would have to remember to update the docs too.
2. Alternatively, should we deprecate `self.DEFAULT_SCAN_SIZE` and enforce that `batch_size` must be set for `datasets.scan`, with a default size of 250 everywhere? Then people can see the default batch size in the signature?

I think we should do option 2. Let me know how you feel.

---

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

Modified and updated a test, ran all tests.

**Checklist**

- [x] I have merged the original branch into my forked branch
- [x] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

---

- Tom Aarsen