### PR TITLE
Dataset index creation

### DIFF
--- a/src/argilla/server/daos/backend/client_adapters/opensearch.py
+++ b/src/argilla/server/daos/backend/client_adapters/opensearch.py
@@ -28,11 +28,7 @@ from argilla.server.daos.backend import query_helpers
 from argilla.server.daos.backend.base import BackendErrorHandler, IndexNotFoundError
 from argilla.server.daos.backend.client_adapters.base import IClientAdapter
 from argilla.server.daos.backend.metrics.base import ElasticsearchMetric
-from argilla.server.daos.backend.search.model import (
-    BaseQuery,
-    SortableField,
-    SortConfig,
-)
+from argilla.server.daos.backend.search.model import BaseQuery, SortConfig
 from argilla.server.daos.backend.search.query_builder import (
     HighlightParser,
     OpenSearchQueryBuilder,
@@ -545,7 +541,6 @@ class OpenSearchClient(IClientAdapter):
                         "settings": settings or {},
                         "mappings": mappings or {},
                     },
-                    ignore=400,
                 )
 
     def index_documents(

--- a/src/argilla/server/daos/backend/client_adapters/opensearch.py
+++ b/src/argilla/server/daos/backend/client_adapters/opensearch.py
@@ -28,7 +28,11 @@ from argilla.server.daos.backend import query_helpers
 from argilla.server.daos.backend.base import BackendErrorHandler, IndexNotFoundError
 from argilla.server.daos.backend.client_adapters.base import IClientAdapter
 from argilla.server.daos.backend.metrics.base import ElasticsearchMetric
-from argilla.server.daos.backend.search.model import BaseQuery, SortConfig
+from argilla.server.daos.backend.search.model import (
+    BaseQuery,
+    SortableField,
+    SortConfig,
+)
 from argilla.server.daos.backend.search.query_builder import (
     HighlightParser,
     OpenSearchQueryBuilder,
@@ -541,6 +545,7 @@ class OpenSearchClient(IClientAdapter):
                         "settings": settings or {},
                         "mappings": mappings or {},
                     },
+                    ignore=400,
                 )
 
     def index_documents(

--- a/src/argilla/server/elasticsearch.py
+++ b/src/argilla/server/elasticsearch.py
@@ -26,7 +26,7 @@ class ElasticSearchEngine:
     def __post_init__(self):
         self._client = ElasticsearchClient(vector_search_supported=False, index_shards=1, config_backend=self.config)
 
-    def create_records_index(self, dataset: Dataset) -> str:
+    def create_dataset_index(self, dataset: Dataset) -> str:
         fields = {}
 
         for annotation in dataset.annotations:
@@ -45,14 +45,11 @@ class ElasticSearchEngine:
         return index_name
 
     def _field_mapping_for_annotation(self, annotation_task: Annotation):
-        mapping = {}
         if annotation_task.type == AnnotationType.rating:
             # See https://www.elastic.co/guide/en/elasticsearch/reference/current/number.html
-            mapping.update({"type": "integer"})
+            return {"type": "integer"}
         elif annotation_task.type == AnnotationType.text:
             # See https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html
-            mapping.update({"type": "text"})
+            return {"type": "text"}
         else:
             raise ValueError(f"Annotation of type {annotation_task.type} cannot be processed")
-
-        return mapping

--- a/src/argilla/server/elasticsearch.py
+++ b/src/argilla/server/elasticsearch.py
@@ -13,9 +13,10 @@
 #  limitations under the License.
 
 import dataclasses
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
-from argilla.server.daos.backend.client_adapters import ElasticsearchClient
+from elasticsearch import Elasticsearch
+
 from argilla.server.models import Annotation, AnnotationType, Dataset
 
 
@@ -24,7 +25,7 @@ class ElasticSearchEngine:
     config: Dict[str, Any]
 
     def __post_init__(self):
-        self._client = ElasticsearchClient(vector_search_supported=False, index_shards=1, config_backend=self.config)
+        self._client = Elasticsearch(**self.config)
 
     def create_dataset_index(self, dataset: Dataset) -> str:
         fields = {}
@@ -40,7 +41,7 @@ class ElasticSearchEngine:
         }
 
         index_name = f"rg.{dataset.id}"
-        self._client.create_index(index_name, mappings=mappings)
+        self._client.indices.create(index=index_name, body={"mappings": mappings})
 
         return index_name
 

