### PR TITLE
refactor: Make workspace required in requests

### DIFF
--- a/src/argilla/server/security/model.py
+++ b/src/argilla/server/security/model.py
@@ -79,11 +79,6 @@ class User(BaseModel):
 
         return list(set(value))
 
-    @property
-    def default_workspace(self) -> Optional[str]:
-        """Get the default user workspace"""
-        return self.username
-
     def check_workspaces(self, workspaces: List[str]) -> List[str]:
         """
         Given a list of workspaces, apply a belongs to validation for each one. Then, return

--- a/src/argilla/server/security/model.py
+++ b/src/argilla/server/security/model.py
@@ -18,7 +18,7 @@ from typing import List, Optional
 from pydantic import BaseModel, Field, root_validator, validator
 
 from argilla._constants import ES_INDEX_REGEX_PATTERN
-from argilla.server.errors import EntityNotFoundError
+from argilla.server.errors import BadRequestError, EntityNotFoundError
 
 WORKSPACE_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_\-]*$")
 _EMAIL_REGEX_PATTERN = r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}"
@@ -122,7 +122,7 @@ class User(BaseModel):
 
         """
         if not workspace:
-            return self.default_workspace
+            raise BadRequestError("Missing workspace. A workspace must by provided")
         elif workspace not in self.workspaces:
             raise EntityNotFoundError(name=workspace, type="Workspace")
         return workspace

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -26,7 +26,10 @@ from starlette.testclient import TestClient
 class SecuredClient:
     def __init__(self, client: TestClient):
         self._client = client
-        self._header = {API_KEY_HEADER_NAME: settings.default_apikey}
+        self._header = {
+            API_KEY_HEADER_NAME: settings.default_apikey,
+            WORKSPACE_HEADER_NAME: "argilla",  # Hard-coded default workspace
+        }
         self._current_user = None
 
     @property

--- a/tests/server/security/test_model.py
+++ b/tests/server/security/test_model.py
@@ -67,17 +67,8 @@ def test_check_user_workspaces():
         assert user.check_workspaces(["not-found-ws"])
 
 
-def test_default_workspace():
-    user = User(username="admin")
-    assert user.default_workspace == "admin"
-
-    test_user = User(username="test", workspaces=["ws"])
-    assert test_user.default_workspace == test_user.username
-
-
 def test_workspace_for_superuser():
     user = User(username="admin")
-    assert user.default_workspace == "admin"
 
     with pytest.raises(EntityNotFoundError):
         assert user.check_workspace("some") == "some"

--- a/tests/server/security/test_model.py
+++ b/tests/server/security/test_model.py
@@ -117,6 +117,7 @@ def test_check_workspaces_with_default(workspaces):
 )
 def test_check_workspace_without_workspace(user):
     with pytest.raises(BadRequestError):
-        assert user.check_workspace("") == "some"
+        user.check_workspace("")
+
     with pytest.raises(BadRequestError):
-        assert user.check_workspace(None) == "some"
+        user.check_workspace(None)

--- a/tests/server/security/test_model.py
+++ b/tests/server/security/test_model.py
@@ -70,6 +70,8 @@ def test_check_user_workspaces():
 def test_workspace_for_superuser():
     user = User(username="admin")
 
+    assert user.check_workspace("admin") == "admin"
+
     with pytest.raises(EntityNotFoundError):
         assert user.check_workspace("some") == "some"
 

--- a/tests/server/security/test_model.py
+++ b/tests/server/security/test_model.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 import pytest
-from argilla.server.errors import EntityNotFoundError
+from argilla.server.errors import BadRequestError, EntityNotFoundError
 from argilla.server.security.model import User
 from pydantic import ValidationError
 
@@ -82,9 +82,6 @@ def test_workspace_for_superuser():
     with pytest.raises(EntityNotFoundError):
         assert user.check_workspace("some") == "some"
 
-    assert user.check_workspace(None) == "admin"
-    assert user.check_workspace("") == "admin"
-
     user.workspaces = ["some"]
     assert user.check_workspaces(["some"]) == ["some"]
 
@@ -111,17 +108,22 @@ def test_is_superuser():
     assert user.is_superuser()
 
 
+@pytest.mark.parametrize("workspaces", [None, [], ["a"]])
+def test_check_workspaces_with_default(workspaces):
+    user = User(username="user", workspaces=workspaces)
+    assert set(user.check_workspace(user.username)) == set(user.username)
+
+
 @pytest.mark.parametrize(
-    "workspaces, expected",
+    "user",
     [
-        (None, {"user"}),
-        ([], {"user"}),
-        (["a"], {"user", "a"}),
+        User(username="admin", workspaces=None, superuser=True),
+        User(username="mock", workspaces=None, superuser=False),
+        User(username="user", workspaces=["ab"], superuser=True),
     ],
 )
-def test_check_workspaces_with_default(workspaces, expected):
-    user = User(username="user", workspaces=workspaces)
-    assert set(user.check_workspaces([])) == expected
-    assert set(user.check_workspaces(None)) == expected
-    assert set(user.check_workspaces([None])) == expected
-    assert set(user.check_workspace(user.username)) == set(user.username)
+def test_check_workspace_without_workspace(user):
+    with pytest.raises(BadRequestError):
+        assert user.check_workspace("") == "some"
+    with pytest.raises(BadRequestError):
+        assert user.check_workspace(None) == "some"


### PR DESCRIPTION
# Description

Preparing new DB integration, some workspace validation and logic will be removed. This PR prepares this integration by forcing sending workspace on each request, instead using the `default_workspace`.

For the current clients and UIs, this won't be a problem since the workspace is sent on each request right now.

**Type of change**

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (change restructuring the codebase without changing functionality)

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
