### PR TITLE
Feature/return scores from search

### DIFF
--- a/docs/_source/guides/query_datasets.md
+++ b/docs/_source/guides/query_datasets.md
@@ -5,6 +5,7 @@ It allows you to perform simple fuzzy searches of words and phrases, or complex 
 
 The same query can be used in the search bar of the Argilla web app, or with the Python client as optional arguments.
 
+To load an Argilla dataset from a query, you can use the `load` function.
 
 ```python
 import argilla as rg
@@ -12,6 +13,11 @@ import argilla as rg
 rg.load("my_dataset", query="text.exact:example")
 ```
 
+To query an Argilla dataset for similar records, and get the records and their similarity score to the query, you can use the `query` function.
+
+```python
+rg.query("my_dataset", query="text.exact:example")
+```
 ## Search fields
 
 An important concept when searching with Elasticsearch is the *field* concept.
@@ -106,6 +112,10 @@ Note that the URL cannot exceed the metadata length limit.
 ## Vector fields
 
 It is also possible to query the presense of vector field. Imagine you only want to include records with `vectors={"vector_1": vector_1}`. You can then define a query `vectors.vector_1: *`.
+
+```python
+rg.query("my_dataset", vectors={"my_vector": [1, 2, 3]})
+```
 ## Filters as query string
 
 Just like the metadata, you can also use the filter fields in you query.

--- a/docs/_source/reference/python/python_client.rst
+++ b/docs/_source/reference/python/python_client.rst
@@ -15,7 +15,7 @@ Methods
 -------
 
 .. automodule:: argilla
-   :members: init, log, load, copy, delete, set_workspace, get_workspace, delete_records, active_client
+   :members: init, log, load, query, copy, delete, set_workspace, get_workspace, delete_records, active_client
 
 .. _python ref records:
 

