### PR TITLE
fix: added flag check for re-logging projection block #2534

### DIFF
--- a/src/argilla/client/models.py
+++ b/src/argilla/client/models.py
@@ -343,7 +343,7 @@ class TokenClassificationRecord(_Validators):
     search_keywords: Optional[List[str]] = None
     _span_utils: SpanUtils = PrivateAttr()
 
-    projection: Optional[bool] = None  # TODO: remove after https://github.com/argilla-io/argilla/issues/2535
+    projection: Optional[bool] = Field(default=None, exclude=True)  # TODO: remove after https://github.com/argilla-io/argilla/issues/2535
 
     def __init__(
         self,

--- a/src/argilla/client/models.py
+++ b/src/argilla/client/models.py
@@ -238,7 +238,9 @@ class TextClassificationRecord(_Validators):
     metrics: Optional[Dict[str, Any]] = None
     search_keywords: Optional[List[str]] = None
 
-    projection: Optional[bool] = None  # TODO: remove after https://github.com/argilla-io/argilla/issues/2535
+    projection: Optional[bool] = None  Field(
+        default=None, exclude=True
+    )  # TODO: remove after https://github.com/argilla-io/argilla/issues/2535
 
     @root_validator
     def _check_text_and_inputs(cls, values):
@@ -552,7 +554,9 @@ class Text2TextRecord(_Validators):
     metrics: Optional[Dict[str, Any]] = None
     search_keywords: Optional[List[str]] = None
 
-    projection: Optional[bool] = None  # TODO: remove after https://github.com/argilla-io/argilla/issues/2535
+    projection: Optional[bool] = None  Field(
+        default=None, exclude=True
+    )  # TODO: remove after https://github.com/argilla-io/argilla/issues/2535
 
     @validator("prediction")
     def prediction_as_tuples(cls, prediction: Optional[List[Union[str, Tuple[str, float]]]]):

--- a/src/argilla/client/models.py
+++ b/src/argilla/client/models.py
@@ -343,7 +343,9 @@ class TokenClassificationRecord(_Validators):
     search_keywords: Optional[List[str]] = None
     _span_utils: SpanUtils = PrivateAttr()
 
-    projection: Optional[bool] = Field(default=None, exclude=True)  # TODO: remove after https://github.com/argilla-io/argilla/issues/2535
+    projection: Optional[bool] = Field(
+        default=None, exclude=True
+    )  # TODO: remove after https://github.com/argilla-io/argilla/issues/2535
 
     def __init__(
         self,

--- a/src/argilla/client/models.py
+++ b/src/argilla/client/models.py
@@ -238,6 +238,8 @@ class TextClassificationRecord(_Validators):
     metrics: Optional[Dict[str, Any]] = None
     search_keywords: Optional[List[str]] = None
 
+    projection: Optional[bool] = None  # TODO: remove after https://github.com/argilla-io/argilla/issues/2535
+
     @root_validator
     def _check_text_and_inputs(cls, values):
         """Check if either text or inputs were provided. Copy text to inputs."""
@@ -340,6 +342,8 @@ class TokenClassificationRecord(_Validators):
     metrics: Optional[Dict[str, Any]] = None
     search_keywords: Optional[List[str]] = None
     _span_utils: SpanUtils = PrivateAttr()
+
+    projection: Optional[bool] = None  # TODO: remove after https://github.com/argilla-io/argilla/issues/2535
 
     def __init__(
         self,
@@ -545,6 +549,8 @@ class Text2TextRecord(_Validators):
 
     metrics: Optional[Dict[str, Any]] = None
     search_keywords: Optional[List[str]] = None
+
+    projection: Optional[bool] = None  # TODO: remove after https://github.com/argilla-io/argilla/issues/2535
 
     @validator("prediction")
     def prediction_as_tuples(cls, prediction: Optional[List[Union[str, Tuple[str, float]]]]):

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -160,6 +160,19 @@ def test_trailing_slash(mock_response_200):
     assert api.active_api()._client.base_url == "http://mock.com"
 
 
+def test_log_projection(mocked_client):
+    dataset_name = "test-dataset"
+    mocked_client.delete(f"/api/datasets/{dataset_name}")
+
+    api.init()
+    api.log(
+        name=dataset_name, records=rg.TextClassificationRecord(inputs={"text": "This is a test"}, annotation="label")
+    )
+    with pytest.raises(InputValueError):
+        rec = rg.load(dataset_name, fields=["id", "text"])
+        rg.log(rec, name=dataset_name)
+
+
 def test_log_something(mocked_client):
     dataset_name = "test-dataset"
     mocked_client.delete(f"/api/datasets/{dataset_name}")

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -252,6 +252,7 @@ class TestDatasetForTextClassification:
             "status",
             "event_timestamp",
             "metrics",
+            "projection",
         ]
         assert dataset_ds.features["prediction"] == [
             {
@@ -540,6 +541,7 @@ class TestDatasetForTokenClassification:
             "status",
             "event_timestamp",
             "metrics",
+            "projection",
         ]
         assert dataset_ds.features["prediction"] == [
             {
@@ -802,6 +804,7 @@ class TestDatasetForText2Text:
             "status",
             "event_timestamp",
             "metrics",
+            "projection",
         ]
         assert dataset_ds.features["prediction"] == [
             {

--- a/tests/client/test_models.py
+++ b/tests/client/test_models.py
@@ -210,7 +210,7 @@ def test_metadata_values_length():
 def test_model_serialization_with_numpy_nan():
     record = Text2TextRecord(text="My name is Sarah and I love my dog.", metadata={"nan": numpy.nan})
 
-    json_record = json.loads(record.json())
+    json.loads(record.json())
 
 
 def test_warning_when_only_agent():


### PR DESCRIPTION
# Description

avoids allowing users to potentially overwrite their original data after having obtained a projection of their data.

Closes #2534

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

See changes.

**Checklist**

N.A.