### PR TITLE
[Tests] Update tests using Rubrix datasets to use Argilla datasets

### DIFF
--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -57,7 +57,6 @@ def gutenberg_spacy_ner(mocked_client):
     from datasets import load_dataset
 
     dataset = "gutenberg_spacy_ner"
-    # TODO(@frascuchon): Move dataset to new organization
     dataset_ds = load_dataset(
         "argilla/gutenberg_spacy-ner",
         split="train",

--- a/tests/client/test_dataset.py
+++ b/tests/client/test_dataset.py
@@ -432,9 +432,8 @@ class TestDatasetForTextClassification:
         reason="You need a HF Hub access token to test the push_to_hub feature",
     )
     def test_from_dataset_with_non_argilla_format_multilabel(self):
-        # TODO(@frascuchon): Move dataset to the new org
         ds = datasets.load_dataset(
-            "rubrix/go_emotions_test_100",
+            "argilla/_go_emotions_test_100",
             split="test",
             use_auth_token=_HF_HUB_ACCESS_TOKEN,
         )
@@ -474,8 +473,7 @@ class TestDatasetForTextClassification:
     )
     def test_from_dataset_with_non_argilla_format(self):
         ds = datasets.load_dataset(
-            # TODO(@frascuchon): Move dataset to the new org
-            "rubrix/app_reviews_train_100",
+            "argilla/_app_reviews_train_100",
             split="train",
             use_auth_token=_HF_HUB_ACCESS_TOKEN,
         )
@@ -608,15 +606,13 @@ class TestDatasetForTokenClassification:
         dataset_ds = rg.DatasetForTokenClassification(tokenclassification_records).to_datasets()
         _push_to_hub_with_retries(
             dataset_ds,
-            # TODO(@frascuchon): Move dataset to the new org
-            repo_id="rubrix/_test_token_classification_records",
+            repo_id="argilla/_test_token_classification_records",
             token=_HF_HUB_ACCESS_TOKEN,
             private=True,
         )
         sleep(1)
         dataset_ds = datasets.load_dataset(
-            # TODO(@frascuchon): Move dataset to the new org
-            "rubrix/_test_token_classification_records",
+            "argilla/_test_token_classification_records",
             use_auth_token=_HF_HUB_ACCESS_TOKEN,
             split="train",
         )
@@ -629,8 +625,7 @@ class TestDatasetForTokenClassification:
     )
     def test_prepare_for_training_with_spacy(self):
         ner_dataset = datasets.load_dataset(
-            # TODO(@frascuchon): Move dataset to the new org
-            "rubrix/gutenberg_spacy-ner",
+            "argilla/gutenberg_spacy-ner",
             use_auth_token=_HF_HUB_ACCESS_TOKEN,
             split="train",
         )
@@ -661,8 +656,7 @@ class TestDatasetForTokenClassification:
     )
     def test_prepare_for_training_with_spark_nlp(self):
         ner_dataset = datasets.load_dataset(
-            # TODO(@frascuchon): Move dataset to the new org
-            "rubrix/gutenberg_spacy-ner",
+            "argilla/gutenberg_spacy-ner",
             use_auth_token=_HF_HUB_ACCESS_TOKEN,
             split="train",
         )
@@ -686,8 +680,7 @@ class TestDatasetForTokenClassification:
     )
     def test_prepare_for_training(self):
         ner_dataset = datasets.load_dataset(
-            # TODO(@frascuchon): Move dataset to the new org
-            "rubrix/gutenberg_spacy-ner",
+            "argilla/gutenberg_spacy-ner",
             use_auth_token=_HF_HUB_ACCESS_TOKEN,
             split="train",
         )
@@ -750,8 +743,7 @@ class TestDatasetForTokenClassification:
     )
     def test_from_dataset_with_non_argilla_format(self):
         ds = datasets.load_dataset(
-            # TODO(@frascuchon): Move dataset to the new org
-            "rubrix/wikiann_es_test_100",
+            "argilla/_wikiann_es_test_100",
             split="test",
             use_auth_token=_HF_HUB_ACCESS_TOKEN,
         )
