### PR TITLE
fix: create equal sized batches within batch size for logging #2341

### DIFF
--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -393,13 +393,18 @@ class Argilla:
         # divide records in chunks of chunk size based on their byte size
         batch_size = int(batch_size / (len(records) / batch_size)) + 1
         n_batches = math.ceil(len(records) / batch_size)
-        rec_size = [sys.getsizeof(rec.json()) for rec in records]
-        records = [rec for _, rec in sorted(zip(rec_size, records), key=lambda pair: pair[0])]
-        records_new = dict.fromkeys(range(n_batches + 1), [])
-        while records:
-            for i in records_new:
-                records_new[i].append(records.pop(0))
-        records = [item for sublist in records_new.values() for item in sublist]
+        
+        if n_batches > 1:
+            rec_size = [sys.getsizeof(rec.json()) for rec in records]
+            records = [rec for _, rec in sorted(zip(rec_size, records), key=lambda pair: pair[0])]
+            
+            records_new = dict.fromkeys(range(n_batches), [])
+            for idx, record in enumerate(records):
+                records_new[idx % n_batches].append(record)
+            
+            records = []
+            for batch_list in records_new.values():
+                records.extend(batch_list)
 
         # log records
         processed, failed = 0, 0

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -393,15 +393,15 @@ class Argilla:
         # divide records in chunks of chunk size based on their byte size
         batch_size = int(batch_size / (len(records) / batch_size)) + 1
         n_batches = math.ceil(len(records) / batch_size)
-        
+
         if n_batches > 1:
             rec_size = [sys.getsizeof(rec.json()) for rec in records]
             records = [rec for _, rec in sorted(zip(rec_size, records), key=lambda pair: pair[0])]
-            
+
             records_new = dict.fromkeys(range(n_batches), [])
             for idx, record in enumerate(records):
                 records_new[idx % n_batches].append(record)
-            
+
             records = []
             for batch_list in records_new.values():
                 records.extend(batch_list)


### PR DESCRIPTION
# Description

dives logging data in equal batches in two ways
1. len(record) ==700 AND batch_size == 500 => batch_size = 350
2. if size of record [2,2,1,1] batches 0=>[[2,1][2,1]]

Closes #2341 
**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)


- [X] New feature (non-breaking change which adds functionality)


**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

Not sure how to test this

**Checklist**
N.A.