### PR TITLE
fix: WIP: Align token-underline and text in Token Classifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 
 - Allow URL to be clickable in Jupyter notebook again. Closes [#2527](https://github.com/argilla-io/argilla/issues/2527)
+- Align token-underline and text in Token Classifier Closes [#2620](https://github.com/argilla-io/argilla/pull/2620)
 
 ### Removed
 

--- a/frontend/components/token-classifier/results/EntityHighlight.vue
+++ b/frontend/components/token-classifier/results/EntityHighlight.vue
@@ -28,16 +28,16 @@
       @dblclick="removeEntity"
       v-html="visualizeToken(token, i)"
     ></span
-    ><span class="whitespace">{{ charsBetweenTokens }}</span>
-    <svgicon
+    ><span class="whitespace">{{ charsBetweenTokens }}</span
+    ><svgicon
       class="remove-button"
       @click="removeEntity"
       v-if="annotationEnabled && span.origin === 'annotation'"
       width="11"
       height="11"
       name="close"
-    ></svgicon>
-    <lazy-text-span-tooltip v-if="showTooltip" :span="span" />
+    ></svgicon
+    ><lazy-text-span-tooltip v-if="showTooltip" :span="span" />
   </span>
 </template>
 


### PR DESCRIPTION
# Description

This PR  aligns token-underline and text in Token Classifier, removing the ghost space between inline-block elements

Closes #2588

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)