### PR TITLE
Make workspace mandatory for dataset requests

### DIFF
--- a/src/argilla/server/apis/v0/handlers/datasets.py
+++ b/src/argilla/server/apis/v0/handlers/datasets.py
@@ -19,7 +19,10 @@ from fastapi import APIRouter, Body, Depends, Security
 from pydantic import parse_obj_as
 
 from argilla.server.apis.v0.helpers import deprecate_endpoint
-from argilla.server.apis.v0.models.commons.params import CommonTaskHandlerDependencies
+from argilla.server.apis.v0.models.commons.params import (
+    CommonTaskHandlerDependencies,
+    OptionalWorkspaceRequestDependency,
+)
 from argilla.server.errors import EntityNotFoundError
 from argilla.server.models import User
 from argilla.server.schemas.datasets import (
@@ -43,13 +46,13 @@ router = APIRouter(tags=["datasets"], prefix="/datasets")
     operation_id="list_datasets",
 )
 async def list_datasets(
-    request_deps: CommonTaskHandlerDependencies = Depends(),
+    workspace_request: OptionalWorkspaceRequestDependency = Depends(),
     service: DatasetsService = Depends(DatasetsService.get_instance),
     current_user: User = Security(auth.get_current_user),
 ) -> List[Dataset]:
     datasets = service.list(
         user=current_user,
-        workspaces=[request_deps.workspace] if request_deps.workspace is not None else None,
+        workspaces=[workspace_request.workspace] if workspace_request.workspace is not None else None,
     )
 
     return parse_obj_as(List[Dataset], datasets)

--- a/src/argilla/server/apis/v0/models/commons/params.py
+++ b/src/argilla/server/apis/v0/models/commons/params.py
@@ -21,6 +21,7 @@ from argilla._constants import (
     ES_INDEX_REGEX_PATTERN,
     WORKSPACE_HEADER_NAME,
 )
+from argilla.server.errors import BadRequestError, MissingInputParamError
 
 DATASET_NAME_PATH_PARAM = Path(..., regex=ES_INDEX_REGEX_PATTERN, description="The dataset name")
 
@@ -34,26 +35,29 @@ class RequestPagination:
 
 
 @dataclass
-class CommonTaskHandlerDependencies:
+class OptionalWorkspaceRequestDependency:
     """Common task query dependencies"""
 
-    # TODO(@frascuchon): we could include the request user and parametrize the action scopes
-    #   Depends(CommonTaskHandlerDependencies.create(scopes=[...])
+    _description = (
+        "The workspace where dataset belongs to. A valid workspace name should be provided. "
+        "If not provided, the request will raise a 400 response error."
+    )
 
-    __workspace_header__: str = Header(None, alias=WORKSPACE_HEADER_NAME)
-    __old_workspace_header__: str = Header(
-        None,
-        alias=_OLD_WORKSPACE_HEADER_NAME,
-        description="This is for backward comp. with old clients",
-    )
-    __workspace_param__: str = Query(
-        None,
-        alias="workspace",
-        description="The workspace where dataset belongs to. If not provided default user team will be used",
-    )
+    __workspace_header__: str = Header(None, alias=WORKSPACE_HEADER_NAME, deprecated=True, description=_description)
+
+    __workspace_param__: str = Query(None, alias="workspace", description=_description)
 
     @property
     def workspace(self) -> str:
         """Return read workspace. Query param prior to header param"""
-        workspace = self.__workspace_param__ or self.__workspace_header__ or self.__old_workspace_header__
+        return self.__workspace_param__ or self.__workspace_header__
+
+
+@dataclass
+class CommonTaskHandlerDependencies(OptionalWorkspaceRequestDependency):
+    @property
+    def workspace(self) -> str:
+        workspace = super().workspace
+        if not workspace:
+            raise MissingInputParamError("A workspace must be provided!")
         return workspace

--- a/src/argilla/server/apis/v0/models/commons/params.py
+++ b/src/argilla/server/apis/v0/models/commons/params.py
@@ -59,5 +59,5 @@ class CommonTaskHandlerDependencies(OptionalWorkspaceRequestDependency):
     def workspace(self) -> str:
         workspace = super().workspace
         if not workspace:
