### PR TITLE
[Docs] Update old rubrix readthedocs link

### DIFF
--- a/src/argilla/client/api.py
+++ b/src/argilla/client/api.py
@@ -336,7 +336,7 @@ def delete_records(
         workspace: The workspace to which records will be logged/loaded. If `None` (default) and the
             env variable ``ARGILLA_WORKSPACE`` is not set, it will default to the private user workspace.
         query: An ElasticSearch query with the `query string syntax
-            <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
+            <https://docs.argilla.io/en/latest/guides/query_datasets.html>`_
         ids: If provided, deletes dataset records with given ids.
         discard_only: If `True`, matched records won't be deleted. Instead, they will be marked as `Discarded`
         discard_when_forbidden: Only super-user or dataset creator can delete records from a dataset.

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -437,7 +437,7 @@ class Argilla:
         Args:
             name: The dataset name.
             query: An ElasticSearch query with the `query string syntax
-                <https://rubrix.readthedocs.io/en/stable/guides/queries.html>`_
+                <https://docs.argilla.io/en/latest/guides/query_datasets.html>`_
             ids: If provided, deletes dataset records with given ids.
             discard_only: If `True`, matched records won't be deleted. Instead, they will be marked as `Discarded`
             discard_when_forbidden: Only super-user or dataset creator can delete records from a dataset.


### PR DESCRIPTION
# Description
Replace an old rubrix readthedocs link (https://rubrix.readthedocs.io/en/stable/guides/queries.html) with the new Argilla docs link (https://docs.argilla.io/en/latest/guides/query_datasets.html).

**Type of change**

- [x] Documentation update

**How Has This Been Tested**

N\A

**Checklist**

- [x] I have merged the original branch into my forked branch
- [x] I added relevant documentation
- [x] follows the style guidelines of this project
- ~I did a self-review of my code~
- [x] I made corresponding changes to the documentation
- ~My changes generate no new warnings~
- ~I have added tests that prove my fix is effective or that my feature works~
- ~I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)~