### PR TITLE
chore: Review active client doc references

### DIFF
--- a/docs/_source/guides/log_load_and_prepare_data.ipynb
+++ b/docs/_source/guides/log_load_and_prepare_data.ipynb
@@ -312,10 +312,9 @@
    "outputs": [],
    "source": [
     "import argilla as rg\n",
-    "from argilla.client.api import active_client\n",
     "\n",
     "rg.init()\n",
-    "client = active_client()\n",
+    "client = rg.active_client()\n",
     "\n",
     "# This metadata key was used by the UI to store created labels in datasets\n",
     "CUSTOM_DATA_KEY = \"rubrix.recogn.ai/ui/custom/userData.v1\"\n",

--- a/docs/_source/guides/log_load_and_prepare_data.ipynb
+++ b/docs/_source/guides/log_load_and_prepare_data.ipynb
@@ -312,9 +312,10 @@
    "outputs": [],
    "source": [
     "import argilla as rg\n",
+    "from argilla.client import api\n",
     "\n",
     "rg.init()\n",
-    "client = rg.active_client()\n",
+    "client = api.active_client()\n",
     "\n",
     "# This metadata key was used by the UI to store created labels in datasets\n",
     "CUSTOM_DATA_KEY = \"rubrix.recogn.ai/ui/custom/userData.v1\"\n",
@@ -517,9 +518,10 @@
    "outputs": [],
    "source": [
     "import argilla as rg\n",
+    "from argilla.client import api\n",
     "\n",
     "rg.init()\n",
-    "rg_client = rg.active_client()\n",
+    "rg_client = api.active_client()\n",
     "\n",
     "new_workspace = \"<put-target-workspace-here>\"\n",
     "\n",


### PR DESCRIPTION
Just a minimal change using new the `rg.active_client` function for migration scripts. This allows copy-pasting the code snippet without upgrading argilla.