### PR TITLE
Add basic role support to users

### DIFF
--- a/src/argilla/server/alembic/versions/74694870197c_create_users_table.py
+++ b/src/argilla/server/alembic/versions/74694870197c_create_users_table.py
@@ -36,6 +36,7 @@ def upgrade() -> None:
         sa.Column("first_name", sa.String, nullable=False),
         sa.Column("last_name", sa.String),
         sa.Column("username", sa.String, nullable=False, unique=True, index=True),
+        sa.Column("role", sa.String, nullable=False, index=True),
         sa.Column("api_key", sa.Text, nullable=False, unique=True, index=True),
         sa.Column("password_hash", sa.Text, nullable=False),
         sa.Column("inserted_at", sa.DateTime, nullable=False),

--- a/src/argilla/server/contexts/accounts.py
+++ b/src/argilla/server/contexts/accounts.py
@@ -100,6 +100,7 @@ def create_user(db: Session, user_create: UserCreate):
         first_name=user_create.first_name,
         last_name=user_create.last_name,
         username=user_create.username,
+        role=user_create.role,
         password_hash=_CRYPT_CONTEXT.hash(user_create.password),
     )
 

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -14,6 +14,7 @@
 
 import secrets
 from datetime import datetime
+from enum import Enum
 from typing import List, Optional
 from uuid import UUID, uuid4
 
@@ -31,6 +32,11 @@ def generate_user_api_key():
 
 def default_inserted_at(context):
     return context.get_current_parameters()["inserted_at"]
+
+
+class UserRole(str, Enum):
+    admin = "admin"
+    annotator = "annotator"
 
 
 class WorkspaceUser(Base):
@@ -74,6 +80,7 @@ class User(Base):
     first_name: Mapped[str]
     last_name: Mapped[Optional[str]]
     username: Mapped[str] = mapped_column(unique=True)
+    role: Mapped[UserRole] = mapped_column(default=UserRole.annotator)
     api_key: Mapped[str] = mapped_column(Text, unique=True, default=generate_user_api_key)
     password_hash: Mapped[str] = mapped_column(Text)
 
@@ -85,4 +92,4 @@ class User(Base):
     )
 
     def __repr__(self):
