### PR TITLE
Explicit setup to add alembic.ini in package distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
+include src/argilla/alembic.ini
 graft src/argilla/server/static
 prune docs


### PR DESCRIPTION
It's what it is

@jfcalvo I see also that the `script.mako` file is not included by default. Do we need it?