### PR TITLE
Rich print via "[link]" syntax, fixes unresponsive URL in Jupyter Notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the fields to retrieve when loading the data from argilla. `rg.load` takes too long because of the vector field, even when users don't need it. Closes [#2398](https://github.com/argilla-io/argilla/issues/2398)
 
 
+### Fixes
+
+- Allow URL to be clickable in Jupyter notebook again. Closes [#2527](https://github.com/argilla-io/argilla/issues/2527)
+
+
 ### Removed
 
 - Removing some data scan deprecated endpoints used by old clients. This change will break compatibility with client `<v1.3.0`

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -419,7 +419,8 @@ class Argilla:
             workspace = self.get_workspace()
             if not workspace:  # Just for backward comp. with datasets with no workspaces
                 workspace = "-"
-            rprint(f"{processed} records logged to {self._client.base_url}/datasets/{workspace}/{name}")
+            url = f"{self._client.base_url}/datasets/{workspace}/{name}"
+            rprint(f"{processed} records logged to [link={url}]{url}[/link]")
 
         # Creating a composite BulkResponse with the total processed and failed
         return BulkResponse(dataset=name, processed=processed, failed=failed)


### PR DESCRIPTION
Closes #2527

Hello!

## Pull Request overview
* Print via the recommended [link syntax](https://rich.readthedocs.io/en/stable/markup.html#links).

## Details
See #2527 for details on the issue at hand. This PR allows the link to work in Jupyter notebooks again.

---

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

Manual verification that the URL is clickable both in a Jupyter Notebook environment and in the terminal.

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

---

- Tom Aarsen