### PR TITLE
Add basic authorization policies

### DIFF
--- a/src/argilla/server/apis/v0/handlers/users.py
+++ b/src/argilla/server/apis/v0/handlers/users.py
@@ -86,7 +86,7 @@ def delete_user(
         # https://github.com/jazzband/django-push-notifications/issues/586
         raise EntityNotFoundError(name=str(user_id), type=User)
 
-    authorize(current_user, UserPolicy.delete, user)
+    authorize(current_user, UserPolicy.delete(user))
 
     accounts.delete_user(db, user)
 

--- a/src/argilla/server/apis/v0/handlers/workspaces.py
+++ b/src/argilla/server/apis/v0/handlers/workspaces.py
@@ -68,7 +68,7 @@ def delete_workspace(
     if not workspace:
         raise EntityNotFoundError(name=str(workspace_id), type=Workspace)
 
-    authorize(current_user, WorkspacePolicy.delete, workspace)
+    authorize(current_user, WorkspacePolicy.delete(workspace))
 
     accounts.delete_workspace(db, workspace)
 
@@ -123,7 +123,7 @@ def delete_workspace_user(
     if not workspace_user:
         raise EntityNotFoundError(name=str(user_id), type=User)
 
-    authorize(current_user, WorkspaceUserPolicy.delete, workspace_user)
+    authorize(current_user, WorkspaceUserPolicy.delete(workspace_user))
 
     user = workspace_user.user
     accounts.delete_workspace_user(db, workspace_user)

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -91,5 +91,13 @@ class User(Base):
         secondary="workspaces_users", back_populates="users", order_by=WorkspaceUser.inserted_at.asc()
     )
 
+    @property
+    def is_admin(self):
+        return self.role == UserRole.admin
+
+    @property
+    def is_annotator(self):
+        return self.role == UserRole.annotator
+
     def __repr__(self):
         return f"User(id={str(self.id)!r}, first_name={self.first_name!r}, last_name={self.last_name!r}, username={self.username!r}, role={self.role.value!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -18,61 +18,52 @@ from argilla.server.models import User, UserRole, Workspace, WorkspaceUser
 
 class WorkspaceUserPolicy:
     @classmethod
-    def list(cls, actor: User, workspace_user: WorkspaceUser):
-        return True
+    def list(cls, actor: User, workspace_user: WorkspaceUser) -> bool:
+        return actor.role == UserRole.admin
 
     @classmethod
-    def create(cls, actor: User, workspace_user: WorkspaceUser):
-        return True
+    def create(cls, actor: User, workspace_user: WorkspaceUser) -> bool:
+        return actor.role == UserRole.admin
 
     @classmethod
-    def delete(cls, actor: User, workspace_user: WorkspaceUser):
-        return True
+    def delete(cls, actor: User, workspace_user: WorkspaceUser) -> bool:
+        return actor.role == UserRole.admin
 
 
 class WorkspacePolicy:
     @classmethod
-    def list(cls, actor: User, workspace: Workspace):
+    def list(cls, actor: User, workspace: Workspace) -> bool:
         return True
 
     @classmethod
-    def create(cls, actor: User, workspace: Workspace):
-        # return user.is_admin
+    def create(cls, actor: User, workspace: Workspace) -> bool:
+        # TODO: Once we receive ORM User models instead of Pydantic schema for current_user we can
+        # change role checks to use `actor.is_admin` or `actor.is_annotator`
         return actor.role == UserRole.admin
 
     @classmethod
-    def delete(cls, actor: User, workspace: Workspace):
-        # return user.is_admin and workspace in user.workspaces
-        return actor.role == UserRole.admin and workspace in actor.workspaces
-
-    # Example using closures
-    # @classmethod
-    # def delete(cls, workspace: Workspace):
-    #     return lambda user: user.role == UserRole and workspace in user.workspaces
+    def delete(cls, actor: User, workspace: Workspace) -> bool:
+        return actor.role == UserRole.admin
 
 
 class UserPolicy:
     @classmethod
-    def whoami(cls, actor: User, user: User):
-        return actor.id == user.id
+    def list(cls, actor: User, user: User) -> bool:
+        return actor.role == UserRole.admin
 
     @classmethod
-    def list(cls, actor: User, user: User):
-        return True
+    def create(cls, actor: User, user: User) -> bool:
+        return actor.role == UserRole.admin
 
     @classmethod
-    def create(cls, actor: User, user: User):
-        return True
-
-    @classmethod
-    def delete(cls, actor: User, user: User):
-        return True
+    def delete(cls, actor: User, user: User) -> bool:
+        return actor.role == UserRole.admin
 
 
-def authorize(user: User, policy_action, resource=None):
-    if not is_authorized(user, policy_action, resource):
+def authorize(actor: User, policy_action, resource=None):
+    if not is_authorized(actor, policy_action, resource):
         raise ForbiddenOperationError()
 
 
-def is_authorized(user: User, policy_action, resource=None):
-    return policy_action(user, resource)
+def is_authorized(actor: User, policy_action, resource=None) -> bool:
+    return policy_action(actor, resource)

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -1,0 +1,78 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from argilla.server.errors import ForbiddenOperationError
+from argilla.server.models import User, UserRole, Workspace, WorkspaceUser
+
+
+class WorkspaceUserPolicy:
+    @classmethod
+    def list(cls, actor: User, workspace_user: WorkspaceUser):
+        return True
+
+    @classmethod
+    def create(cls, actor: User, workspace_user: WorkspaceUser):
+        return True
+
+    @classmethod
+    def delete(cls, actor: User, workspace_user: WorkspaceUser):
+        return True
+
+
+class WorkspacePolicy:
+    @classmethod
+    def list(cls, actor: User, workspace: Workspace):
+        return True
+
+    @classmethod
+    def create(cls, actor: User, workspace: Workspace):
+        # return user.is_admin
+        return actor.role == UserRole.admin
+
+    @classmethod
+    def delete(cls, actor: User, workspace: Workspace):
+        # return user.is_admin and workspace in user.workspaces
+        return actor.role == UserRole.admin and workspace in actor.workspaces
+
+    # Example using closures
+    # @classmethod
+    # def delete(cls, workspace: Workspace):
+    #     return lambda user: user.role == UserRole and workspace in user.workspaces
+
+
+class UserPolicy:
+    @classmethod
+    def whoami(cls, actor: User, user: User):
+        return actor.id == user.id
+
+    @classmethod
+    def list(cls, actor: User, user: User):
+        return True
+
+    @classmethod
+    def create(cls, actor: User, user: User):
+        return True
+
+    @classmethod
+    def delete(cls, actor: User, user: User):
+        return True
+
+
+def authorize(user: User, policy_action, resource=None):
+    if not is_authorized(user, policy_action, resource):
+        raise ForbiddenOperationError()
+
+
+def is_authorized(user: User, policy_action, resource=None):
+    return policy_action(user, resource)

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -12,58 +12,62 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from typing import Callable
+
 from argilla.server.errors import ForbiddenOperationError
 from argilla.server.models import User, UserRole, Workspace, WorkspaceUser
+
+PolicyAction = Callable[[User], bool]
 
 
 class WorkspaceUserPolicy:
     @classmethod
-    def list(cls, actor: User, workspace_user: WorkspaceUser) -> bool:
+    def list(cls, actor: User) -> bool:
         return actor.role == UserRole.admin
 
     @classmethod
-    def create(cls, actor: User, workspace_user: WorkspaceUser) -> bool:
+    def create(cls, actor: User) -> bool:
         return actor.role == UserRole.admin
 
     @classmethod
-    def delete(cls, actor: User, workspace_user: WorkspaceUser) -> bool:
-        return actor.role == UserRole.admin
+    def delete(cls, workspace_user: WorkspaceUser) -> PolicyAction:
+        return lambda actor: actor.role == UserRole.admin
 
 
 class WorkspacePolicy:
     @classmethod
-    def list(cls, actor: User, workspace: Workspace) -> bool:
+    def list(cls, actor: User) -> bool:
         return True
 
     @classmethod
-    def create(cls, actor: User, workspace: Workspace) -> bool:
+    def create(cls, actor: User) -> bool:
         # TODO: Once we receive ORM User models instead of Pydantic schema for current_user we can
         # change role checks to use `actor.is_admin` or `actor.is_annotator`
         return actor.role == UserRole.admin
 
     @classmethod
-    def delete(cls, actor: User, workspace: Workspace) -> bool:
-        return actor.role == UserRole.admin
+    def delete(cls, workspace: Workspace) -> PolicyAction:
+        return lambda actor: actor.role == UserRole.admin
 
 
 class UserPolicy:
     @classmethod
-    def list(cls, actor: User, user: User) -> bool:
+    def list(cls, actor: User) -> bool:
         return actor.role == UserRole.admin
 
     @classmethod
-    def create(cls, actor: User, user: User) -> bool:
+    def create(cls, actor: User) -> bool:
         return actor.role == UserRole.admin
 
     @classmethod
-    def delete(cls, actor: User, user: User) -> bool:
-        return actor.role == UserRole.admin
+    def delete(cls, user: User) -> PolicyAction:
+        return lambda actor: actor.role == UserRole.admin
 
 
-def authorize(actor: User, policy_action, resource=None):
-    if not is_authorized(actor, policy_action, resource):
+def authorize(actor: User, policy_action: PolicyAction) -> None:
+    if not is_authorized(actor, policy_action):
         raise ForbiddenOperationError()
 
 
-def is_authorized(actor: User, policy_action, resource=None) -> bool:
-    return policy_action(actor, resource)
+def is_authorized(actor: User, policy_action: PolicyAction) -> bool:
+    return policy_action(actor)

--- a/src/argilla/server/server.py
+++ b/src/argilla/server/server.py
@@ -46,6 +46,7 @@ from argilla.server.database import get_db
 from argilla.server.errors import (
     APIErrorHandler,
     EntityNotFoundError,
+    ForbiddenOperationError,
     UnauthorizedError,
 )
 from argilla.server.models import User, UserRole, Workspace
@@ -76,6 +77,7 @@ def configure_api_exceptions(api: FastAPI):
     api.exception_handler(EntityNotFoundError)(APIErrorHandler.common_exception_handler)
     api.exception_handler(Exception)(APIErrorHandler.common_exception_handler)
     api.exception_handler(UnauthorizedError)(APIErrorHandler.common_exception_handler)
+    api.exception_handler(ForbiddenOperationError)(APIErrorHandler.common_exception_handler)
     api.exception_handler(RequestValidationError)(APIErrorHandler.common_exception_handler)
 
 
@@ -232,7 +234,8 @@ def configure_database(app: FastAPI):
             f"We recommend that you create a new admin user and then delete the default {DEFAULT_USERNAME!r} one."
         )
 
-    @app.on_event("startup")
+    # This was breaking tests adding the default user
+    # @app.on_event("startup")
     async def create_default_user_if_not_present():
         with get_db_wrapper() as db:
             if db.query(User).count() == 0:

--- a/src/argilla/server/server.py
+++ b/src/argilla/server/server.py
@@ -234,8 +234,7 @@ def configure_database(app: FastAPI):
             f"We recommend that you create a new admin user and then delete the default {DEFAULT_USERNAME!r} one."
         )
 
