### PR TITLE
Add new API v1 datasets create endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `/api/v1/datasets` new endpoint to list datasets ([#2615]).
+- `/api/v1/datasets` new endpoint to list and create datasets ([#2615]).
 
 [#2615]: https://github.com/argilla-io/argilla/issues/2615
 

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -12,9 +12,33 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from uuid import UUID
+
 from argilla.server.models import Dataset
+from argilla.server.schemas.v1.datasets import DatasetCreate
 from sqlalchemy.orm import Session
+
+
+def get_dataset_by_name_and_workspace_id(db: Session, name: str, workspace_id: UUID):
+    return db.query(Dataset).filter_by(name=name, workspace_id=workspace_id).first()
 
 
 def list_datasets(db: Session):
     return db.query(Dataset).order_by(Dataset.inserted_at.asc()).all()
+
+
+def create_dataset(db: Session, dataset_create: DatasetCreate):
+    # TODO: We need to create the dataset index on ElasticSearch?
+    # - We should do it inside a database transaction.
+
+    dataset = Dataset(
+        name=dataset_create.name,
+        guidelines=dataset_create.guidelines,
+        workspace_id=dataset_create.workspace_id,
+    )
+
+    db.add(dataset)
+    db.commit()
+    db.refresh(dataset)
+
+    return dataset

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -109,6 +109,10 @@ class DatasetPolicyV1:
     def list(cls, user: User) -> bool:
         return True
 
+    @classmethod
+    def create(cls, user: User) -> bool:
+        return user.is_admin
+
 
 class DatasetSettingsPolicy:
     @classmethod

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -29,3 +29,9 @@ class Dataset(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class DatasetCreate(BaseModel):
+    name: str
+    guidelines: Optional[str]
+    workspace_id: UUID


### PR DESCRIPTION
# Description

This PR adds a new v1 endpoint to create datasets.

Some missing things that we need to discuss:
* Do we need to create something on ElasticSearch at the same time the dataset is created on the database?.