### PR TITLE
Clean user pydantic model

### DIFF
--- a/src/argilla/server/apis/v0/models/commons/params.py
+++ b/src/argilla/server/apis/v0/models/commons/params.py
@@ -21,7 +21,6 @@ from argilla._constants import (
     ES_INDEX_REGEX_PATTERN,
     WORKSPACE_HEADER_NAME,
 )
-from argilla.server.security.model import WORKSPACE_NAME_PATTERN
 
 DATASET_NAME_PATH_PARAM = Path(..., regex=ES_INDEX_REGEX_PATTERN, description="The dataset name")
 
@@ -57,8 +56,4 @@ class CommonTaskHandlerDependencies:
     def workspace(self) -> str:
         """Return read workspace. Query param prior to header param"""
         workspace = self.__workspace_param__ or self.__workspace_header__ or self.__old_workspace_header__
-        if workspace:
-            assert WORKSPACE_NAME_PATTERN.match(workspace), (
-                "Wrong workspace format. " f"Workspace must match pattern {WORKSPACE_NAME_PATTERN.pattern}"
-            )
         return workspace

--- a/src/argilla/server/security/model.py
+++ b/src/argilla/server/security/model.py
@@ -24,15 +24,12 @@ from pydantic.utils import GetterDict
 from argilla._constants import ES_INDEX_REGEX_PATTERN
 from argilla.server.errors import EntityNotFoundError
 
-_WORKSPACE_NAME_REGEX = r"^[a-zA-Z0-9][a-zA-Z0-9_\-]*$"
+_WORKSPACE_NAME_REGEX = ES_INDEX_REGEX_PATTERN
 
-_EMAIL_REGEX_PATTERN = r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}"
 
 _USER_PASSWORD_MIN_LENGTH = 8
 _USER_PASSWORD_MAX_LENGTH = 100
 _USER_USERNAME_REGEX = ES_INDEX_REGEX_PATTERN
-
-WORKSPACE_NAME_PATTERN = re.compile(_WORKSPACE_NAME_REGEX)
 
 
 class WorkspaceUserCreate(BaseModel):
@@ -76,7 +73,6 @@ class User(BaseModel):
 
     id: UUID
     username: str = Field()
-    email: Optional[str] = Field(None, regex=_EMAIL_REGEX_PATTERN)
     full_name: Optional[str] = None
     disabled: Optional[bool] = None
 
@@ -90,24 +86,6 @@ class User(BaseModel):
     class Config:
         orm_mode = True
         getter_dict = UserGetter
-
-    @validator("username")
-    def check_username(cls, value):
-        if not re.compile(ES_INDEX_REGEX_PATTERN).match(value):
-            raise ValueError(
-                "Wrong username. " f"The username {value} does not match the pattern {ES_INDEX_REGEX_PATTERN}"
-            )
-        return value
-
-    @validator("workspaces", each_item=True)
-    def check_workspace_pattern(cls, workspace: str):
-        """Check workspace pattern"""
-        if not workspace:
-            return workspace
-        assert WORKSPACE_NAME_PATTERN.match(workspace), (
-            "Wrong workspace format. " f"Workspace must match pattern {WORKSPACE_NAME_PATTERN.pattern}"
-        )
-        return workspace
 
     @root_validator()
     def check_defaults(cls, values):

--- a/tests/server/security/test_model.py
+++ b/tests/server/security/test_model.py
@@ -16,34 +16,8 @@ from datetime import datetime
 
 import pytest
 from argilla.server.errors import EntityNotFoundError
-from argilla.server.security.model import User, UserCreate
+from argilla.server.security.model import User, UserCreate, WorkspaceCreate
 from pydantic import ValidationError
-
-
-@pytest.mark.parametrize("email", ["my@email.com", "infra@argilla.io"])
-def test_valid_mail(email):
-    user = User(
-        username="user",
-        api_key="api-key",
-        email=email,
-        id=uuid.uuid4(),
-        inserted_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
-    )
-    assert user.email == email
-
-
-@pytest.mark.parametrize("wrong_email", ["non-valid-email", "wrong@mail", "@wrong" "wrong.mail"])
-def test_email_validator(wrong_email):
-    with pytest.raises(ValidationError):
-        User(
-            username="user",
-            api_key="api-key",
-            email=wrong_email,
-            id=uuid.uuid4(),
-            inserted_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
-        )
 
 
 @pytest.mark.parametrize("wrong_name", ["user name", "user/name", "user.name", "UserName", "userName"])
@@ -55,14 +29,7 @@ def test_username_validator(wrong_name):
 @pytest.mark.parametrize("wrong_workspace", ["work space", "work/space", "work.space", "_", "-"])
 def test_workspace_validator(wrong_workspace):
     with pytest.raises(ValidationError):
-        User(
-            username="username",
-            api_key="api-key",
-            workspaces=[wrong_workspace],
-            id=uuid.uuid4(),
-            inserted_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
-        )
+        WorkspaceCreate(name=wrong_workspace)
 
 
 def test_check_non_provided_workspaces():


### PR DESCRIPTION
We remove extra things from the `User` pydantic model.

- The `email` attribute
- Extra not needed validators, like username or workspace patterns, since they are already done in the  `UserCreate` and `WorkspaceCreate` classes

In a separate PR, workspace validations will be moved to a proper validation module/class used for that purpose. 