### PR TITLE
Add task to create default user on database

### DIFF
--- a/src/argilla/server/contexts/accounts.py
+++ b/src/argilla/server/contexts/accounts.py
@@ -23,7 +23,7 @@ from argilla.server.security.model import (
 from passlib.context import CryptContext
 from sqlalchemy.orm import Session
 
-CRYPT_CONTEXT = CryptContext(schemes=["bcrypt"], deprecated="auto")
+_CRYPT_CONTEXT = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
 def get_workspace_user_by_workspace_id_and_user_id(db: Session, workspace_id: UUID, user_id: UUID):
@@ -101,7 +101,7 @@ def create_user(db: Session, user_create: UserCreate):
         last_name=user_create.last_name,
         username=user_create.username,
         role=user_create.role,
-        password_hash=CRYPT_CONTEXT.hash(user_create.password),
+        password_hash=hash_password(user_create.password),
     )
 
     db.add(user)
@@ -121,9 +121,17 @@ def delete_user(db: Session, user: User):
 def authenticate_user(db: Session, username: str, password: str):
     user = get_user_by_username(db, username)
 
-    if user and CRYPT_CONTEXT.verify(password, user.password_hash):
+    if user and verify_password(password, user.password_hash):
         return user
     elif user:
         return
     else:
-        CRYPT_CONTEXT.dummy_verify()
+        _CRYPT_CONTEXT.dummy_verify()
+
+
+def hash_password(password: str):
+    return _CRYPT_CONTEXT.hash(password)
+
+
+def verify_password(password: str, password_hash: str):
+    return _CRYPT_CONTEXT.verify(password, password_hash)

--- a/src/argilla/server/server.py
+++ b/src/argilla/server/server.py
@@ -207,7 +207,7 @@ def configure_database(app: FastAPI):
     get_db_wrapper = contextlib.contextmanager(get_db)
 
     def _user_has_default_credentials(user: User):
-        return user.api_key == DEFAULT_API_KEY or accounts.CRYPT_CONTEXT.verify(DEFAULT_PASSWORD, user.password_hash)
+        return user.api_key == DEFAULT_API_KEY or accounts.verify_password(DEFAULT_PASSWORD, user.password_hash)
 
     def _log_default_user_warning():
         _LOGGER.warning(

--- a/src/argilla/tasks/users/__init__.py
+++ b/src/argilla/tasks/users/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/src/argilla/tasks/users/create_default.py
+++ b/src/argilla/tasks/users/create_default.py
@@ -1,0 +1,47 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import click
+
+from argilla._constants import DEFAULT_API_KEY, DEFAULT_PASSWORD, DEFAULT_USERNAME
+from argilla.server.contexts import accounts
+from argilla.server.database import SessionLocal
+from argilla.server.models import User, UserRole, Workspace
+
+
+@click.command()
+@click.option("-q", "--quiet", is_flag=True, default=False, help="Run without output.")
+def create_default(quiet: bool):
+    """Creates a user with default credentials on database suitable to start experimenting with argilla."""
+    with SessionLocal() as session, session.begin():
+        session.add(
+            User(
+                first_name="",
+                username=DEFAULT_USERNAME,
+                role=UserRole.admin,
+                api_key=DEFAULT_API_KEY,
+                password_hash=accounts.hash_password(DEFAULT_PASSWORD),
+                workspaces=[Workspace(name=DEFAULT_USERNAME)],
+            )
+        )
+
+    if not quiet:
+        click.echo("User with default credentials succesfully created:")
+        click.echo(f"• username: {DEFAULT_USERNAME!r}")
+        click.echo(f"• password: {DEFAULT_PASSWORD!r}")
+        click.echo(f"• api_key:  {DEFAULT_API_KEY!r}")
+
+
+if __name__ == "__main__":
+    create_default()

--- a/tests/tasks/users/__init__.py
+++ b/tests/tasks/users/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/tasks/users/test_create_default.py
+++ b/tests/tasks/users/test_create_default.py
@@ -1,0 +1,42 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from argilla._constants import DEFAULT_API_KEY, DEFAULT_PASSWORD, DEFAULT_USERNAME
+from argilla.server.contexts import accounts
+from argilla.server.models import User, UserRole
+from argilla.tasks.users.create_default import create_default
+from click.testing import CliRunner
+from sqlalchemy.orm import Session
+
+
+def test_create_default(db: Session):
+    result = CliRunner().invoke(create_default)
+
+    assert result.exit_code == 0
+    assert result.output != ""
+    assert db.query(User).count() == 1
+
+    default_user = db.query(User).filter_by(username=DEFAULT_USERNAME).first()
+    assert default_user
+    assert default_user.role == UserRole.admin
+    assert default_user.api_key == DEFAULT_API_KEY
+    assert accounts.verify_password(DEFAULT_PASSWORD, default_user.password_hash)
+    assert [ws.name for ws in default_user.workspaces] == [DEFAULT_USERNAME]
+
+
+def test_create_default_quiet(db: Session):
+    result = CliRunner().invoke(create_default, ["--quiet"])
+
+    assert result.exit_code == 0
+    assert result.output == ""


### PR DESCRIPTION
This PR adds a new task to create user with defaults credentials on database.

```sh
# Get help
$ python -m argilla.tasks.users.create_default --help

# Create the default user
$ python -m argilla.tasks.users.create_default

# Create the default user without output
$ python -m argilla.tasks.users.create_default --quiet
```

I have refactored a little bit some `contexts.accounts` functions related with passwords, maybe it could be applied later to some other PRs on the go.