@@ -899,14 +891,13 @@ class TestDatasetForText2Text:
         dataset_ds = rg.DatasetForText2Text(text2text_records).to_datasets()
         _push_to_hub_with_retries(
             dataset_ds,
-            # TODO(@frascuchon): Move dataset to the new org
-            repo_id="rubrix/_test_text2text_records",
+            repo_id="argilla/_test_text2text_records",
             token=_HF_HUB_ACCESS_TOKEN,
             private=True,
         )
         sleep(1)
         dataset_ds = datasets.load_dataset(
-            "rubrix/_test_text2text_records",
+            "argilla/_test_text2text_records",
             use_auth_token=_HF_HUB_ACCESS_TOKEN,
             split="train",
         )
@@ -919,7 +910,7 @@ class TestDatasetForText2Text:
     )
     def test_from_dataset_with_non_argilla_format(self):
         ds = datasets.load_dataset(
-            "rubrix/big_patent_a_test_100",
+            "argilla/_big_patent_a_test_100",
             split="test",
             use_auth_token=_HF_HUB_ACCESS_TOKEN,
         )

--- a/tests/functional_tests/test_log_for_token_classification.py
+++ b/tests/functional_tests/test_log_for_token_classification.py
@@ -443,8 +443,7 @@ def test_search_keywords(mocked_client, api):
     dataset = "test_search_keywords"
     from datasets import load_dataset
 
-    # TODO(@frascuchon): Move dataset to new organization
-    dataset_ds = load_dataset("rubrix/gutenberg_spacy-ner", split="train")
+    dataset_ds = load_dataset("argilla/gutenberg_spacy-ner", split="train")
     dataset_rb = argilla.read_datasets(dataset_ds, task="TokenClassification")
 
     api.delete(dataset)

--- a/tests/functional_tests/test_log_for_token_classification.py
+++ b/tests/functional_tests/test_log_for_token_classification.py
@@ -443,7 +443,12 @@ def test_search_keywords(mocked_client, api):
     dataset = "test_search_keywords"
     from datasets import load_dataset
 
-    dataset_ds = load_dataset("argilla/gutenberg_spacy-ner", split="train")
+    dataset_ds = load_dataset(
+        "argilla/gutenberg_spacy-ner",
+        split="train",
+        # This revision does not includes the vectors info, so tests will pass
+        revision="fff5f572e4cc3127f196f46ba3f9914c6fd0d763",
+    )
     dataset_rb = argilla.read_datasets(dataset_ds, task="TokenClassification")
 
     api.delete(dataset)

--- a/tests/metrics/test_common_metrics.py
+++ b/tests/metrics/test_common_metrics.py
@@ -26,6 +26,8 @@ def gutenberg_spacy_ner(mocked_client):
     dataset_ds = load_dataset(
         "argilla/gutenberg_spacy-ner",
         split="train",
+        # This revision does not includes the vectors info, so tests will pass
+        revision="fff5f572e4cc3127f196f46ba3f9914c6fd0d763",
     )
 
     dataset_rb = argilla.read_datasets(dataset_ds, task="TokenClassification")

--- a/tests/metrics/test_common_metrics.py
+++ b/tests/metrics/test_common_metrics.py
@@ -23,9 +23,8 @@ def gutenberg_spacy_ner(mocked_client):
     from datasets import load_dataset
 
     dataset = "gutenberg_spacy_ner"
-    # TODO(@frascuchon): Move dataset to new organization
     dataset_ds = load_dataset(
-        "rubrix/gutenberg_spacy-ner",
+        "argilla/gutenberg_spacy-ner",
         split="train",
     )
 


### PR DESCRIPTION
# Description

I went through all tests that use datasets from the `rubrix` namespace, and updated them to use `argilla` **if** an equivalently named Argilla dataset existed (that wasn't always the case). I don't have the HF token locally, so most of these tests were skipped locally, but I hope that they'll run in the CI.
Otherwise I'll try to get a token that works.

**Type of change**

- [x] Refactor (change restructuring the codebase without changing functionality)

**How Has This Been Tested**
Ran `pytest` locally, but most of these tests are under a `skipif`, so hopefully the CI has the token (I haven't looked into this yet).

**Checklist**

- [x] I have merged the original branch into my forked branch
- ~I added relevant documentation~
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- ~I made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- ~I have added tests that prove my fix is effective or that my feature works~
- ~I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)~