### PR TITLE
Add support to create workspaces for argilla users.create task

### DIFF
--- a/src/argilla/tasks/users/create.py
+++ b/src/argilla/tasks/users/create.py
@@ -12,29 +12,32 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Optional
+from typing import List, Optional
 
 import click
+from sqlalchemy.orm import Session
 
 from argilla.server.contexts import accounts
 from argilla.server.database import SessionLocal
-from argilla.server.models import User, UserRole
-from argilla.server.security.model import USER_PASSWORD_MIN_LENGTH, UserCreate
+from argilla.server.models import User, UserRole, Workspace
+from argilla.server.security.model import (
+    USER_PASSWORD_MIN_LENGTH,
+    UserCreate,
+    WorkspaceCreate,
+)
 
 
-def _show_created_user(user: User):
-    message = f"\nUsername: {user.username!r}" f"\nRole: {user.role.value!r}" f"\nFirst name: {user.first_name!r}"
+class UserCreateWithWorkspaces(UserCreate):
+    workspaces: Optional[List[WorkspaceCreate]]
 
-    if user.last_name:
-        message += f"\nLast name: {user.last_name!r}"
 
-    message += f"\nAPI-Key: {user.api_key!r}"
-
-    return message
+def _get_or_new_workspace(session: Session, workspace_name: str):
+    return session.query(Workspace).filter_by(name=workspace_name).first() or Workspace(name=workspace_name)
 
 
 @click.command()
 @click.option("--first-name", prompt=True)
+@click.option("--last-name")
 @click.option(
     "--username",
     prompt=True,
@@ -46,23 +49,56 @@ def _show_created_user(user: User):
     type=click.Choice(UserRole.__members__, case_sensitive=False),
     default=UserRole.annotator,
     show_default=True,
+    help="A role for the user.",
 )
 @click.password_option(
-    "--password", prompt=True, help=f"A password with a minimum length of {USER_PASSWORD_MIN_LENGTH} characters."
+    "--password",
+    prompt=f"Password (min. {USER_PASSWORD_MIN_LENGTH} characters)",
+    help=f"A password with a minimum length of {USER_PASSWORD_MIN_LENGTH} characters.",
 )
-@click.option("--last-name", required=False)
-def create(first_name: str, username: str, role: UserRole, password: str, last_name: Optional[str]):
-    """Creates a new user in the Argilla DB with provided parameters"""
-
+@click.option(
+    "--workspace", multiple=True, help="A workspace that the user will be a member of (can be used multiple times)."
+)
+def create(
+    first_name: str,
+    username: str,
+    role: UserRole,
+    password: str,
+    last_name: Optional[str],
+    workspace: Optional[List[str]],
+):
+    """Creates a new user in the Argilla database with provided parameters"""
     with SessionLocal() as session:
