### PR TITLE
fix: Using backend config to check version

### DIFF
--- a/src/argilla/server/daos/backend/client_adapters/factory.py
+++ b/src/argilla/server/daos/backend/client_adapters/factory.py
@@ -15,6 +15,7 @@ import logging
 from typing import Tuple, Type
 
 import httpx
+from opensearchpy import OpenSearch
 from packaging.version import parse
 
 from argilla.server.daos.backend.base import GenericSearchError
@@ -39,29 +40,24 @@ class ClientAdapterFactory:
         max_retries: int = 5,
     ) -> IClientAdapter:
 
-        (
-            client_class,
-            support_vector_search,
-        ) = cls._resolve_client_class_with_vector_support(hosts)
+        client_config = dict(
+            hosts=hosts,
+            verify_certs=ssl_verify,
+            ca_certs=ca_path,
+            retry_on_timeout=retry_on_timeout,
+            max_retries=max_retries,
+        )
+
+        version, distribution = cls._fetch_cluster_version_info(client_config)
+
+        (client_class, support_vector_search) = cls._resolve_client_class_with_vector_support(version, distribution)
 
         return client_class(
-            index_shards=index_shards,
-            vector_search_supported=support_vector_search,
-            config_backend=dict(
-                hosts=hosts,
-                verify_certs=ssl_verify,
-                ca_certs=ca_path,
-                retry_on_timeout=retry_on_timeout,
-                max_retries=max_retries,
-            ),
+            index_shards=index_shards, vector_search_supported=support_vector_search, config_backend=client_config
         )
 
     @classmethod
-    def _resolve_client_class_with_vector_support(
-        cls,
-        hosts: str,
-    ) -> Tuple[Type, bool]:
-        version, distribution = cls._fetch_cluster_version_info(hosts)
+    def _resolve_client_class_with_vector_support(cls, version: str, distribution: str) -> Tuple[Type, bool]:
 
         support_vector_search = True
 
@@ -85,10 +81,12 @@ class ClientAdapterFactory:
         return client_class, support_vector_search
 
     @classmethod
-    def _fetch_cluster_version_info(cls, hosts: str) -> Tuple[str, str]:
+    def _fetch_cluster_version_info(cls, client_config: dict) -> Tuple[str, str]:
         try:
-            response = httpx.get(hosts)
-            data = response.json()
+            # All security config will be used here.
+            # See here https://opensearch.org/docs/latest/clients/index/#legacy-clients
+            client = OpenSearch(**client_config)
+            data = client.info()
 
             version_info = data["version"]
             version: str = version_info["number"]

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -59,7 +59,7 @@ def gutenberg_spacy_ner(mocked_client):
 
     dataset = "gutenberg_spacy_ner"
     # TODO(@frascuchon): Move dataset to new organization
-    dataset_ds = load_dataset("argilla/gutenberg_spacy-ner", split="train")
+    dataset_ds = load_dataset("rubrix/gutenberg_spacy-ner", split="train")
     dataset_rb = argilla.read_datasets(dataset_ds, task="TokenClassification")
 
     argilla.delete(dataset)

--- a/tests/functional_tests/test_log_for_token_classification.py
+++ b/tests/functional_tests/test_log_for_token_classification.py
@@ -519,7 +519,7 @@ def test_search_keywords(mocked_client):
     from datasets import load_dataset
 
     # TODO(@frascuchon): Move dataset to new organization
-    dataset_ds = load_dataset("argilla/gutenberg_spacy-ner", split="train")
+    dataset_ds = load_dataset("rubrix/gutenberg_spacy-ner", split="train")
     dataset_rb = argilla.read_datasets(dataset_ds, task="TokenClassification")
 
     argilla.delete(dataset)


### PR DESCRIPTION
# Description

The backend version check request is not using the backend configuration setup from Argilla, so in some security environments, this check may fail. 

Instead of using a standard http request, on this PR we use a widely compatible `OpenSearch` client to request the version info.

Closes #2311 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

Manual test in a secured environment

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