--- a/src/argilla/server/elasticsearch.py
+++ b/src/argilla/server/elasticsearch.py
@@ -1,0 +1,58 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import dataclasses
+from typing import Any, Dict, Optional
+
+from argilla.server.daos.backend.client_adapters import ElasticsearchClient
+from argilla.server.models import Annotation, AnnotationType, Dataset
+
+
+@dataclasses.dataclass
+class ElasticSearchEngine:
+    config: Dict[str, Any]
+
+    def __post_init__(self):
+        self._client = ElasticsearchClient(vector_search_supported=False, index_shards=1, config_backend=self.config)
+
+    def create_records_index(self, dataset: Dataset) -> str:
+        fields = {}
+
+        for annotation in dataset.annotations:
+            fields[annotation.name] = self._field_mapping_for_annotation(annotation)
+
+        # See https://www.elastic.co/guide/en/elasticsearch/reference/current/explicit-mapping.html
+        mappings = {
+            # See https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic.html#dynamic-parameters
+            "dynamic": "strict",
+            "properties": fields,
+        }
+
+        index_name = f"rg.{dataset.id}"
+        self._client.create_index(index_name, mappings=mappings)
+
+        return index_name
+
+    def _field_mapping_for_annotation(self, annotation_task: Annotation):
+        mapping = {}
+        if annotation_task.type == AnnotationType.rating:
+            # See https://www.elastic.co/guide/en/elasticsearch/reference/current/number.html
+            mapping.update({"type": "integer"})
+        elif annotation_task.type == AnnotationType.text:
+            # See https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html
+            mapping.update({"type": "text"})
+        else:
+            raise ValueError(f"Annotation of type {annotation_task.type} cannot be processed")
+
+        return mapping

--- a/src/argilla/server/elasticsearch.py
+++ b/src/argilla/server/elasticsearch.py
@@ -27,7 +27,7 @@ class ElasticSearchEngine:
     def __post_init__(self):
         self._client = Elasticsearch(**self.config)
 
-    def create_dataset_index(self, dataset: Dataset) -> str:
+    def create_index(self, dataset: Dataset):
         fields = {}
 
         for annotation in dataset.annotations:
@@ -42,8 +42,6 @@ class ElasticSearchEngine:
 
         index_name = f"rg.{dataset.id}"
         self._client.indices.create(index=index_name, body={"mappings": mappings})
-
-        return index_name
 
     def _field_mapping_for_annotation(self, annotation_task: Annotation):
         if annotation_task.type == AnnotationType.rating:

--- a/tests/server/test_elasticsearch.py
+++ b/tests/server/test_elasticsearch.py
@@ -1,0 +1,82 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import random
+
+import pytest
+from argilla.server.elasticsearch import ElasticSearchEngine
+from argilla.server.models import AnnotationType, Dataset
+from elasticsearch import Elasticsearch
+from sqlalchemy.orm import Session
+
+from tests.factories import AnnotationFactory, DatasetFactory
+
+
+@pytest.fixture(scope="session")
+def es_config():
+    return {"hosts": "http://localhost:9200"}
+
+
+@pytest.fixture(scope="session")
+def search_engine(es_config):
+    return ElasticSearchEngine(config=es_config)
+
+
+@pytest.fixture(scope="session")
+def elasticsearch(es_config):
+    client = Elasticsearch(**es_config)
+    yield client
+
+    for index_info in client.cat.indices(format="json"):
+        client.indices.delete(index=index_info["index"])
+
+
+def test_create_index_for_dataset(search_engine: ElasticSearchEngine, elasticsearch: Elasticsearch):
+    dataset = DatasetFactory.create()
+    index_name = search_engine.create_records_index(dataset)
+
+    assert elasticsearch.indices.exists(index=index_name)
+
+    index = elasticsearch.indices.get(index=index_name)[index_name]
+    assert index["mappings"] == {"dynamic": "strict"}
+
+
+@pytest.mark.parametrize(
+    argnames=("text_ann_size", "rating_ann_size"),
+    argvalues=[(random.randint(1, 9), random.randint(1, 9)) for _ in range(1, 5)],
+)
+def test_create_index_for_dataset_with_annotations(
+    search_engine: ElasticSearchEngine,
+    elasticsearch: Elasticsearch,
+    db: Session,
+    text_ann_size: int,
+    rating_ann_size: int,
+):
+    text_annotations = AnnotationFactory.create_batch(size=text_ann_size, type=AnnotationType.text)
+    rating_annotations = AnnotationFactory.create_batch(size=rating_ann_size, type=AnnotationType.rating)
+
+    dataset = DatasetFactory.create(annotations=text_annotations + rating_annotations)
+
+    index_name = search_engine.create_records_index(dataset)
+
+    assert elasticsearch.indices.exists(index=index_name)
+
+    index = elasticsearch.indices.get(index=index_name)[index_name]
+    assert index["mappings"] == {
+        "dynamic": "strict",
+        "properties": {
+            **{annotation.name: {"type": "text"} for annotation in text_annotations},
+            **{annotation.name: {"type": "integer"} for annotation in rating_annotations},
+        },
+    }