-    # This was breaking tests adding the default user
-    # @app.on_event("startup")
+    @app.on_event("startup")
     async def create_default_user_if_not_present():
         with get_db_wrapper() as db:
             if db.query(User).count() == 0:

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -14,7 +14,7 @@
 
 import factory
 from argilla.server.database import SessionLocal
-from argilla.server.models import User, Workspace, WorkspaceUser
+from argilla.server.models import User, UserRole, Workspace, WorkspaceUser
 
 
 class WorkspaceUserFactory(factory.alchemy.SQLAlchemyModelFactory):
@@ -43,3 +43,11 @@ class UserFactory(factory.alchemy.SQLAlchemyModelFactory):
     username = factory.Sequence(lambda n: f"username-{n}")
     api_key = factory.Sequence(lambda n: f"api-key-{n}")
     password_hash = "$2y$05$eaw.j2Kaw8s8vpscVIZMfuqSIX3OLmxA21WjtWicDdn0losQ91Hw."
+
+
+class AdminFactory(UserFactory):
+    role = UserRole.admin
+
+
+class AnnotatorFactory(UserFactory):
+    role = UserRole.annotator


### PR DESCRIPTION
This is a first proposal of the new authorization policies after visiting them for the first time on @frascuchon PR: https://github.com/argilla-io/argilla/pull/2469

The general idea is to have a `policies` package where we can create different policies classes including the authorization logic for every model in our application.

The `policies` package will include also two method to facilitate check authorization policies on API handlers.
- `authorized`: that will raise a `ForbiddenOperationError` exception if the policy does not check.
- `is_authorized`: that will return `True` or `False` depending if the policy checks or not.

Things to have into account:
- The user that we get as `current_user` on API handlers is not an SQLAlchemy ORM `User` model (we need to take a look to this @frascuchon).
- The creation of default user on server startup it's breaking some of my tests so I have disabled it (we can discuss if with the new user creation task this can be removed).
- There is an alternative version of authorization policies that we can implement using closures. It has a lot of flexibility but adds a little bit of complexity to the code.

