### PR TITLE
feat: `configure_dataset` accepts a workspace as argument

### DIFF
--- a/src/argilla/datasets/__init__.py
+++ b/src/argilla/datasets/__init__.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+from typing import Optional
 
 from argilla.client import api
 from argilla.client.apis.datasets import (
@@ -22,7 +23,7 @@ from argilla.client.apis.datasets import (
 __all__ = [TextClassificationSettings, TokenClassificationSettings, Settings]
 
 
-def configure_dataset(name: str, settings: Settings) -> None:
+def configure_dataset(name: str, settings: Settings, workspace: Optional[str]) -> None:
     """
     Configures a dataset with a set of configured labels. If dataset does not
     exist yet, an empty dataset will be created.
@@ -32,7 +33,8 @@ def configure_dataset(name: str, settings: Settings) -> None:
     Args:
         name: The dataset name
         settings: The dataset settings
+        workspace: The workspace name where the dataset will belongs to
     """
     active_api = api.active_api()
     datasets = active_api.datasets
-    datasets.configure(name, settings=settings)
+    datasets.configure(name, workspace=workspace or active_api.get_workspace(), settings=settings)

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -34,8 +34,10 @@ from argilla.client.sdk.commons.errors import ForbiddenApiError
 )
 def test_settings_workflow(mocked_client, settings_, wrong_settings):
     dataset = "test-dataset"
+    workspace = rg.get_workspace()
+
     rg.delete(dataset)
-    rg.configure_dataset(dataset, settings=settings_)
+    rg.configure_dataset(dataset, settings=settings_, workspace=workspace)
 
     current_api = api.active_api()
     datasets_api = current_api.datasets
@@ -44,13 +46,13 @@ def test_settings_workflow(mocked_client, settings_, wrong_settings):
     assert found_settings == settings_
 
     settings_.label_schema = {"LALALA"}
-    rg.configure_dataset(dataset, settings_)
+    rg.configure_dataset(dataset, settings_, workspace=workspace)
 
     found_settings = datasets_api.load_settings(dataset)
     assert found_settings == settings_
 
     with pytest.raises(ValueError, match="Task type mismatch"):
-        rg.configure_dataset(dataset, wrong_settings)
+        rg.configure_dataset(dataset, wrong_settings, workspace=workspace)
 
 
 def test_list_dataset(mocked_client):
@@ -66,8 +68,12 @@ def test_list_dataset(mocked_client):
 def test_delete_dataset_by_non_creator(mocked_client):
     try:
         dataset = "test_delete_dataset_by_non_creator"
+        workspace = rg.get_workspace()
+        settings = TextClassificationSettings(label_schema={"A", "B", "C"})
+
         rg.delete(dataset)
-        rg.configure_dataset(dataset, settings=TextClassificationSettings(label_schema={"A", "B", "C"}))
+        rg.configure_dataset(dataset, settings=settings, workspace=workspace)
+
         mocked_client.change_current_user("mock-user")
         with pytest.raises(ForbiddenApiError):
             rg.delete(dataset)


### PR DESCRIPTION
The `rg.configure_dataset` accepts a workspace name as a param.

The inner dataset creation request will use the workspace inside the request body. (See [here](https://github.com/argilla-io/argilla/pull/2403/commits/1cae0aacaae9a458ee50a6c390e558f8ff180ca1#diff-54f1605eb0a3cdc8cdd1c9c9e4628c5e30b3460588e640e38dfcfb95d8cd97e3L70))