### PR TITLE
Add new ADMIN_ENABLED environment variable to release.Dockerfile

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,13 +10,16 @@ services:
     environment:
       ARGILLA_HOME_PATH: /var/lib/argilla
       ARGILLA_ELASTICSEARCH: http://elasticsearch:9200
-      # Opt-out for telemetry https://docs.argilla.io/en/latest/reference/telemetry.html
-      # ARGILLA_ENABLE_TELEMETRY: 0
+      # ARGILLA_ENABLE_TELEMETRY: 0 # Opt-out for telemetry https://docs.argilla.io/en/latest/reference/telemetry.html
 
       # Set user configuration https://docs.argilla.io/en/latest/getting_started/installation/user_management.html
       # ARGILLA_LOCAL_AUTH_USERS_DB_FILE: /config/.users.yaml
       # volumes:
       #- ${PWD}/.users.yaml:/config/.users.yaml
+
+      # DEFAULT_USER_ENABLED: false # Uncomment this line to disable the creation of the default user
+      # DEFAULT_USER_PASSWORD: custom-password # Uncomment this line to set a custom password for the default user
+      # DEFAULT_USER_API_KEY: custom-api-key # Uncomment this line to set a custom api-key for the default user
     networks:
       - argilla
     volumes:

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.9-slim
 
 # Environment Variables
 ENV ARGILLA_HOME_PATH=/var/lib/argilla
+ENV ADMIN_ENABLED=true
 ENV ADMIN_PASSWORD=1234
 ENV ADMIN_API_KEY=argilla.apikey
 ENV USERS_DB=/config/.users.yml

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -2,9 +2,9 @@ FROM python:3.9-slim
 
 # Environment Variables
 ENV ARGILLA_HOME_PATH=/var/lib/argilla
-ENV ADMIN_ENABLED=true
-ENV ADMIN_PASSWORD=1234
-ENV ADMIN_API_KEY=argilla.apikey
+ENV DEFAULT_USER_ENABLED=true
+ENV DEFAULT_USER_PASSWORD=1234
+ENV DEFAULT_USER_API_KEY=argilla.apikey
 ENV USERS_DB=/config/.users.yml
 ENV UVICORN_PORT=6900
 

--- a/scripts/start_argilla_server.sh
+++ b/scripts/start_argilla_server.sh
@@ -5,8 +5,8 @@ set -e
 python -m argilla.tasks.database.migrate
 
 # Create default user
-if [ "$ADMIN_ENABLED" = "true" ]; then
-  python -m argilla.tasks.users.create_default --password $ADMIN_PASSWORD --api-key $ADMIN_API_KEY
+if [ "$DEFAULT_USER_ENABLED" = "true" ]; then
+  python -m argilla.tasks.users.create_default --password $DEFAULT_USER_PASSWORD --api-key $DEFAULT_USER_API_KEY
 fi
 
 # Run argilla-server (See https://www.uvicorn.org/settings/#settings)

--- a/scripts/start_argilla_server.sh
+++ b/scripts/start_argilla_server.sh
@@ -5,7 +5,9 @@ set -e
 python -m argilla.tasks.database.migrate
 
 # Create default user
-python -m argilla.tasks.users.create_default --password $ADMIN_PASSWORD --api-key $ADMIN_API_KEY
+if [ "$ADMIN_ENABLED" = "true" ]; then
+  python -m argilla.tasks.users.create_default --password $ADMIN_PASSWORD --api-key $ADMIN_API_KEY
+fi
 
 # Run argilla-server (See https://www.uvicorn.org/settings/#settings)
 #


### PR DESCRIPTION
This PR adds a new `ADMIN_ENABLED` environment variable with a default value of `true`. This environment variable is checked to create or not the default admin user for Docker image generated by `release.Dockerfile`.

We will set this environment variable to `false` later for `PRE` and `PRO` Docker compose file so the default admin user is not created on these environments.