### PR TITLE
feat: add `ArgillaSpaCyTrainer` for both `TokenClassification` and `TextClassification`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,8 @@ sw.*
 # Vim swap files
 *.swp
 
+# Ruff cache
+.ruff_cache/
 
 yarn.lock
 package-lock.json

--- a/src/argilla/client/datasets.py
+++ b/src/argilla/client/datasets.py
@@ -433,7 +433,7 @@ class DatasetBase:
             return self._prepare_for_training_with_transformers(train_size=train_size, test_size=test_size, seed=seed)
         elif framework is Framework.SPACY and lang is None:
             raise ValueError(
-                "Please provide a spacy language model to prepare the" " dataset for training with the spacy framework."
+                "Please provide a spacy language model to prepare the dataset for training with the spacy framework."
             )
         elif framework in [Framework.SPACY, Framework.SPARK_NLP]:
             if train_size and test_size:

--- a/src/argilla/training/base.py
+++ b/src/argilla/training/base.py
@@ -61,8 +61,7 @@ class ArgillaTrainer(object):
                 self._multi_label = True
         elif isinstance(self.rg_dataset_snapshot, rg.DatasetForTokenClassification):
             self._rg_dataset_type = rg.DatasetForTokenClassification
-            self._required_fields = ["id", "text", "tokens", "ner_tags"]
-
+            self._required_fields = ["id", "text", "tokens", "annotation"]
         elif isinstance(self.rg_dataset_snapshot, rg.DatasetForText2Text):
             self._rg_dataset_type = rg.DatasetForText2Text
             self._required_fields = ["id", "text", "annotation"]

--- a/src/argilla/training/base.py
+++ b/src/argilla/training/base.py
@@ -113,10 +113,8 @@ class ArgillaTrainer(object):
                 model=self.model,
             )
         elif framework == "spacy":
