### PR TITLE
Change policies for dataset update

### DIFF
--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -81,7 +81,7 @@ class DatasetPolicy:
     @classmethod
     def update(cls, dataset: Dataset) -> PolicyAction:
         is_get_allowed = cls.get(dataset)
-        return lambda actor: actor.is_admin or (is_get_allowed(actor) and actor.username == dataset.created_by)
+        return lambda actor: actor.is_admin or is_get_allowed(actor)
 
     @classmethod
     def delete(cls, dataset: Dataset) -> PolicyAction:
@@ -95,7 +95,8 @@ class DatasetPolicy:
 
     @classmethod
     def close(cls, dataset: Dataset) -> PolicyAction:
-        return lambda actor: actor.is_admin
+        is_get_allowed = cls.get(dataset)
+        return lambda actor: actor.is_admin or (is_get_allowed(actor) and actor.username == dataset.created_by)
 
     @classmethod
     def copy(cls, dataset: Dataset) -> PolicyAction:

--- a/src/argilla/server/services/datasets.py
+++ b/src/argilla/server/services/datasets.py
@@ -120,9 +120,6 @@ class DatasetsService:
         tags: Dict[str, str],
         metadata: Dict[str, Any],
     ) -> Dataset:
-        if not (tags or metadata):
-            return dataset
-
         found = self.find_by_name(user=user, name=dataset.name, task=dataset.task, workspace=dataset.workspace)
 
         if not is_authorized(user, DatasetPolicy.update(found)):

--- a/src/argilla/server/services/datasets.py
+++ b/src/argilla/server/services/datasets.py
@@ -120,6 +120,9 @@ class DatasetsService:
         tags: Dict[str, str],
         metadata: Dict[str, Any],
     ) -> Dataset:
+        if not (tags or metadata):
+            return dataset
+
         found = self.find_by_name(user=user, name=dataset.name, task=dataset.task, workspace=dataset.workspace)
 
         if not is_authorized(user, DatasetPolicy.update(found)):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,24 @@ def admin(db):
     db.add(user)
     db.commit()
     db.refresh(user)
+
+    return user
+
+
+@pytest.fixture(scope="function")
+def annotator(db):
+    user = User(
+        first_name="Annotator",
+        username="annotator",
+        password_hash="$2y$05$eaw.j2Kaw8s8vpscVIZMfuqSIX3OLmxA21WjtWicDdn0losQ91Hw.",
+        api_key="annotator.apikey",
+        role=UserRole.annotator,
+    )
+
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
     return user
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ from argilla.server.database import SessionLocal
 from argilla.server.models import User, UserRole, Workspace, WorkspaceUser
 from starlette.testclient import TestClient
 
+from .factories import AnnotatorFactory
 from .helpers import SecuredClient
 
 
@@ -65,19 +66,7 @@ def admin(db):
 
 @pytest.fixture(scope="function")
 def annotator(db):
-    user = User(
-        first_name="Annotator",
-        username="annotator",
-        password_hash="$2y$05$eaw.j2Kaw8s8vpscVIZMfuqSIX3OLmxA21WjtWicDdn0losQ91Hw.",
-        api_key="annotator.apikey",
-        role=UserRole.annotator,
-    )
-
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-
-    return user
+    return AnnotatorFactory.create(first_name="Annotator", username="annotator", api_key="annotator.apikey")
 
 
 @pytest.fixture

--- a/tests/server/datasets/test_api.py
+++ b/tests/server/datasets/test_api.py
@@ -315,6 +315,7 @@ def test_update_dataset_by_annotator_without_changes(
     assert response.status_code == 200
 
     created_dataset = response.json()
+    created_dataset.pop("last_updated")
 
     response = test_client.patch(
         f"/api/datasets/{dataset_name}?workspace={argilla_user.username}",
@@ -323,7 +324,11 @@ def test_update_dataset_by_annotator_without_changes(
     )
 
     assert response.status_code == 200
-    assert response.json() == created_dataset
+
+    updated_dataset = response.json()
+    updated_dataset.pop("last_updated")
+
+    assert updated_dataset == created_dataset
 
 
 def test_open_and_close_dataset(

--- a/tests/server/datasets/test_api.py
+++ b/tests/server/datasets/test_api.py
@@ -262,6 +262,70 @@ def test_update_dataset(test_client: TestClient, argilla_user: User, argilla_aut
     assert ds.metadata["new"] == "value"
 
 
+def test_update_dataset_by_annotator(
+    test_client: TestClient, argilla_user: User, argilla_auth_header: dict, dataset_name: str, annotator: User
+):
+    workspace_name = argilla_user.username
+
+    for workspace in argilla_user.workspaces:
+        if workspace.name == workspace_name:
+            WorkspaceUserFactory.create(workspace_id=workspace.id, user_id=annotator.id)
+            break
+
+    create_mock_dataset(test_client, dataset_name=dataset_name, headers=argilla_auth_header, workspace=workspace_name)
+
+    response = test_client.patch(
+        f"/api/datasets/{dataset_name}?workspace={workspace_name}",
+        json={"metadata": {"new": "metadata"}},
+        headers={API_KEY_HEADER_NAME: annotator.api_key},
+    )
+
+    assert response.status_code == 200
+
+
+def test_update_dataset_by_annotator_without_permissions(
+    test_client: TestClient, argilla_user: User, argilla_auth_header: dict, dataset_name: str, annotator: User
+):
+    create_mock_dataset(
+        test_client, dataset_name=dataset_name, headers=argilla_auth_header, workspace=argilla_user.username
+    )
+
+    response = test_client.patch(
+        f"/api/datasets/{dataset_name}?workspace={argilla_user.username}",
+        json={"metadata": {"new": "metadata"}},
+        headers={API_KEY_HEADER_NAME: annotator.api_key},
+    )
+
+    assert response.status_code == 403
+
+
+def test_update_dataset_by_annotator_without_changes(
+    test_client: TestClient, argilla_user: User, argilla_auth_header: dict, dataset_name: str, annotator: User
+):
+    for workspace in argilla_user.workspaces:
+        WorkspaceUserFactory.create(workspace_id=workspace.id, user_id=annotator.id)
+
+    create_mock_dataset(
+        test_client, dataset_name=dataset_name, headers=argilla_auth_header, workspace=argilla_user.username
+    )
+
+    response = test_client.get(
+        f"/api/datasets/{dataset_name}?workspace={argilla_user.username}", headers=argilla_auth_header
+    )
+    assert response.status_code == 200
+
+    created_dataset = response.json()
+
+    response = test_client.patch(
+        f"/api/datasets/{dataset_name}?workspace={argilla_user.username}",
+        json={},
+        headers={API_KEY_HEADER_NAME: annotator.api_key},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == created_dataset
+
+
 def test_open_and_close_dataset(
     test_client: TestClient, argilla_user: User, argilla_auth_header: dict, dataset_name: str
 ):


### PR DESCRIPTION
This PR changes the update dataset policy to accept updating a dataset (tags and metadata) for all users linked to the dataset workspace.

This may change in the future.