### PR TITLE
Support api-key and password as parameter when using users.create_default task

### DIFF
--- a/src/argilla/_constants.py
+++ b/src/argilla/_constants.py
@@ -13,14 +13,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-DEFAULT_MAX_KEYWORD_LENGTH = 128
-
 API_KEY_HEADER_NAME = "X-Argilla-Api-Key"
 WORKSPACE_HEADER_NAME = "X-Argilla-Workspace"
 
 DEFAULT_USERNAME = "argilla"
 DEFAULT_PASSWORD = "1234"
-DEFAULT_API_KEY = "argilla.apikey"  # Keep the same api key for now
+DEFAULT_API_KEY = "argilla.apikey"
+DEFAULT_MAX_KEYWORD_LENGTH = 128
+DEFAULT_TELEMETRY_KEY = "C6FkcaoCbt78rACAgvyBxGBcMB3dM3nn"
 
 # TODO: This constant will be drop out with issue
 #  https://github.com/argilla-io/argilla/issues/2251 fix
@@ -29,6 +29,3 @@ _OLD_API_KEY_HEADER_NAME = "X-Rubrix-Api-Key"
 _OLD_WORKSPACE_HEADER_NAME = "X-Rubrix-Workspace"
 
 ES_INDEX_REGEX_PATTERN = r"^(?!-|_)[a-z0-9-_]+$"
-
-
-DEFAULT_TELEMETRY_KEY = "C6FkcaoCbt78rACAgvyBxGBcMB3dM3nn"

--- a/src/argilla/server/settings.py
+++ b/src/argilla/server/settings.py
@@ -24,7 +24,12 @@ from urllib.parse import urlparse
 
 from pydantic import BaseSettings, Field, root_validator, validator
 
-from argilla._constants import DEFAULT_MAX_KEYWORD_LENGTH, DEFAULT_TELEMETRY_KEY
+from argilla._constants import (
+    DEFAULT_API_KEY,
+    DEFAULT_MAX_KEYWORD_LENGTH,
+    DEFAULT_PASSWORD,
+    DEFAULT_TELEMETRY_KEY,
+)
 
 
 class Settings(BaseSettings):
@@ -61,6 +66,9 @@ class Settings(BaseSettings):
 
     __DATASETS_INDEX_NAME__ = "ar.datasets"
     __DATASETS_RECORDS_INDEX_NAME__ = "ar.dataset.{}"
+
+    api_key: str = Field(default=DEFAULT_API_KEY, description="The api key used when creating default user")
+    password: str = Field(default=DEFAULT_PASSWORD, description="The password used when creating default user")
 
     home_path: Optional[str] = Field(description="The home path where argilla related files will be stored")
     base_url: Optional[str] = Field(description="The default base url where server will be deployed")

--- a/src/argilla/server/settings.py
+++ b/src/argilla/server/settings.py
@@ -24,12 +24,7 @@ from urllib.parse import urlparse
 
 from pydantic import BaseSettings, Field, root_validator, validator
 
-from argilla._constants import (
-    DEFAULT_API_KEY,
-    DEFAULT_MAX_KEYWORD_LENGTH,
-    DEFAULT_PASSWORD,
-    DEFAULT_TELEMETRY_KEY,
-)
+from argilla._constants import DEFAULT_MAX_KEYWORD_LENGTH, DEFAULT_TELEMETRY_KEY
 
 
 class Settings(BaseSettings):
@@ -66,9 +61,6 @@ class Settings(BaseSettings):
 
     __DATASETS_INDEX_NAME__ = "ar.datasets"
     __DATASETS_RECORDS_INDEX_NAME__ = "ar.dataset.{}"
-
-    api_key: str = Field(default=DEFAULT_API_KEY, description="The api key used when creating default user")
-    password: str = Field(default=DEFAULT_PASSWORD, description="The password used when creating default user")
 
     home_path: Optional[str] = Field(description="The home path where argilla related files will be stored")
     base_url: Optional[str] = Field(description="The default base url where server will be deployed")

