### PR TITLE
Add new API v1 endpoint to delete annotations

### DIFF
--- a/src/argilla/server/apis/v1/handlers/annotations.py
+++ b/src/argilla/server/apis/v1/handlers/annotations.py
@@ -1,0 +1,53 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Security, status
+from sqlalchemy.orm import Session
+
+from argilla.server.contexts import datasets
+from argilla.server.database import get_db
+from argilla.server.policies import AnnotationPolicyV1, authorize
+from argilla.server.schemas.v1.datasets import Annotation
+from argilla.server.security import auth
+from argilla.server.security.model import User
+
+router = APIRouter(tags=["annotations"])
+
+
+@router.delete("/annotations/{annotation_id}", response_model=Annotation)
+def delete_annotation(
+    *,
+    db: Session = Depends(get_db),
+    annotation_id: UUID,
+    current_user: User = Security(auth.get_current_user),
+):
+    authorize(current_user, AnnotationPolicyV1.delete)
+
+    annotation = datasets.get_annotation_by_id(db, annotation_id)
+    if not annotation:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Annotation with id `{annotation_id}` not found",
+        )
+
+    # TODO: We should split API v1 into different FastAPI apps so we can customize error management.
+    # After mapping ValueError to 422 errors for API v1 then we can remove this try except.
+    try:
+        datasets.delete_annotation(db, annotation)
+    except ValueError as err:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(err))
+
+    return annotation

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -68,6 +68,10 @@ def delete_dataset(db: Session, dataset: Dataset):
     return dataset
 
 
+def get_annotation_by_id(db: Session, annotation_id: UUID):
+    return db.get(Annotation, annotation_id)
+
+
 def get_annotation_by_name_and_dataset_id(db: Session, name: str, dataset_id: UUID):
     return db.query(Annotation).filter_by(name=name, dataset_id=dataset_id).first()
 
@@ -87,6 +91,16 @@ def create_annotation(db: Session, dataset: Dataset, annotation_create: Annotati
     db.add(annotation)
     db.commit()
     db.refresh(annotation)
+
+    return annotation
+
+
+def delete_annotation(db: Session, annotation: Annotation):
+    if annotation.dataset.is_ready:
+        raise ValueError("Annotations cannot be deleted for a published dataset")
+
+    db.delete(annotation)
+    db.commit()
 
     return annotation
 

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -142,6 +142,12 @@ class DatasetPolicyV1:
         return actor.is_admin
 
 
+class AnnotationPolicyV1:
+    @classmethod
+    def delete(cls, actor: User) -> bool:
+        return actor.is_admin
+
+
 class DatasetSettingsPolicy:
     @classmethod
     def list(cls, dataset: Dataset) -> PolicyAction:

--- a/src/argilla/server/routes.py
+++ b/src/argilla/server/routes.py
@@ -33,6 +33,7 @@ from argilla.server.apis.v0.handlers import (
     users,
     workspaces,
 )
+from argilla.server.apis.v1.handlers import annotations as annotations_v1
 from argilla.server.apis.v1.handlers import datasets as datasets_v1
 from argilla.server.errors.base_errors import __ALL__
 
@@ -58,3 +59,4 @@ for router in [
 
 # API v1
 api_router.include_router(datasets_v1.router, prefix="/v1")
+api_router.include_router(annotations_v1.router, prefix="/v1")

--- a/tests/server/api/v1/test_annotations.py
+++ b/tests/server/api/v1/test_annotations.py
@@ -1,0 +1,69 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from uuid import uuid4
+
+from argilla._constants import API_KEY_HEADER_NAME
+from argilla.server.models import Annotation, DatasetStatus
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from tests.factories import AnnotatorFactory, DatasetFactory, TextAnnotationFactory
+
+
+def test_delete_annotation(client: TestClient, db: Session, admin_auth_header: dict):
+    annotation = TextAnnotationFactory.create()
+
+    response = client.delete(f"/api/v1/annotations/{annotation.id}", headers=admin_auth_header)
+
+    assert response.status_code == 200
+    assert db.query(Annotation).count() == 0
+
+
+def test_delete_annotation_without_authentication(client: TestClient, db: Session):
+    annotation = TextAnnotationFactory.create()
+
+    response = client.delete(f"/api/v1/annotations/{annotation.id}")
+
+    assert response.status_code == 401
+    assert db.query(Annotation).count() == 1
+
+
+def test_delete_annotation_as_annotator(client: TestClient, db: Session):
+    annotator = AnnotatorFactory.create()
+    annotation = TextAnnotationFactory.create()
+
+    response = client.delete(f"/api/v1/annotations/{annotation.id}", headers={API_KEY_HEADER_NAME: annotator.api_key})
+
+    assert response.status_code == 403
+    assert db.query(Annotation).count() == 1
+
+
+def test_delete_annotation_belonging_to_published_dataset(client: TestClient, db: Session, admin_auth_header: dict):
+    annotation = TextAnnotationFactory.create(dataset=DatasetFactory.build(status=DatasetStatus.ready))
+
+    response = client.delete(f"/api/v1/annotations/{annotation.id}", headers=admin_auth_header)
+
+    assert response.status_code == 422
+    assert response.json() == {"detail": "Annotations cannot be deleted for a published dataset"}
+    assert db.query(Annotation).count() == 1
+
+
+def test_delete_annotation_with_nonexistent_annotation_id(client: TestClient, db: Session, admin_auth_header: dict):
+    TextAnnotationFactory.create()
+
+    response = client.delete(f"/api/v1/annotations/{uuid4()}", headers=admin_auth_header)
+
+    assert response.status_code == 404
+    assert db.query(Annotation).count() == 1

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from uuid import UUID, uuid4
 
 from argilla._constants import API_KEY_HEADER_NAME
-from argilla.server.models import Annotation, AnnotationType, Dataset, DatasetStatus
+from argilla.server.models import Annotation, Dataset, DatasetStatus
 from argilla.server.schemas.v1.datasets import (
     RATING_OPTIONS_MAX_ITEMS,
     RATING_OPTIONS_MIN_ITEMS,


### PR DESCRIPTION
# Description

This PR adds a new API v1 endpoint to delete dataset annotations. If the associated annotation dataset is published the annotation cannot be deleted.