### PR TITLE
Add new ARGILLA_HOME_PATH environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,3 @@ package-lock.json
 
 # App generated files
 src/**/server/static/
-
-# SQLite database
-argilla.db

--- a/src/argilla/_constants.py
+++ b/src/argilla/_constants.py
@@ -13,8 +13,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-DEFAULT_MAX_KEYWORD_LENGTH = 128
+import os
+from pathlib import Path
 
+ARGILLA_HOME_PATH = os.getenv("ARGILLA_HOME_PATH", os.path.join(Path.home(), ".argilla"))
+ARGILLA_DATABASE_URL = os.getenv("ARGILLA_DATABASE_URL", f"sqlite:///{os.path.join(ARGILLA_HOME_PATH, 'argilla.db')}?check_same_thread=False")
+
+# Create argilla home path directory if it doesn't exist
+Path(ARGILLA_HOME_PATH).mkdir(parents=True, exist_ok=True)
+
+DEFAULT_MAX_KEYWORD_LENGTH = 128
 
 API_KEY_HEADER_NAME = "X-Argilla-Api-Key"
 WORKSPACE_HEADER_NAME = "X-Argilla-Workspace"

--- a/src/argilla/_constants.py
+++ b/src/argilla/_constants.py
@@ -13,17 +13,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import os
-from pathlib import Path
-
-ARGILLA_HOME_PATH = os.getenv("ARGILLA_HOME_PATH", os.path.join(Path.home(), ".argilla"))
-ARGILLA_DATABASE_URL = os.getenv(
-    "ARGILLA_DATABASE_URL", f"sqlite:///{os.path.join(ARGILLA_HOME_PATH, 'argilla.db')}?check_same_thread=False"
-)
-
-# Create argilla home path directory if it doesn't exist
-Path(ARGILLA_HOME_PATH).mkdir(parents=True, exist_ok=True)
-
 DEFAULT_MAX_KEYWORD_LENGTH = 128
 
 API_KEY_HEADER_NAME = "X-Argilla-Api-Key"

--- a/src/argilla/_constants.py
+++ b/src/argilla/_constants.py
@@ -17,7 +17,9 @@ import os
 from pathlib import Path
 
 ARGILLA_HOME_PATH = os.getenv("ARGILLA_HOME_PATH", os.path.join(Path.home(), ".argilla"))
-ARGILLA_DATABASE_URL = os.getenv("ARGILLA_DATABASE_URL", f"sqlite:///{os.path.join(ARGILLA_HOME_PATH, 'argilla.db')}?check_same_thread=False")
+ARGILLA_DATABASE_URL = os.getenv(
+    "ARGILLA_DATABASE_URL", f"sqlite:///{os.path.join(ARGILLA_HOME_PATH, 'argilla.db')}?check_same_thread=False"
+)
 
 # Create argilla home path directory if it doesn't exist
 Path(ARGILLA_HOME_PATH).mkdir(parents=True, exist_ok=True)

--- a/src/argilla/server/alembic/env.py
+++ b/src/argilla/server/alembic/env.py
@@ -15,15 +15,15 @@
 from logging.config import fileConfig
 
 from alembic import context
-from argilla._constants import ARGILLA_DATABASE_URL
+from argilla.server.settings import settings
 from sqlalchemy import engine_from_config, pool
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
 
-# Overwrites the SQLAlchemy URL getting it from argilla database config
-config.set_main_option("sqlalchemy.url", ARGILLA_DATABASE_URL)
+# Overwrites the SQLAlchemy URL getting it from argilla database_url settings
+config.set_main_option("sqlalchemy.url", settings.database_url)
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.

--- a/src/argilla/server/alembic/env.py
+++ b/src/argilla/server/alembic/env.py
@@ -15,7 +15,7 @@
 from logging.config import fileConfig
 
 from alembic import context
-from argilla.server.database import SQLALCHEMY_DATABASE_URL
+from argilla._constants import ARGILLA_DATABASE_URL
 from sqlalchemy import engine_from_config, pool
 
 # this is the Alembic Config object, which provides
@@ -23,7 +23,7 @@ from sqlalchemy import engine_from_config, pool
 config = context.config
 
 # Overwrites the SQLAlchemy URL getting it from argilla database config
-config.set_main_option("sqlalchemy.url", SQLALCHEMY_DATABASE_URL)
+config.set_main_option("sqlalchemy.url", ARGILLA_DATABASE_URL)
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.

--- a/src/argilla/server/database.py
+++ b/src/argilla/server/database.py
@@ -18,7 +18,7 @@ from sqlalchemy import create_engine, event
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
-from argilla._constants import ARGILLA_DATABASE_URL
+from argilla.server.settings import settings
 
 
 @event.listens_for(Engine, "connect")
@@ -29,7 +29,7 @@ def set_sqlite_pragma(dbapi_connection, connection_record):
         cursor.close()
 
 
-engine = create_engine(ARGILLA_DATABASE_URL)
+engine = create_engine(settings.database_url)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 

--- a/src/argilla/server/database.py
+++ b/src/argilla/server/database.py
@@ -12,15 +12,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import os
 from sqlite3 import Connection as SQLite3Connection
 
 from sqlalchemy import create_engine, event
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
-# TODO: Should we move this to some settings file?
-SQLALCHEMY_DATABASE_URL = os.getenv("ARGILLA_DATABASE_URL", "sqlite:///argilla.db?check_same_thread=False")
+from argilla._constants import ARGILLA_DATABASE_URL
 
 
 @event.listens_for(Engine, "connect")
@@ -31,7 +29,7 @@ def set_sqlite_pragma(dbapi_connection, connection_record):
         cursor.close()
 
 
-engine = create_engine(SQLALCHEMY_DATABASE_URL)
+engine = create_engine(ARGILLA_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 

--- a/tests/server/commons/test_settings.py
+++ b/tests/server/commons/test_settings.py
@@ -15,7 +15,7 @@
 import os
 
 import pytest
-from argilla.server.settings import ApiSettings
+from argilla.server.settings import Settings
 from pydantic import ValidationError
 
 
@@ -23,12 +23,12 @@ from pydantic import ValidationError
 def test_wrong_settings_namespace(bad_namespace):
     os.environ["ARGILLA_NAMESPACE"] = bad_namespace
     with pytest.raises(ValidationError):
-        ApiSettings()
+        Settings()
 
 
 def test_settings_namespace():
     os.environ["ARGILLA_NAMESPACE"] = "namespace"
-    settings = ApiSettings()
+    settings = Settings()
 
     assert settings.namespace == "namespace"
     assert settings.dataset_index_name == "namespace.ar.datasets"


### PR DESCRIPTION
This PR adds `ARGILLA_HOME_PATH` new environment variable with a default value equal to `~/.argilla`.

After that `ARGILLA_HOME_PATH` is used to define the default value for `ARGILLA_DATABASE_URL`.

I have added these changes to `_const.py` file but maybe we should create a `settings.py` file or something similar.