### PR TITLE
Provide a default sort for text classification inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the fields to retrieve when loading the data from argilla. `rg.load` takes too long because of the vector field, even when users don't need it. Closes [#2398](https://github.com/argilla-io/argilla/issues/2398)
 - Add new page and components for dataset settings. Closes [#2442](https://github.com/argilla-io/argilla/issues/2003)
 - Add ability to show image in records (for TokenClassification and TextClassification) if an URL is passed in metadata with the key \_image_url
-- Non-searchable fields support in metadata. (#2570)
+- Non-searchable fields support in metadata. [#2570](https://github.com/argilla-io/argilla/pull/2570)
 
 ### Changed
 
 - Labels are now centralized in a specific vuex ORM called GlobalLabel Model, see https://github.com/argilla-io/argilla/issues/2210. This model is the same for TokenClassification and TextClassification (so both task have labels with color_id and shortcuts parameters in the vuex ORM)
 - The shortcuts improvement for labels [#2339](https://github.com/argilla-io/argilla/pull/2339) have been moved to the vuex ORM in dataset settings feature [#2444](https://github.com/argilla-io/argilla/commit/eb37c3bcff3ad253481d6a10f8abb093384f2dcb)
 - Update "Define a labeling schema" section in docs.
+- The record inputs are sorted alphabetically in UI by default. [#2581](https://github.com/argilla-io/argilla/pull/2581)
 
 ### Fixes
 

--- a/frontend/components/text-classifier/results/RecordInputs.vue
+++ b/frontend/components/text-classifier/results/RecordInputs.vue
@@ -56,7 +56,10 @@ export default {
   }),
   computed: {
     data() {
-      return this.record.inputs;
+      const entries = Object.entries(this.record.inputs);
+      entries.sort(([keyA], [keyB]) => keyA.localeCompare(keyB));
+
+      return Object.fromEntries(entries);
     },
     explanation() {
       return this.record.explanation;


### PR DESCRIPTION
# Description

Since it's hard to keep the default inputs order (see [here](https://github.com/argilla-io/argilla/issues/2233#issuecomment-1477691608) and [here](https://github.com/elastic/elasticsearch/issues/17639)), in this PR we add a default alphabetical short for text classification inputs in UI. 

This behavior can be used to control how record inputs will be shown by defining the proper keys.


Refs  #2233 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Refactor (change restructuring the codebase without changing functionality)
- [x] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

Visual manual tests are done.

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)