--- a/src/argilla/tasks/users/create_default.py
+++ b/src/argilla/tasks/users/create_default.py
@@ -14,10 +14,11 @@
 
 import click
 
-from argilla._constants import DEFAULT_API_KEY, DEFAULT_PASSWORD, DEFAULT_USERNAME
+from argilla._constants import DEFAULT_USERNAME
 from argilla.server.contexts import accounts
 from argilla.server.database import SessionLocal
 from argilla.server.models import User, UserRole, Workspace
+from argilla.server.settings import settings
 
 
 @click.command()
@@ -30,8 +31,8 @@ def create_default(quiet: bool):
                 first_name="",
                 username=DEFAULT_USERNAME,
                 role=UserRole.admin,
-                api_key=DEFAULT_API_KEY,
-                password_hash=accounts.hash_password(DEFAULT_PASSWORD),
+                api_key=settings.api_key,
+                password_hash=accounts.hash_password(settings.password),
                 workspaces=[Workspace(name=DEFAULT_USERNAME)],
             )
         )
@@ -39,8 +40,8 @@ def create_default(quiet: bool):
     if not quiet:
         click.echo("User with default credentials succesfully created:")
         click.echo(f"• username: {DEFAULT_USERNAME!r}")
-        click.echo(f"• password: {DEFAULT_PASSWORD!r}")
-        click.echo(f"• api_key:  {DEFAULT_API_KEY!r}")
+        click.echo(f"• password: {settings.password!r}")
+        click.echo(f"• api_key:  {settings.api_key!r}")
 
 
 if __name__ == "__main__":

--- a/src/argilla/tasks/users/create_default.py
+++ b/src/argilla/tasks/users/create_default.py
@@ -26,7 +26,13 @@ from argilla.server.models import User, UserRole, Workspace
 @click.option("-q", "--quiet", is_flag=True, default=False, help="Run without output.")
 def create_default(api_key: str, password: str, quiet: bool):
     """Creates a user with default credentials on database suitable to start experimenting with argilla."""
-    with SessionLocal() as session, session.begin():
+    with SessionLocal() as session:
+        if accounts.get_user_by_username(session, DEFAULT_USERNAME):
+            if not quiet:
+                click.echo(f"User with default username already found on database, will not do anything.")
+
+            return
+
         session.add(
             User(
                 first_name="",
@@ -37,12 +43,13 @@ def create_default(api_key: str, password: str, quiet: bool):
                 workspaces=[Workspace(name=DEFAULT_USERNAME)],
             )
         )
+        session.commit()
 
-    if not quiet:
-        click.echo("User with default credentials succesfully created:")
-        click.echo(f"• username: {DEFAULT_USERNAME!r}")
-        click.echo(f"• password: {password!r}")
-        click.echo(f"• api_key:  {api_key!r}")
+        if not quiet:
+            click.echo("User with default credentials succesfully created:")
+            click.echo(f"• username: {DEFAULT_USERNAME!r}")
+            click.echo(f"• password: {password!r}")
+            click.echo(f"• api_key:  {api_key!r}")
 
 
 if __name__ == "__main__":

--- a/src/argilla/tasks/users/create_default.py
+++ b/src/argilla/tasks/users/create_default.py
@@ -14,16 +14,17 @@
 
 import click
 
-from argilla._constants import DEFAULT_USERNAME
+from argilla._constants import DEFAULT_API_KEY, DEFAULT_PASSWORD, DEFAULT_USERNAME
 from argilla.server.contexts import accounts
 from argilla.server.database import SessionLocal
 from argilla.server.models import User, UserRole, Workspace
-from argilla.server.settings import settings
 
 
 @click.command()
+@click.option("--api-key", default=DEFAULT_API_KEY, help="API key for the user.")
+@click.option("--password", default=DEFAULT_PASSWORD, help="Password for the user.")
 @click.option("-q", "--quiet", is_flag=True, default=False, help="Run without output.")