-            raise MissingInputParamError("A workspace must be provided!")
+            raise MissingInputParamError("A workspace must be provided")
         return workspace

--- a/src/argilla/server/server.py
+++ b/src/argilla/server/server.py
@@ -31,7 +31,7 @@ from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
-from pydantic import ConfigError
+from pydantic import ConfigError, ValidationError
 
 from argilla import __version__ as argilla_version
 from argilla._constants import DEFAULT_API_KEY, DEFAULT_PASSWORD, DEFAULT_USERNAME
@@ -45,8 +45,11 @@ from argilla.server.daos.records import DatasetRecordsDAO
 from argilla.server.database import get_db
 from argilla.server.errors import (
     APIErrorHandler,
+    ClosedDatasetError,
+    EntityAlreadyExistsError,
     EntityNotFoundError,
     ForbiddenOperationError,
+    MissingInputParamError,
     UnauthorizedError,
 )
 from argilla.server.models import User
@@ -78,6 +81,10 @@ def configure_api_exceptions(api: FastAPI):
     api.exception_handler(Exception)(APIErrorHandler.common_exception_handler)
     api.exception_handler(UnauthorizedError)(APIErrorHandler.common_exception_handler)
     api.exception_handler(ForbiddenOperationError)(APIErrorHandler.common_exception_handler)
+    api.exception_handler(EntityAlreadyExistsError)(APIErrorHandler.common_exception_handler)
+    api.exception_handler(ClosedDatasetError)(APIErrorHandler.common_exception_handler)
+    api.exception_handler(ValidationError)(APIErrorHandler.common_exception_handler)
+    api.exception_handler(MissingInputParamError)(APIErrorHandler.common_exception_handler)
     api.exception_handler(RequestValidationError)(APIErrorHandler.common_exception_handler)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,11 @@ def admin_auth_header(db, admin):
     return {API_KEY_HEADER_NAME: admin.api_key}
 
 
