### PR TITLE
chore: added more explicit warning for having too little labels #2665

### DIFF
--- a/src/argilla/client/datasets.py
+++ b/src/argilla/client/datasets.py
@@ -741,6 +741,11 @@ class DatasetForTextClassification(DatasetBase):
         else:
             labels = {label: None for label in ds_dict["label"]}
 
+        if len(labels) == 1:
+            raise ValueError(
+                "The dataset contains only one labels. Classification datasets should have at least 2 labels."
+            )
+
         class_label = (
             datasets.ClassLabel(names=sorted(labels.keys()))
             if ds_dict["label"]


### PR DESCRIPTION
# Description

The prepare for training with transformer did not provide a concise failure message when using only one label.

Closes #2665 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

N.A.

**Checklist**

- [ ] I have merged the original branch into my forked branch