### PR TITLE
Add datasets get endpoint and refactor API v1 errors and status codes

### DIFF
--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -15,12 +15,11 @@
 from typing import List
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Security
+from fastapi import APIRouter, Depends, HTTPException, Security, status
 from sqlalchemy.orm import Session
 
 from argilla.server.contexts import datasets
 from argilla.server.database import get_db
-from argilla.server.errors import EntityAlreadyExistsError, EntityNotFoundError
 from argilla.server.policies import DatasetPolicyV1, authorize
 from argilla.server.schemas.v1.datasets import Dataset, DatasetCreate
 from argilla.server.security import auth
@@ -30,7 +29,11 @@ router = APIRouter(tags=["datasets"])
 
 
 @router.get("/datasets", response_model=List[Dataset])
-def list_datasets(*, db: Session = Depends(get_db), current_user: User = Security(auth.get_current_user)):
+def list_datasets(
+    *,
+    db: Session = Depends(get_db),
+    current_user: User = Security(auth.get_current_user),
+):
     authorize(current_user, DatasetPolicyV1.list)
 
     if current_user.is_admin:
@@ -39,7 +42,26 @@ def list_datasets(*, db: Session = Depends(get_db), current_user: User = Securit
         return current_user.datasets
 
 
-@router.post("/datasets", response_model=Dataset)
+@router.get("/datasets/{dataset_id}", response_model=Dataset)
+def get_dataset(
+    *,
+    db: Session = Depends(get_db),
+    dataset_id: UUID,
+    current_user: User = Security(auth.get_current_user),
+):
+    dataset = datasets.get_dataset_by_id(db, dataset_id)
+    if not dataset:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Dataset with id `{dataset_id}` not found",
+        )
+
+    authorize(current_user, DatasetPolicyV1.get(dataset))
+
+    return dataset
+
+
+@router.post("/datasets", status_code=status.HTTP_201_CREATED, response_model=Dataset)
 def create_dataset(
     *,
     db: Session = Depends(get_db),
@@ -49,7 +71,10 @@ def create_dataset(
     authorize(current_user, DatasetPolicyV1.create)
 
     if datasets.get_dataset_by_name_and_workspace_id(db, dataset_create.name, dataset_create.workspace_id):
-        raise EntityAlreadyExistsError(name=dataset_create.name, type=Dataset)
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Dataset with name `{dataset_create.name}` already exists for workspace with id `{dataset_create.workspace_id}`",
+        )
 
     return datasets.create_dataset(db, dataset_create)
 
@@ -65,7 +90,10 @@ def delete_dataset(
 
     dataset = datasets.get_dataset_by_id(db, dataset_id)
     if not dataset:
-        raise EntityNotFoundError(name=str(dataset_id), type=Dataset)
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Dataset with id `{dataset_id}` not found",
+        )
 
     datasets.delete_dataset(db, dataset)
 


### PR DESCRIPTION
# Description

This PR adds a new endpoint useful to get datasets to API v1.

I have added some changes too:
* Now instead of raising custom exceptions I'm using FastAPI `HTTPException`.
* `status_code` is changed for the creation route from `200` to `201`.

@frascuchon please take a look to the v1 policies for Datasets and check that everything is correct.