### PR TITLE
ci: Update docker images description only for release events

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -333,7 +333,7 @@ jobs:
 
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v3
-        if: ${{ github.event_name == 'release' }} && env.IS_DEPLOYABLE == 'true'
+        if: github.event_name == 'release' && env.IS_DEPLOYABLE == 'true'
         with:
           username: ${{ secrets.AR_DOCKER_USERNAME }}
           password: ${{ secrets.AR_DOCKER_PASSWORD }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -333,12 +333,13 @@ jobs:
 
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v3
+        if: ${{ github.event_name == 'release' }} && env.IS_DEPLOYABLE == 'true'
         with:
           username: ${{ secrets.AR_DOCKER_USERNAME }}
           password: ${{ secrets.AR_DOCKER_PASSWORD }}
           repository: ${{ matrix.image }}
           readme-filepath: ${{ matrix.readme }}
-        if: env.IS_DEPLOYABLE == 'true'
+
 
   # This job will upload a Python Package using Twine when a release is created
   # For more information see:


### PR DESCRIPTION
# Description

The docker image description is updated on every docker image publication. This PR changes this behavior to update it only when a release event is triggered. 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

Launching the ci pipeline.

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)