-            if self._rg_dataset_type != rg.DatasetForTokenClassification:
-                raise NotImplementedError(
-                    "`argilla.training` does not support `TextClassification` nor `Text2Text` tasks yet."
-                )
+            if self._rg_dataset_type == rg.DatasetForText2Text:
+                raise NotImplementedError("`argilla.training` does not support `Text2Text` tasks yet.")
             self._trainer = ArgillaSpaCyTrainer(
                 record_class=self._rg_dataset_type._RECORD_TYPE,
                 dataset=self.dataset_full_prepared,

--- a/src/argilla/training/base.py
+++ b/src/argilla/training/base.py
@@ -26,7 +26,7 @@ class ArgillaTrainer(object):
     _logger = logging.getLogger("argilla.training")
 
     def __init__(
-        self, name: str, framework: str, model: str = None, train_size: float = None, seed: int = None, **load_kwargs
+        self, name: str, framework: str, model: str = None, train_size: float = None, seed: int = None, **load_kwargs: dict,
     ):
         """
         `__init__` is a function that initializes the class

--- a/src/argilla/training/base.py
+++ b/src/argilla/training/base.py
@@ -121,6 +121,8 @@ class ArgillaTrainer(object):
                 record_class=self._rg_dataset_type._RECORD_TYPE,
                 dataset=self.dataset_full_prepared,
                 model=self.model,
+                multi_label=self._multi_label,
+                seed=self._seed,
             )
         else:
             raise NotImplementedError(f"Framework {framework} is not supported.")

--- a/src/argilla/training/base.py
+++ b/src/argilla/training/base.py
@@ -88,6 +88,8 @@ class ArgillaTrainer(object):
             raise NotImplementedError(f"Dataset type {type(self.rg_dataset_snapshot)} is not supported.")
 
         self.dataset_full = rg.load(name=self._name, fields=self._required_fields, **load_kwargs)
+
+        framework = Framework(framework)
         if framework is Framework.SPACY:
             import spacy
 

--- a/src/argilla/training/base.py
+++ b/src/argilla/training/base.py
@@ -19,6 +19,7 @@ from typing import List, Union
 import argilla as rg
 from argilla.training.setfit import ArgillaSetFitTrainer
 from argilla.training.transformers import ArgillaTransformersTrainer
+from argilla.training.spacy import ArgillaSpaCyTrainer
 
 
 class ArgillaTrainer(object):
@@ -69,9 +70,15 @@ class ArgillaTrainer(object):
             raise NotImplementedError(f"Dataset type {type(self.rg_dataset_snapshot)} is not supported.")
 
         self.dataset_full = rg.load(name=self._name, fields=self._required_fields, **load_kwargs)
-        self.dataset_full_prepared = self.dataset_full.prepare_for_training(
-            framework=framework, train_size=self._train_size, seed=self._seed
-        )
+        if framework == "spacy":
+            import spacy
+            self.dataset_full_prepared = self.dataset_full.prepare_for_training(
+                framework=framework, train_size=self._train_size, seed=self._seed, lang=spacy.blank("en"),
+            )
+        else:
+            self.dataset_full_prepared = self.dataset_full.prepare_for_training(
+                framework=framework, train_size=self._train_size, seed=self._seed,
+            )
 
         if framework == "setfit":
             if self._rg_dataset_type != rg.DatasetForTextClassification():
@@ -91,6 +98,14 @@ class ArgillaTrainer(object):
                 dataset=self.dataset_full_prepared,
                 multi_label=self._multi_label,
                 seed=self._seed,
+                model=self.model,
+            )
+        elif framework == "spacy":
+            if self._rg_dataset_type != rg.DatasetForTokenClassification:
+                raise NotImplementedError("`argilla.training` does not support `TextClassification` nor `Text2Text` tasks yet.")
+            self._trainer = ArgillaSpaCyTrainer(
+                record_class=self._rg_dataset_type._RECORD_TYPE,
+                dataset=self.dataset_full_prepared,
                 model=self.model,
             )
         else:

--- a/src/argilla/training/base.py
+++ b/src/argilla/training/base.py
@@ -18,15 +18,21 @@ from typing import List, Union
 
 import argilla as rg
 from argilla.training.setfit import ArgillaSetFitTrainer
-from argilla.training.transformers import ArgillaTransformersTrainer
 from argilla.training.spacy import ArgillaSpaCyTrainer
+from argilla.training.transformers import ArgillaTransformersTrainer
 
 
 class ArgillaTrainer(object):
     _logger = logging.getLogger("argilla.training")
 
     def __init__(
-        self, name: str, framework: str, model: str = None, train_size: float = None, seed: int = None, **load_kwargs: dict,
+        self,
+        name: str,
+        framework: str,
+        model: str = None,
+        train_size: float = None,
+        seed: int = None,
+        **load_kwargs: dict,
     ):
         """
         `__init__` is a function that initializes the class
@@ -72,12 +78,18 @@ class ArgillaTrainer(object):
         self.dataset_full = rg.load(name=self._name, fields=self._required_fields, **load_kwargs)
         if framework == "spacy":
             import spacy
+
             self.dataset_full_prepared = self.dataset_full.prepare_for_training(
-                framework=framework, train_size=self._train_size, seed=self._seed, lang=spacy.blank("en"),
+                framework=framework,
+                train_size=self._train_size,
+                seed=self._seed,
+                lang=spacy.blank("en"),
             )
         else:
             self.dataset_full_prepared = self.dataset_full.prepare_for_training(
-                framework=framework, train_size=self._train_size, seed=self._seed,
+                framework=framework,
+                train_size=self._train_size,
+                seed=self._seed,
             )
 
         if framework == "setfit":
@@ -102,7 +114,9 @@ class ArgillaTrainer(object):
             )
         elif framework == "spacy":
             if self._rg_dataset_type != rg.DatasetForTokenClassification:
