### PR TITLE
feat: access to list of rules while rule metrics are pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update "Define a labeling schema" section in docs.
 - The record inputs are sorted alphabetically in UI by default. [#2581](https://github.com/argilla-io/argilla/pull/2581)
 - The record inputs are fully visible when pagination size is one and the height of collapsed area size is bigger for laptop screen. [#2587](https://github.com/argilla-io/argilla/pull/2587/files)
+- the list of rules is now accessible while metrics are computed [#2117](https://github.com/argilla-io/argilla/issues/2117)
 
 ### Fixes
 

--- a/frontend/components/base/base-feedback/BaseFeedback.component.vue
+++ b/frontend/components/base/base-feedback/BaseFeedback.component.vue
@@ -7,7 +7,7 @@
     :buttonLabels="feedbackInput.buttonLabels"
     @on-click="onClick"
   />
-  <div v-else>{{ feedbackType }}</div>
+  <div v-else>{{ feedbackInput.message }}</div>
 </template>
 
 <script>

--- a/frontend/components/base/base-feedback/BaseFeedback.component.vue
+++ b/frontend/components/base/base-feedback/BaseFeedback.component.vue
@@ -3,6 +3,7 @@
     id="baseFeedBackId"
     v-if="isFeedbackError"
     :message="feedbackInput.message"
+    :isLoading="isLoading"
     :buttonLabels="feedbackInput.buttonLabels"
     @on-click="onClick"
   />
@@ -23,6 +24,10 @@ export default {
     feedbackInput: {
       type: Object,
       required: true,
+    },
+    isLoading: {
+      type: Boolean,
+      default: false,
     },
   },
   computed: {

--- a/frontend/components/base/base-feedback/base-feedback-error/BaseFeedbackError.component.vue
+++ b/frontend/components/base/base-feedback/base-feedback-error/BaseFeedbackError.component.vue
@@ -8,6 +8,7 @@
         </BaseButton>
       </div>
     </div>
+    <BaseSpinner v-if="isLoading" />
   </div>
 </template>
 
@@ -21,6 +22,10 @@ export default {
     },
     buttonLabels: {
       type: Array | null,
+    },
+    isLoading: {
+      type: Boolean,
+      default: false,
     },
   },
   computed: {

--- a/frontend/components/text-classifier/labeling-rules/RuleDefinition.vue
+++ b/frontend/components/text-classifier/labeling-rules/RuleDefinition.vue
@@ -23,7 +23,6 @@
           <template #button-bottom>
             <base-button
               class="rule__button primary light"
-              :disabled="isLoading"
               @click="showRulesList"
               >Manage rules</base-button
             >

--- a/frontend/components/text-classifier/labeling-rules/RulesManagement.vue
+++ b/frontend/components/text-classifier/labeling-rules/RulesManagement.vue
@@ -191,7 +191,7 @@ export default {
       const metrics = _.isNil(this.perRuleMetrics)
         ? null
         : this.perRuleMetrics[rule.query];
-      
+
       if (!metrics) {
         return {};
       }

--- a/frontend/components/text-classifier/labeling-rules/RulesManagement.vue
+++ b/frontend/components/text-classifier/labeling-rules/RulesManagement.vue
@@ -22,13 +22,24 @@
         placeholder="Search rule by name"
         @input="onSearch"
       />
+
+      <BaseFeedbackComponent
+        v-if="areMetricsInPending"
+        :feedbackInput="{
+          feedbackType: 'ERROR',
+          message: 'The metrics of the rules are in pending',
+        }"
+        :isLoading="areMetricsInPending"
+        class="feedback-area"
+      />
+
       <base-table-info
         class="rules-management__table"
         :data="formattedRules"
         :sorted-order="sortedOrder"
         :sorted-by-field="sortedByField"
         :columns="tableColumns"
-        :actions="actions"
+        :actions="areMetricsInPending ? [] : actions"
         :query-search="querySearch"
         :global-actions="false"
         search-on="query"
@@ -70,7 +81,6 @@ export default {
     return {
       querySearch: undefined,
       visibleModalId: undefined,
-      isLoading: undefined,
       sortedOrder: "desc",
       sortedByField: "created_at",
       actions: [{ name: "delete", icon: "trash-empty", title: "Delete rule" }],
@@ -181,6 +191,12 @@ export default {
         text: `You are about to delete the rule <strong>"${this.visibleModalId}"</strong> from your dataset. This action cannot be undone.`,
       };
     },
+    areMetricsInPending() {
+      return (
+        this.rules?.length !== 0 &&
+        this.rules.length !== Object.keys(this.perRuleMetrics || {})?.length
+      );
+    },
   },
   methods: {
     ...mapActions({
@@ -191,7 +207,7 @@ export default {
       const metrics = _.isNil(this.perRuleMetrics)
         ? null
         : this.perRuleMetrics[rule.query];
-      
+
       if (!metrics) {
         return {};
       }

--- a/frontend/components/text-classifier/labeling-rules/RulesManagement.vue
+++ b/frontend/components/text-classifier/labeling-rules/RulesManagement.vue
@@ -43,8 +43,10 @@
     </div>
   </div>
 </template>
+
 <script>
 import "assets/icons/unavailable";
+import _ from "lodash";
 import { mapActions } from "vuex";
 import { getDatasetFromORM } from "@/models/dataset.utilities";
 import { getViewSettingsByDatasetName } from "@/models/viewSettings.queries";
@@ -186,7 +188,10 @@ export default {
     }),
 
     metricsForRule(rule) {
-      const metrics = this.perRuleMetrics[rule.query];
+      const metrics = _.isNil(this.perRuleMetrics)
+        ? null
+        : this.perRuleMetrics[rule.query];
+      
       if (!metrics) {
         return {};
       }

--- a/frontend/components/text-classifier/labeling-rules/RulesManagement.vue
+++ b/frontend/components/text-classifier/labeling-rules/RulesManagement.vue
@@ -25,10 +25,7 @@
 
       <BaseFeedbackComponent
         v-if="areMetricsInPending"
-        :feedbackInput="{
-          feedbackType: 'ERROR',
-          message: 'The metrics of the rules are in pending',
-        }"
+        :feedbackInput="feedbackInputInMetricsPendingState"
         :isLoading="areMetricsInPending"
         class="feedback-area"
       />
@@ -83,6 +80,10 @@ export default {
       visibleModalId: undefined,
       sortedOrder: "desc",
       sortedByField: "created_at",
+      feedbackInputInMetricsPendingState: {
+        message: "Calculating rule metrics",
+        feedbackType: "ERROR",
+      },
       actions: [{ name: "delete", icon: "trash-empty", title: "Delete rule" }],
       noDataInfo: {
         title: "0 rules defined",


### PR DESCRIPTION
# Description
Allow to access rule management while rule metrics are pending

Note: this is not the most performant solution since the base-table component is rerendered each time the input change

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Closes #2117 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [x] Text classification

**Checklist**

- [x] I have merged the original branch into my forked branch
- N/A I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- N/A I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)