### PR TITLE
Raise EntityAlreadyExistsError for new endpoint handlers

### DIFF
--- a/src/argilla/server/apis/v0/handlers/users.py
+++ b/src/argilla/server/apis/v0/handlers/users.py
@@ -24,7 +24,7 @@ from argilla.server import models
 from argilla.server.commons import telemetry
 from argilla.server.contexts import accounts
 from argilla.server.database import get_db
-from argilla.server.errors import EntityNotFoundError
+from argilla.server.errors import EntityAlreadyExistsError, EntityNotFoundError
 from argilla.server.policies import UserPolicy, authorize
 from argilla.server.security import auth
 from argilla.server.security.model import User, UserCreate
@@ -88,6 +88,9 @@ def create_user(
     current_user: models.User = Security(auth.get_current_user),
 ):
     authorize(current_user, UserPolicy.create)
+
+    if accounts.get_user_by_username(db, user_create.username):
+        raise EntityAlreadyExistsError(name=user_create.username, type=User)
 
     user = accounts.create_user(db, user_create)
 

--- a/src/argilla/server/server.py
+++ b/src/argilla/server/server.py
@@ -77,8 +77,8 @@ def configure_middleware(app: FastAPI):
 
 def configure_api_exceptions(api: FastAPI):
     """Configures fastapi exception handlers"""
-    api.exception_handler(EntityNotFoundError)(APIErrorHandler.common_exception_handler)
     api.exception_handler(Exception)(APIErrorHandler.common_exception_handler)
+    api.exception_handler(EntityNotFoundError)(APIErrorHandler.common_exception_handler)
     api.exception_handler(UnauthorizedError)(APIErrorHandler.common_exception_handler)
     api.exception_handler(ForbiddenOperationError)(APIErrorHandler.common_exception_handler)
     api.exception_handler(EntityAlreadyExistsError)(APIErrorHandler.common_exception_handler)

--- a/tests/server/api/v0/test_users.py
+++ b/tests/server/api/v0/test_users.py
@@ -151,6 +151,16 @@ def test_create_user_as_annotator(client: TestClient, db: Session):
     assert db.query(User).count() == 1
 
 
+def test_create_user_with_existent_username(client: TestClient, db: Session, admin_auth_header: dict):
+    UserFactory.create(username="username")
+    user = {"first_name": "first-name", "username": "username", "password": "12345678"}
+
+    response = client.post("/api/users", headers=admin_auth_header, json=user)
+
+    assert response.status_code == 409
+    assert db.query(User).count() == 2
+
+
 def test_create_user_with_invalid_min_length_first_name(client: TestClient, db: Session, admin_auth_header: dict):
     user = {"first_name": "", "username": "username", "password": "12345678"}
 

--- a/tests/server/api/v0/test_workspaces.py
+++ b/tests/server/api/v0/test_workspaces.py
@@ -83,6 +83,15 @@ def test_create_workspace_as_annotator(client: TestClient, db: Session):
     assert db.query(Workspace).count() == 0
 
 
+def test_create_workspace_with_existent_name(client: TestClient, db: Session, admin_auth_header: dict):
+    WorkspaceFactory.create(name="workspace")
+
+    response = client.post("/api/workspaces", headers=admin_auth_header, json={"name": "workspace"})
+
+    assert response.status_code == 409
+    assert db.query(Workspace).count() == 1
+
+
 def test_create_workspace_with_invalid_min_length_name(client: TestClient, db: Session, admin_auth_header: dict):
     response = client.post("/api/workspaces", headers=admin_auth_header, json={"name": ""})
 
@@ -203,6 +212,18 @@ def test_create_workspace_user_with_nonexistent_user_id(client: TestClient, db: 
 
     assert response.status_code == 404
     assert db.query(WorkspaceUser).count() == 0
+
+
+def test_create_workspace_user_with_existent_workspace_id_and_user_id(
+    client: TestClient, db: Session, admin: User, admin_auth_header: dict
+):
+    workspace = WorkspaceFactory.create()
+    WorkspaceUserFactory.create(workspace_id=workspace.id, user_id=admin.id)
+
+    response = client.post(f"/api/workspaces/{workspace.id}/users/{admin.id}", headers=admin_auth_header)
+
+    assert response.status_code == 409
+    assert db.query(WorkspaceUser).count() == 1
 
 
 def test_delete_workspace_user(client: TestClient, db: Session, admin_auth_header: dict):


### PR DESCRIPTION
This PR includes some additional checks to new endpoints that are creating entities to check before hand if those entities exists.

These changes are included for the following endpoints:
- Create users.
- Create workspaces.
- Create workspace users.