-def create_default(quiet: bool):
+def create_default(api_key: str, password: str, quiet: bool):
     """Creates a user with default credentials on database suitable to start experimenting with argilla."""
     with SessionLocal() as session, session.begin():
         session.add(
@@ -31,8 +32,8 @@ def create_default(quiet: bool):
                 first_name="",
                 username=DEFAULT_USERNAME,
                 role=UserRole.admin,
-                api_key=settings.api_key,
-                password_hash=accounts.hash_password(settings.password),
+                api_key=api_key,
+                password_hash=accounts.hash_password(password),
                 workspaces=[Workspace(name=DEFAULT_USERNAME)],
             )
         )
@@ -40,8 +41,8 @@ def create_default(quiet: bool):
     if not quiet:
         click.echo("User with default credentials succesfully created:")
         click.echo(f"• username: {DEFAULT_USERNAME!r}")
-        click.echo(f"• password: {settings.password!r}")
-        click.echo(f"• api_key:  {settings.api_key!r}")
+        click.echo(f"• password: {password!r}")
+        click.echo(f"• api_key:  {api_key!r}")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/users/test_create_default.py
+++ b/tests/tasks/users/test_create_default.py
@@ -36,11 +36,8 @@ def test_create_default(db: Session):
     assert [ws.name for ws in default_user.workspaces] == [DEFAULT_USERNAME]
 
 
-def test_create_default_with_specific_api_key_and_password(monkeypatch, db: Session):
-    monkeypatch.setattr(settings, "api_key", "my-api-key")
-    monkeypatch.setattr(settings, "password", "my-password")
-
-    result = CliRunner().invoke(create_default)
+def test_create_default_with_specific_api_key_and_password(db: Session):
+    result = CliRunner().invoke(create_default, "--api-key my-api-key --password my-password")
 
     assert result.exit_code == 0
     assert result.output != ""

--- a/tests/tasks/users/test_create_default.py
+++ b/tests/tasks/users/test_create_default.py
@@ -56,3 +56,32 @@ def test_create_default_quiet(db: Session):
 
     assert result.exit_code == 0
     assert result.output == ""
+    assert db.query(User).count() == 1
+
+
+def test_create_default_with_existent_default_user(db: Session):
+    result = CliRunner().invoke(create_default)
+
+    assert result.exit_code == 0
+    assert result.output != ""
+    assert db.query(User).count() == 1
+
+    result = CliRunner().invoke(create_default)
+
+    assert result.exit_code == 0
+    assert result.output == "User with default username already found on database, will not do anything.\n"
+    assert db.query(User).count() == 1
+
+
+def test_create_default_with_existent_default_user_and_quiet(db: Session):
+    result = CliRunner().invoke(create_default)
+
+    assert result.exit_code == 0
+    assert result.output != ""
+    assert db.query(User).count() == 1
+
+    result = CliRunner().invoke(create_default, ["--quiet"])
+
+    assert result.exit_code == 0
+    assert result.output == ""
+    assert db.query(User).count() == 1

--- a/tests/tasks/users/test_create_default.py
+++ b/tests/tasks/users/test_create_default.py
@@ -15,7 +15,6 @@
 from argilla._constants import DEFAULT_API_KEY, DEFAULT_PASSWORD, DEFAULT_USERNAME
 from argilla.server.contexts import accounts
 from argilla.server.models import User, UserRole
-from argilla.server.settings import settings
 from argilla.tasks.users.create_default import create_default
 from click.testing import CliRunner
 from sqlalchemy.orm import Session


### PR DESCRIPTION
This PR includes the following changes:
* Adds `--api-key` and `--password` parameters to `argilla.tasks.users.create_default`.
* Now `argilla.tasks.users.create_default` checks if there is a user using default username before creating it and showing a message in such case (but not raising an error).