### PR TITLE
Add argilla_data volume to docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,9 @@ services:
     networks:
       - argilla
     volumes:
-      - data:/var/lib/argilla
+      # ARGILLA_HOME_PATH is used to define where Argilla will save it's application data.
+      # If you change ARGILLA_HOME_PATH value please copy that same value to argilladata volume too.
+      - argilladata:/var/lib/argilla
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.5.3
     environment:
@@ -55,5 +57,5 @@ networks:
   argilla:
     driver: bridge
 volumes:
-  data:
+  argilladata:
   elasticdata:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
     ports:
       - "6900:6900"
     environment:
+      ARGILLA_HOME_PATH: /var/lib/argilla
       ARGILLA_ELASTICSEARCH: http://elasticsearch:9200
       # Opt-out for telemetry https://docs.argilla.io/en/latest/reference/telemetry.html
       # ARGILLA_ENABLE_TELEMETRY: 0
@@ -18,7 +19,8 @@ services:
       #- ${PWD}/.users.yaml:/config/.users.yaml
     networks:
       - argilla
-
+    volumes:
+      - data:/var/lib/argilla
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.5.3
     environment:
@@ -48,8 +50,10 @@ services:
       ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'
     networks:
       - argilla
+
 networks:
   argilla:
     driver: bridge
 volumes:
+  data:
   elasticdata:


### PR DESCRIPTION
In this PR we are defining an argilla data volume to be used on our `docker-compose.yaml`.

Things to have into account:
- <del>I'm defining the volume as `data` because docker adds the `argilla_` prefix once it's created being `argilla_data` at the end.</del>
- Environment variables defined on the docker compose cannot being used on the right side of the volumes section. This can potentially provoke errors if the users sets the `ARGILLA_HOME_PATH` value.

I have successfully tested to set a custom volume pointing to a host folder with:

```dockerfile
argilla:
    volumes:
      - ${HOME}/.argilla:/var/lib/argilla
     
networks:
  argilla:
    driver: bridge
volumes:
  # argilladata:
  elasticdata:
```

And the database file is correctly created on my home folder. Restarting the docker compose is working too.