### PR TITLE
chore: Update "Keep a Changelog" version URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]


### PR DESCRIPTION
# Description

Updated the Keep a Changelog link from https://keepachangelog.com/en/1.0.0/ to https://keepachangelog.com/en/1.1.0/, as we use the most recent version.

### Note
The [1.1.0 version](https://keepachangelog.com/en/1.1.0/) of Keep a Changelog actually links to 1.0.0 for some reason in their example, which is a tad odd. I still think we should update the link to v1.1.0 though.

**Type of change**

- [x] Documentation update

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

---

Oh, I'm so tempted to jokingly add "Updated CHANGELOG link" as a Changelog entry 😉 

- Tom Aarsen