### PR TITLE
Add new task to execute alembic database migrations

### DIFF
--- a/src/argilla/server/database.py
+++ b/src/argilla/server/database.py
@@ -14,6 +14,7 @@
 
 from sqlite3 import Connection as SQLite3Connection
 
+import alembic.config
 from sqlalchemy import create_engine, event
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
@@ -39,6 +40,10 @@ def get_db():
         yield db
     finally:
         db.close()
+
+
+def migrate_db():
+    alembic.config.main(argv=["upgrade", "head"])
 
 
 class Base(DeclarativeBase):

--- a/src/argilla/tasks/database/__init__.py
+++ b/src/argilla/tasks/database/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/src/argilla/tasks/database/migrate.py
+++ b/src/argilla/tasks/database/migrate.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-if __name__ == "__main__":
-    from argilla.server.database import migrate_db
+from argilla.server.database import migrate_db
 
+if __name__ == "__main__":
     migrate_db()

--- a/src/argilla/tasks/database/migrate.py
+++ b/src/argilla/tasks/database/migrate.py
@@ -1,0 +1,18 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+if __name__ == "__main__":
+    from argilla.server.database import migrate_db
+
+    migrate_db()


### PR DESCRIPTION
This PR adds a new task to run alembic database migration in the same way that we do with `alembic upgrade head` but using an argilla task.

To execute the task you need to do:

```sh
$ python -m argilla.tasks.database.migrate
```

