### PR TITLE
Add datasets annotations create endpoint

### DIFF
--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -14,8 +14,8 @@
 
 from uuid import UUID
 
-from argilla.server.models import Dataset
-from argilla.server.schemas.v1.datasets import DatasetCreate
+from argilla.server.models import Annotation, Dataset
+from argilla.server.schemas.v1.datasets import AnnotationCreate, DatasetCreate
 from sqlalchemy.orm import Session
 
 
@@ -50,3 +50,24 @@ def delete_dataset(db: Session, dataset: Dataset):
     db.commit()
 
     return dataset
+
+
+def get_annotation_by_name_and_dataset_id(db: Session, name: str, dataset_id: UUID):
+    return db.query(Annotation).filter_by(name=name, dataset_id=dataset_id).first()
+
+
+def create_annotation(db: Session, dataset: Dataset, annotation_create: AnnotationCreate):
+    annotation = Annotation(
+        name=annotation_create.name,
+        title=annotation_create.title,
+        type=annotation_create.type,
+        required=annotation_create.required,
+        settings=annotation_create.settings,
+        dataset_id=dataset.id,
+    )
+
+    db.add(annotation)
+    db.commit()
+    db.refresh(annotation)
+
+    return annotation

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -13,12 +13,15 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import Optional
+from typing import Any, List, Optional, Union
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, conlist, validator
 
 from argilla.server.models import AnnotationType
+
+RATING_MIN_ITEMS = 2
+RATING_MAX_ITEMS = 100
 
 
 class Dataset(BaseModel):
