### PR TITLE
fix: prevent to include query+* in highlights

### DIFF
--- a/frontend/plugins/highlight-search.js
+++ b/frontend/plugins/highlight-search.js
@@ -40,8 +40,8 @@ export default (context, inject) => {
   }
 
   function createPattern(value) {
-    const pattern = "[^a-zA-ZÀ-ÿ\u00f1\u00d1]";
-    return `(${pattern}|^)${escapeRegExp(value)}(${pattern})`;
+    const pattern = "[^A-Za-z0-9_@./#&+-]";
+    return `(${pattern})${escapeRegExp(value)}(${pattern})`;
   }
 
   const escapeRegExp = function (text) {

--- a/frontend/plugins/highlight-search.js
+++ b/frontend/plugins/highlight-search.js
@@ -40,7 +40,7 @@ export default (context, inject) => {
   }
 
   function createPattern(value) {
-    const pattern = "[^A-Za-z0-9_@./#&+-]";
+    const pattern = "[^A-Za-zÀ-ÿ\u00f1\u00d10-9_@./#&+-]";
     return `(${pattern})${escapeRegExp(value)}(${pattern})`;
   }
 

--- a/frontend/plugins/highlight-search.js
+++ b/frontend/plugins/highlight-search.js
@@ -40,7 +40,8 @@ export default (context, inject) => {
   }
 
   function createPattern(value) {
-    return `([^a-zA-ZÀ-ÿ\u00f1\u00d1]|^)${escapeRegExp(value)}`;
+    const pattern = "[^a-zA-ZÀ-ÿ\u00f1\u00d1]";
+    return `(${pattern}|^)${escapeRegExp(value)}(${pattern})`;
   }
 
   const escapeRegExp = function (text) {


### PR DESCRIPTION
# Description

This PR includes some changes in highlight pattern to prevent to include query+* in highlights

closes #2049

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)


**Checklist**

- [x] I have merged the original branch into my forked branch
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