+@pytest.fixture(scope="function")
+def argilla_auth_header(db, argilla_user):
+    return {API_KEY_HEADER_NAME: argilla_user.api_key}
+
+
 @pytest.fixture
 def argilla_user(db):
     user = User(

--- a/tests/server/datasets/test_api.py
+++ b/tests/server/datasets/test_api.py
@@ -12,96 +12,163 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Optional
+from typing import Any, Dict, List
 
+import pytest
+from argilla._constants import API_KEY_HEADER_NAME
 from argilla.server.apis.v0.models.text_classification import (
     TextClassificationBulkRequest,
 )
 from argilla.server.commons.models import TaskType
+from argilla.server.models import User
 from argilla.server.schemas.datasets import Dataset
+from starlette.testclient import TestClient
 
 from tests.factories import WorkspaceUserFactory
-from tests.helpers import SecuredClient
 
 
-def test_delete_dataset(mocked_client):
-    dataset = "test_delete_dataset"
-    create_mock_dataset(mocked_client, dataset)
+@pytest.fixture(scope="function")
+def dataset_name(test_client: TestClient, argilla_user: User, argilla_auth_header: dict):
+    dataset_name = "test_dataset"
+    try:
+        test_client.delete(
+            f"/api/datasets/{dataset_name}?workspace={argilla_user.username}", headers=argilla_auth_header
+        )
+        yield dataset_name
+    finally:
+        test_client.delete(
+            f"/api/datasets/{dataset_name}?workspace={argilla_user.username}",
+            headers=argilla_auth_header,
+        )
 
-    delete_dataset(mocked_client, dataset)
 
-    response = mocked_client.get(f"/api/datasets/{dataset}")
-    assert response.status_code == 404
+def delete_dataset(client: TestClient, dataset_name, workspace: str, headers: Dict[str, Any]):
+    url = f"/api/datasets/{dataset_name}?workspace={workspace}"
+
+    client.delete(url, headers=headers)
+
+
+def create_mock_dataset(
+    client: TestClient, dataset_name: str, headers: Dict[str, Any], workspace: str, records: List = None
+):
+    url = f"/api/datasets/{dataset_name}/TextClassification:bulk?workspace={workspace}"
+
+    bulk_data = TextClassificationBulkRequest(
+        tags={"env": "test", "class": "text classification"},
+        metadata={"config": {"the": "config"}},
+        records=records or [],
+    ).dict(by_alias=True)
+
+    response = client.post(url, json=bulk_data, headers=headers)
+    assert response.status_code == 200, response.json()
+
+
+def test_delete_dataset(test_client: TestClient, argilla_user: User, argilla_auth_header: dict, dataset_name: str):
+    workspace_name = argilla_user.username
+
+    create_mock_dataset(test_client, dataset_name=dataset_name, workspace=workspace_name, headers=argilla_auth_header)
+
+    delete_dataset(test_client, dataset_name=dataset_name, workspace=workspace_name, headers=argilla_auth_header)
+
+    response = test_client.get(f"/api/datasets/{dataset_name}?workspace={workspace_name}", headers=argilla_auth_header)
+    assert response.status_code == 404, response.json()
+
     assert response.json() == {
         "detail": {
             "code": "argilla.api.errors::EntityNotFoundError",
-            "params": {"name": "test_delete_dataset", "type": "ServiceDataset"},
+            "params": {"name": dataset_name, "type": "ServiceDataset"},
         }
     }
 
 
-def test_create_dataset(mocked_client):
-    dataset_name = "test_create_dataset"
-    delete_dataset(mocked_client, dataset_name)
+def test_delete_dataset_with_missing_workspace(test_client: TestClient, argilla_user: User, argilla_auth_header: dict):
+    response = test_client.delete(f"/api/datasets/dataset", headers=argilla_auth_header)
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": {
+            "code": "argilla.api.errors::MissingInputParamError",
+            "params": {"message": "A workspace must be provided!"},
+        }
+    }
+
+
+def test_create_dataset(test_client: TestClient, argilla_user: User, argilla_auth_header: dict, dataset_name: str):
+    workspace_name = argilla_user.username
+
     request = dict(
         name=dataset_name,
         task=TaskType.text_classification,
         tags={"env": "test", "class": "text classification"},
         metadata={"config": {"the": "config"}},
     )
-    response = mocked_client.post(
-        "/api/datasets",
-        json=request,
-    )
+
+    response = test_client.post(f"/api/datasets?workspace={workspace_name}", json=request, headers=argilla_auth_header)
     assert response.status_code == 200
+
     dataset = Dataset.parse_obj(response.json())
+
     assert dataset.id
-    assert dataset.created_by == "argilla"
+    assert dataset.created_by == argilla_user.username
     assert dataset.metadata == request["metadata"]
     assert dataset.tags == request["tags"]
     assert dataset.name == dataset_name
-    assert dataset.workspace == "argilla"
+    assert dataset.workspace == workspace_name
     assert dataset.task == TaskType.text_classification
 
