### PR TITLE
Review annotator policies for dataset settings

### DIFF
--- a/src/argilla/server/apis/v0/handlers/text_classification_dataset_settings.py
+++ b/src/argilla/server/apis/v0/handlers/text_classification_dataset_settings.py
@@ -26,13 +26,7 @@ from argilla.server.apis.v0.validators.text_classification import DatasetValidat
 from argilla.server.commons.models import TaskType
 from argilla.server.models import User
 from argilla.server.security import auth
-from argilla.server.services.datasets import DatasetsService, ServiceBaseDatasetSettings
-
-__svc_settings_class__: Type[ServiceBaseDatasetSettings] = type(
-    f"{TaskType.text_classification}_DatasetSettings",
-    (ServiceBaseDatasetSettings, TextClassificationSettings),
-    {},
-)
+from argilla.server.services.datasets import DatasetsService
 
 
 def configure_router(router: APIRouter):
@@ -63,8 +57,10 @@ def configure_router(router: APIRouter):
             task=task,
         )
 
-        settings = await datasets.get_settings(user=current_user, dataset=found_ds, class_type=__svc_settings_class__)
-        return TextClassificationSettings.parse_obj(settings)
+        settings = await datasets.get_settings(
+            user=current_user, dataset=found_ds, class_type=TextClassificationSettings
+        )
+        return settings
 
     @deprecate_endpoint(
         path=base_endpoint,
@@ -94,9 +90,9 @@ def configure_router(router: APIRouter):
         settings = await datasets.save_settings(
             user=current_user,
             dataset=found_ds,
-            settings=__svc_settings_class__.parse_obj(request.dict()),
+            settings=TextClassificationSettings.parse_obj(request.dict()),
         )
-        return TextClassificationSettings.parse_obj(settings)
+        return settings
 
     @deprecate_endpoint(
         path=base_endpoint,

--- a/src/argilla/server/apis/v0/handlers/token_classification_dataset_settings.py
+++ b/src/argilla/server/apis/v0/handlers/token_classification_dataset_settings.py
@@ -26,13 +26,7 @@ from argilla.server.apis.v0.validators.token_classification import DatasetValida
 from argilla.server.commons.models import TaskType
 from argilla.server.models import User
 from argilla.server.security import auth
-from argilla.server.services.datasets import DatasetsService, ServiceBaseDatasetSettings
-
-__svc_settings_class__: Type[ServiceBaseDatasetSettings] = type(
-    f"{TaskType.token_classification}_DatasetSettings",
-    (ServiceBaseDatasetSettings, TokenClassificationSettings),
-    {},
-)
+from argilla.server.services.datasets import DatasetsService
 
 
 def configure_router(router: APIRouter):
@@ -63,8 +57,10 @@ def configure_router(router: APIRouter):
             task=task,
         )
 
-        settings = await datasets.get_settings(user=current_user, dataset=found_ds, class_type=__svc_settings_class__)
-        return TokenClassificationSettings.parse_obj(settings)
+        settings = await datasets.get_settings(
+            user=current_user, dataset=found_ds, class_type=TokenClassificationSettings
+        )
+        return settings
 
     @deprecate_endpoint(
         path=base_endpoint,
@@ -90,13 +86,16 @@ def configure_router(router: APIRouter):
             task=task,
             workspace=ws_params.workspace,
         )
+
         await validator.validate_dataset_settings(user=current_user, dataset=found_ds, settings=request)
+
         settings = await datasets.save_settings(
             user=current_user,
             dataset=found_ds,
-            settings=__svc_settings_class__.parse_obj(request.dict()),
+            settings=TokenClassificationSettings.parse_obj(request.dict()),
         )
-        return TokenClassificationSettings.parse_obj(settings)
+
+        return settings
 
     @deprecate_endpoint(
         path=base_endpoint,

--- a/src/argilla/server/apis/v0/validators/text_classification.py
+++ b/src/argilla/server/apis/v0/validators/text_classification.py
@@ -12,25 +12,17 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import List, Optional, Set, Type
+from typing import List, Optional, Set
 
 from fastapi import Depends
 
 from argilla.server.apis.v0.models.dataset_settings import TextClassificationSettings
-from argilla.server.commons.models import TaskType
 from argilla.server.errors import BadRequestError, EntityNotFoundError
 from argilla.server.models import User
 from argilla.server.schemas.datasets import Dataset
-from argilla.server.services.datasets import DatasetsService, ServiceBaseDatasetSettings
-from argilla.server.services.tasks.text_classification.metrics import DatasetLabels
-
-__svc_settings_class__: Type[ServiceBaseDatasetSettings] = type(
-    f"{TaskType.text_classification}_DatasetSettings",
-    (ServiceBaseDatasetSettings, TextClassificationSettings),
-    {},
-)
-
+from argilla.server.services.datasets import DatasetsService
 from argilla.server.services.metrics import MetricsService
+from argilla.server.services.tasks.text_classification.metrics import DatasetLabels
 from argilla.server.services.tasks.text_classification.model import (
     ServiceTextClassificationRecord,
 )
@@ -80,7 +72,7 @@ class DatasetValidator:
     ):
         try:
             settings: TextClassificationSettings = await self.__datasets__.get_settings(
-                user=user, dataset=dataset, class_type=__svc_settings_class__
+                user=user, dataset=dataset, class_type=TextClassificationSettings
             )
             if settings and settings.label_schema:
                 label_schema = set([label.name for label in settings.label_schema.labels])

--- a/src/argilla/server/apis/v0/validators/token_classification.py
+++ b/src/argilla/server/apis/v0/validators/token_classification.py
@@ -12,25 +12,17 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import List, Set, Type
+from typing import List, Set
 
 from fastapi import Depends
 
 from argilla.server.apis.v0.models.dataset_settings import TokenClassificationSettings
-from argilla.server.commons.models import TaskType
 from argilla.server.errors import BadRequestError, EntityNotFoundError
 from argilla.server.models import User
 from argilla.server.schemas.datasets import Dataset
-from argilla.server.services.datasets import DatasetsService, ServiceBaseDatasetSettings
-from argilla.server.services.tasks.token_classification.metrics import DatasetLabels
-
-__svc_settings_class__: Type[ServiceBaseDatasetSettings] = type(
-    f"{TaskType.token_classification}_DatasetSettings",
-    (ServiceBaseDatasetSettings, TokenClassificationSettings),
-    {},
-)
-
+from argilla.server.services.datasets import DatasetsService
 from argilla.server.services.metrics import MetricsService
+from argilla.server.services.tasks.token_classification.metrics import DatasetLabels
 from argilla.server.services.tasks.token_classification.model import (
     ServiceTokenClassificationAnnotation,
     ServiceTokenClassificationRecord,
@@ -81,7 +73,7 @@ class DatasetValidator:
     ):
         try:
             settings: TokenClassificationSettings = await self.__datasets__.get_settings(
-                user=user, dataset=dataset, class_type=__svc_settings_class__
+                user=user, dataset=dataset, class_type=TokenClassificationSettings
             )
             if settings and settings.label_schema:
                 label_schema = set([label.name for label in settings.label_schema.labels])

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -103,7 +103,7 @@ class DatasetPolicy:
         return lambda actor: actor.is_admin or is_get_allowed(actor) and cls.create(actor)
 
 
-class TaskDatasetSettingsPolicy:
+class DatasetSettingsPolicy:
     @classmethod
     def list(cls, dataset: Dataset) -> PolicyAction:
         return DatasetPolicy.get(dataset)

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -103,6 +103,20 @@ class DatasetPolicy:
         return lambda actor: actor.is_admin or is_get_allowed(actor) and cls.create(actor)
 
 
+class TaskDatasetSettingsPolicy:
+    @classmethod
+    def list(cls, dataset: Dataset) -> PolicyAction:
+        return DatasetPolicy.get(dataset)
+
+    @classmethod
+    def save(cls, dataset: Dataset) -> PolicyAction:
+        return lambda actor: actor.is_admin
+
+    @classmethod
+    def delete(cls, dataset: Dataset) -> PolicyAction:
+        return lambda actor: actor.is_admin
+
+
 def authorize(actor: User, policy_action: PolicyAction) -> None:
     if not is_authorized(actor, policy_action):
         raise ForbiddenOperationError()

--- a/src/argilla/server/services/datasets.py
+++ b/src/argilla/server/services/datasets.py
@@ -32,7 +32,7 @@ from argilla.server.errors import (
 from argilla.server.models import User, Workspace
 from argilla.server.policies import (
     DatasetPolicy,
-    TaskDatasetSettingsPolicy,
+    DatasetSettingsPolicy,
     is_authorized,
 )
 from argilla.server.schemas.datasets import CreateDatasetRequest, Dataset
@@ -227,10 +227,8 @@ class DatasetsService:
         if not settings:
             raise EntityNotFoundError(name=dataset.name, type=class_type)
 
-        if not is_authorized(user, TaskDatasetSettingsPolicy.list(dataset)):
-            raise ForbiddenOperationError(
-                "You don't have the necessary permissions to list settings for this dataset."
-            )
+        if not is_authorized(user, DatasetSettingsPolicy.list(dataset)):
+            raise ForbiddenOperationError("You don't have the necessary permissions to list settings for this dataset.")
         return class_type.parse_obj(settings.dict())
 
     def raw_dataset_update(self, dataset):
@@ -239,16 +237,14 @@ class DatasetsService:
     async def save_settings(
         self, user: User, dataset: ServiceDataset, settings: ServiceDatasetSettings
     ) -> ServiceDatasetSettings:
-        if not is_authorized(user, TaskDatasetSettingsPolicy.save(dataset)):
-            raise ForbiddenOperationError(
-                "You don't have the necessary permissions to save settings for this dataset."
-            )
+        if not is_authorized(user, DatasetSettingsPolicy.save(dataset)):
+            raise ForbiddenOperationError("You don't have the necessary permissions to save settings for this dataset.")
 
         self.__dao__.save_settings(dataset=dataset, settings=settings)
         return settings
 
     async def delete_settings(self, user: User, dataset: ServiceDataset) -> None:
-        if not is_authorized(user, TaskDatasetSettingsPolicy.delete(dataset)):
+        if not is_authorized(user, DatasetSettingsPolicy.delete(dataset)):
             raise ForbiddenOperationError(
                 "You don't have the necessary permissions to delete settings for this dataset."
             )

--- a/src/argilla/server/services/datasets.py
+++ b/src/argilla/server/services/datasets.py
@@ -30,7 +30,11 @@ from argilla.server.errors import (
     WrongTaskError,
 )
 from argilla.server.models import User, Workspace
-from argilla.server.policies import DatasetPolicy, is_authorized
+from argilla.server.policies import (
+    DatasetPolicy,
+    TaskDatasetSettingsPolicy,
+    is_authorized,
+)
 from argilla.server.schemas.datasets import CreateDatasetRequest, Dataset
 
 
@@ -38,12 +42,8 @@ class ServiceBaseDataset(BaseDatasetDB):
     pass
 
 
-class ServiceBaseDatasetSettings(BaseDatasetSettingsDB):
-    pass
-
-
 ServiceDataset = TypeVar("ServiceDataset", bound=ServiceBaseDataset)
-ServiceDatasetSettings = TypeVar("ServiceDatasetSettings", bound=ServiceBaseDatasetSettings)
+ServiceDatasetSettings = TypeVar("ServiceDatasetSettings", bound=BaseDatasetSettingsDB)
 
 
 class DatasetsService:
@@ -226,6 +226,11 @@ class DatasetsService:
         settings = self.__dao__.load_settings(dataset=dataset, as_class=class_type)
         if not settings:
             raise EntityNotFoundError(name=dataset.name, type=class_type)
+
+        if not is_authorized(user, TaskDatasetSettingsPolicy.list(dataset)):
+            raise ForbiddenOperationError(
+                "You don't have the necessary permissions to list settings for this dataset. "
+            )
         return class_type.parse_obj(settings.dict())
 
     def raw_dataset_update(self, dataset):
@@ -234,8 +239,18 @@ class DatasetsService:
     async def save_settings(
         self, user: User, dataset: ServiceDataset, settings: ServiceDatasetSettings
     ) -> ServiceDatasetSettings:
+        if not is_authorized(user, TaskDatasetSettingsPolicy.save(dataset)):
+            raise ForbiddenOperationError(
+                "You don't have the necessary permissions to save settings for this dataset. "
+            )
+
         self.__dao__.save_settings(dataset=dataset, settings=settings)
         return settings
 
     async def delete_settings(self, user: User, dataset: ServiceDataset) -> None:
+        if not is_authorized(user, TaskDatasetSettingsPolicy.delete(dataset)):
+            raise ForbiddenOperationError(
+                "You don't have the necessary permissions to delete settings for this dataset. "
+            )
+
         self.__dao__.delete_settings(dataset=dataset)

--- a/src/argilla/server/services/datasets.py
+++ b/src/argilla/server/services/datasets.py
@@ -229,7 +229,7 @@ class DatasetsService:
 
         if not is_authorized(user, TaskDatasetSettingsPolicy.list(dataset)):
             raise ForbiddenOperationError(
-                "You don't have the necessary permissions to list settings for this dataset. "
+                "You don't have the necessary permissions to list settings for this dataset."
             )
         return class_type.parse_obj(settings.dict())
 
@@ -241,7 +241,7 @@ class DatasetsService:
     ) -> ServiceDatasetSettings:
         if not is_authorized(user, TaskDatasetSettingsPolicy.save(dataset)):
             raise ForbiddenOperationError(
-                "You don't have the necessary permissions to save settings for this dataset. "
+                "You don't have the necessary permissions to save settings for this dataset."
             )
 
         self.__dao__.save_settings(dataset=dataset, settings=settings)
@@ -250,7 +250,7 @@ class DatasetsService:
     async def delete_settings(self, user: User, dataset: ServiceDataset) -> None:
         if not is_authorized(user, TaskDatasetSettingsPolicy.delete(dataset)):
             raise ForbiddenOperationError(
-                "You don't have the necessary permissions to delete settings for this dataset. "
+                "You don't have the necessary permissions to delete settings for this dataset."
             )
 
         self.__dao__.delete_settings(dataset=dataset)

--- a/tests/server/text_classification/test_api_settings.py
+++ b/tests/server/text_classification/test_api_settings.py
@@ -158,7 +158,7 @@ def test_save_settings_as_annotator(test_client: TestClient, argilla_auth_header
     assert response.json() == {
         "detail": {
             "code": "argilla.api.errors::ForbiddenOperationError",
-            "params": {"detail": "You don't have the necessary permissions to " "save settings for this dataset. "},
+            "params": {"detail": "You don't have the necessary permissions to " "save settings for this dataset."},
         }
     }
 
@@ -187,7 +187,7 @@ def test_delete_settings_as_annotator(test_client: TestClient, argilla_auth_head
     assert response.json() == {
         "detail": {
             "code": "argilla.api.errors::ForbiddenOperationError",
-            "params": {"detail": "You don't have the necessary permissions to " "delete settings for this dataset. "},
+            "params": {"detail": "You don't have the necessary permissions to " "delete settings for this dataset."},
         }
     }
 


### PR DESCRIPTION
For an annotator, dataset settings are visible in read-only mode.

This PR adds task dataset settings-related policies and uses them in dataset settings-related actions.

Also, new tests are added to test this functionality. 