-        user_create = UserCreate(
-            username=username, password=password, role=role, first_name=first_name, last_name=last_name
+        user_create = UserCreateWithWorkspaces(
+            first_name=first_name,
+            last_name=last_name,
+            username=username,
+            role=role,
+            password=password,
+            workspaces=[WorkspaceCreate(name=workspace_name) for workspace_name in workspace],
         )
-        user = accounts.create_user(session, user_create)
 
-        click.echo(f"User created successfully!")
-        click.echo(_show_created_user(user))
-        click.echo("\nPlease, save user credentials")
+        user = User(
+            first_name=user_create.first_name,
+            last_name=user_create.last_name,
+            username=user_create.username,
+            role=user_create.role,
+            password_hash=accounts.hash_password(user_create.password),
+            workspaces=[_get_or_new_workspace(session, workspace.name) for workspace in user_create.workspaces],
+        )
+
+        session.add(user)
+        session.commit()
+        session.refresh(user)
+
+        click.echo("User succesfully created:")
+        click.echo(f"• first_name: {user.first_name!r}")
+        if user.last_name:
+            click.echo(f"• last_name: {user.last_name!r}")
+        click.echo(f"• username: {user.username!r}")
+        click.echo(f"• role: {user.role.value!r}")
+        click.echo(f"• api_key: {user.api_key!r}")
+        click.echo(f"• workspaces: {[workspace.name for workspace in user.workspaces]!r}")
 
 
 if __name__ == "__main__":

--- a/tests/server/datasets/test_api.py
+++ b/tests/server/datasets/test_api.py
@@ -88,7 +88,7 @@ def test_delete_dataset_with_missing_workspace(test_client: TestClient, argilla_
     assert response.json() == {
         "detail": {
             "code": "argilla.api.errors::MissingInputParamError",
-            "params": {"message": "A workspace must be provided!"},
+            "params": {"message": "A workspace must be provided"},
         }
     }
 

--- a/tests/tasks/users/test_create.py
+++ b/tests/tasks/users/test_create.py
@@ -13,115 +13,162 @@
 #  limitations under the License.
 
 from argilla.server.contexts import accounts
-from argilla.server.models import User, UserRole
+from argilla.server.models import User, UserRole, Workspace
 from argilla.tasks.users.create import create
 from click.testing import CliRunner
 from sqlalchemy.orm import Session
 
+from tests.factories import WorkspaceFactory
 
-def test_create_passing_all_params(db: Session):
-    username = "test-user"
-    first_name = "First"
-    role = UserRole.admin
-    password = "12345678"
 
-    cli_params = f"--first-name {first_name} --username {username} --role {role} --password {password}"
-    CliRunner().invoke(create, cli_params)
+def test_create(db: Session):
+    result = CliRunner().invoke(
+        create,
+        "--first-name first-name --username username --role admin --password 12345678 --workspace workspace",
+    )
 
-    user = db.query(User).filter_by(username=username).first()
+    assert result.exit_code == 0
+    assert db.query(User).count() == 1
+    assert db.query(Workspace).count() == 1
+
+    user = db.query(User).filter_by(username="username").first()
     assert user
-    assert user.first_name == first_name
-    assert user.role == role
-    assert accounts.verify_password(password, user.password_hash)
-
-
-def test_create_with_input_role(db: Session):
-    username = "test-user"
-    role = UserRole.admin
-
-    cli_params = f"--username {username} --password 12345678 --first-name First"
-    CliRunner().invoke(create, cli_params, input=f"{role}\n")
-
-    user = db.query(User).filter_by(username=username).first()
-    assert user
-    assert user.role == role
-
-
-def test_create_with_input_password(db: Session):
-    username = "test-user"
-    password = "12345678"
-
-    cli_params = f"--username {username} --role admin --first-name First"
-    CliRunner().invoke(create, cli_params, input=f"{password}\n{password}\n")
-
-    user = db.query(User).filter_by(username=username).first()
-    assert user
-    assert accounts.verify_password(password, user.password_hash)
+    assert user.first_name == "first-name"
+    assert user.username == "username"
+    assert user.role == UserRole.admin
+    assert accounts.verify_password("12345678", user.password_hash)
+    assert [ws.name for ws in user.workspaces] == ["workspace"]
 
 
 def test_create_with_default_role(db: Session):
-    username = "test-user"
-    password = "12345678"
+    result = CliRunner().invoke(
+        create,
+        "--first-name first-name --username username --password 12345678",
+        input="\n",
+    )
 
-    cli_params = f"--username {username} --password {password} --first-name First"
-    CliRunner().invoke(create, cli_params, input=f"\n")
+    assert result.exit_code == 0
+    assert db.query(User).count() == 1
+    assert db.query(Workspace).count() == 0
 
-    user = db.query(User).filter_by(username=username).first()
+    user = db.query(User).filter_by(username="username").first()
     assert user
     assert user.role == UserRole.annotator
 
 
-def test_create_with_input_username(db: Session):
-    username = "test-user"
-    password = "12345678"
-
-    cli_params = f"--password {password} --first-name First"
-    CliRunner().invoke(create, cli_params, input=f"{username}\n")
-
-    assert db.query(User).filter_by(username=username).first()
-
-
-def test_create_with_last_name(db: Session):
-    username = "test-user"
-    password = "12345678"
-    last_name = "Last"
-
-    cli_params = f"--username {username} --password {password} --role admin --first-name First --last-name {last_name}"
-    CliRunner().invoke(create, cli_params)
-
-    user = db.query(User).filter_by(username=username).first()
-    assert user
-    assert user.last_name == last_name
-
-
-def test_create_with_invalid_username(db: Session):
-    username = "Invalid-Username"
-    password = "12345678"
-
-    runner = CliRunner()
-    cli_params = f"--username {username} --password {password} --role admin --first-name First"
-    result = runner.invoke(create, cli_params)
-
-    assert db.query(User).filter_by(username=username).first() is None
-    assert str(result.exception) == (
-        "1 validation error for UserCreate\n"
-        "username\n"
-        '  string does not match regex "^(?!-|_)[a-z0-9-_]+$" '
-        "(type=value_error.str.regex; pattern=^(?!-|_)[a-z0-9-_]+$)"
+def test_create_with_input_role(db: Session):
+    result = CliRunner().invoke(
+        create,
+        "--first-name first-name --username username --password 12345678",
+        input="admin\n",
     )
+
+    assert result.exit_code == 0
+    assert db.query(User).count() == 1
+    assert db.query(Workspace).count() == 0
+
+    user = db.query(User).filter_by(username="username").first()
+    assert user
+    assert user.role == UserRole.admin
+
+
+def test_create_with_input_password(db: Session):
+    result = CliRunner().invoke(
+        create,
+        "--first-name first-name --username username --role admin",
+        input="12345678\n12345678\n",
+    )
+
+    assert result.exit_code == 0
+    assert db.query(User).count() == 1
+    assert db.query(Workspace).count() == 0
+
+    user = db.query(User).filter_by(username="username").first()
+    assert user
+    assert accounts.verify_password("12345678", user.password_hash)
 
 
 def test_create_with_invalid_password(db: Session):
-    username = "username"
-    password = "11"
+    result = CliRunner().invoke(create, "--first-name first-name --username username --password 1234 --role admin")
 
-    cli_params = f"--username {username} --password {password} --role admin --first-name First"
-    result = CliRunner().invoke(create, cli_params)
+    assert result.exit_code == 1
+    assert db.query(User).count() == 0
+    assert db.query(Workspace).count() == 0
 
-    assert db.query(User).filter_by(username=username).first() is None
-    assert str(result.exception) == (
-        "1 validation error for UserCreate\n"
-        "password\n"
-        "  ensure this value has at least 8 characters "
-        "(type=value_error.any_str.min_length; limit_value=8)"
+
+def test_create_with_input_username(db: Session):
+    result = CliRunner().invoke(create, "--first-name first-name --password 12345678", input="username\n")
+
+    assert result.exit_code == 0
+    assert db.query(User).count() == 1
+    assert db.query(Workspace).count() == 0
+
+    assert db.query(User).filter_by(username="username").first()
+
+
+def test_create_with_invalid_username(db: Session):
+    result = CliRunner().invoke(
+        create, "--first-name first-name --username Invalid-Username --password 12345678 --role admin"
     )
+
+    assert result.exit_code == 1
+    assert db.query(User).count() == 0
+    assert db.query(Workspace).count() == 0
+
+
+def test_create_with_last_name(db: Session):
+    result = CliRunner().invoke(
+        create, "--first-name first-name --last-name last-name --username username --password 12345678 --role admin"
+    )
+
+    assert result.exit_code == 0
+    assert db.query(User).count() == 1
+    assert db.query(Workspace).count() == 0
+
+    user = db.query(User).filter_by(username="username").first()
+    assert user
+    assert user.last_name == "last-name"
+
+
+def test_create_with_multiple_workspaces(db: Session):
+    result = CliRunner().invoke(
+        create,
+        "--first-name first-name --username username --role admin --password 12345678 --workspace workspace-a --workspace workspace-b",
+    )
+
+    assert result.exit_code == 0
+    assert db.query(User).count() == 1
+    assert db.query(Workspace).count() == 2
+
+    user = db.query(User).filter_by(username="username").first()
+    assert user
+    assert [ws.name for ws in user.workspaces] == ["workspace-a", "workspace-b"]
+
+
+def test_create_with_existent_workspaces(db: Session):
+    WorkspaceFactory.create(name="workspace-a")
+    WorkspaceFactory.create(name="workspace-b")
+
+    result = CliRunner().invoke(
+        create,
+        "--first-name first-name --username username --role admin --password 12345678 --workspace workspace-a --workspace workspace-b --workspace workspace-c",
+    )
+
+    assert result.exit_code == 0
+    assert db.query(User).count() == 1
+    assert db.query(Workspace).count() == 3
+
+    user = db.query(User).filter_by(username="username").first()
+    assert user
+    assert [ws.name for ws in user.workspaces] == ["workspace-a", "workspace-b", "workspace-c"]
+
+
+def test_create_with_invalid_workspaces(db: Session):
+    result = CliRunner().invoke(
+        create,
+        "--first-name first-name --username username --role admin --password 12345678 --workspace workspace-a --workspace 'invalid workspace' --workspace workspace-c",
+    )
+
+    assert result.exit_code == 1
+    assert db.query(User).count() == 0
+    assert db.query(Workspace).count() == 0


### PR DESCRIPTION
This PR adds a new optional `--workspace` parameter to the `argilla.tasks.user.create` task. The parameter can be used multiple times to add the user to multiple workspaces.

If the workspaces doesn't exist these will be created.

You can use the new parameter as follows:
```sh
$ python -m argilla.tasks.users.create --first-name John --last-name Doe --role admin --username johndoe --password 12345678 --workspace workspace-a --workspace workspace-b
User succesfully created:
• first_name: 'John'
• last_name: 'Doe'
• username: 'johndoe'
• role: 'admin'
• api_key: 'hZQKQa-zWzXSaw1VMgy8Ego6B8u2qoPFb7bp_BgKOKWnueYFzcvvevihs6YqlNOuHzFC_MQNwpmo41J5Ce3Htgj8mT6KIrYrt3mk4EFJ5S8'
• workspaces: ['workspace-a', 'workspace-b']
```