### PR TITLE
Add new API v1 datasets list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `/api/v1/datasets` new endpoint to list datasets ([#2615]).
+
+[#2615]: https://github.com/argilla-io/argilla/issues/2615
+
+## [Unreleased]
+
+### Added
+
 - `ARGILLA_HOME_PATH` new environment variable ([#2564]).
 - `ARGILLA_DATABASE_URL` new environment variable ([#2564]).
 - Basic support for user roles with `admin` and `annotator` ([#2564]).
@@ -37,7 +45,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Copying datasets between workspaces with proper owner/workspace info. Closes [#2562](https://github.com/argilla-io/argilla/issues/2562)
 - Using elasticsearch config to request backend version. Closes [#2311](https://github.com/argilla-io/argilla/issues/2311)
 
-
 ### Removed
 
 - `email` user field ([#2564]).
@@ -46,7 +53,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ARGILLA_LOCAL_AUTH_DEFAULT_APIKEY` and `ARGILLA_LOCAL_AUTH_DEFAULT_PASSWORD` environment variables. Use `python -m argilla.tasks.users.create_default` instead ([#2564]).
 
 [#2564]: https://github.com/argilla-io/argilla/issues/2564
-
 
 ## [1.5.0](https://github.com/recognai/rubrix/compare/v1.4.0...v1.5.0) - 2023-03-21
 

--- a/src/argilla/server/alembic/versions/b9099dc08489_create_datasets_table.py
+++ b/src/argilla/server/alembic/versions/b9099dc08489_create_datasets_table.py
@@ -33,10 +33,14 @@ def upgrade() -> None:
     op.create_table(
         "datasets",
         sa.Column("id", sa.Uuid, primary_key=True),
-        sa.Column("name", sa.String, nullable=False, index=True),  # TODO: Should the name of a dataset be unique?.
-        sa.Column("guidelines", sa.Text),  # TODO: I understand the guidelines are optional.
+        sa.Column("name", sa.String, nullable=False, index=True),
+        sa.Column("guidelines", sa.Text),
+        sa.Column(
+            "workspace_id", sa.Uuid, sa.ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False, index=True
+        ),
         sa.Column("inserted_at", sa.DateTime, nullable=False),
         sa.Column("updated_at", sa.DateTime, nullable=False),
+        sa.UniqueConstraint("name", "workspace_id", name="dataset_name_workspace_id_uq"),
     )
 
 

--- a/src/argilla/server/alembic/versions/b9099dc08489_create_datasets_table.py
+++ b/src/argilla/server/alembic/versions/b9099dc08489_create_datasets_table.py
@@ -35,7 +35,6 @@ def upgrade() -> None:
         sa.Column("id", sa.Uuid, primary_key=True),
         sa.Column("name", sa.String, nullable=False, index=True),  # TODO: Should the name of a dataset be unique?.
         sa.Column("guidelines", sa.Text),  # TODO: I understand the guidelines are optional.
-        sa.Column("status", sa.String, nullable=False, index=True),
         sa.Column("inserted_at", sa.DateTime, nullable=False),
         sa.Column("updated_at", sa.DateTime, nullable=False),
     )

--- a/src/argilla/server/alembic/versions/b9099dc08489_create_datasets_table.py
+++ b/src/argilla/server/alembic/versions/b9099dc08489_create_datasets_table.py
@@ -1,0 +1,45 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""create datasets table
+
+Revision ID: b9099dc08489
+Revises: 1769ee58fbb4
+Create Date: 2023-03-29 17:26:25.432467
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b9099dc08489"
+down_revision = "1769ee58fbb4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "datasets",
+        sa.Column("id", sa.Uuid, primary_key=True),
+        sa.Column("name", sa.String, nullable=False, index=True),  # TODO: Should the name of a dataset be unique?.
+        sa.Column("guidelines", sa.Text),  # TODO: I understand the guidelines are optional.
+        sa.Column("status", sa.String, nullable=False, index=True),
+        sa.Column("inserted_at", sa.DateTime, nullable=False),
+        sa.Column("updated_at", sa.DateTime, nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("datasets")

--- a/src/argilla/server/apis/v1/__init__.py
+++ b/src/argilla/server/apis/v1/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/src/argilla/server/apis/v1/handlers/__init__.py
+++ b/src/argilla/server/apis/v1/handlers/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -31,4 +31,7 @@ router = APIRouter(tags=["datasets"])
 def list_datasets(*, db: Session = Depends(get_db), current_user: User = Security(auth.get_current_user)):
     authorize(current_user, DatasetPolicyV1.list)
 
-    return datasets.list_datasets(db)
+    if current_user.is_admin:
+        return datasets.list_datasets(db)
+    else:
+        return current_user.datasets

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -1,0 +1,34 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import List
+
+from fastapi import APIRouter, Depends, Security
+from sqlalchemy.orm import Session
+
+from argilla.server.contexts import datasets
+from argilla.server.database import get_db
+from argilla.server.policies import DatasetPolicyV1, authorize
+from argilla.server.schemas.v1.datasets import Dataset
+from argilla.server.security import auth
+from argilla.server.security.model import User
+
+router = APIRouter()
+
+
+@router.get("/", response_model=List[Dataset])
+def list_datasets(*, db: Session = Depends(get_db), current_user: User = Security(auth.get_current_user)):
+    authorize(current_user, DatasetPolicyV1.list)
+
+    return datasets.list_datasets(db)

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -24,10 +24,10 @@ from argilla.server.schemas.v1.datasets import Dataset
 from argilla.server.security import auth
 from argilla.server.security.model import User
 
-router = APIRouter()
+router = APIRouter(tags=["datasets"])
 
 
-@router.get("/", response_model=List[Dataset])
+@router.get("/datasets", response_model=List[Dataset])
 def list_datasets(*, db: Session = Depends(get_db), current_user: User = Security(auth.get_current_user)):
     authorize(current_user, DatasetPolicyV1.list)
 

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -1,0 +1,20 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from argilla.server.models import Dataset
+from sqlalchemy.orm import Session
+
+
+def list_datasets(db: Session):
+    return db.query(Dataset).order_by(Dataset.inserted_at.asc()).all()

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -34,9 +34,29 @@ def default_inserted_at(context):
     return context.get_current_parameters()["inserted_at"]
 
 
+class DatasetStatus(str, Enum):
+    draft = "draft"
+    ready = "ready"
+
+
 class UserRole(str, Enum):
     admin = "admin"
     annotator = "annotator"
+
+
+class Dataset(Base):
+    __tablename__ = "datasets"
+
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    name: Mapped[str]
+    guidelines: Mapped[Optional[str]]
+    status: Mapped[DatasetStatus] = mapped_column(default=DatasetStatus.draft)
+
+    inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
+
+    def __repr__(self):
+        return f"Dataset(id={str(self.id)!r}, name={self.name!r}, guidelines={self.guidelines!r}, status={self.status.value!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
 
 
 class WorkspaceUser(Base):

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -34,11 +34,6 @@ def default_inserted_at(context):
     return context.get_current_parameters()["inserted_at"]
 
 
-class DatasetStatus(str, Enum):
-    draft = "draft"
-    ready = "ready"
-
-
 class UserRole(str, Enum):
     admin = "admin"
     annotator = "annotator"
@@ -50,13 +45,12 @@ class Dataset(Base):
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
     name: Mapped[str]
     guidelines: Mapped[Optional[str]]
-    status: Mapped[DatasetStatus] = mapped_column(default=DatasetStatus.draft)
 
     inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
     def __repr__(self):
-        return f"Dataset(id={str(self.id)!r}, name={self.name!r}, guidelines={self.guidelines!r}, status={self.status.value!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        return f"Dataset(id={str(self.id)!r}, name={self.name!r}, guidelines={self.guidelines!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
 
 
 class WorkspaceUser(Base):

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -45,9 +45,12 @@ class Dataset(Base):
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
     name: Mapped[str]
     guidelines: Mapped[Optional[str]]
+    workspace_id: Mapped[UUID] = mapped_column(ForeignKey("workspaces.id"))
 
     inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
+
+    workspace: Mapped["Workspace"] = relationship(back_populates="datasets")
 
     def __repr__(self):
         return f"Dataset(id={str(self.id)!r}, name={self.name!r}, guidelines={self.guidelines!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
@@ -79,6 +82,7 @@ class Workspace(Base):
     inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
+    datasets: Mapped[List["Dataset"]] = relationship(back_populates="workspace", order_by=Dataset.inserted_at.asc())
     users: Mapped[List["User"]] = relationship(
         secondary="workspaces_users", back_populates="workspaces", order_by=WorkspaceUser.inserted_at.asc()
     )

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -18,7 +18,7 @@ from enum import Enum
 from typing import List, Optional
 from uuid import UUID, uuid4
 
-from sqlalchemy import ForeignKey, Text
+from sqlalchemy import ForeignKey, Text, and_
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from argilla.server.database import Base
@@ -107,6 +107,16 @@ class User(Base):
 
     workspaces: Mapped[List["Workspace"]] = relationship(
         secondary="workspaces_users", back_populates="users", order_by=WorkspaceUser.inserted_at.asc()
+    )
+    datasets: Mapped[List["Dataset"]] = relationship(
+        secondary="workspaces_users",
+        primaryjoin=id == WorkspaceUser.user_id,
+        secondaryjoin=and_(
+            Workspace.id == Dataset.workspace_id,
+            WorkspaceUser.workspace_id == Workspace.id,
+        ),
+        viewonly=True,
+        order_by=Dataset.inserted_at.asc(),
     )
 
     @property

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -104,6 +104,12 @@ class DatasetPolicy:
         return lambda actor: actor.is_admin or is_get_allowed(actor) and cls.create(actor)
 
 
+class DatasetPolicyV1:
+    @classmethod
+    def list(cls, user: User) -> bool:
+        return True
+
+
 class DatasetSettingsPolicy:
     @classmethod
     def list(cls, dataset: Dataset) -> PolicyAction:

--- a/src/argilla/server/routes.py
+++ b/src/argilla/server/routes.py
@@ -33,6 +33,7 @@ from argilla.server.apis.v0.handlers import (
     users,
     workspaces,
 )
+from argilla.server.apis.v1.handlers import datasets as datasets_v1
 from argilla.server.errors.base_errors import __ALL__
 
 api_router = APIRouter(responses={error.HTTP_STATUS: error.api_documentation() for error in __ALL__})
@@ -54,3 +55,6 @@ for router in [
     text2text.router,
 ]:
     api_router.include_router(router, dependencies=dependencies)
+
+# API v1
+api_router.include_router(datasets_v1.router, prefix="/v1/datasets", tags=["datasets"])

--- a/src/argilla/server/routes.py
+++ b/src/argilla/server/routes.py
@@ -57,4 +57,4 @@ for router in [
     api_router.include_router(router, dependencies=dependencies)
 
 # API v1
-api_router.include_router(datasets_v1.router, prefix="/v1/datasets", tags=["datasets"])
+api_router.include_router(datasets_v1.router, prefix="/v1")

--- a/src/argilla/server/schemas/v1/__init__.py
+++ b/src/argilla/server/schemas/v1/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -1,0 +1,31 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class Dataset(BaseModel):
+    id: UUID
+    name: str
+    guidelines: Optional[str]
+    workspace_id: UUID
+    inserted_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -14,7 +14,16 @@
 
 import factory
 from argilla.server.database import SessionLocal
-from argilla.server.models import User, UserRole, Workspace, WorkspaceUser
+from argilla.server.models import Dataset, User, UserRole, Workspace, WorkspaceUser
+
+
+class Dataset(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = Dataset
+        sqlalchemy_session = SessionLocal()
+        sqlalchemy_session_persistence = "commit"
+
+    name = factory.Sequence(lambda n: f"dataset-{n}")
 
 
 class WorkspaceUserFactory(factory.alchemy.SQLAlchemyModelFactory):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -15,37 +15,41 @@
 import factory
 from argilla.server.database import SessionLocal
 from argilla.server.models import Dataset, User, UserRole, Workspace, WorkspaceUser
+from sqlalchemy import orm
 
-
-class Dataset(factory.alchemy.SQLAlchemyModelFactory):
-    class Meta:
-        model = Dataset
-        sqlalchemy_session = SessionLocal()
-        sqlalchemy_session_persistence = "commit"
-
-    name = factory.Sequence(lambda n: f"dataset-{n}")
+Session = orm.scoped_session(SessionLocal)
 
 
 class WorkspaceUserFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = WorkspaceUser
-        sqlalchemy_session = SessionLocal()
+        sqlalchemy_session = Session
         sqlalchemy_session_persistence = "commit"
 
 
 class WorkspaceFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = Workspace
-        sqlalchemy_session = SessionLocal()
+        sqlalchemy_session = Session
         sqlalchemy_session_persistence = "commit"
 
     name = factory.Sequence(lambda n: f"workspace-{n}")
 
 
+class DatasetFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = Dataset
+        sqlalchemy_session = Session
+        sqlalchemy_session_persistence = "commit"
+
+    name = factory.Sequence(lambda n: f"dataset-{n}")
+    workspace = factory.SubFactory(WorkspaceFactory)
+
+
 class UserFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = User
-        sqlalchemy_session = SessionLocal()
+        sqlalchemy_session = Session
         sqlalchemy_session_persistence = "commit"
 
     first_name = factory.Faker("first_name")

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -18,13 +18,36 @@ from tests.factories import DatasetFactory
 
 
 def test_list_datasets(client: TestClient, admin_auth_header: dict):
-    DatasetFactory.create(name="dataset-a")
-    DatasetFactory.create(name="dataset-b")
-    DatasetFactory.create(name="dataset-c")
+    dataset_a = DatasetFactory.create(name="dataset-a")
+    dataset_b = DatasetFactory.create(name="dataset-b", guidelines="guidelines")
+    dataset_c = DatasetFactory.create(name="dataset-c")
 
     response = client.get("/api/v1/datasets", headers=admin_auth_header)
 
     assert response.status_code == 200
-
-    response_body = response.json()
-    assert [dataset["name"] for dataset in response_body] == ["dataset-a", "dataset-b", "dataset-c"]
+    assert response.json() == [
+        {
+            "id": str(dataset_a.id),
+            "name": "dataset-a",
+            "guidelines": None,
+            "workspace_id": str(dataset_a.workspace_id),
+            "inserted_at": dataset_a.inserted_at.isoformat(),
+            "updated_at": dataset_a.updated_at.isoformat(),
+        },
+        {
+            "id": str(dataset_b.id),
+            "name": "dataset-b",
+            "guidelines": "guidelines",
+            "workspace_id": str(dataset_b.workspace_id),
+            "inserted_at": dataset_b.inserted_at.isoformat(),
+            "updated_at": dataset_b.updated_at.isoformat(),
+        },
+        {
+            "id": str(dataset_c.id),
+            "name": "dataset-c",
+            "guidelines": None,
+            "workspace_id": str(dataset_c.workspace_id),
+            "inserted_at": dataset_c.inserted_at.isoformat(),
+            "updated_at": dataset_c.updated_at.isoformat(),
+        },
+    ]

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -1,0 +1,30 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from fastapi.testclient import TestClient
+
+from tests.factories import DatasetFactory
+
+
+def test_list_datasets(client: TestClient, admin_auth_header: dict):
+    DatasetFactory.create(name="dataset-a")
+    DatasetFactory.create(name="dataset-b")
+    DatasetFactory.create(name="dataset-c")
+
+    response = client.get("/api/v1/datasets", headers=admin_auth_header)
+
+    assert response.status_code == 200
+
+    response_body = response.json()
+    assert [dataset["name"] for dataset in response_body] == ["dataset-a", "dataset-b", "dataset-c"]


### PR DESCRIPTION
# Description

This PR adds the first v1 endpoint for list datasets.

Some changes that we need to discuss:
- I have added `DatasetPolicyV1` class into `policies.py`. We can think into alternatives to split the policies into different versions if required.
- I have not used `response_model_exclude_none=True` into the new endpoint. I think it's not a good idea to remove attributes becase they are empty and I have taken the chance of not using it with this new v1.
- I have changed how database sessions are managed with the factories. Now it's possible to work with relationships so for example now the workspace is automatically created when a dataset factory is used.