### PR TITLE
Add admin password and admin api-key to release Dockerfile

### DIFF
--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.9-slim
 
 # Environment Variables
 ENV ARGILLA_HOME_PATH=/var/lib/argilla
+ENV ADMIN_PASSWORD=1234
+ENV ADMIN_API_KEY=argilla.apikey
 ENV USERS_DB=/config/.users.yml
 ENV UVICORN_PORT=6900
 

--- a/scripts/start_argilla_server.sh
+++ b/scripts/start_argilla_server.sh
@@ -5,7 +5,7 @@ set -e
 python -m argilla.tasks.database.migrate
 
 # Create default user
-python -m argilla.tasks.users.create_default --quiet
+python -m argilla.tasks.users.create_default --password $ADMIN_PASSWORD --api-key $ADMIN_API_KEY
 
 # Run argilla-server (See https://www.uvicorn.org/settings/#settings)
 #


### PR DESCRIPTION
Only adding two new env vars `ADMIN_PASSWORD` and `ADMIN_API_KEY` allowing the configuration of the password and api key when using `release.Dockerfile`.