### PR TITLE
Replace team.apikey with admin.apikey on the entire project

### DIFF
--- a/docs/_source/getting_started/installation/deployments/huggingface-spaces.md
+++ b/docs/_source/getting_started/installation/deployments/huggingface-spaces.md
@@ -69,7 +69,7 @@ You can create your first dataset by logging it into Argilla using your endpoint
 import argilla as rg
 
 # connect to your app endpoint (uses default team API key)
-rg.init(api_url="[your_space_url]", api_key="team.apikey")
+rg.init(api_url="[your_space_url]", api_key="admin.apikey")
 
 # transform dataset into Argilla's format and log it
 rg.log(rg.read_datasets(dataset, task="TextClassification"), name="bankingapp_sentiment")

--- a/docs/_source/tutorials/notebooks/deploying-text2text-dvc-explainability.ipynb
+++ b/docs/_source/tutorials/notebooks/deploying-text2text-dvc-explainability.ipynb
@@ -135,7 +135,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/deploying-texttokenclassification-fastapi.ipynb
+++ b/docs/_source/tutorials/notebooks/deploying-texttokenclassification-fastapi.ipynb
@@ -127,7 +127,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },
@@ -660,7 +660,7 @@
     "\n",
     "argilla.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   }

--- a/docs/_source/tutorials/notebooks/labelling-text2text-disaggregators-explainability.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-text2text-disaggregators-explainability.ipynb
@@ -122,7 +122,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-gpt3-fewshot.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-gpt3-fewshot.ipynb
@@ -117,7 +117,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-sentence-transformers-semantic.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-sentence-transformers-semantic.ipynb
@@ -118,7 +118,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-sentencetransformers-weaksupervision.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-sentencetransformers-weaksupervision.ipynb
@@ -152,7 +152,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-setfit-zeroshot.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-setfit-zeroshot.ipynb
@@ -132,7 +132,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(    \n",
     "    api_url=\"put_here_your_url\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-sklearn-weaksupervision.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-sklearn-weaksupervision.ipynb
@@ -134,7 +134,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-snorkel-weaksupervision.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-snorkel-weaksupervision.ipynb
@@ -135,7 +135,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/labelling-tokenclassification-flair-fewshot.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-tokenclassification-flair-fewshot.ipynb
@@ -135,7 +135,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/labelling-tokenclassification-skweak-weaksupervision.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-tokenclassification-skweak-weaksupervision.ipynb
@@ -146,7 +146,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/labelling-tokenclassification-spacy-pretrained.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-tokenclassification-spacy-pretrained.ipynb
@@ -115,7 +115,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/monitoring-textclassification-cleanlab-explainability.ipynb
+++ b/docs/_source/tutorials/notebooks/monitoring-textclassification-cleanlab-explainability.ipynb
@@ -115,7 +115,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/monitoring-textclassification-shaptransformersinterpret-explainability.ipynb
+++ b/docs/_source/tutorials/notebooks/monitoring-textclassification-shaptransformersinterpret-explainability.ipynb
@@ -108,7 +108,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/monitoring-textclassification-transformers-explainability.ipynb
+++ b/docs/_source/tutorials/notebooks/monitoring-textclassification-transformers-explainability.ipynb
@@ -136,7 +136,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/template.ipynb
+++ b/docs/_source/tutorials/notebooks/template.ipynb
@@ -115,7 +115,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/training-textclassification-classyclassification-activelearning.ipynb
+++ b/docs/_source/tutorials/notebooks/training-textclassification-classyclassification-activelearning.ipynb
@@ -112,7 +112,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/training-textclassification-modal-activelearning.ipynb
+++ b/docs/_source/tutorials/notebooks/training-textclassification-modal-activelearning.ipynb
@@ -116,7 +116,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/training-textclassification-setfit-fewshot.ipynb
+++ b/docs/_source/tutorials/notebooks/training-textclassification-setfit-fewshot.ipynb
@@ -116,7 +116,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/training-textclassification-setfit-sentiment.ipynb
+++ b/docs/_source/tutorials/notebooks/training-textclassification-setfit-sentiment.ipynb
@@ -111,7 +111,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/training-textclassification-smalltext-activelearning.ipynb
+++ b/docs/_source/tutorials/notebooks/training-textclassification-smalltext-activelearning.ipynb
@@ -133,7 +133,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/training-textclassification-transformers-pretrained.ipynb
+++ b/docs/_source/tutorials/notebooks/training-textclassification-transformers-pretrained.ipynb
@@ -119,7 +119,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },

--- a/docs/_source/tutorials/notebooks/training-textgeneration-unstructured.ipynb
+++ b/docs/_source/tutorials/notebooks/training-textgeneration-unstructured.ipynb
@@ -115,7 +115,7 @@
     "# Replace api_key if you configured a custom API key\n",
     "rg.init(\n",
     "    api_url=\"http://localhost:6900\", \n",
-    "    api_key=\"team.apikey\"\n",
+    "    api_key=\"admin.apikey\"\n",
     ")"
    ]
   },


### PR DESCRIPTION
With the latest changes done to Quickstart Dockerfile we changed the default api-key for admin user from `team.apikey` to `admin.apikey`.

This PR replace all the ocurrences of the old `team.apikey` with the new `admin.apikey`.