### PR TITLE
Refactor/typing settings properly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     # pandas -> For data loading
     "pandas >=1.0.0,<2.0.0",
     # Aligned pydantic version with server fastAPI
-    "pydantic >= 1.7.1",
+    "pydantic >= 1.10.7",
     # monitoring
     "wrapt >= 1.13,< 1.15",
     # weaksupervision

--- a/src/argilla/server/alembic/versions/3a8e2f9b5dea_create_annotations_table.py
+++ b/src/argilla/server/alembic/versions/3a8e2f9b5dea_create_annotations_table.py
@@ -36,7 +36,6 @@ def upgrade() -> None:
         sa.Column("id", sa.Uuid, primary_key=True),
         sa.Column("name", sa.String, nullable=False, index=True),
         sa.Column("title", sa.Text, nullable=False),
-        sa.Column("type", sa.String, nullable=False, index=True),
         sa.Column("required", sa.Boolean, nullable=False, server_default=expression.false()),
         sa.Column("settings", sa.JSON, nullable=False),
         sa.Column("dataset_id", sa.Uuid, sa.ForeignKey("datasets.id", ondelete="CASCADE"), nullable=False, index=True),

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -60,7 +60,6 @@ def create_annotation(db: Session, dataset: Dataset, annotation_create: Annotati
     annotation = Annotation(
         name=annotation_create.name,
         title=annotation_create.title,
-        type=annotation_create.type,
         required=annotation_create.required,
         settings=annotation_create.settings.dict(),
         dataset_id=dataset.id,

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -62,7 +62,7 @@ def create_annotation(db: Session, dataset: Dataset, annotation_create: Annotati
         title=annotation_create.title,
         type=annotation_create.type,
         required=annotation_create.required,
-        settings=annotation_create.settings,
+        settings=annotation_create.settings.dict(),
         dataset_id=dataset.id,
     )
 

--- a/src/argilla/server/elasticsearch.py
+++ b/src/argilla/server/elasticsearch.py
@@ -44,11 +44,13 @@ class ElasticSearchEngine:
         self._client.indices.create(index=index_name, body={"mappings": mappings})
 
     def _field_mapping_for_annotation(self, annotation_task: Annotation):
-        if annotation_task.type == AnnotationType.rating:
+        settings_type = annotation_task.settings.get("type")
+
+        if settings_type == AnnotationType.rating:
             # See https://www.elastic.co/guide/en/elasticsearch/reference/current/number.html
             return {"type": "integer"}
-        elif annotation_task.type == AnnotationType.text:
+        elif settings_type == AnnotationType.text:
             # See https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html
             return {"type": "text"}
         else:
-            raise ValueError(f"Annotation of type {annotation_task.type} cannot be processed")
+            raise ValueError(f"Annotation of type {settings_type} cannot be processed")

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -50,7 +50,6 @@ class Annotation(Base):
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
     name: Mapped[str]
     title: Mapped[str] = mapped_column(Text)
-    type: Mapped[AnnotationType] = mapped_column(default=AnnotationType.text)
     required: Mapped[bool] = mapped_column(default=False)
     settings: Mapped[dict] = mapped_column(JSON, default={})
     dataset_id: Mapped[UUID] = mapped_column(ForeignKey("datasets.id"))
@@ -61,7 +60,7 @@ class Annotation(Base):
     dataset: Mapped["Dataset"] = relationship(back_populates="annotations")
 
     def __repr__(self):
-        return f"Annotation(id={str(self.id)!r}, name={self.name!r}, type={self.type.value!r}, required={self.required!r}, dataset_id={str(self.dataset_id)!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        return f"Annotation(id={str(self.id)!r}, name={self.name!r}, required={self.required!r}, dataset_id={str(self.dataset_id)!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
 
 
 class Dataset(Base):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -66,12 +66,12 @@ class AnnotationFactory(factory.alchemy.SQLAlchemyModelFactory):
 
 
 class TextAnnotationFactory(AnnotationFactory):
-    type = AnnotationType.text
+    settings = {"type": AnnotationType.text.value}
 
 
 class RatingAnnotationFactory(AnnotationFactory):
-    type = AnnotationType.rating
     settings = {
+        "type": AnnotationType.rating.value,
         "options": [
             {"value": 1},
             {"value": 2},
@@ -83,7 +83,7 @@ class RatingAnnotationFactory(AnnotationFactory):
             {"value": 8},
             {"value": 9},
             {"value": 10},
-        ]
+        ],
     }
 
 

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -343,7 +343,7 @@ def test_create_dataset_annotation_as_annotator(client: TestClient, db: Session)
         json=annotation_json,
     )
 
-    response.status_code == 403
+    assert response.status_code == 403
     assert db.query(Annotation).count() == 0
 
 

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from uuid import UUID, uuid4
 
 from argilla._constants import API_KEY_HEADER_NAME
-from argilla.server.models import Annotation, AnnotationType, Dataset
+from argilla.server.models import Annotation, Dataset
 from argilla.server.schemas.v1.datasets import (
     RATING_OPTIONS_MAX_ITEMS,
     RATING_OPTIONS_MIN_ITEMS,
@@ -160,9 +160,8 @@ def test_get_dataset_annotations(client: TestClient, db: Session, admin_auth_hea
             "id": str(text_annotation.id),
             "name": "text-annotation",
             "title": "Text Annotation",
-            "type": AnnotationType.text.value,
             "required": True,
-            "settings": {},
+            "settings": {"type": "text"},
             "inserted_at": text_annotation.inserted_at.isoformat(),
             "updated_at": text_annotation.updated_at.isoformat(),
         },
@@ -170,9 +169,9 @@ def test_get_dataset_annotations(client: TestClient, db: Session, admin_auth_hea
             "id": str(rating_annotation.id),
             "name": "rating-annotation",
             "title": "Rating Annotation",
-            "type": AnnotationType.rating.value,
             "required": False,
             "settings": {
+                "type": "rating",
                 "options": [
                     {"value": 1},
                     {"value": 2},
@@ -184,7 +183,7 @@ def test_get_dataset_annotations(client: TestClient, db: Session, admin_auth_hea
                     {"value": 8},
                     {"value": 9},
                     {"value": 10},
-                ]
+                ],
             },
             "inserted_at": rating_annotation.inserted_at.isoformat(),
             "updated_at": rating_annotation.updated_at.isoformat(),
@@ -290,7 +289,7 @@ def test_create_dataset_annotation(client: TestClient, db: Session, admin_auth_h
     annotation_json = {
         "name": "name",
         "title": "title",
-        "type": AnnotationType.text.value,
+        "settings": {"type": "text"},
     }
 
     response = client.post(
@@ -306,9 +305,8 @@ def test_create_dataset_annotation(client: TestClient, db: Session, admin_auth_h
         "id": str(UUID(response_body["id"])),
         "name": "name",
         "title": "title",
-        "type": AnnotationType.text.value,
         "required": False,
-        "settings": {},
+        "settings": {"type": "text"},
         "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
         "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
     }
@@ -319,7 +317,7 @@ def test_create_dataset_annotation_without_authentication(client: TestClient, db
     annotation_json = {
         "name": "name",
         "title": "title",
-        "type": AnnotationType.text.value,
+        "settings": {"type": "text"},
     }
 
     response = client.post(f"/api/v1/datasets/{dataset.id}/annotations", json=annotation_json)
@@ -334,7 +332,7 @@ def test_create_dataset_annotation_as_annotator(client: TestClient, db: Session)
     annotation_json = {
         "name": "name",
         "title": "title",
-        "type": AnnotationType.text.value,
+        "settings": {"type": "text"},
     }
 
     response = client.post(
@@ -349,7 +347,11 @@ def test_create_dataset_annotation_as_annotator(client: TestClient, db: Session)
 
 def test_create_dataset_annotation_with_existent_name(client: TestClient, db: Session, admin_auth_header: dict):
     annotation = AnnotationFactory.create(name="name")
-    annotation_json = {"name": "name", "title": "title", "type": AnnotationType.text.value}
+    annotation_json = {
+        "name": "name",
+        "title": "title",
+        "settings": {"type": "text"},
+    }
 
     response = client.post(
         f"/api/v1/datasets/{annotation.dataset.id}/annotations", headers=admin_auth_header, json=annotation_json
@@ -366,8 +368,7 @@ def test_create_dataset_annotation_with_nonexistent_dataset_id(
     annotation_json = {
         "name": "text",
         "title": "Text",
-        "type": AnnotationType.text.value,
-        "settings": {"discarded": "values"},
+        "settings": {"type": "text"},
     }
 
     response = client.post(f"/api/v1/datasets/{uuid4()}/annotations", headers=admin_auth_header, json=annotation_json)
@@ -381,8 +382,7 @@ def test_create_dataset_text_annotation(client: TestClient, db: Session, admin_a
     annotation_json = {
         "name": "text",
         "title": "Text",
-        "type": AnnotationType.text.value,
-        "settings": {"discarded": "value"},
+        "settings": {"type": "text", "discarded": "value"},
     }
 
     response = client.post(
@@ -398,9 +398,8 @@ def test_create_dataset_text_annotation(client: TestClient, db: Session, admin_a
         "id": str(UUID(response_body["id"])),
         "name": "text",
         "title": "Text",
-        "type": AnnotationType.text.value,
         "required": False,
-        "settings": {},
+        "settings": {"type": "text"},
         "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
         "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
     }
@@ -411,8 +410,8 @@ def test_create_dataset_rating_annotation(client: TestClient, db: Session, admin
     annotation_json = {
         "name": "rating",
         "title": "Rating",
-        "type": AnnotationType.rating.value,
         "settings": {
+            "type": "rating",
             "options": [
                 {"value": 1},
                 {"value": 2},
@@ -424,7 +423,7 @@ def test_create_dataset_rating_annotation(client: TestClient, db: Session, admin
                 {"value": 8},
                 {"value": 9},
                 {"value": 10},
-            ]
+            ],
         },
     }
 
@@ -441,9 +440,9 @@ def test_create_dataset_rating_annotation(client: TestClient, db: Session, admin
         "id": str(UUID(response_body["id"])),
         "name": "rating",
         "title": "Rating",
-        "type": AnnotationType.rating.value,
         "required": False,
         "settings": {
+            "type": "rating",
             "options": [
                 {"value": 1},
                 {"value": 2},
@@ -455,7 +454,7 @@ def test_create_dataset_rating_annotation(client: TestClient, db: Session, admin
                 {"value": 8},
                 {"value": 9},
                 {"value": 10},
-            ]
+            ],
         },
         "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
         "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
@@ -469,8 +468,10 @@ def test_create_dataset_rating_annotation_with_less_options_than_allowed(
     annotation_json = {
         "name": "rating",
         "title": "Rating",
-        "type": AnnotationType.rating.value,
-        "settings": {"options": [{"value": value} for value in range(0, RATING_OPTIONS_MIN_ITEMS - 1)]},
+        "settings": {
+            "type": "rating",
+            "options": [{"value": value} for value in range(0, RATING_OPTIONS_MIN_ITEMS - 1)],
+        },
     }
 
     response = client.post(
@@ -488,8 +489,10 @@ def test_create_dataset_rating_annotation_with_more_options_than_allowed(
     annotation_json = {
         "name": "rating",
         "title": "Rating",
-        "type": AnnotationType.rating.value,
-        "settings": {"options": [{"value": value} for value in range(0, RATING_OPTIONS_MAX_ITEMS + 1)]},
+        "settings": {
+            "type": "rating",
+            "options": [{"value": value} for value in range(0, RATING_OPTIONS_MAX_ITEMS + 1)],
+        },
     }
 
     response = client.post(
@@ -507,8 +510,8 @@ def test_create_dataset_rating_annotation_with_invalid_settings(
     annotation_json = {
         "name": "rating",
         "title": "Rating",
-        "type": AnnotationType.rating.value,
         "settings": {
+            "type": "rating",
             "options": "invalid",
         },
     }
@@ -528,14 +531,14 @@ def test_create_dataset_rating_annotation_with_invalid_settings_options_values(
     annotation_json = {
         "name": "rating",
         "title": "Rating",
-        "type": AnnotationType.rating.value,
         "settings": {
+            "type": "rating",
             "options": [
                 {"value": "A"},
                 {"value": "B"},
                 {"value": "C"},
                 {"value": "D"},
-            ]
+            ],
         },
     }
 

--- a/tests/server/test_elasticsearch.py
+++ b/tests/server/test_elasticsearch.py
@@ -22,7 +22,12 @@ from elasticsearch import BadRequestError, Elasticsearch
 from opensearchpy import OpenSearch
 from sqlalchemy.orm import Session
 
-from tests.factories import AnnotationFactory, DatasetFactory
+from tests.factories import (
+    AnnotationFactory,
+    DatasetFactory,
+    RatingAnnotationFactory,
+    TextAnnotationFactory,
+)
 
 
 def _running_with_elasticsearch() -> str:
@@ -83,8 +88,8 @@ def test_create_index_for_dataset_with_annotations(
     text_ann_size: int,
     rating_ann_size: int,
 ):
-    text_annotations = AnnotationFactory.create_batch(size=text_ann_size, type=AnnotationType.text)
-    rating_annotations = AnnotationFactory.create_batch(size=rating_ann_size, type=AnnotationType.rating)
+    text_annotations = TextAnnotationFactory.create_batch(size=text_ann_size)
+    rating_annotations = RatingAnnotationFactory.create_batch(size=rating_ann_size)
 
     dataset = DatasetFactory.create(annotations=text_annotations + rating_annotations)
 


### PR DESCRIPTION
Changes in this PR allow to expose setting classes to the API docs, instead of having a raw dictionary without the proper schema info.