### PR TITLE
Add datasets annotations get enpdoint

### DIFF
--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -18,6 +18,8 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
+from argilla.server.models import AnnotationType
+
 
 class Dataset(BaseModel):
     id: UUID
@@ -35,3 +37,17 @@ class DatasetCreate(BaseModel):
     name: str
     guidelines: Optional[str]
     workspace_id: UUID
+
+
+class Annotation(BaseModel):
+    id: UUID
+    name: str
+    title: str
+    type: AnnotationType
+    required: bool
+    settings: dict
+    inserted_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -16,6 +16,7 @@ import factory
 from argilla.server.database import SessionLocal
 from argilla.server.models import (
     Annotation,
+    AnnotationType,
     Dataset,
     User,
     UserRole,
@@ -62,6 +63,14 @@ class AnnotationFactory(factory.alchemy.SQLAlchemyModelFactory):
     name = factory.Sequence(lambda n: f"annotation-{n}")
     title = "Annotation Title"
     dataset = factory.SubFactory(DatasetFactory)
+
+
+class TextAnnotationFactory(AnnotationFactory):
+    type = AnnotationType.text
+
+
+class RatingAnnotationFactory(AnnotationFactory):
+    type = AnnotationType.rating
 
 
 class UserFactory(factory.alchemy.SQLAlchemyModelFactory):

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -16,13 +16,15 @@ from datetime import datetime
 from uuid import UUID, uuid4
 
 from argilla._constants import API_KEY_HEADER_NAME
-from argilla.server.models import Dataset
+from argilla.server.models import AnnotationType, Dataset
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from tests.factories import (
     AnnotatorFactory,
     DatasetFactory,
+    RatingAnnotationFactory,
+    TextAnnotationFactory,
     WorkspaceFactory,
 )
 
@@ -130,6 +132,87 @@ def test_get_dataset_with_nonexistent_dataset_id(client: TestClient, db: Session
     DatasetFactory.create()
 
     response = client.get(f"/api/v1/datasets/{uuid4()}", headers=admin_auth_header)
+
+    assert response.status_code == 404
+
+
+def test_get_dataset_annotations(client: TestClient, db: Session, admin_auth_header: dict):
+    dataset = DatasetFactory.create()
+    text_annotation = TextAnnotationFactory.create(
+        name="text-annotation", title="Text Annotation", required=True, dataset=dataset
+    )
+    rating_annotation = RatingAnnotationFactory.create(
+        name="rating-annotation", title="Rating Annotation", dataset=dataset
+    )
+    TextAnnotationFactory.create()
+    RatingAnnotationFactory.create()
+
+    response = client.get(f"/api/v1/datasets/{dataset.id}/annotations", headers=admin_auth_header)
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "id": str(text_annotation.id),
+            "name": "text-annotation",
+            "title": "Text Annotation",
+            "type": AnnotationType.text.value,
+            "required": True,
+            "settings": {},
+            "inserted_at": text_annotation.inserted_at.isoformat(),
+            "updated_at": text_annotation.updated_at.isoformat(),
+        },
+        {
+            "id": str(rating_annotation.id),
+            "name": "rating-annotation",
+            "title": "Rating Annotation",
+            "type": AnnotationType.rating.value,
+            "required": False,
+            "settings": {},
+            "inserted_at": rating_annotation.inserted_at.isoformat(),
+            "updated_at": rating_annotation.updated_at.isoformat(),
+        },
+    ]
+
+
+def test_get_dataset_annotations_without_authentication(client: TestClient, db: Session):
+    dataset = DatasetFactory.create()
+
+    response = client.get(f"/api/v1/datasets/{dataset.id}/annotations")
+
+    assert response.status_code == 401
+
+
+def test_get_dataset_annotations_as_annotator(client: TestClient, db: Session):
+    dataset = DatasetFactory.create()
+    annotator = AnnotatorFactory.create(workspaces=[dataset.workspace])
+    TextAnnotationFactory.create(name="text-annotation", dataset=dataset)
+    RatingAnnotationFactory.create(name="rating-annotation", dataset=dataset)
+    TextAnnotationFactory.create()
+    RatingAnnotationFactory.create()
+
+    response = client.get(
+        f"/api/v1/datasets/{dataset.id}/annotations", headers={API_KEY_HEADER_NAME: annotator.api_key}
+    )
+
+    assert response.status_code == 200
+    assert [annotation["name"] for annotation in response.json()] == ["text-annotation", "rating-annotation"]
+
+
+def test_get_dataset_annotations_as_annotator_from_different_workspace(client: TestClient, db: Session):
+    dataset = DatasetFactory.create()
+    annotator = AnnotatorFactory.create(workspaces=[WorkspaceFactory.build()])
+
+    response = client.get(
+        f"/api/v1/datasets/{dataset.id}/annotations", headers={API_KEY_HEADER_NAME: annotator.api_key}
+    )
+
+    assert response.status_code == 403
+
+
+def test_get_dataset_annotations_with_nonexistent_dataset_id(client: TestClient, db: Session, admin_auth_header: dict):
+    DatasetFactory.create()
+
+    response = client.get(f"/api/v1/datasets/{uuid4()}/annotations", headers=admin_auth_header)
 
     assert response.status_code == 404
 


### PR DESCRIPTION
# Description

This PR adds a new v1 endpoint to get all the annotations belonging to a specific dataset.

Notes:
* I'm not returning the `dataset_id` on the `Annotation` Pydantic schema. The reason behind this is because we are requesting annotations for a dataset so the `dataset_id` is implicit.
* I have created the `Annotation` Pydantic schema inside `src/argilla/server/schemas/v1/datasets.py`. The reason behind this is because this is the schema for dataset annotations, if required we can have another set of schemas for annotations not related with the dataset (.i.e. we have an endpoint only for annotations).