### PR TITLE
Run alembic migrations for server startup and users migrator

### DIFF
--- a/src/argilla/server/alembic/env.py
+++ b/src/argilla/server/alembic/env.py
@@ -28,7 +28,7 @@ config.set_main_option("sqlalchemy.url", settings.database_url)
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
-    fileConfig(config.config_file_name)
+    fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 # add your model's MetaData object here
 # for 'autogenerate' support

--- a/src/argilla/server/database.py
+++ b/src/argilla/server/database.py
@@ -14,6 +14,7 @@
 
 from sqlite3 import Connection as SQLite3Connection
 
+import alembic.config
 from sqlalchemy import create_engine, event
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
@@ -39,6 +40,10 @@ def get_db():
         yield db
     finally:
         db.close()
+
+
+def run_db_migrations():
+    alembic.config.main(argv=["upgrade", "head"])
 
 
 class Base(DeclarativeBase):

--- a/src/argilla/tasks/users_migrator.py
+++ b/src/argilla/tasks/users_migrator.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import os
 from typing import List, Optional
 
 import yaml
@@ -20,7 +19,7 @@ from pydantic import BaseModel, constr
 from rich import print
 from sqlalchemy.orm import Session
 
-from argilla.server.database import SessionLocal
+from argilla.server.database import SessionLocal, run_db_migrations
 from argilla.server.models import User, UserRole, Workspace
 from argilla.server.security.auth_provider.local.settings import settings
 from argilla.server.security.model import USER_USERNAME_REGEX, WORKSPACE_NAME_REGEX
@@ -102,4 +101,5 @@ class UsersMigrator:
 
 
 if __name__ == "__main__":
+    run_db_migrations()
     UsersMigrator(settings.users_db_file).migrate()


### PR DESCRIPTION
This PR adds a new `run_db_migrations` function to `argilla.server.database` package which execute alembic migrations like `$ alembic upgrade head` command.

This new function is used on the following places:
- On `argilla.tasks.users_migrator` execution
- On `argilla.server` startup.

Once that we create a  new task to add users on demand we should run this function too.