### PR TITLE
First integration of new resources with current API endpoints

### DIFF
--- a/src/argilla/server/apis/v0/handlers/datasets.py
+++ b/src/argilla/server/apis/v0/handlers/datasets.py
@@ -143,7 +143,7 @@ def delete_dataset(
     if not workspace:
         raise EntityNotFoundError(name=workspace_name, type=Workspace)
 
-    dataset = datasets.find_by_name(name=name, workspace=workspace.name)
+    dataset = datasets.find_by_name_and_workspace(name=name, workspace=workspace.name)
     if dataset:
         if not is_authorized(user, DatasetPolicy.delete(dataset)):
             raise ForbiddenOperationError(

--- a/src/argilla/server/apis/v0/handlers/datasets.py
+++ b/src/argilla/server/apis/v0/handlers/datasets.py
@@ -144,14 +144,16 @@ def delete_dataset(
         raise EntityNotFoundError(name=workspace_name, type=Workspace)
 
     dataset = datasets.find_by_name_and_workspace(name=name, workspace=workspace.name)
-    if dataset:
-        if not is_authorized(user, DatasetPolicy.delete(dataset)):
-            raise ForbiddenOperationError(
-                "You don't have the necessary permissions to delete this dataset. "
-                "Only dataset creators or administrators can delete datasets"
-            )
-        else:
-            datasets.delete_dataset(dataset)
+    if not dataset:
+        return
+
+    if not is_authorized(user, DatasetPolicy.delete(dataset)):
+        raise ForbiddenOperationError(
+            "You don't have the necessary permissions to delete this dataset. "
+            "Only dataset creators or administrators can delete datasets"
+        )
+
+    datasets.delete_dataset(dataset)
 
 
 @router.put(

--- a/src/argilla/server/apis/v0/handlers/datasets.py
+++ b/src/argilla/server/apis/v0/handlers/datasets.py
@@ -143,19 +143,15 @@ def delete_dataset(
     if not workspace:
         raise EntityNotFoundError(name=workspace_name, type=Workspace)
 
-    try:
-        dataset = datasets.find_by_name(name=name, workspace=workspace.name)
-        if not dataset:
-            raise EntityNotFoundError(name=name, type=Dataset)
-
+    dataset = datasets.find_by_name(name=name, workspace=workspace.name)
+    if dataset:
         if not is_authorized(user, DatasetPolicy.delete(dataset)):
             raise ForbiddenOperationError(
                 "You don't have the necessary permissions to delete this dataset. "
                 "Only dataset creators or administrators can delete datasets"
             )
-        datasets.delete_dataset(dataset)
-    except EntityNotFoundError:
-        pass
+        else:
+            datasets.delete_dataset(dataset)
 
 
 @router.put(

--- a/src/argilla/server/daos/datasets.py
+++ b/src/argilla/server/daos/datasets.py
@@ -118,6 +118,9 @@ class DatasetsDAO:
     def delete_dataset(self, dataset: DatasetDB):
         self._es.delete(dataset.id)
 
+    def find_by_name_and_workspace(self, name: str, workspace: str) -> Optional[DatasetDB]:
+        return self.find_by_name(name=name, workspace=workspace)
+
     def find_by_name(
         self,
         name: str,

--- a/src/argilla/server/daos/datasets.py
+++ b/src/argilla/server/daos/datasets.py
@@ -124,10 +124,7 @@ class DatasetsDAO:
         workspace: str,
         as_dataset_class: Type[DatasetDB] = BaseDatasetDB,
     ) -> Optional[DatasetDB]:
-        dataset_id = BaseDatasetDB.build_dataset_id(
-            name=name,
-            workspace=workspace,
-        )
+        dataset_id = BaseDatasetDB.build_dataset_id(name=name, workspace=workspace)
         document = self._es.find_dataset(id=dataset_id)
         if document is None:
             return None

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -16,6 +16,7 @@ from typing import Callable
 
 from argilla.server.errors import ForbiddenOperationError
 from argilla.server.models import User, UserRole, Workspace, WorkspaceUser
+from argilla.server.schemas.datasets import Dataset
 
 PolicyAction = Callable[[User], bool]
 
@@ -62,6 +63,20 @@ class UserPolicy:
     @classmethod
     def delete(cls, user: User) -> PolicyAction:
         return lambda actor: actor.role == UserRole.admin
+
+
+class DatasetPolicy:
+    @classmethod
+    def get(cls, workspace: Workspace) -> PolicyAction:
+        return lambda actor: actor.role == UserRole.admin or workspace in actor.workspaces
+
+    @classmethod
+    def create(cls, workspace: Workspace) -> PolicyAction:
+        return lambda actor: actor.role == UserRole.admin or workspace in actor.workspaces
+
+    @classmethod
+    def delete(cls, dataset: Dataset) -> PolicyAction:
+        return lambda actor: actor.role == UserRole.admin or actor.username == dataset.created_by
 
 
 def authorize(actor: User, policy_action: PolicyAction) -> None:

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -67,16 +67,8 @@ class UserPolicy:
 
 class DatasetPolicy:
     @classmethod
-    def get(cls, workspace: Workspace) -> PolicyAction:
-        return lambda actor: actor.role == UserRole.admin or workspace in actor.workspaces
-
-    @classmethod
-    def create(cls, workspace: Workspace) -> PolicyAction:
-        return lambda actor: actor.role == UserRole.admin or workspace in actor.workspaces
-
-    @classmethod
     def delete(cls, dataset: Dataset) -> PolicyAction:
-        return lambda actor: actor.role == UserRole.admin or actor.username == dataset.created_by
+        return lambda actor: actor.is_admin or actor.username == dataset.created_by
 
 
 def authorize(actor: User, policy_action: PolicyAction) -> None:


### PR DESCRIPTION
Using the `DELETE /api/datasets/:name`, this PR shows how the integration with the new database, models, and policies could be applied.

- A new `DatasetPolicy` class has been created
- The current user used for this endpoint is now a `models.User` instance (using the new method `provider.get_current_user`)