### PR TITLE
Fix Pydantic User schema full_name attribute to don't use last_name when is None

### DIFF
--- a/src/argilla/server/security/model.py
+++ b/src/argilla/server/security/model.py
@@ -62,7 +62,7 @@ class UserCreate(BaseModel):
 class UserGetter(GetterDict):
     def get(self, key: str, default: Any = None) -> Any:
         if key == "full_name":
-            return " ".join(filter(None, [self._obj.first_name, self._obj.last_name]))
+            return f"{self._obj.first_name} {self._obj.last_name}" if self._obj.last_name else self._obj.first_name
         elif key == "workspaces":
             return [workspace.name for workspace in self._obj.workspaces]
         else:

--- a/src/argilla/server/security/model.py
+++ b/src/argilla/server/security/model.py
@@ -62,7 +62,7 @@ class UserCreate(BaseModel):
 class UserGetter(GetterDict):
     def get(self, key: str, default: Any = None) -> Any:
         if key == "full_name":
-            return f"{self._obj.first_name} {self._obj.last_name}"
+            return " ".join(filter(None, [self._obj.first_name, self._obj.last_name]))
         elif key == "workspaces":
             return [workspace.name for workspace in self._obj.workspaces]
         else:

--- a/tests/server/datasets/test_api.py
+++ b/tests/server/datasets/test_api.py
@@ -88,7 +88,7 @@ def test_delete_dataset_with_missing_workspace(test_client: TestClient, argilla_
     assert response.json() == {
         "detail": {
             "code": "argilla.api.errors::MissingInputParamError",
-            "params": {"message": "A workspace must be provided!"},
+            "params": {"message": "A workspace must be provided"},
         }
     }
 

--- a/tests/server/security/test_model.py
+++ b/tests/server/security/test_model.py
@@ -37,8 +37,9 @@ def test_user_full_name(db: Session):
     assert User.from_orm(user).full_name == "first-name last-name"
 
 
-def test_user_full_name_without_last_name(db: Session):
-    user = UserFactory.create(first_name="first-name", last_name=None)
+@pytest.mark.parametrize("last_name", [None, ""])
+def test_user_full_name_without_last_name(db: Session, last_name):
+    user = UserFactory.create(first_name="first-name", last_name=last_name)
 
     assert User.from_orm(user).full_name == "first-name"
 


### PR DESCRIPTION
`last_name` column on `users` database is optional and was wrongly rendered on `User` Pydantic schema for `full_name` dict property.

This PR only returns the user `first_name` when `last_name` is not available (when is `None`).