### PR TITLE
fix:  issue 2562

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+
+- Copying datasets between workspaces with proper owner/workspace info. Closes [#2562](https://github.com/argilla-io/argilla/issues/2562)
+
 ## [1.5.0](https://github.com/recognai/rubrix/compare/v1.4.0...v1.5.0) - 2023-03-21
 
 ### Added

--- a/src/argilla/server/daos/backend/search/query_builder.py
+++ b/src/argilla/server/daos/backend/search/query_builder.py
@@ -105,9 +105,11 @@ class EsQueryBuilder:
         query_filters = []
         if query.workspaces:
             query_filters.append(
-                filters.terms_filter(
-                    "owner.keyword",  # This will be moved to "workspace.keyword"
-                    query.workspaces,
+                filters.boolean_filter(
+                    should_filters=[
+                        filters.terms_filter("owner.keyword", query.workspaces),  # backward comp.
+                        filters.terms_filter("workspace.keyword", query.workspaces),
+                    ]
                 )
             )
 

--- a/src/argilla/server/daos/models/datasets.py
+++ b/src/argilla/server/daos/models/datasets.py
@@ -36,6 +36,9 @@ class BaseDatasetDB(BaseModel):
     )
     last_updated: datetime = None
 
+    class Config:
+        validate_assignment = True
+
     @root_validator(pre=True)
     def set_defaults(cls, values):
         workspace = values.get("workspace") or values.get("owner")

--- a/tests/server/datasets/test_model.py
+++ b/tests/server/datasets/test_model.py
@@ -81,3 +81,18 @@ def test_accept_create_dataset_without_created_by():
 
     assert ds
     assert ds.created_by is None
+
+
+def test_change_workspace_by_setting():
+    dataset = BaseDatasetDB(
+        name="a-dataset",
+        task=TaskType.text_classification,
+        workspace="workspace_name",
+        created_at=datetime.datetime.utcnow(),
+        last_updated=datetime.datetime.utcnow(),
+    )
+
+    assert dataset.workspace == dataset.owner
+    dataset.workspace = "another_workspace"
+
+    assert dataset.workspace == dataset.owner


### PR DESCRIPTION
# Description

Copying datasets between workspaces does not work as expected since workspace/owner info is now well-updated. This  PR fixes it by enabling the `validate_assignment` attribute. 


Closes #2562 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

Added proper tests

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)