### PR TITLE
Move dataset dump to `train`, ignored unnecessary imports, & remove `_required_fields` attribute

### DIFF
--- a/src/argilla/training/base.py
+++ b/src/argilla/training/base.py
@@ -76,20 +76,17 @@ class ArgillaTrainer(object):
 
         if isinstance(self.rg_dataset_snapshot, rg.DatasetForTextClassification):
             self._rg_dataset_type = rg.DatasetForTextClassification
-            self._required_fields = ["id", "text", "inputs", "annotation", "multi_label"]
             if self.rg_dataset_snapshot[0].multi_label:
                 self._multi_label = True
         elif isinstance(self.rg_dataset_snapshot, rg.DatasetForTokenClassification):
             self._rg_dataset_type = rg.DatasetForTokenClassification
-            self._required_fields = ["id", "text", "tokens", "annotation", "ner_tags"]
         elif isinstance(self.rg_dataset_snapshot, rg.DatasetForText2Text):
             self._rg_dataset_type = rg.DatasetForText2Text
-            self._required_fields = ["id", "text", "annotation"]
             raise NotImplementedError("`argilla.training` does not support `Text2Text` tasks yet.")
         else:
             raise NotImplementedError(f"Dataset type {type(self.rg_dataset_snapshot)} is not supported.")
 
-        self.dataset_full = rg.load(name=self._name, fields=self._required_fields, **load_kwargs)
+        self.dataset_full = rg.load(name=self._name, **load_kwargs)
 
         framework = Framework(framework)
         if framework is Framework.SPACY:
@@ -160,7 +157,6 @@ class ArgillaTrainer(object):
                 dataset: {self._name}
                 task: {self._rg_dataset_type.__name__}
                 multi_label: {self._multi_label}
-                required_fields: {self._required_fields}
                 train_size: {self._train_size}
                 seed: {self._seed}
 

--- a/src/argilla/training/base.py
+++ b/src/argilla/training/base.py
@@ -19,9 +19,6 @@ from typing import TYPE_CHECKING, List, Optional, Union
 
 import argilla as rg
 from argilla.client.models import Framework
-from argilla.training.setfit import ArgillaSetFitTrainer
-from argilla.training.spacy import ArgillaSpaCyTrainer
-from argilla.training.transformers import ArgillaTransformersTrainer
 
 os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
 
@@ -114,6 +111,8 @@ class ArgillaTrainer(object):
         if framework is Framework.SETFIT:
             if self._rg_dataset_type != rg.DatasetForTextClassification():
                 raise NotImplementedError(f"{Framework.SETFIT} only support `TextClassification` tasks.")
+            from argilla.training.setfit import ArgillaSetFitTrainer
+
             self._trainer = ArgillaSetFitTrainer(
                 record_class=self._rg_dataset_type._RECORD_TYPE,
                 dataset=self.dataset_full_prepared,
@@ -122,6 +121,8 @@ class ArgillaTrainer(object):
                 model=self.model,
             )
         elif framework is Framework.TRANSFORMERS:
+            from argilla.training.transformers import ArgillaTransformersTrainer
+
             self._trainer = ArgillaTransformersTrainer(
                 record_class=self._rg_dataset_type._RECORD_TYPE,
                 dataset=self.dataset_full_prepared,
@@ -130,6 +131,8 @@ class ArgillaTrainer(object):
                 model=self.model,
             )
         elif framework is Framework.SPACY:
+            from argilla.training.spacy import ArgillaSpaCyTrainer
+
             self._trainer = ArgillaSpaCyTrainer(
                 record_class=self._rg_dataset_type._RECORD_TYPE,
                 dataset=self.dataset_full_prepared,

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -74,15 +74,6 @@ class ArgillaSpaCyTrainer:
         import spacy
         from spacy.cli.init_config import init_config
 
-        self._train_dataset, self._dev_dataset = (
-            dataset if isinstance(dataset, tuple) and len(dataset) > 1 else (dataset, None)
-        )
-        self._train_dataset_path = "./train.spacy"
-        self._train_dataset.to_disk(self._train_dataset_path)
-        if self._dev_dataset:
-            self._dev_dataset_path = "./dev.spacy"
-            self._dev_dataset.to_disk(self._dev_dataset_path)
-
         self._multi_label = multi_label
 
         self._record_class = record_class
@@ -98,6 +89,12 @@ class ArgillaSpaCyTrainer:
                 self._pipeline_name = "textcat"
         else:
             raise NotImplementedError("`rg.Text2TextRecord` is not supported yet.")
+
+        self._train_dataset, self._dev_dataset = (
+            dataset if isinstance(dataset, tuple) and len(dataset) > 1 else (dataset, None)
+        )
+        self._train_dataset_path = "./train.spacy"
+        self._dev_dataset_path = "./dev.spacy" if self._dev_dataset else None
 
         self.language = language or "en"
         self.gpu_id = gpu_id
@@ -161,6 +158,17 @@ class ArgillaSpaCyTrainer:
         """
         from spacy.training.initialize import init_nlp
         from spacy.training.loop import train as train_nlp
+
+        self._logger.warn(
+            "Note that the spaCy training is expected to be used through the CLI not "
+            "programatically, so the dataset needs to be dumped into the disk and then "
+            "loaded from disk. More information at https://spacy.io/usage/training#api"
+        )
+        self._logger.info(f"Dumping the train dataset to {self._train_dataset_path}")
+        self._train_dataset.to_disk(self._train_dataset_path)
+        if self._dev_dataset:
+            self._logger.info(f"Dumping the dev dataset to {self._dev_dataset_path}")
+            self._dev_dataset.to_disk(self._dev_dataset_path)
 
         self._nlp = init_nlp(self.config, use_gpu=self.gpu_id)
         self._nlp, _ = train_nlp(self._nlp, use_gpu=self.gpu_id, stdout=sys.stdout, stderr=sys.stderr)

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -160,7 +160,7 @@ class ArgillaSpaCyTrainer:
         from spacy.training.loop import train as train_nlp
 
         self._logger.warn(
-            "Note that the spaCy training is expected to be used through the CLI not "
+            "Note that the spaCy training is expected to be used through the CLI rather than "
             "programatically, so the dataset needs to be dumped into the disk and then "
             "loaded from disk. More information at https://spacy.io/usage/training#api"
         )


### PR DESCRIPTION
# Description

As of recent updates and findings, some things could be improved in `argilla.training`.

Since the `ArgillaSpaCyTrainer` needs to dump the dataset to disk before actually training the model, it has been moved out of the `__init__` so that the dataset/s are dumped once the `train()` method is called. Additionally, a warning message has been included to let the user know that the process may take longer due to the dataset dump being a requirement from `spaCy` training.

Besides that, some other things have been spotted:
* As the `ArgillaSetFitTrainer` and `ArgillaTransformersTrainer` imports are on the top of the file, those are imported when using any framework in `ArgillaTrainer`. So on, since some of those require specific dependencies, we've moved those inside their respective if-statements, so that e.g. `ArgillaSpaCyTrainer` doesn't require `setfit` to be installed.
* As of dfa1ee444b42fbe1831f2f3ca111146322385048, the param `fields` has been removed in `rg.load`, so on, the `_require_fields` attribute set in `ArgillaTrainer` is no longer valid.

**Type of change**

- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

Since the unit tests are being developed in the target branch, those have not been created in this PR, but the following script has been tested successfully!

```python
import argilla as rg
from argilla.training import ArgillaTrainer

rg.init(api_url="https://alvarobartt-argilla-datasets.hf.space", api_key="team.apikey")

trainer = ArgillaTrainer(name="ner", framework="spacy", train_size=0.8)
trainer.update_config(max_epochs=2)
trainer.train(output_dir="ner")
records = trainer.predict("I live in Barcelona.", as_argilla_records=True)

rg.log(
    records=records,
    name="ner",
    tags={
        "task": "NER",
        "family": "token-classification",
        "dataset": "gutenberg-time",
    },
)
```

**Checklist**

- [X] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)