-    response = mocked_client.post(
-        "/api/datasets",
-        json=request,
+
+def test_create_dataset_with_already_created_error(
+    test_client: TestClient, argilla_user: User, argilla_auth_header: dict, dataset_name: str
+):
+    workspace_name = argilla_user.username
+
+    create_mock_dataset(test_client, dataset_name=dataset_name, headers=argilla_auth_header, workspace=workspace_name)
+
+    response = test_client.post(
+        f"/api/datasets?workspace={workspace_name}",
+        json={"name": dataset_name, "task": TaskType.text_classification},
+        headers=argilla_auth_header,
     )
     assert response.status_code == 409
 
 
-def test_fetch_dataset_using_workspaces(mocked_client: SecuredClient, mock_user):
-    dataset_name = "test_fetch_dataset_using_workspaces"
+def test_create_workspace_with_missing_workspace(
+    test_client: TestClient, argilla_user: User, argilla_auth_header: dict
+):
+    dataset_name = "missing-workspace-dataset"
 
-    mocked_client.update_api_key(mock_user.api_key)
+    response = test_client.post(
+        "/api/datasets",
+        json={"name": dataset_name, "task": TaskType.text_classification},
+        headers=argilla_auth_header,
+    )
 
+    assert response.status_code == 400
+
+
+def test_create_dataset_using_several_workspaces(
+    test_client: TestClient, argilla_user: User, mock_user: User, argilla_auth_header: dict, dataset_name: str
+):
+    mock_auth_headers = {API_KEY_HEADER_NAME: mock_user.api_key}
     for workspace in mock_user.workspaces:
-        for workspace in mock_user.workspaces:
-            delete_dataset(mocked_client, dataset_name, workspace=workspace.name)
+        delete_dataset(test_client, dataset_name=dataset_name, workspace=workspace.name, headers=mock_auth_headers)
 
-        request = dict(
-            name=dataset_name,
-            task=TaskType.text_classification,
-        )
+        request = dict(name=dataset_name, task=TaskType.text_classification)
 
         workspace = workspace.name
-
-        response = mocked_client.post(
-            f"/api/datasets?workspace={workspace}",
-            json=request,
-        )
+        response = test_client.post(f"/api/datasets?workspace={workspace}", json=request, headers=mock_auth_headers)
 
         assert response.status_code == 200, response.json()
+
         dataset = Dataset.parse_obj(response.json())
+
         assert dataset.created_by == mock_user.username
         assert dataset.name == dataset_name
         assert dataset.owner == workspace
         assert dataset.task == TaskType.text_classification
 
-        response = mocked_client.post(
-            f"/api/datasets?workspace={workspace}",
-            json=request,
-        )
+        response = test_client.post(f"/api/datasets?workspace={workspace}", json=request, headers=mock_auth_headers)
+
         assert response.status_code == 409, response.json()
 
         another_ws = None
@@ -110,49 +177,29 @@ def test_fetch_dataset_using_workspaces(mocked_client: SecuredClient, mock_user)
                 another_ws = ws.name
                 break
 
-        response = mocked_client.post(
-            f"/api/datasets?workspace={another_ws}",
-            json=request,
-        )
+        response = test_client.post(f"/api/datasets?workspace={another_ws}", json=request, headers=mock_auth_headers)
 
         assert response.status_code == 200, response.json()
+
         dataset = Dataset.parse_obj(response.json())
+
         assert dataset.created_by == mock_user.username
         assert dataset.name == dataset_name
-        assert dataset.owner == another_ws
+        assert dataset.workspace == another_ws
         assert dataset.task == TaskType.text_classification
 
 
-def test_dataset_naming_validation(mocked_client):
+@pytest.mark.parametrize("task", [TaskType.text_classification, TaskType.token_classification, TaskType.text2text])
+def test_dataset_naming_validation(test_client: TestClient, argilla_user: User, argilla_auth_header: dict, task):
     request = TextClassificationBulkRequest(records=[])
-    dataset = "Wrong dataset name"
+    dataset_name = "Wrong dataset name"
 
-    response = mocked_client.post(
-        f"/api/datasets/{dataset}/TextClassification:bulk",
+    response = test_client.post(
+        f"/api/datasets/{dataset_name}/{task}:bulk?workspace={argilla_user.username}",
         json=request.dict(by_alias=True),
+        headers=argilla_auth_header,
     )
-    assert response.status_code == 422
-    assert response.json() == {
-        "detail": {
-            "code": "argilla.api.errors::ValidationError",
-            "params": {
-                "errors": [
-                    {
-                        "ctx": {"pattern": "^(?!-|_)[a-z0-9-_]+$"},
-                        "loc": ["name"],
-                        "msg": "string does not match regex " '"^(?!-|_)[a-z0-9-_]+$"',
-                        "type": "value_error.str.regex",
-                    }
-                ],
-                "model": "CreateDatasetRequest",
-            },
-        }
-    }
 
-    response = mocked_client.post(
-        f"/api/datasets/{dataset}/TokenClassification:bulk",
-        json=request.dict(by_alias=True),
-    )
     assert response.status_code == 422
     assert response.json() == {
         "detail": {
@@ -172,84 +219,89 @@ def test_dataset_naming_validation(mocked_client):
     }
 
 
-def test_list_datasets(mocked_client):
-    dataset = "test_list_datasets"
-    delete_dataset(mocked_client, dataset)
+def test_list_datasets(test_client: TestClient, argilla_user: User, argilla_auth_header: dict, dataset_name: str):
+    create_mock_dataset(
+        test_client, dataset_name=dataset_name, headers=argilla_auth_header, workspace=argilla_user.username
+    )
 
-    create_mock_dataset(mocked_client, dataset)
-
-    response = mocked_client.get("/api/datasets/")
+    response = test_client.get(f"/api/datasets?workspace={argilla_user.username}", headers=argilla_auth_header)
     assert response.status_code == 200
 
     datasets = [Dataset.parse_obj(item) for item in response.json()]
     assert len(datasets) > 0
-    assert dataset in [ds.name for ds in datasets]
+
+    assert dataset_name in [ds.name for ds in datasets]
     for ds in datasets:
         assert ds.id
 
 
-def test_update_dataset(mocked_client):
-    dataset = "test_update_dataset"
-    delete_dataset(mocked_client, dataset)
-    create_mock_dataset(mocked_client, dataset)
+def test_list_datasets_without_workspace(test_client: TestClient, argilla_user: User, argilla_auth_header: dict):
+    response = test_client.get("/api/datasets", headers=argilla_auth_header)
 
-    response = mocked_client.patch(f"/api/datasets/{dataset}", json={"metadata": {"new": "value"}})
     assert response.status_code == 200
 
-    response = mocked_client.get(f"/api/datasets/{dataset}")
+
+def test_update_dataset(test_client: TestClient, argilla_user: User, argilla_auth_header: dict, dataset_name: str):
+    create_mock_dataset(
+        test_client, dataset_name=dataset_name, headers=argilla_auth_header, workspace=argilla_user.username
+    )
+
+    response = test_client.patch(
+        f"/api/datasets/{dataset_name}?workspace={argilla_user.username}",
+        json={"metadata": {"new": "value"}},
+        headers=argilla_auth_header,
+    )
     assert response.status_code == 200
+
+    response = test_client.get(
+        f"/api/datasets/{dataset_name}?workspace={argilla_user.username}", headers=argilla_auth_header
+    )
+    assert response.status_code == 200, response.json()
+
     ds = Dataset.parse_obj(response.json())
     assert ds.metadata["new"] == "value"
 
 
-def test_open_and_close_dataset(mocked_client):
-    dataset = "test_open_and_close_dataset"
-    delete_dataset(mocked_client, dataset)
-    create_mock_dataset(mocked_client, dataset)
+def test_open_and_close_dataset(
+    test_client: TestClient, argilla_user: User, argilla_auth_header: dict, dataset_name: str
+):
+    workspace_name = argilla_user.username
+    endpoint_url = f"/api/datasets/{dataset_name}:{{action}}?workspace={workspace_name}"
 
-    assert mocked_client.put(f"/api/datasets/{dataset}:close").status_code == 200
+    create_mock_dataset(test_client, dataset_name=dataset_name, workspace=workspace_name, headers=argilla_auth_header)
 
-    response = mocked_client.post(f"/api/datasets/{dataset}/TextClassification:search")
+    assert test_client.put(endpoint_url.format(action="close"), headers=argilla_auth_header).status_code == 200
+
+    response = test_client.post(
+        f"/api/datasets/{dataset_name}/TextClassification:search?workspace={workspace_name}",
+        headers=argilla_auth_header,
+    )
     assert response.status_code == 400
     assert response.json() == {
-        "detail": {
-            "code": "argilla.api.errors::ClosedDatasetError",
-            "params": {"name": dataset},
-        }
+        "detail": {"code": "argilla.api.errors::ClosedDatasetError", "params": {"name": dataset_name}}
     }
 
-    assert mocked_client.put(f"/api/datasets/{dataset}:open").status_code == 200
-    assert mocked_client.post(f"/api/datasets/{dataset}/TextClassification:search").status_code == 200
-
-
-def delete_dataset(client, dataset, workspace: Optional[str] = None):
-    url = f"/api/datasets/{dataset}"
-    if workspace:
-        url += f"?workspace={workspace}"
-    assert client.delete(url).status_code == 200
-
-
-def create_mock_dataset(client, dataset, records=[]):
-    client.post(
-        f"/api/datasets/{dataset}/TextClassification:bulk",
-        json=TextClassificationBulkRequest(
-            tags={"env": "test", "class": "text classification"},
-            metadata={"config": {"the": "config"}},
-            records=records,
-        ).dict(by_alias=True),
+    assert test_client.put(endpoint_url.format(action="open"), headers=argilla_auth_header).status_code == 200
+    assert (
+        test_client.post(
+            f"/api/datasets/{dataset_name}/TextClassification:search?workspace={workspace_name}",
+            headers=argilla_auth_header,
+        ).status_code
+        == 200
     )
 
 
-def test_delete_records(mocked_client, argilla_user, mock_user):
-    dataset_name = "test_delete_records"
-    delete_dataset(mocked_client, dataset_name)
-
+def test_delete_records(
+    test_client: TestClient, argilla_user: User, mock_user: User, argilla_auth_header: dict, dataset_name: str
+):
     for workspace in argilla_user.workspaces:
         WorkspaceUserFactory.create(workspace_id=workspace.id, user_id=mock_user.id)
 
     create_mock_dataset(
-        mocked_client,
-        dataset=dataset_name,
+        test_client,
+        dataset_name=dataset_name,
+        workspace=argilla_user.username,
+        headers=argilla_auth_header,
         records=[
             {
                 "id": i,
@@ -258,16 +310,21 @@ def test_delete_records(mocked_client, argilla_user, mock_user):
             for i in range(1, 100)
         ],
     )
-    response = mocked_client.delete(
-        f"/api/datasets/{dataset_name}/data",
+    response = test_client.request(
+        "DELETE",
+        url=f"/api/datasets/{dataset_name}/data?workspace={argilla_user.username}",
         json={"ids": [1]},
+        headers=argilla_auth_header,
     )
+
     assert response.status_code == 200
     assert response.json() == {"matched": 1, "processed": 1}
 
-    mocked_client.update_api_key(mock_user.api_key)
+    response = test_client.delete(
+        f"/api/datasets/{dataset_name}/data?workspace={argilla_user.username}",
+        headers={API_KEY_HEADER_NAME: mock_user.api_key},
+    )
 
-    response = mocked_client.delete(f"/api/datasets/{dataset_name}/data?workspace=argilla")
     assert response.status_code == 403
     assert response.json() == {
         "detail": {
@@ -279,9 +336,10 @@ def test_delete_records(mocked_client, argilla_user, mock_user):
         }
     }
 
-    response = mocked_client.delete(f"/api/datasets/{dataset_name}/data?mark_as_discarded=true&workspace=argilla")
+    response = test_client.delete(
+        f"/api/datasets/{dataset_name}/data?mark_as_discarded=true&workspace={argilla_user.username}",
+        headers={API_KEY_HEADER_NAME: mock_user.api_key},
+    )
+
     assert response.status_code == 200
-    assert response.json() == {
-        "matched": 99,
-        "processed": 98,
-    }  # different values are caused by conflicts found
+    assert response.json() == {"matched": 99, "processed": 98}  # different values are caused by conflicts found

--- a/tests/server/datasets/test_api.py
+++ b/tests/server/datasets/test_api.py
@@ -82,7 +82,7 @@ def test_delete_dataset(test_client: TestClient, argilla_user: User, argilla_aut
 
 
 def test_delete_dataset_with_missing_workspace(test_client: TestClient, argilla_user: User, argilla_auth_header: dict):
-    response = test_client.delete(f"/api/datasets/dataset", headers=argilla_auth_header)
+    response = test_client.delete("/api/datasets/dataset", headers=argilla_auth_header)
 
     assert response.status_code == 400
     assert response.json() == {


### PR DESCRIPTION
The workspace name will be mandatory for those requests working with datasets.

All except the dataset list, which will remain optional.

Also, the dataset tests are upgraded using the `test_client` fixture, instead of custom mocked_client