### PR TITLE
Add new annotations table and ORM model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `/api/v1/datasets` new endpoint to list and create datasets ([#2615]).
+- `/api/v1/datasets/{dataset_id}` new endpoint to delete datasets ([#2615]).
 
 [#2615]: https://github.com/argilla-io/argilla/issues/2615
 

--- a/src/argilla/server/alembic/versions/3a8e2f9b5dea_create_annotations_table.py
+++ b/src/argilla/server/alembic/versions/3a8e2f9b5dea_create_annotations_table.py
@@ -1,0 +1,50 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""create annotations table
+
+Revision ID: 3a8e2f9b5dea
+Revises: b9099dc08489
+Create Date: 2023-04-03 17:24:53.836750
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.sql import expression
+
+# revision identifiers, used by Alembic.
+revision = "3a8e2f9b5dea"
+down_revision = "b9099dc08489"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "annotations",
+        sa.Column("id", sa.Uuid, primary_key=True),
+        sa.Column("name", sa.String, nullable=False, index=True),
+        sa.Column("title", sa.Text, nullable=False),
+        sa.Column("type", sa.String, nullable=False, index=True),
+        sa.Column("required", sa.Boolean, nullable=False, server_default=expression.false()),
+        sa.Column("settings", sa.JSON, nullable=False),
+        sa.Column("dataset_id", sa.Uuid, sa.ForeignKey("datasets.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column("inserted_at", sa.DateTime, nullable=False),
+        sa.Column("updated_at", sa.DateTime, nullable=False),
+        sa.UniqueConstraint("name", "dataset_id", name="annotation_name_dataset_id_uq"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("annotations")

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -50,9 +50,9 @@ class Annotation(Base):
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
     name: Mapped[str]
     title: Mapped[str] = mapped_column(Text)
-    type: Mapped[Optional[AnnotationType]] = mapped_column(default=AnnotationType.text)
-    required: Mapped[Optional[bool]] = mapped_column(default=False)
-    settings: Mapped[Optional[dict]] = mapped_column(JSON, default={})
+    type: Mapped[AnnotationType] = mapped_column(default=AnnotationType.text)
+    required: Mapped[bool] = mapped_column(default=False)
+    settings: Mapped[dict] = mapped_column(JSON, default={})
     dataset_id: Mapped[UUID] = mapped_column(ForeignKey("datasets.id"))
 
     inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -36,7 +36,7 @@ def default_inserted_at(context):
 
 class AnnotationType(str, Enum):
     text = "text"
-    single_label = "single_label"
+    rating = "rating"
 
 
 class UserRole(str, Enum):

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -18,7 +18,7 @@ from enum import Enum
 from typing import List, Optional
 from uuid import UUID, uuid4
 
-from sqlalchemy import ForeignKey, Text, and_
+from sqlalchemy import JSON, ForeignKey, Text, and_
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from argilla.server.database import Base
@@ -34,9 +34,34 @@ def default_inserted_at(context):
     return context.get_current_parameters()["inserted_at"]
 
 
+class AnnotationType(str, Enum):
+    text = "text"
+    single_label = "single_label"
+
+
 class UserRole(str, Enum):
     admin = "admin"
     annotator = "annotator"
+
+
+class Annotation(Base):
+    __tablename__ = "annotations"
+
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    name: Mapped[str]
+    title: Mapped[str] = mapped_column(Text)
+    type: Mapped[Optional[AnnotationType]] = mapped_column(default=AnnotationType.text)
+    required: Mapped[Optional[bool]] = mapped_column(default=False)
+    settings: Mapped[Optional[dict]] = mapped_column(JSON, default={})
+    dataset_id: Mapped[UUID] = mapped_column(ForeignKey("datasets.id"))
+
+    inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
+
+    dataset: Mapped["Dataset"] = relationship(back_populates="annotations")
+
+    def __repr__(self):
+        return f"Annotation(id={str(self.id)!r}, name={self.name!r}, type={self.type.value!r}, required={self.required!r}, dataset_id={str(self.dataset_id)!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
 
 
 class Dataset(Base):
@@ -44,16 +69,19 @@ class Dataset(Base):
 
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
     name: Mapped[str]
-    guidelines: Mapped[Optional[str]]
+    guidelines: Mapped[Optional[str]] = mapped_column(Text)
     workspace_id: Mapped[UUID] = mapped_column(ForeignKey("workspaces.id"))
 
     inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
     workspace: Mapped["Workspace"] = relationship(back_populates="datasets")
+    annotations: Mapped[List["Annotation"]] = relationship(
+        back_populates="dataset", order_by=Annotation.inserted_at.asc()
+    )
 
     def __repr__(self):
-        return f"Dataset(id={str(self.id)!r}, name={self.name!r}, guidelines={self.guidelines!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        return f"Dataset(id={str(self.id)!r}, name={self.name!r}, guidelines={self.guidelines!r}, workspace_id={str(self.workspace_id)!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
 
 
 class WorkspaceUser(Base):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -14,7 +14,14 @@
 
 import factory
 from argilla.server.database import SessionLocal
-from argilla.server.models import Dataset, User, UserRole, Workspace, WorkspaceUser
+from argilla.server.models import (
+    Annotation,
+    Dataset,
+    User,
+    UserRole,
+    Workspace,
+    WorkspaceUser,
+)
 from sqlalchemy import orm
 
 Session = orm.scoped_session(SessionLocal)
@@ -44,6 +51,17 @@ class DatasetFactory(factory.alchemy.SQLAlchemyModelFactory):
 
     name = factory.Sequence(lambda n: f"dataset-{n}")
     workspace = factory.SubFactory(WorkspaceFactory)
+
+
+class AnnotationFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = Annotation
+        sqlalchemy_session = Session
+        sqlalchemy_session_persistence = "commit"
+
+    name = factory.Sequence(lambda n: f"annotation-{n}")
+    title = "Annotation Title"
+    dataset = factory.SubFactory(DatasetFactory)
 
 
 class UserFactory(factory.alchemy.SQLAlchemyModelFactory):


### PR DESCRIPTION
# Description

This PR adds the following changes:
* A new migration to create `annotations` table. This is a temporal name if we think a better one is possible we can change it later.
* A new `Annotation` ORM model with the required relationships.
* Some missing details from previous PRs.