### PR TITLE
fix: Allow copy dataset with empty workspace to the default user workspace

### DIFF
--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -1,0 +1,40 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+
+from argilla.server.daos.backend import GenericElasticEngineBackend
+from argilla.server.daos.datasets import DatasetsDAO
+from argilla.server.daos.records import DatasetRecordsDAO
+from argilla.server.services.datasets import DatasetsService
+
+
+@pytest.fixture(scope="session")
+def es():
+    return GenericElasticEngineBackend.get_instance()
+
+
+@pytest.fixture(scope="session")
+def records_dao(es: GenericElasticEngineBackend):
+    return DatasetRecordsDAO.get_instance(es)
+
+
+@pytest.fixture(scope="session")
+def datasets_dao(records_dao: DatasetRecordsDAO, es: GenericElasticEngineBackend):
+    return DatasetsDAO.get_instance(es=es, records_dao=records_dao)
+
+
+@pytest.fixture(scope="session")
+def datasets_service(datasets_dao: DatasetsDAO):
+    return DatasetsService.get_instance(datasets_dao)

--- a/tests/server/services/__init__.py
+++ b/tests/server/services/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/server/services/test_datasets.py
+++ b/tests/server/services/test_datasets.py
@@ -1,0 +1,48 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from argilla.server.commons.models import TaskType
+from argilla.server.daos.datasets import DatasetsDAO
+from argilla.server.daos.models.datasets import BaseDatasetDB
+from argilla.server.security.model import User
+from argilla.server.services.datasets import DatasetsService
+
+
+def test_copy_dataset_with_no_owner_info(
+    datasets_service: DatasetsService, datasets_dao: DatasetsDAO
+):
+    dataset_name = "test_copy_dataset_with_no_owned_dataset"
+    dataset_copy_name = f"{dataset_name}_copy"
+
+    dataset = BaseDatasetDB(name=dataset_name, task=TaskType.text_classification)
+    user = User(username="test-user")
+
+    datasets_dao.delete_dataset(dataset)
+    datasets_dao.delete_dataset(
+        BaseDatasetDB(
+            name=dataset_copy_name,
+            task=TaskType.text_classification,
+            owner=user.username,
+        )
+    )
+
+    datasets_dao.create_dataset(dataset)
+
+    dataset_copy = datasets_service.copy_dataset(
+        user, dataset=dataset, copy_name=dataset_copy_name
+    )
+
+    assert dataset_copy.created_by == user.username
+    assert dataset_copy.name == dataset_copy_name
+    assert dataset_copy.owner == user.username


### PR DESCRIPTION
# Description

When users have an old dataset without workspaces (`-`) and try to migrate to a proper workspace (the user default), an error is raised with a 409 error:

```bash
AlreadyExistsApiError: Argilla server returned an error with http status: 409
Error details: [{'code': 'argilla.api.errors::EntityAlreadyExistsError', 'params': {'name': 'my_dataset', 'type': 'ServiceBaseDataset', 'workspace': 'argilla'}}]
```

This PR fixes this problem by checking the existence target workspace by searching with provided name + workspace, instead of using a more wide way.

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

Tests checking this behavior are added.

**Checklist**

- [x] I have merged the original branch into my forked branch
- [x] follows the style guidelines of this project
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
