### PR TITLE
Add first name and last name to user schema

### DIFF
--- a/src/argilla/server/security/model.py
+++ b/src/argilla/server/security/model.py
@@ -73,14 +73,14 @@ class User(BaseModel):
     """Base user model"""
 
     id: UUID
+    first_name: str
+    last_name: Optional[str]
+    full_name: Optional[str]
     username: str = Field()
     role: UserRole
-    full_name: Optional[str] = None
-
     superuser: Optional[bool]
     workspaces: Optional[List[str]]
     api_key: str
-
     inserted_at: datetime
     updated_at: datetime
 

--- a/src/argilla/server/security/model.py
+++ b/src/argilla/server/security/model.py
@@ -75,7 +75,7 @@ class User(BaseModel):
     id: UUID
     first_name: str
     last_name: Optional[str]
-    full_name: Optional[str]
+    full_name: Optional[str] = Field(description="Deprecated. Use `first_name` and `last_name` instead")
     username: str = Field()
     role: UserRole
     superuser: Optional[bool]

--- a/src/argilla/server/security/model.py
+++ b/src/argilla/server/security/model.py
@@ -62,7 +62,7 @@ class UserCreate(BaseModel):
 class UserGetter(GetterDict):
     def get(self, key: str, default: Any = None) -> Any:
         if key == "full_name":
-            return f"{self._obj.first_name} {self._obj.last_name}"
+            return " ".join(filter(None, [self._obj.first_name, self._obj.last_name]))
         elif key == "workspaces":
             return [workspace.name for workspace in self._obj.workspaces]
         else:

--- a/tests/server/datasets/test_api.py
+++ b/tests/server/datasets/test_api.py
@@ -88,7 +88,7 @@ def test_delete_dataset_with_missing_workspace(test_client: TestClient, argilla_
     assert response.json() == {
         "detail": {
             "code": "argilla.api.errors::MissingInputParamError",
-            "params": {"message": "A workspace must be provided!"},
+            "params": {"message": "A workspace must be provided"},
         }
     }
 

--- a/tests/server/security/test_model.py
+++ b/tests/server/security/test_model.py
@@ -31,6 +31,18 @@ def test_user_create_invalid_username(invalid_username):
         UserCreate(first_name="first-name", username=invalid_username, password="12345678")
 
 
+def test_user_first_name(db: Session):
+    user = UserFactory.create(first_name="first-name")
+
+    assert User.from_orm(user).first_name == "first-name"
+
+
+def test_user_last_name(db: Session):
+    user = UserFactory.create(last_name="last-name")
+
+    assert User.from_orm(user).last_name == "last-name"
+
+
 def test_user_full_name(db: Session):
     user = UserFactory.create(first_name="first-name", last_name="last-name")
 


### PR DESCRIPTION
**Note:** This PR is based on changes added by https://github.com/argilla-io/argilla/pull/2545 so please review https://github.com/argilla-io/argilla/pull/2545 first.

In this PR I'm adding `first_name` and `last_name` to `User` Pydantic schema. I have not found a proper way to deprecate `full_name` field (I have only found this https://github.com/pydantic/pydantic/issues/2255). @frascuchon if you know of some proper way to deprecate this field and automagically show that on swagger docs please tell me.