### PR TITLE
Fix default user credentials

### DIFF
--- a/docs/_source/getting_started/quickstart.ipynb
+++ b/docs/_source/getting_started/quickstart.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "[![deploy on spaces](https://huggingface.co/datasets/huggingface/badges/raw/main/deploy-to-spaces-lg.svg)](https://huggingface.co/new-space?template=argilla/argilla-template-space)\n",
     "\n",
-    "If everything goes well, you'll see your online Argilla UI login page. You can log in with username `admin` and password `12345678`. You can find the direct URL by clicking on the Embed space button. You'll use this URL for sending data to your Argilla instance. \n",
+    "If everything goes well, you'll see your online Argilla UI login page. You can log in with username `argilla` and password `1234`. You can find the direct URL by clicking on the Embed space button. You'll use this URL for sending data to your Argilla instance. \n",
     "\n",
     "<div class=\"flex justify-center\">\n",
     "<img src=\"https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/hub/spaces-argilla-duplicate-space.png\"/>\n",


### PR DESCRIPTION
# Description

`admin` / `12345678` login / password combination doesn't work, while `argilla` / `1234` from https://docs.argilla.io/en/latest/getting_started/installation/configurations/user_management.html#default-user page matches successfully

**Type of change**

- [x] Documentation update