### PR TITLE
Add default user and show warning message on startup when no users found

### DIFF
--- a/src/argilla/_constants.py
+++ b/src/argilla/_constants.py
@@ -17,6 +17,9 @@ DEFAULT_MAX_KEYWORD_LENGTH = 128
 
 API_KEY_HEADER_NAME = "X-Argilla-Api-Key"
 WORKSPACE_HEADER_NAME = "X-Argilla-Workspace"
+
+DEFAULT_USERNAME = "argilla"
+DEFAULT_PASSWORD = "1234"
 DEFAULT_API_KEY = "argilla.apikey"  # Keep the same api key for now
 
 # TODO: This constant will be drop out with issue

--- a/src/argilla/server/contexts/accounts.py
+++ b/src/argilla/server/contexts/accounts.py
@@ -23,7 +23,7 @@ from argilla.server.security.model import (
 from passlib.context import CryptContext
 from sqlalchemy.orm import Session
 
-_CRYPT_CONTEXT = CryptContext(schemes=["bcrypt"], deprecated="auto")
+CRYPT_CONTEXT = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
 def get_workspace_user_by_workspace_id_and_user_id(db: Session, workspace_id: UUID, user_id: UUID):
@@ -101,7 +101,7 @@ def create_user(db: Session, user_create: UserCreate):
         last_name=user_create.last_name,
         username=user_create.username,
         role=user_create.role,
-        password_hash=_CRYPT_CONTEXT.hash(user_create.password),
+        password_hash=CRYPT_CONTEXT.hash(user_create.password),
     )
 
     db.add(user)
@@ -121,9 +121,9 @@ def delete_user(db: Session, user: User):
 def authenticate_user(db: Session, username: str, password: str):
     user = get_user_by_username(db, username)
 
-    if user and _CRYPT_CONTEXT.verify(password, user.password_hash):
+    if user and CRYPT_CONTEXT.verify(password, user.password_hash):
         return user
     elif user:
         return
     else:
-        _CRYPT_CONTEXT.dummy_verify()
+        CRYPT_CONTEXT.dummy_verify()

--- a/src/argilla/server/security/auth_provider/local/settings.py
+++ b/src/argilla/server/security/auth_provider/local/settings.py
@@ -15,7 +15,6 @@
 
 from pydantic import BaseSettings
 
-from argilla._constants import DEFAULT_API_KEY
 from argilla.server import helpers
 from argilla.server.settings import settings as server_settings
 
@@ -41,9 +40,6 @@ class Settings(BaseSettings):
     algorithm: str = "HS256"
     token_expiration_in_minutes: int = 30000
     token_api_url: str = "/api/security/token"
-
-    default_apikey: str = DEFAULT_API_KEY
-    default_password: str = "$2y$12$MPcRR71ByqgSI8AaqgxrMeSdrD4BcxDIdYkr.ePQoKz7wsGK7SAca"  # 1234
     users_db_file: str = ".users.yml"
 
     @property

--- a/src/argilla/server/server.py
+++ b/src/argilla/server/server.py
@@ -34,7 +34,7 @@ from pydantic import ConfigError
 from sqlalchemy.orm import Session
 
 from argilla import __version__ as argilla_version
-from argilla._constants import DEFAULT_PASSWORD, DEFAULT_USERNAME
+from argilla._constants import DEFAULT_API_KEY, DEFAULT_PASSWORD, DEFAULT_USERNAME
 from argilla.logging import configure_logging
 from argilla.server import helpers
 from argilla.server.contexts import accounts
@@ -51,9 +51,6 @@ from argilla.server.errors import (
 from argilla.server.models import User, UserRole, Workspace
 from argilla.server.routes import api_router
 from argilla.server.security import auth
-from argilla.server.security.auth_provider.local.settings import (
-    settings as auth_settings,
-)
 from argilla.server.settings import settings
 from argilla.server.static_rewrite import RewriteStaticFiles
 
@@ -214,8 +211,8 @@ def configure_database(app: FastAPI):
             first_name="",
             username=DEFAULT_USERNAME,
             role=UserRole.admin,
-            api_key=auth_settings.default_apikey,
-            password_hash=auth_settings.default_password,
+            api_key=DEFAULT_API_KEY,
+            password_hash=accounts.CRYPT_CONTEXT.hash(DEFAULT_PASSWORD),
             workspaces=[Workspace(name=DEFAULT_USERNAME)],
         )
 
@@ -226,9 +223,7 @@ def configure_database(app: FastAPI):
         return user
 
     def _user_has_default_credentials(user: User):
-        return user.api_key == auth_settings.default_apikey or accounts.CRYPT_CONTEXT.verify(
-            DEFAULT_PASSWORD, user.password_hash
-        )
+        return user.api_key == DEFAULT_API_KEY or accounts.CRYPT_CONTEXT.verify(DEFAULT_PASSWORD, user.password_hash)
 
     def _log_default_user_warning():
         _LOGGER.warning(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from argilla._constants import API_KEY_HEADER_NAME
+from argilla._constants import API_KEY_HEADER_NAME, DEFAULT_API_KEY
 from argilla.server.security.auth_provider.local.settings import settings
 from fastapi import FastAPI
 from starlette.testclient import TestClient
@@ -21,7 +21,7 @@ from starlette.testclient import TestClient
 class SecuredClient:
     def __init__(self, client: TestClient):
         self._client = client
-        self._header = {API_KEY_HEADER_NAME: settings.default_apikey}
+        self._header = {API_KEY_HEADER_NAME: DEFAULT_API_KEY}
         self._current_user = None
 
     def update_api_key(self, api_key):


### PR DESCRIPTION
With this PR we will add a default `argilla` user (with `argilla`) when there are not users on the database.

We also show a warning message indicating that it could be dangerous to have default `argilla` user in a production environment and what to do in that case.

In the case that we already have users on the database (because of the migration) we check if the `argilla` default user is using default credentials (password and api key) and in that case we show the same previous warning.