-                raise NotImplementedError("`argilla.training` does not support `TextClassification` nor `Text2Text` tasks yet.")
+                raise NotImplementedError(
+                    "`argilla.training` does not support `TextClassification` nor `Text2Text` tasks yet."
+                )
             self._trainer = ArgillaSpaCyTrainer(
                 record_class=self._rg_dataset_type._RECORD_TYPE,
                 dataset=self.dataset_full_prepared,

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -96,7 +96,7 @@ class ArgillaSpaCyTrainer:
         self.config["paths"]["train"] = self._train_dataset_path
         self.config["paths"]["dev"] = self._valid_dataset_path or self._train_dataset_path
         self.config["paths"]["vectors"] = model
-        self.config["system"]["seed"] = seed
+        self.config["system"]["seed"] = seed or 42
 
     def __repr__(self) -> None:
         """Return the string representation of the `ArgillaSpaCyTrainer` object containing

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -14,7 +14,8 @@
 
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import Any, Dict, TYPE_CHECKING, List, Optional, Tuple, Union
+from pydantic import BaseModel
 
 import argilla as rg
 
@@ -83,7 +84,7 @@ class ArgillaSpaCyTrainer:
             path.mkdir(parents=True)
         self._nlp.to_disk(path)
 
-    def predict(self, text: Union[List[str], str], as_argilla_records: bool = True):
+    def predict(self, text: Union[List[str], str], as_argilla_records: bool = True) -> Union[List[Dict[str, Any]], List[BaseModel]]:
         if isinstance(text, str):
             text = [text]
 

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -81,8 +81,12 @@ class ArgillaSpaCyTrainer:
             self._column_mapping = {"text": "text", "token": "tokens", "ner_tags": "ner_tags"}
             self._pipeline_name = "ner"
         elif self._record_class == rg.TextClassificationRecord:
-            self._column_mapping = {"text": "text", "label": "label"}
-            self._pipeline_name = "textcat_multilabel" if self._multi_label else "textcat"
+            if self._multi_label:
+                self._column_mapping = {"text": "text", "binarized_label": "label"}
+                self._pipeline_name = "textcat_multilabel"
+            else:
+                self._column_mapping = {"text": "text", "label": "label"}
+                self._pipeline_name = "textcat"
         else:
             raise NotImplementedError("`rg.Text2TextRecord` is not supported yet.")
 

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -65,7 +65,15 @@ class ArgillaSpaCyTrainer:
         )
         self.config["paths"]["train"] = self._train_dataset_path
         self.config["paths"]["dev"] = self._valid_dataset_path or self._train_dataset_path
-        self.config["paths"]["vectors"] = self.model
+
+    def __repr__(self) -> None:
+        formatted_string = []
+        formatted_string.append("`ArgillaSpaCyTrainer`")
+        for key, val in self.config["training"].items():
+            if isinstance(val, dict):
+                continue
+            formatted_string.append(f"{key}: {val}")
+        return "\n".join(formatted_string)
 
     def update_config(
         self,

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -65,14 +65,14 @@ class ArgillaSpaCyTrainer:
         import spacy
         from spacy.cli.init_config import init_config
 
-        self._train_dataset, self._valid_dataset = (
+        self._train_dataset, self._dev_dataset = (
             dataset if isinstance(dataset, tuple) and len(dataset) > 1 else (dataset, None)
         )
         self._train_dataset_path = "./train.spacy"
         self._train_dataset.to_disk(self._train_dataset_path)
-        if self._valid_dataset:
-            self._valid_dataset_path = "./valid.spacy"
-            self._valid_dataset.to_disk(self._valid_dataset_path)
+        if self._dev_dataset:
+            self._dev_dataset_path = "./dev.spacy"
+            self._dev_dataset.to_disk(self._dev_dataset_path)
 
         self._multi_label = multi_label
 
@@ -103,7 +103,7 @@ class ArgillaSpaCyTrainer:
             pipeline=[self._pipeline_name],
         )
         self.config["paths"]["train"] = self._train_dataset_path
-        self.config["paths"]["dev"] = self._valid_dataset_path or self._train_dataset_path
+        self.config["paths"]["dev"] = self._dev_dataset_path or self._train_dataset_path
         self.config["paths"]["vectors"] = model
         self.config["system"]["seed"] = seed or 42
 

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -183,12 +183,11 @@ class ArgillaSpaCyTrainer:
             str_input = True
 
         formatted_prediction = []
-        for t in text:
-            doc = self._nlp(t)
+        for doc in self._nlp.pipe(text):
             if self._pipeline_name == "ner":
                 entities = [(ent.label_, ent.start_char, ent.end_char) for ent in doc.ents]
                 pred = {
-                    "text": t,
+                    "text": doc.text,
                     "tokens": [t.text for t in doc],
                     "prediction": entities,
                 }
@@ -196,7 +195,7 @@ class ArgillaSpaCyTrainer:
                     pred = self._record_class(**pred)
             elif self._pipeline_name in ["textcat", "textcat_multilabel"]:
                 pred = {
-                    "text": t,
+                    "text": doc.text,
                     "prediction": [(k, v) for k, v in doc.cats.items()],
                 }
                 if as_argilla_records:

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -124,13 +124,19 @@ class ArgillaSpaCyTrainer:
         """
         self.config["training"].update(spacy_training_config)
 
-    def train(self) -> None:
-        """Train the pipeline using `spaCy`."""
+    def train(self, path: Optional[str] = None) -> None:
+        """Train the pipeline using `spaCy`.
+
+        Args:
+            path: A `str` with the path to save the trained pipeline. Defaults to None.
+        """
         from spacy.training.initialize import init_nlp
         from spacy.training.loop import train as train_nlp
 
         self._nlp = init_nlp(self.config, use_gpu=self.gpu_id)
         self._nlp, _ = train_nlp(self._nlp, use_gpu=self.gpu_id, stdout=sys.stdout, stderr=sys.stderr)
+        if path:
+            self.save(path)
 
     def save(self, path: str) -> None:
         """Save the trained pipeline to disk.

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -87,7 +87,12 @@ class ArgillaSpaCyTrainer:
             raise NotImplementedError("`rg.Text2TextRecord` is not supported yet.")
 
         self.language = language or "en"
-        self.gpu_id = gpu_id if spacy.prefer_gpu(gpu_id) else -1
+        self.gpu_id = gpu_id
+        if self.gpu_id != -1:
+            try:
+                spacy.prefer_gpu(self.gpu_id)
+            except:
+                self.gpu_id = -1
 
         self.config = init_config(
             lang=self.language,

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -31,6 +31,8 @@ class ArgillaSpaCyTrainer:
             rg.TextClassificationRecord, rg.TokenClassificationRecord, rg.Text2TextRecord
         ] = rg.DatasetForTokenClassification._RECORD_TYPE,
         model: Optional[str] = None,
+        seed: Optional[int] = None,
+        multi_label: bool = False,
         language: Optional[str] = None,
         gpu_id: Optional[int] = -1,
     ) -> None:

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Dict, List, Optional, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import argilla as rg
 
@@ -46,8 +46,8 @@ class ArgillaSpaCyTrainer:
 
     def train(self) -> None:
         import spacy
-        from spacy.cli.train import train as spacy_train
         from spacy.cli.init_config import init_config
+        from spacy.cli.train import train as spacy_train
 
         config_path = "train.cfg"
         init_config(

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -111,11 +111,15 @@ class ArgillaSpaCyTrainer:
         """Return the string representation of the `ArgillaSpaCyTrainer` object containing
         just the args that can be updated via `update_config`."""
         formatted_string = []
-        formatted_string.append("`ArgillaSpaCyTrainer`")
+        formatted_string.append(
+            "WARNING:`ArgillaSpaCyTrainer.update_config` just supports the update of the `training` "
+            "args defined in the `config.yaml` file for the sake of simplicity."
+        )
+        formatted_string.append("\n\t\t`ArgillaSpaCyTrainer`")
         for key, val in self.config["training"].items():
             if isinstance(val, dict):
                 continue
-            formatted_string.append(f"{key}: {val}")
+            formatted_string.append(f"\t\t\t{key}: {val}")
         return "\n".join(formatted_string)
 
     def update_config(

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -1,0 +1,90 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Dict, List, Optional, Union, TYPE_CHECKING
+
+import argilla as rg
+
+if TYPE_CHECKING:
+    from spacy.tokens import DocBin
+
+
+class ArgillaSpaCyTrainer:
+    def __init__(
+        self,
+        dataset: Dict[str, "DocBin"],
+        record_class: Union[
+            rg.TextClassificationRecord, rg.TokenClassificationRecord, rg.Text2TextRecord
+        ] = rg.DatasetForTokenClassification._RECORD_TYPE,
+        model: Optional[str] = None,
+    ) -> None:
+        self._train_dataset, self._valid_dataset = (
+            dataset if isinstance(dataset, tuple) and len(dataset) == 2 else (dataset, None)
+        )
+        self._train_dataset_path = self._train_dataset.to_disk("./train.spacy")
+        if self._valid_dataset:
+            self._valid_dataset = self._valid_dataset.to_disk("./valid.spacy")
+
+        self.model = model  #  or "en_core_web_trf"
+
+        self._record_class = record_class
+        if self._record_class == rg.TokenClassificationRecord:
+            self._column_mapping = {"text": "text", "token": "tokens", "ner_tags": "ner_tags"}
+        else:
+            raise NotImplementedError("`rg.TextClassificationRecord` and `rg.Text2TextRecord` are not supported yet.")
+
+    def train(self) -> None:
+        import spacy
+        from spacy.cli.train import train as spacy_train
+        from spacy.cli.init_config import init_config
+
+        config_path = "train.cfg"
+        init_config(
+            lang="en",
+            pipeline=["ner"],
+        ).to_disk(config_path)
+
+        output_model_path = "ner"
+        spacy_train(
+            config_path,
+            output_path=output_model_path,
+            overrides={
+                "paths.train": "train.spacy",
+                "paths.dev": "valid.spacy",
+                "paths.vectors": self.model,
+                "training.max_steps": 50,
+            },
+        )
+        self._model = spacy.load(f"{output_model_path}/model-best")
+
+    def save(self, path: str) -> None:
+        pass
+
+    def predict(self, text: Union[List[str], str], as_argilla_records: bool = True):
+        if isinstance(text, str):
+            text = [text]
+
+        preds = []
+        for t in text:
+            doc = self._model(t)
+            entities = [(ent.label_, ent.start_char, ent.end_char) for ent in doc.ents]
+            pred = {
+                "text": t,
+                "tokens": [t.text for t in doc],
+                "prediction": entities,
+            }
+            if as_argilla_records:
+                pred = self._record_class(**pred)
+            preds.append(pred)
+        return preds

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -30,8 +30,10 @@ class ArgillaSpaCyTrainer:
             rg.TextClassificationRecord, rg.TokenClassificationRecord, rg.Text2TextRecord
         ] = rg.DatasetForTokenClassification._RECORD_TYPE,
         model: Optional[str] = None,
-        use_gpu: bool = True,
+        gpu_id: Optional[int] = -1,
     ) -> None:
+        import spacy
+
         self._train_dataset, self._valid_dataset = (
             dataset if isinstance(dataset, tuple) and len(dataset) > 1 else (dataset, None)
         )
@@ -49,7 +51,7 @@ class ArgillaSpaCyTrainer:
         else:
             raise NotImplementedError("`rg.TextClassificationRecord` and `rg.Text2TextRecord` are not supported yet.")
 
-        self.use_gpu = use_gpu
+        self.gpu_id = gpu_id if spacy.prefer_gpu(gpu_id) else -1
 
     def train(self) -> None:
         import tempfile


### PR DESCRIPTION
# Description

This PR adds `ArgillaSpaCyTrainer` to use `spaCy` to train both `token-classification` and `text-classification` models through as of the recent development of `argilla.training`. `ArgillaSpaCyTrainer` leverages the features of [`spacy train`](https://spacy.io/usage/training) programmatically, to simplify the integration with Argilla.

This PR has been created on top of https://github.com/argilla-io/argilla/pull/2574 which is the former PR created by @davidberenstein1957 to add `argilla.training`.

Closes #2594

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

No unit tests have been developed as part of this PR since those will either be pushed as part of the main PR at https://github.com/argilla-io/argilla/pull/2574, or on another PR before merging into `develop`.

I took the chance to create a Jupyter Notebook following the `template.ipynb` provided by Argilla. The Jupyter Notebook shows how to train a NER from scratch using `spaCy`, and is available at https://colab.research.google.com/drive/1zwIpSMMhfyuUmuy2lMpp-HbZc-un8S2N?usp=share_link

**Checklist**

- [X] I have merged the original branch into my forked branch
- [x] I added relevant documentation
- [X] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)