### PR TITLE
fix: Remove extra-action dropdown state after navigation

### DIFF
--- a/frontend/components/commons/results/RecordExtraActions.vue
+++ b/frontend/components/commons/results/RecordExtraActions.vue
@@ -87,6 +87,9 @@ export default {
       },
     },
   },
+  beforeDestroy() {
+    this.close();
+  },
   methods: {
     // TODO: call vuex-actions here instead of trigger event
     onChangeRecordStatus(status) {


### PR DESCRIPTION
# Description

This PR restarts the initial state of the dropdown after navigation

Closes #2158

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] I have merged the original branch into my forked branch
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
