### PR TITLE
Set documentation copyright attribute with dynamic current year

### DIFF
--- a/docs/_source/community/developer_docs.rst
+++ b/docs/_source/community/developer_docs.rst
@@ -68,11 +68,11 @@ Building the documentation
 --------------------------
 
 To build the documentation, make sure you set up your system for *Argilla* development.
-Then go to the `docs` folder in your cloned repo and execute the ``make`` command:
+Then go to the `docs/_source` folder in your cloned repo and execute the ``make html`` command:
 
 .. code-block:: bash
 
-    cd docs
+    cd docs/_source
     make html
 
 This will create a ``_build/html`` folder in which you can find the ``index.html`` file of the documentation.

--- a/docs/_source/conf.py
+++ b/docs/_source/conf.py
@@ -31,6 +31,7 @@
 
 # -- Project information -----------------------------------------------------
 import os
+from datetime import datetime
 
 try:
     import argilla as rg
@@ -41,7 +42,7 @@ except ModuleNotFoundError:
 
 
 project = "Argilla"
-copyright = "2022, Argilla.io"
+copyright = f"{datetime.today().year}, Argilla.io"
 author = "Argilla.io"
 
 # Normally the full version, including alpha/beta/rc tags.


### PR DESCRIPTION
# Description

This PR changes how `copyright` docs attribute is set. Now instead of a fix string we are getting dynamically the current year.

See https://github.com/argilla-io/argilla/issues/2569#issuecomment-1482996933

**Type of change**

- [x] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**
 
- [x] I have locally generated the documentation and I can see that the copyright footer on the generated documentation is showing the current year.

**Checklist**

- [x] I have merged the original branch into my forked branch.
- [x] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] <del>I have added tests that prove my fix is effective or that my feature works</del> Not necessary.
- [ ] <del>I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)</del> Not necessary.