--- a/src/argilla/__init__.py
+++ b/src/argilla/__init__.py
@@ -82,7 +82,7 @@ _import_structure = {
         "get_workspace",
         "init",
         "load",
-        "load_similar",
+        "query",
         "log",
         "log_async",
         "set_workspace",

--- a/src/argilla/__init__.py
+++ b/src/argilla/__init__.py
@@ -82,6 +82,7 @@ _import_structure = {
         "get_workspace",
         "init",
         "load",
+        "load_similar",
         "log",
         "log_async",
         "set_workspace",

--- a/src/argilla/client/api.py
+++ b/src/argilla/client/api.py
@@ -280,6 +280,65 @@ def load(
     )
 
 
+def load_similar(
+    name: str,
+    workspace: Optional[str] = None,
+    query: Optional[str] = None,
+    vector: Optional[Tuple[str, List[float]]] = None,
+    limit: Optional[int] = None,
+    sort: Optional[List[Tuple[str, str]]] = None,
+) -> Dataset:
+    """Loads a argilla dataset.
+
+    Args:
+        name: The dataset name.
+        workspace: The workspace to which records will be logged/loaded. If `None` (default) and the
+            env variable ``ARGILLA_WORKSPACE`` is not set, it will default to the private user workspace.
+        query: An ElasticSearch query with the `query string
+            syntax <https://argilla.readthedocs.io/en/stable/guides/queries.html>`_
+        vector: Vector configuration for a semantic search
+        ids: If provided, load dataset records with given ids.
+        limit: The number of records to retrieve.
+        sort: The fields on which to sort [(<field_name>, 'asc|decs')].
+        id_from: If provided, starts gathering the records starting from that Record.
+            As the Records returned with the load method are sorted by ID, ´id_from´
+            can be used to load using batches.
+        batch_size: If provided, load `batch_size` samples per request. A lower batch
+            size may help avoid timeouts.
+        as_pandas: DEPRECATED! To get a pandas DataFrame do
+            ``rg.load('my_dataset').to_pandas()``.
+
+    Returns:
+        A argilla dataset.
+
+    Examples:
+        **Basic Loading: load the samples sorted by their ID**
+
+        >>> import argilla as rg
+        >>> dataset = rg.load(name="example-dataset")
+
+        **Iterate over a large dataset:**
+            When dealing with a large dataset you might want to load it in batches to optimize memory consumption
+            and avoid network timeouts. To that end, a simple batch-iteration over the whole database can be done
+            employing the `from_id` parameter. This parameter will act as a delimiter, retrieving the N items after
+            the given id, where N is determined by the `limit` parameter. **NOTE** If
+            no `limit` is given the whole dataset after that ID will be retrieved.
+
+        >>> import argilla as rg
+        >>> dataset_batch_1 = rg.load(name="example-dataset", limit=1000)
+        >>> dataset_batch_2 = rg.load(name="example-dataset", limit=1000, id_from=dataset_batch_1[-1].id)
+
+    """
+    return ArgillaSingleton.get().load_similar(
+        name=name,
+        workspace=workspace,
+        query=query,
+        vector=vector,
+        limit=limit,
+        sort=sort,
+    )
+
+
 def copy(
     dataset: str,
     name_of_copy: str,

--- a/src/argilla/client/api.py
+++ b/src/argilla/client/api.py
@@ -280,15 +280,15 @@ def load(
     )
 
 
-def load_similar(
+def query(
     name: str,
     workspace: Optional[str] = None,
     query: Optional[str] = None,
     vector: Optional[Tuple[str, List[float]]] = None,
     limit: Optional[int] = None,
     sort: Optional[List[Tuple[str, str]]] = None,
-) -> Dataset:
-    """Loads a argilla dataset.
+) -> Iterable[Tuple[Record, float]]:
+    """Query an argilla dataset for records similar to a given vector.
 
     Args:
         name: The dataset name.
@@ -297,39 +297,19 @@ def load_similar(
         query: An ElasticSearch query with the `query string
             syntax <https://argilla.readthedocs.io/en/stable/guides/queries.html>`_
         vector: Vector configuration for a semantic search
-        ids: If provided, load dataset records with given ids.
         limit: The number of records to retrieve.
         sort: The fields on which to sort [(<field_name>, 'asc|decs')].
-        id_from: If provided, starts gathering the records starting from that Record.
-            As the Records returned with the load method are sorted by ID, ´id_from´
-            can be used to load using batches.
-        batch_size: If provided, load `batch_size` samples per request. A lower batch
-            size may help avoid timeouts.
-        as_pandas: DEPRECATED! To get a pandas DataFrame do
-            ``rg.load('my_dataset').to_pandas()``.
-
     Returns:
-        A argilla dataset.
+        Tuples of (record, score) sorted by score.
 
     Examples:
         **Basic Loading: load the samples sorted by their ID**
 
         >>> import argilla as rg
-        >>> dataset = rg.load(name="example-dataset")
-
-        **Iterate over a large dataset:**
-            When dealing with a large dataset you might want to load it in batches to optimize memory consumption
-            and avoid network timeouts. To that end, a simple batch-iteration over the whole database can be done
-            employing the `from_id` parameter. This parameter will act as a delimiter, retrieving the N items after
-            the given id, where N is determined by the `limit` parameter. **NOTE** If
-            no `limit` is given the whole dataset after that ID will be retrieved.
-
-        >>> import argilla as rg
-        >>> dataset_batch_1 = rg.load(name="example-dataset", limit=1000)
-        >>> dataset_batch_2 = rg.load(name="example-dataset", limit=1000, id_from=dataset_batch_1[-1].id)
+        >>> results = rg.query(name="example-dataset", vector=("my_vector", [1, 2, 3])
 
     """
-    return ArgillaSingleton.get().load_similar(
+    return ArgillaSingleton.get().query(
         name=name,
         workspace=workspace,
         query=query,

--- a/src/argilla/client/apis/search.py
+++ b/src/argilla/client/apis/search.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 import dataclasses
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from argilla.client.apis import AbstractApi
 from argilla.client.models import Record
@@ -34,7 +34,7 @@ class SearchResults:
     total: int
 
     records: List[Record]
-    scores: List[float]
+    scores: Optional[List[float]] = None
 
 
 class Search(AbstractApi):
@@ -82,5 +82,5 @@ class Search(AbstractApi):
         return SearchResults(
             total=response["total"],
             records=[record_class.parse_obj(r).to_client() for r in response["records"]],
-            scores=response["scores"],
+            scores=response["scores"] if "scores" in response else None,
         )

--- a/src/argilla/client/apis/search.py
+++ b/src/argilla/client/apis/search.py
@@ -34,6 +34,7 @@ class SearchResults:
     total: int
 
     records: List[Record]
+    scores: List[float]
 
 
 class Search(AbstractApi):
@@ -81,4 +82,5 @@ class Search(AbstractApi):
         return SearchResults(
             total=response["total"],
             records=[record_class.parse_obj(r).to_client() for r in response["records"]],
+            scores=response["scores"],
         )

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -535,7 +535,7 @@ class Argilla:
             )
         return records
 
-    def load_similar(
+    def query(
         self,
         name: str,
         workspace: Optional[str] = None,

--- a/src/argilla/server/apis/v0/handlers/text2text.py
+++ b/src/argilla/server/apis/v0/handlers/text2text.py
@@ -141,7 +141,7 @@ def configure_router():
             total=result.total,
             records=[Text2TextRecord.parse_obj(r) for r in result.records],
             aggregations=Text2TextSearchAggregations.parse_obj(result.metrics) if result.metrics else None,
-            scores=result.scores,
+            scores=result.scores if any(result.scores) else None,
         )
 
     metrics.configure_router(

--- a/src/argilla/server/apis/v0/handlers/text2text.py
+++ b/src/argilla/server/apis/v0/handlers/text2text.py
@@ -141,7 +141,7 @@ def configure_router():
             total=result.total,
             records=[Text2TextRecord.parse_obj(r) for r in result.records],
             aggregations=Text2TextSearchAggregations.parse_obj(result.metrics) if result.metrics else None,
-            scores=result.scores if any(result.scores) else None,
+            scores=result.scores,
         )
 
     metrics.configure_router(

--- a/src/argilla/server/apis/v0/handlers/text2text.py
+++ b/src/argilla/server/apis/v0/handlers/text2text.py
@@ -141,6 +141,7 @@ def configure_router():
             total=result.total,
             records=[Text2TextRecord.parse_obj(r) for r in result.records],
             aggregations=Text2TextSearchAggregations.parse_obj(result.metrics) if result.metrics else None,
+            scores=result.scores,
         )
 
     metrics.configure_router(

--- a/src/argilla/server/apis/v0/handlers/text_classification.py
+++ b/src/argilla/server/apis/v0/handlers/text_classification.py
@@ -192,6 +192,7 @@ def configure_router():
             total=result.total,
             records=result.records,
             aggregations=TextClassificationSearchAggregations.parse_obj(result.metrics) if result.metrics else None,
+            scores=result.scores,
         )
 
     @deprecate_endpoint(

--- a/src/argilla/server/apis/v0/handlers/text_classification.py
+++ b/src/argilla/server/apis/v0/handlers/text_classification.py
@@ -192,7 +192,7 @@ def configure_router():
             total=result.total,
             records=result.records,
             aggregations=TextClassificationSearchAggregations.parse_obj(result.metrics) if result.metrics else None,
-            scores=result.scores if any(result.scores) else None,
+            scores=result.scores,
         )
 
     @deprecate_endpoint(

--- a/src/argilla/server/apis/v0/handlers/text_classification.py
+++ b/src/argilla/server/apis/v0/handlers/text_classification.py
@@ -192,7 +192,7 @@ def configure_router():
             total=result.total,
             records=result.records,
             aggregations=TextClassificationSearchAggregations.parse_obj(result.metrics) if result.metrics else None,
-            scores=result.scores,
+            scores=result.scores if any(result.scores) else None,
         )
 
     @deprecate_endpoint(

--- a/src/argilla/server/apis/v0/handlers/token_classification.py
+++ b/src/argilla/server/apis/v0/handlers/token_classification.py
@@ -163,6 +163,7 @@ def configure_router():
             total=results.total,
             records=[TokenClassificationRecord.parse_obj(r) for r in results.records],
             aggregations=TokenClassificationAggregations.parse_obj(results.metrics) if results.metrics else None,
+            scores=results.scores,
         )
 
     token_classification_dataset_settings.configure_router(router)

--- a/src/argilla/server/apis/v0/handlers/token_classification.py
+++ b/src/argilla/server/apis/v0/handlers/token_classification.py
@@ -163,7 +163,7 @@ def configure_router():
             total=results.total,
             records=[TokenClassificationRecord.parse_obj(r) for r in results.records],
             aggregations=TokenClassificationAggregations.parse_obj(results.metrics) if results.metrics else None,
-            scores=results.scores if any(results.scores) else None,
+            scores=results.scores,
         )
 
     token_classification_dataset_settings.configure_router(router)

--- a/src/argilla/server/apis/v0/handlers/token_classification.py
+++ b/src/argilla/server/apis/v0/handlers/token_classification.py
@@ -163,7 +163,7 @@ def configure_router():
             total=results.total,
             records=[TokenClassificationRecord.parse_obj(r) for r in results.records],
             aggregations=TokenClassificationAggregations.parse_obj(results.metrics) if results.metrics else None,
-            scores=results.scores,
+            scores=results.scores if any(results.scores) else None,
         )
 
     token_classification_dataset_settings.configure_router(router)

--- a/src/argilla/server/apis/v0/models/commons/model.py
+++ b/src/argilla/server/apis/v0/models/commons/model.py
@@ -17,7 +17,7 @@
 Common model for task definitions
 """
 
-from typing import Any, Dict, Generic, List, TypeVar
+from typing import Any, Dict, Generic, List, TypeVar, Union
 
 from pydantic import BaseModel, Field
 from pydantic.generics import GenericModel
@@ -71,4 +71,4 @@ class BaseSearchResults(GenericModel, Generic[_Record, ServiceSearchResultsAggre
     total: int = 0
     records: List[_Record] = Field(default_factory=list)
     aggregations: ServiceSearchResultsAggregations = None
-    scores: List[float] = Field(default_factory=list)
+    scores: Union[List[float], None] = None

--- a/src/argilla/server/apis/v0/models/commons/model.py
+++ b/src/argilla/server/apis/v0/models/commons/model.py
@@ -71,3 +71,4 @@ class BaseSearchResults(GenericModel, Generic[_Record, ServiceSearchResultsAggre
     total: int = 0
     records: List[_Record] = Field(default_factory=list)
     aggregations: ServiceSearchResultsAggregations = None
+    scores: List[float] = Field(default_factory=list)

--- a/src/argilla/server/daos/backend/client_adapters/opensearch.py
+++ b/src/argilla/server/daos/backend/client_adapters/opensearch.py
@@ -761,7 +761,7 @@ class OpenSearchClient(IClientAdapter):
             **document["_source"],
             "id": document["_id"],
         }
-
+        data["score"] = document.get("_score", None)
         if add_sort_info and "sort" in document:
             data["sort"] = document["sort"]
 

--- a/src/argilla/server/daos/backend/client_adapters/opensearch.py
+++ b/src/argilla/server/daos/backend/client_adapters/opensearch.py
@@ -761,10 +761,10 @@ class OpenSearchClient(IClientAdapter):
             **document["_source"],
             "id": document["_id"],
         }
-        data["score"] = document.get("_score", None)
+        if "_score" in document and document["_score"] is not None:
+            data["score"] = document.get("_score")
         if add_sort_info and "sort" in document:
             data["sort"] = document["sort"]
-
         if highlight:
             keywords = highlight.parse_highligth_results(
                 doc=document,

--- a/src/argilla/server/services/search/model.py
+++ b/src/argilla/server/services/search/model.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Any, Dict, List, TypeVar
+from typing import Any, Dict, List, TypeVar, Union
 
 from pydantic import BaseModel, Field
 
@@ -68,6 +68,7 @@ class ServiceSearchResults(BaseModel):
     total: int
     records: List[ServiceRecord]
     metrics: Dict[str, Any] = Field(default_factory=dict)
+    scores: List[Union[float, None]] = Field(default_factory=list)
 
 
 ServiceRecordsQuery = TypeVar("ServiceRecordsQuery", bound=ServiceBaseRecordsQuery)

--- a/src/argilla/server/services/search/model.py
+++ b/src/argilla/server/services/search/model.py
@@ -68,7 +68,7 @@ class ServiceSearchResults(BaseModel):
     total: int
     records: List[ServiceRecord]
     metrics: Dict[str, Any] = Field(default_factory=dict)
-    scores: List[Union[float, None]] = Field(default_factory=list)
+    scores: Union[List[float], None] = None
 
 
 ServiceRecordsQuery = TypeVar("ServiceRecordsQuery", bound=ServiceBaseRecordsQuery)

--- a/src/argilla/server/services/search/model.py
+++ b/src/argilla/server/services/search/model.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Any, Dict, List, TypeVar, Union
+from typing import Any, Dict, List, Optional, TypeVar
 
 from pydantic import BaseModel, Field
 
@@ -68,7 +68,7 @@ class ServiceSearchResults(BaseModel):
     total: int
     records: List[ServiceRecord]
     metrics: Dict[str, Any] = Field(default_factory=dict)
-    scores: Union[List[float], None] = None
+    scores: Optional[List[float]] = None
 
 
 ServiceRecordsQuery = TypeVar("ServiceRecordsQuery", bound=ServiceBaseRecordsQuery)

--- a/src/argilla/server/services/search/service.py
+++ b/src/argilla/server/services/search/service.py
@@ -103,6 +103,7 @@ class SearchRecordsService:
             total=results.total,
             records=[record_type.parse_obj(r) for r in results.records],
             metrics=metrics_results if metrics_results else {},
+            scores=[r.get("score", 0.0) for r in results.records],
         )
 
     async def find_record_by_id(

--- a/src/argilla/server/services/search/service.py
+++ b/src/argilla/server/services/search/service.py
@@ -99,11 +99,13 @@ class SearchRecordsService:
                 self.__LOGGER__.warning("Cannot compute metric [%s]. Error: %s", metric.id, ex)
                 metrics_results[metric.id] = {}
 
+        similarity_scores = [r.get("score", 0.0) for r in results.records]
+
         return ServiceSearchResults(
             total=results.total,
             records=[record_type.parse_obj(r) for r in results.records],
             metrics=metrics_results if metrics_results else {},
-            scores=[r.get("score", 0.0) for r in results.records],
+            scores=similarity_scores if any(similarity_scores) else None,
         )
 
     async def find_record_by_id(

--- a/src/argilla/server/services/search/service.py
+++ b/src/argilla/server/services/search/service.py
@@ -99,7 +99,7 @@ class SearchRecordsService:
                 self.__LOGGER__.warning("Cannot compute metric [%s]. Error: %s", metric.id, ex)
                 metrics_results[metric.id] = {}
 
-        similarity_scores = [r.get("score", 0.0) for r in results.records]
+        similarity_scores = [r.pop("score", 0.0) for r in results.records]
 
         return ServiceSearchResults(
             total=results.total,

--- a/tests/functional_tests/search/test_search_service.py
+++ b/tests/functional_tests/search/test_search_service.py
@@ -136,8 +136,4 @@ def test_failing_metrics(service, mocked_client):
         record_type=TextClassificationRecord,
     )
 
-    assert results.dict() == {
-        "metrics": {"missing-metric": {}},
-        "records": [],
-        "total": 1,
-    }
+    assert results.dict() == {"metrics": {"missing-metric": {}}, "records": [], "total": 1, "scores": None}

--- a/tests/functional_tests/test_log_for_text_classification.py
+++ b/tests/functional_tests/test_log_for_text_classification.py
@@ -128,7 +128,7 @@ def test_similarity_search_in_python_client(
     condition=not SUPPORTED_VECTOR_SEARCH,
     reason="Vector search not supported",
 )
-def test_similarity_search_returns_score_in_python_client(
+def test_similarity_search_query_records_in_python_client(
     mocked_client: SecuredClient,
 ):
     dataset_name = "test_similarity_search_in_python_client_2"
@@ -158,7 +158,7 @@ def test_similarity_search_returns_score_in_python_client(
         ),
         name=dataset_name,
     )
-    records_scores = rg.load_similar(dataset_name, vector=("vinter", [1, 1, 1, 1]))
+    records_scores = rg.query(dataset_name, vector=("vinter", [1, 1, 1, 1]))
     scores = [score for _, score in records_scores]
     records = [record for record, _ in records_scores]
     assert all(map(lambda x: isinstance(x, float), scores))

--- a/tests/functional_tests/test_log_for_text_classification.py
+++ b/tests/functional_tests/test_log_for_text_classification.py
@@ -128,6 +128,50 @@ def test_similarity_search_in_python_client(
     condition=not SUPPORTED_VECTOR_SEARCH,
     reason="Vector search not supported",
 )
+def test_similarity_search_returns_score_in_python_client(
+    mocked_client: SecuredClient,
+):
+    dataset_name = "test_similarity_search_in_python_client_2"
+    text = "This is a text"
+    rg.delete(dataset_name)
+    rg.log(
+        rg.TextClassificationRecord(
+            id=0,
+            inputs=text,
+            vectors={"vinter": [0, 0, 0, 0]},
+        ),
+        name=dataset_name,
+    )
+    rg.log(
+        rg.TextClassificationRecord(
+            id=1,
+            inputs=text,
+            vectors={"vinter": [1, 1, 1, 1]},
+        ),
+        name=dataset_name,
+    )
+    rg.log(
+        rg.TextClassificationRecord(
+            id=2,
+            inputs=text,
+            vectors={"vinter": [2, 2, 2, 2]},
+        ),
+        name=dataset_name,
+    )
+    records_scores = rg.load_similar(dataset_name, vector=("vinter", [1, 1, 1, 1]))
+    scores = [score for _, score in records_scores]
+    records = [record for record, _ in records_scores]
+    assert all(map(lambda x: isinstance(x, float), scores))
+    assert all(map(lambda x: isinstance(x, rg.TextClassificationRecord), records))
+    assert scores[0] == 1.0
+    assert scores[1] == 0.2
+    assert scores[2] == 0.2
+
+
+@pytest.mark.skipif(
+    condition=not SUPPORTED_VECTOR_SEARCH,
+    reason="Vector search not supported",
+)
 def test_log_data_with_vectors_and_update_ok(
     mocked_client: SecuredClient,
 ):

--- a/tests/functional_tests/test_log_for_token_classification.py
+++ b/tests/functional_tests/test_log_for_token_classification.py
@@ -572,3 +572,50 @@ def test_log_data_with_vectors_and_update_ok(
 
     assert len(ds) == 5
     assert ds[0].id == 3
+
+
+@pytest.mark.skipif(
+    condition=not SUPPORTED_VECTOR_SEARCH,
+    reason="Vector search not supported",
+)
+def test_similarity_search_query_records_in_python_client(
+    mocked_client: SecuredClient,
+):
+    dataset_name = "test_similarity_search_in_python_client_2"
+    text = "This is a text"
+    argilla.delete(dataset_name)
+    argilla.log(
+        argilla.TokenClassificationRecord(
+            id=0,
+            text=text,
+            tokens=text.split(),
+            vectors={"vinter": [0, 0, 0, 0]},
+        ),
+        name=dataset_name,
+    )
+    argilla.log(
+        argilla.TokenClassificationRecord(
+            id=1,
+            text=text,
+            tokens=text.split(),
+            vectors={"vinter": [1, 1, 1, 1]},
+        ),
+        name=dataset_name,
+    )
+    argilla.log(
+        argilla.TokenClassificationRecord(
+            id=2,
+            text=text,
+            tokens=text.split(),
+            vectors={"vinter": [2, 2, 2, 2]},
+        ),
+        name=dataset_name,
+    )
+    records_scores = argilla.query(dataset_name, vector=("vinter", [1, 1, 1, 1]))
+    scores = [score for _, score in records_scores]
+    records = [record for record, _ in records_scores]
+    assert all(map(lambda x: isinstance(x, float), scores))
+    assert all(map(lambda x: isinstance(x, argilla.TokenClassificationRecord), records))
+    assert scores[0] == 1.0
+    assert scores[1] == 0.2
+    assert scores[2] == 0.2


### PR DESCRIPTION
# Description

This PR adds a new client function, `query` which takes a vector and a dataset name. The function returns the most similar records to the vector and the similarity scores from elasticsearch.

On documentation, the `query` function is added to 'methods' docs. The guide `docs/_source/guides/query_datasets.md` has been enhance to include the `query` method in relation to vector querying.

The guides `docs/_source/guides/label_records_with_semanticsearch.ipynb` and  `docs/_source/guides/schedule_jobs_with_listeners.ipynb` still use `load` method with a vector because they do not use the `score` attribute and would require functional changes. 
The `load` function still supports vectors. Let me know if you would prefer a different approach here.

Closes #2348 #2565 

**Type of change**


- [ ] New feature (non-breaking change which adds functionality)


**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] `tests.functional_tests.test_log_for_text_classification.test_similarity_search_query_records_in_python_client`
- [ ] `tests.functional_tests.test_log_for_token_classification.test_similarity_search_query_records_in_python_client`


**Checklist**

- [x] I have merged the original branch into my forked branch
- [x] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)