-        return f"User(id={str(self.id)!r}, first_name={self.first_name!r}, last_name={self.last_name!r}, username={self.username!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        return f"User(id={str(self.id)!r}, first_name={self.first_name!r}, last_name={self.last_name!r}, username={self.username!r}, role={self.role.value!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"

--- a/src/argilla/server/security/model.py
+++ b/src/argilla/server/security/model.py
@@ -23,6 +23,7 @@ from pydantic.utils import GetterDict
 
 from argilla._constants import ES_INDEX_REGEX_PATTERN
 from argilla.server.errors import EntityNotFoundError
+from argilla.server.models import UserRole
 
 _WORKSPACE_NAME_REGEX = ES_INDEX_REGEX_PATTERN
 
@@ -55,6 +56,7 @@ class UserCreate(BaseModel):
     first_name: constr(min_length=1, strip_whitespace=True)
     last_name: Optional[constr(min_length=1, strip_whitespace=True)]
     username: constr(regex=_USER_USERNAME_REGEX, min_length=1)
+    role: Optional[UserRole]
     password: constr(min_length=_USER_PASSWORD_MIN_LENGTH, max_length=_USER_PASSWORD_MAX_LENGTH)
 
 
@@ -73,6 +75,7 @@ class User(BaseModel):
 
     id: UUID
     username: str = Field()
+    role: UserRole
     full_name: Optional[str] = None
     disabled: Optional[bool] = None
 

--- a/src/argilla/server/seeds.py
+++ b/src/argilla/server/seeds.py
@@ -14,7 +14,7 @@
 
 from argilla._constants import DEFAULT_API_KEY
 from argilla.server.database import SessionLocal
-from argilla.server.models import User, Workspace
+from argilla.server.models import User, UserRole, Workspace
 
 
 def development_seeds():
@@ -27,6 +27,7 @@ def development_seeds():
                     first_name="John",
                     last_name="Doe",
                     username="argilla",
+                    role=UserRole.admin,
                     password_hash="$2y$05$eaw.j2Kaw8s8vpscVIZMfuqSIX3OLmxA21WjtWicDdn0losQ91Hw.",
                     api_key="1234",
                 ),
@@ -50,6 +51,7 @@ def test_seeds(db: SessionLocal):
                     User(
                         first_name="Argilla",
                         username="argilla",
+                        role=UserRole.admin,
                         password_hash="$2y$05$eaw.j2Kaw8s8vpscVIZMfuqSIX3OLmxA21WjtWicDdn0losQ91Hw.",
                         api_key=DEFAULT_API_KEY,
                     ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ from argilla.client.client import Argilla
 from argilla.client.sdk.users import api as users_api
 from argilla.server.commons import telemetry
 from argilla.server.database import SessionLocal
-from argilla.server.models import User, Workspace, WorkspaceUser
+from argilla.server.models import User, UserRole, Workspace, WorkspaceUser
 from starlette.testclient import TestClient
 
 from .helpers import SecuredClient
@@ -51,6 +51,7 @@ def admin(db):
     user = User(
         first_name="Admin",
         username="admin",
+        role=UserRole.admin,
         password_hash="$2y$05$eaw.j2Kaw8s8vpscVIZMfuqSIX3OLmxA21WjtWicDdn0losQ91Hw.",
         api_key="admin.apikey",
     )
@@ -86,6 +87,7 @@ def argilla_user(db):
     user = User(
         first_name="Argilla",
         username="argilla",
+        role=UserRole.admin,
         password_hash="$2y$05$eaw.j2Kaw8s8vpscVIZMfuqSIX3OLmxA21WjtWicDdn0losQ91Hw.",
         api_key=DEFAULT_API_KEY,
         workspaces=[Workspace(name="argilla")],

--- a/tests/server/security/test_model.py
+++ b/tests/server/security/test_model.py
@@ -16,6 +16,7 @@ from datetime import datetime
 
 import pytest
 from argilla.server.errors import EntityNotFoundError
+from argilla.server.models import UserRole
 from argilla.server.security.model import User, UserCreate, WorkspaceCreate
 from pydantic import ValidationError
 
@@ -34,9 +35,10 @@ def test_workspace_validator(wrong_workspace):
 
 def test_check_non_provided_workspaces():
     user = User(
-        username="test",
-        api_key="api-key",
         id=uuid.uuid4(),
+        username="test",
+        role=UserRole.annotator,
+        api_key="api-key",
         inserted_at=datetime.utcnow(),
         updated_at=datetime.utcnow(),
     )
@@ -44,9 +46,10 @@ def test_check_non_provided_workspaces():
     assert user.check_workspaces([]) == ["test"]
 
     user = User(
+        id=uuid.uuid4(),
         username="test",
         workspaces=["ws"],
-        id=uuid.uuid4(),
+        role=UserRole.annotator,
         inserted_at=datetime.utcnow(),
         updated_at=datetime.utcnow(),
         api_key="api-key",
@@ -61,10 +64,11 @@ def test_check_user_workspaces():
     a_ws = "A-workspace"
     expected_workspaces = [a_ws, "B-ws"]
     user = User(
+        id=uuid.uuid4(),
         username="test-user",
+        role=UserRole.annotator,
         api_key="api-key",
         workspaces=[a_ws, "B-ws", "C-ws"],
-        id=uuid.uuid4(),
         inserted_at=datetime.utcnow(),
         updated_at=datetime.utcnow(),
     )
@@ -77,19 +81,21 @@ def test_check_user_workspaces():
 
 def test_default_workspace():
     user = User(
-        username="admin",
-        api_key="api-key",
         id=uuid.uuid4(),
+        username="admin",
+        role=UserRole.admin,
+        api_key="api-key",
         inserted_at=datetime.utcnow(),
         updated_at=datetime.utcnow(),
     )
     assert user.default_workspace == "admin"
 
     test_user = User(
+        id=uuid.uuid4(),
         username="test",
+        role=UserRole.annotator,
         api_key="api-key",
         workspaces=["ws"],
-        id=uuid.uuid4(),
         inserted_at=datetime.utcnow(),
         updated_at=datetime.utcnow(),
     )
@@ -98,9 +104,10 @@ def test_default_workspace():
 
 def test_workspace_for_superuser():
     user = User(
-        username="admin",
-        api_key="api-key",
         id=uuid.uuid4(),
+        username="admin",
+        role=UserRole.admin,
+        api_key="api-key",
         inserted_at=datetime.utcnow(),
         updated_at=datetime.utcnow(),
     )
@@ -119,10 +126,11 @@ def test_workspace_for_superuser():
 def test_workspaces_with_default():
     expected_workspaces = ["user", "ws1"]
     user = User(
+        id=uuid.uuid4(),
         username="user",
+        role=UserRole.annotator,
         workspaces=expected_workspaces,
         api_key="api-key",
-        id=uuid.uuid4(),
         inserted_at=datetime.utcnow(),
         updated_at=datetime.utcnow(),
     )
@@ -133,9 +141,10 @@ def test_workspaces_with_default():
 
 def test_is_superuser():
     admin_user = User(
-        username="admin",
-        api_key="api-key",
         id=uuid.uuid4(),
+        username="admin",
+        role=UserRole.admin,
+        api_key="api-key",
         inserted_at=datetime.utcnow(),
         updated_at=datetime.utcnow(),
     )
@@ -146,10 +155,11 @@ def test_is_superuser():
     assert set(admin_user.workspaces) == {"other-workspace", "admin"}
 
     user = User(
+        id=uuid.uuid4(),
         username="test",
+        role=UserRole.annotator,
         workspaces=["bod"],
         api_key="api-key",
-        id=uuid.uuid4(),
         inserted_at=datetime.utcnow(),
         updated_at=datetime.utcnow(),
     )
@@ -168,10 +178,11 @@ def test_is_superuser():
 )
 def test_check_workspaces_with_default(workspaces, expected):
     user = User(
+        id=uuid.uuid4(),
         username="user",
+        role=UserRole.annotator,
         workspaces=workspaces,
         api_key="api-key",
-        id=uuid.uuid4(),
         inserted_at=datetime.utcnow(),
         updated_at=datetime.utcnow(),
     )


### PR DESCRIPTION
This PR adds the following changes:
- Add a new string `role` column to `users` table. The column is non nullable and indexed.
- Add `UserRole` class as enumerable. The class inherits from `Enum` and `str` (to avoid some JSON encoding problems, maybe we can create a custom JSON encoder to avoid possible problems).
- Add `role` as enumerable field to `User` SQLAlchemy model with `annotator` as default.
- Add `role` as optional for `UserCreate` Pydantic schema.

Changes has been tested locally and are working with PostgreSQL too.