--- a/tests/server/test_elasticsearch.py
+++ b/tests/server/test_elasticsearch.py
@@ -44,7 +44,7 @@ def elasticsearch(es_config):
 
 def test_create_index_for_dataset(search_engine: ElasticSearchEngine, elasticsearch: Elasticsearch):
     dataset = DatasetFactory.create()
-    index_name = search_engine.create_records_index(dataset)
+    index_name = search_engine.create_dataset_index(dataset)
 
     assert elasticsearch.indices.exists(index=index_name)
 
@@ -68,7 +68,7 @@ def test_create_index_for_dataset_with_annotations(
 
     dataset = DatasetFactory.create(annotations=text_annotations + rating_annotations)
 
-    index_name = search_engine.create_records_index(dataset)
+    index_name = search_engine.create_dataset_index(dataset)
 
     assert elasticsearch.indices.exists(index=index_name)
 

--- a/tests/server/test_elasticsearch.py
+++ b/tests/server/test_elasticsearch.py
@@ -38,7 +38,7 @@ def elasticsearch(es_config):
     client = Elasticsearch(**es_config)
     yield client
 
-    for index_info in client.cat.indices(format="json"):
+    for index_info in client.cat.indices(index="ar.*,rg.*", format="json"):
         client.indices.delete(index=index_info["index"])
 
 

--- a/tests/server/test_elasticsearch.py
+++ b/tests/server/test_elasticsearch.py
@@ -59,8 +59,9 @@ def search_engine(es_config):
 )
 def test_create_index_for_dataset(search_engine: ElasticSearchEngine, elasticsearch: Elasticsearch):
     dataset = DatasetFactory.create()
-    index_name = search_engine.create_dataset_index(dataset)
+    search_engine.create_index(dataset)
 
+    index_name = f"rg.{dataset.id}"
     assert elasticsearch.indices.exists(index=index_name)
 
     index = elasticsearch.indices.get(index=index_name)[index_name]
@@ -87,8 +88,9 @@ def test_create_index_for_dataset_with_annotations(
 
     dataset = DatasetFactory.create(annotations=text_annotations + rating_annotations)
 
-    index_name = search_engine.create_dataset_index(dataset)
+    search_engine.create_index(dataset)
 
+    index_name = f"rg.{dataset.id}"
     assert elasticsearch.indices.exists(index=index_name)
 
     index = elasticsearch.indices.get(index=index_name)[index_name]
@@ -109,9 +111,10 @@ def test_create_index_with_existing_index(
     search_engine: ElasticSearchEngine, elasticsearch: Elasticsearch, db: Session
 ):
     dataset = DatasetFactory.create()
-    index_name = search_engine.create_dataset_index(dataset)
+    search_engine.create_index(dataset)
 
+    index_name = f"rg.{dataset.id}"
     assert elasticsearch.indices.exists(index=index_name)
 
     with pytest.raises(BadRequestError, match="'resource_already_exists_exception', 'index"):
-        search_engine.create_dataset_index(dataset)
+        search_engine.create_index(dataset)


### PR DESCRIPTION
 New elastic search engine component and `create_dataset_index` method.

Some notes:

- This component work using the official elasticsearch component, we should provide also opensearch compatibility as the current API endpoints. But we can tackle this in a separate PR.

- The engine is using the dataset id as part of the index name. The `rg` prefix is included to simplify index policies definition (you can define a snapshot policy by defining a wildcard. For Argilla indices this would not be possible only using the dataset id as index name)

