### PR TITLE
Map SQLAlchemy IntegrityError as Argilla EntityAlreadyExistsError

### DIFF
--- a/src/argilla/server/server.py
+++ b/src/argilla/server/server.py
@@ -77,8 +77,8 @@ def configure_middleware(app: FastAPI):
 
 def configure_api_exceptions(api: FastAPI):
     """Configures fastapi exception handlers"""
-    api.exception_handler(EntityNotFoundError)(APIErrorHandler.common_exception_handler)
     api.exception_handler(Exception)(APIErrorHandler.common_exception_handler)
+    api.exception_handler(EntityNotFoundError)(APIErrorHandler.common_exception_handler)
     api.exception_handler(UnauthorizedError)(APIErrorHandler.common_exception_handler)
     api.exception_handler(ForbiddenOperationError)(APIErrorHandler.common_exception_handler)
     api.exception_handler(EntityAlreadyExistsError)(APIErrorHandler.common_exception_handler)

--- a/tests/server/api/v0/test_users.py
+++ b/tests/server/api/v0/test_users.py
@@ -151,6 +151,16 @@ def test_create_user_as_annotator(client: TestClient, db: Session):
     assert db.query(User).count() == 1
 
 
+def test_create_user_with_duplicated_username(client: TestClient, db: Session, admin_auth_header: dict):
+    UserFactory.create(username="username")
+    user = {"first_name": "first-name", "username": "username", "password": "12345678"}
+
+    response = client.post("/api/users", headers=admin_auth_header, json=user)
+
+    assert response.status_code == 409
+    assert db.query(User).count() == 2
+
+
 def test_create_user_with_invalid_min_length_first_name(client: TestClient, db: Session, admin_auth_header: dict):
     user = {"first_name": "", "username": "username", "password": "12345678"}
 

--- a/tests/server/api/v0/test_workspaces.py
+++ b/tests/server/api/v0/test_workspaces.py
@@ -83,6 +83,15 @@ def test_create_workspace_as_annotator(client: TestClient, db: Session):
     assert db.query(Workspace).count() == 0
 
 
+def test_create_workspace_with_duplicated_name(client: TestClient, db: Session, admin_auth_header: dict):
+    WorkspaceFactory.create(name="workspace")
+
+    response = client.post("/api/workspaces", headers=admin_auth_header, json={"name": "workspace"})
+
+    assert response.status_code == 409
+    assert db.query(Workspace).count() == 1
+
+
 def test_create_workspace_with_invalid_min_length_name(client: TestClient, db: Session, admin_auth_header: dict):
     response = client.post("/api/workspaces", headers=admin_auth_header, json={"name": ""})
 
@@ -203,6 +212,16 @@ def test_create_workspace_user_with_nonexistent_user_id(client: TestClient, db: 
 
     assert response.status_code == 404
     assert db.query(WorkspaceUser).count() == 0
+
+
+def test_create_workspace_user_duplicated(client: TestClient, db: Session, admin: User, admin_auth_header: dict):
+    workspace = WorkspaceFactory.create()
+    WorkspaceUserFactory.create(workspace_id=workspace.id, user_id=admin.id)
+
+    response = client.post(f"/api/workspaces/{workspace.id}/users/{admin.id}", headers=admin_auth_header)
+
+    assert response.status_code == 409
+    assert db.query(WorkspaceUser).count() == 1
 
 
 def test_delete_workspace_user(client: TestClient, db: Session, admin_auth_header: dict):


### PR DESCRIPTION
This is a draft pull request with a possible solution to the handlers that need to manage situations where is possible to have an integrity error coming from database and was returning a complete error trace with too many internal details.

The suggested solution is to capture `sqlalchemy.exc.IntegrityError` on the place where this error can happen and raise a new Argilla internal `EntityAlreadyExistsError`.

There is of course alternative solutions to this problem like:
* Change `GenericServerError` to not include complex error messages. (This should include some improvements over the logger system to allow users capture the error messages, even if those are not included in the response).
* Refactor our API error system, right now the responses are too generic and doesn't match sometimes with the required responses, and improve our logging system (including request ids, etc.).