@@ -51,3 +54,27 @@ class Annotation(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class RatingAnnotationSettingsCreate(BaseModel):
+    # TODO: If pydantic is upgraded (something we should do regularly) we should add `unique_items=True`
+    values: conlist(item_type=Union[int, float, str], min_items=RATING_MIN_ITEMS, max_items=RATING_MAX_ITEMS)
+
+
+class AnnotationCreate(BaseModel):
+    name: str
+    title: str
+    type: AnnotationType
+    required: Optional[bool]
+    settings: Optional[dict] = {}
+
+    @validator("settings", always=True)
+    def validate_settings(cls, settings: dict, values):
+        type = values.get("type")
+
+        if type == AnnotationType.text:
+            return {}
+        if type == AnnotationType.rating:
+            return RatingAnnotationSettingsCreate(**settings).dict()
+        else:
+            return settings

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import Any, List, Optional, Union
+from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, conlist, validator

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -20,8 +20,8 @@ from pydantic import BaseModel, conlist, validator
 
 from argilla.server.models import AnnotationType
 
-RATING_MIN_ITEMS = 2
-RATING_MAX_ITEMS = 100
+RATING_OPTIONS_MIN_ITEMS = 2
+RATING_OPTIONS_MAX_ITEMS = 100
 
 
 class Dataset(BaseModel):
@@ -56,9 +56,16 @@ class Annotation(BaseModel):
         orm_mode = True
 
 
+class RatingAnnotationSettingsOptionCreate(BaseModel):
+    value: int
+
+
 class RatingAnnotationSettingsCreate(BaseModel):
-    # TODO: If pydantic is upgraded (something we should do regularly) we should add `unique_items=True`
-    values: conlist(item_type=Union[int, float, str], min_items=RATING_MIN_ITEMS, max_items=RATING_MAX_ITEMS)
+    options: conlist(
+        item_type=RatingAnnotationSettingsOptionCreate,
+        min_items=RATING_OPTIONS_MIN_ITEMS,
+        max_items=RATING_OPTIONS_MAX_ITEMS,
+    )
 
 
 class AnnotationCreate(BaseModel):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -71,6 +71,7 @@ class TextAnnotationFactory(AnnotationFactory):
 
 class RatingAnnotationFactory(AnnotationFactory):
     type = AnnotationType.rating
+    settings = {"values": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
 
 
 class UserFactory(factory.alchemy.SQLAlchemyModelFactory):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -71,7 +71,20 @@ class TextAnnotationFactory(AnnotationFactory):
 
 class RatingAnnotationFactory(AnnotationFactory):
     type = AnnotationType.rating
-    settings = {"values": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}
+    settings = {
+        "options": [
+            {"value": 1},
+            {"value": 2},
+            {"value": 3},
+            {"value": 4},
+            {"value": 5},
+            {"value": 6},
+            {"value": 7},
+            {"value": 8},
+            {"value": 9},
+            {"value": 10},
+        ]
+    }
 
 
 class UserFactory(factory.alchemy.SQLAlchemyModelFactory):

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -169,7 +169,7 @@ def test_get_dataset_annotations(client: TestClient, db: Session, admin_auth_hea
             "title": "Rating Annotation",
             "type": AnnotationType.rating.value,
             "required": False,
-            "settings": {},
+            "settings": {"values": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]},
             "inserted_at": rating_annotation.inserted_at.isoformat(),
             "updated_at": rating_annotation.updated_at.isoformat(),
         },

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -462,7 +462,7 @@ def test_create_dataset_rating_annotation(client: TestClient, db: Session, admin
     }
 
 
-def test_create_dataset_rating_annotation_with_less_values_than_allowed(
+def test_create_dataset_rating_annotation_with_less_options_than_allowed(
     client: TestClient, db: Session, admin_auth_header: dict
 ):
     dataset = DatasetFactory.create()
@@ -481,7 +481,7 @@ def test_create_dataset_rating_annotation_with_less_values_than_allowed(
     assert db.query(Annotation).count() == 0
 
 
-def test_create_dataset_rating_annotation_with_more_values_than_allowed(
+def test_create_dataset_rating_annotation_with_more_options_than_allowed(
     client: TestClient, db: Session, admin_auth_header: dict
 ):
     dataset = DatasetFactory.create()

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -17,7 +17,10 @@ from uuid import UUID, uuid4
 
 from argilla._constants import API_KEY_HEADER_NAME
 from argilla.server.models import Annotation, AnnotationType, Dataset
-from argilla.server.schemas.v1.datasets import RATING_MAX_ITEMS, RATING_MIN_ITEMS
+from argilla.server.schemas.v1.datasets import (
+    RATING_OPTIONS_MAX_ITEMS,
+    RATING_OPTIONS_MIN_ITEMS,
+)
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -169,7 +172,20 @@ def test_get_dataset_annotations(client: TestClient, db: Session, admin_auth_hea
             "title": "Rating Annotation",
             "type": AnnotationType.rating.value,
             "required": False,
-            "settings": {"values": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]},
+            "settings": {
+                "options": [
+                    {"value": 1},
+                    {"value": 2},
+                    {"value": 3},
+                    {"value": 4},
+                    {"value": 5},
+                    {"value": 6},
+                    {"value": 7},
+                    {"value": 8},
+                    {"value": 9},
+                    {"value": 10},
+                ]
+            },
             "inserted_at": rating_annotation.inserted_at.isoformat(),
             "updated_at": rating_annotation.updated_at.isoformat(),
         },
@@ -396,7 +412,20 @@ def test_create_dataset_rating_annotation(client: TestClient, db: Session, admin
         "name": "rating",
         "title": "Rating",
         "type": AnnotationType.rating.value,
-        "settings": {"values": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]},
+        "settings": {
+            "options": [
+                {"value": 1},
+                {"value": 2},
+                {"value": 3},
+                {"value": 4},
+                {"value": 5},
+                {"value": 6},
+                {"value": 7},
+                {"value": 8},
+                {"value": 9},
+                {"value": 10},
+            ]
+        },
     }
 
     response = client.post(
@@ -414,7 +443,20 @@ def test_create_dataset_rating_annotation(client: TestClient, db: Session, admin
         "title": "Rating",
         "type": AnnotationType.rating.value,
         "required": False,
-        "settings": {"values": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]},
+        "settings": {
+            "options": [
+                {"value": 1},
+                {"value": 2},
+                {"value": 3},
+                {"value": 4},
+                {"value": 5},
+                {"value": 6},
+                {"value": 7},
+                {"value": 8},
+                {"value": 9},
+                {"value": 10},
+            ]
+        },
         "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
         "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
     }
@@ -428,7 +470,7 @@ def test_create_dataset_rating_annotation_with_less_values_than_allowed(
         "name": "rating",
         "title": "Rating",
         "type": AnnotationType.rating.value,
-        "settings": {"values": list(range(0, RATING_MIN_ITEMS - 1))},
+        "settings": {"options": [{"value": value} for value in range(0, RATING_OPTIONS_MIN_ITEMS - 1)]},
     }
 
     response = client.post(
@@ -447,7 +489,7 @@ def test_create_dataset_rating_annotation_with_more_values_than_allowed(
         "name": "rating",
         "title": "Rating",
         "type": AnnotationType.rating.value,
-        "settings": {"values": list(range(0, RATING_MAX_ITEMS + 1))},
+        "settings": {"options": [{"value": value} for value in range(0, RATING_OPTIONS_MAX_ITEMS + 1)]},
     }
 
     response = client.post(
@@ -466,7 +508,35 @@ def test_create_dataset_rating_annotation_with_invalid_settings(
         "name": "rating",
         "title": "Rating",
         "type": AnnotationType.rating.value,
-        "settings": {"invalid": "value"},
+        "settings": {
+            "options": "invalid",
+        },
+    }
+
+    response = client.post(
+        f"/api/v1/datasets/{dataset.id}/annotations", headers=admin_auth_header, json=annotation_json
+    )
+
+    assert response.status_code == 422
+    assert db.query(Annotation).count() == 0
+
+
+def test_create_dataset_rating_annotation_with_invalid_settings_options_values(
+    client: TestClient, db: Session, admin_auth_header: dict
+):
+    dataset = DatasetFactory.create()
+    annotation_json = {
+        "name": "rating",
+        "title": "Rating",
+        "type": AnnotationType.rating.value,
+        "settings": {
+            "options": [
+                {"value": "A"},
+                {"value": "B"},
+                {"value": "C"},
+                {"value": "D"},
+            ]
+        },
     }
 
     response = client.post(


### PR DESCRIPTION
# Description

This PR adds a new v1 endpoint to create annotations for a specific dataset.

Notes:
* It includes the `text` and `rating` annotation types.
* `text` annotation settings is empty right now, we can add possible settings in the future if required. At the same time if a users specifies some settings values for this type of annotation they are discarded.
* `rating` annotation settings allow a `options` attribute that can store a list of objects. Every object has the structure `{"value": int}` only allowing integer values.
* `rating` annotation settings allow a `options` attribute with a minimum of 2 items and a maximum of 100. If it doesn't has many sense we can change these values.
* I have tried to use Pydantic's [discriminated unions](https://docs.pydantic.dev/usage/types/#discriminated-unions-aka-tagged-unions) to select between different models based on the `type` attribute for the annotations but without any luck. Looks like it has a bug and JSON serialization is not allowed for subclases using this. I have solved this using a dynamic validator but please tell me if there is another better way to solve this.