### PR TITLE
Create es index when a dataset published

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,8 @@ dynamic = ["version"]
 server = [
     # Basic dependencies
     "fastapi >= 0.75,< 0.89",
-    "opensearch-py >= 1.0,< 2.1",
-    "elasticsearch >=7.11.0,< 8.6.0",
+    "opensearch-py ~= 2.0.0",
+    "elasticsearch8 ~= 8.7.0",
     "uvicorn[standard] >= 0.15.0,< 0.21.0",
     "smart-open",
     "brotli-asgi >= 1.1,< 1.3",

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import Session
 
 from argilla.server.contexts import datasets
 from argilla.server.database import get_db
-from argilla.server.elasticsearch import ElasticSearchEngine, get_engine
+from argilla.server.elasticsearch import ElasticSearchEngine, get_search_engine
 from argilla.server.policies import DatasetPolicyV1, authorize
 from argilla.server.schemas.v1.datasets import (
     Annotation,
@@ -179,7 +179,7 @@ def create_dataset_records(
 async def publish_dataset(
     *,
     db: Session = Depends(get_db),
-    search_engine: ElasticSearchEngine = Depends(get_engine),
+    search_engine: ElasticSearchEngine = Depends(get_search_engine),
     dataset_id: UUID,
     current_user: User = Security(auth.get_current_user),
 ):

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 
 from argilla.server.contexts import datasets
 from argilla.server.database import get_db
+from argilla.server.elasticsearch import ElasticSearchEngine, get_engine
 from argilla.server.policies import DatasetPolicyV1, authorize
 from argilla.server.schemas.v1.datasets import (
     Annotation,
@@ -131,9 +132,10 @@ def create_dataset_annotation(
 
 
 @router.put("/datasets/{dataset_id}/publish", response_model=Dataset)
-def publish_dataset(
+async def publish_dataset(
     *,
     db: Session = Depends(get_db),
+    search_engine: ElasticSearchEngine = Depends(get_engine),
     dataset_id: UUID,
     current_user: User = Security(auth.get_current_user),
 ):
@@ -144,7 +146,7 @@ def publish_dataset(
     # TODO: We should split API v1 into different FastAPI apps so we can customize error management.
     # After mapping ValueError to 422 errors for API v1 then we can remove this try except.
     try:
-        return datasets.publish_dataset(db, dataset)
+        return await datasets.publish_dataset(db, search_engine, dataset)
     except ValueError as err:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(err))
 

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -57,7 +57,10 @@ async def publish_dataset(db: Session, search_engine: ElasticSearchEngine, datas
     try:
         dataset.status = DatasetStatus.ready
         await search_engine.create_index(dataset)
-
+        # TODO: DB rollback is executed if some problem is found creating the index. If the error
+        #  is raised from the commit statement, index creation should be reverted
+        #  We need a way to commit the dataset status before creating the index, and rollback the status
+        #  if something went wrong with index creation
         db.commit()
         db.refresh(dataset)
 

--- a/src/argilla/server/daos/backend/client_adapters/elasticsearch.py
+++ b/src/argilla/server/daos/backend/client_adapters/elasticsearch.py
@@ -15,22 +15,23 @@
 import dataclasses
 from typing import Any, Dict, Iterable, Optional, Tuple
 
-import elasticsearch
-from elasticsearch import Elasticsearch, NotFoundError, RequestError, helpers
-from elasticsearch.helpers import BulkIndexError
-from packaging.version import parse
+import elasticsearch8
 
 from argilla.server.daos.backend.base import BackendErrorHandler
 from argilla.server.daos.backend.client_adapters.opensearch import OpenSearchClient
 from argilla.server.daos.backend.search.query_builder import EsQueryBuilder
 
-ES_CLIENT_VERSION: str = elasticsearch.__versionstr__
+ES_CLIENT_VERSION: str = elasticsearch8.__versionstr__
 
-if parse(elasticsearch.__versionstr__) >= parse("8.0"):
-    from elasticsearch import ApiError, ElasticsearchWarning
-else:
-    from elasticsearch.exceptions import ElasticsearchException as ApiError
-    from elasticsearch.exceptions import ElasticsearchWarning
+from elasticsearch8 import (
+    ApiError,
+    Elasticsearch,
+    ElasticsearchWarning,
+    NotFoundError,
+    RequestError,
+    helpers,
+)
+from elasticsearch8.helpers import BulkIndexError
 
 
 @dataclasses.dataclass

--- a/src/argilla/server/elasticsearch.py
+++ b/src/argilla/server/elasticsearch.py
@@ -15,9 +15,10 @@
 import dataclasses
 from typing import Any, Dict
 
-from elasticsearch import Elasticsearch
+from elasticsearch8 import AsyncElasticsearch as AsyncElasticsearch8x
 
 from argilla.server.models import Annotation, AnnotationType, Dataset
+from argilla.server.settings import settings
 
 
 @dataclasses.dataclass
@@ -25,9 +26,9 @@ class ElasticSearchEngine:
     config: Dict[str, Any]
 
     def __post_init__(self):
-        self._client = Elasticsearch(**self.config)
+        self.client = AsyncElasticsearch8x(**self.config)
 
-    def create_index(self, dataset: Dataset):
+    async def create_index(self, dataset: Dataset):
         fields = {}
 
         for annotation in dataset.annotations:
@@ -41,7 +42,10 @@ class ElasticSearchEngine:
         }
 
         index_name = f"rg.{dataset.id}"
-        self._client.indices.create(index=index_name, body={"mappings": mappings})
+        await self.client.indices.create(index=index_name, mappings=mappings)
+
+    def close(self):
+        self.client.close()
 
     def _field_mapping_for_annotation(self, annotation_task: Annotation):
         settings_type = annotation_task.settings.get("type")
@@ -53,4 +57,19 @@ class ElasticSearchEngine:
             # See https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html
             return {"type": "text"}
         else:
-            raise ValueError(f"Annotation of type {settings_type} cannot be processed")
+            raise ValueError(f"ES mappings for Annotation of type {settings_type} cannot be generated")
+
+
+def get_engine():
+    config = dict(
+        hosts=settings.elasticsearch,
+        verify_certs=settings.elasticsearch_ssl_verify,
+        ca_certs=settings.elasticsearch_ca_path,
+        retry_on_timeout=True,
+        max_retries=5,
+    )
+    search_engine = ElasticSearchEngine(config)
+    try:
+        yield search_engine
+    finally:
+        search_engine.close()

--- a/src/argilla/server/elasticsearch.py
+++ b/src/argilla/server/elasticsearch.py
@@ -44,9 +44,6 @@ class ElasticSearchEngine:
         index_name = f"rg.{dataset.id}"
         await self.client.indices.create(index=index_name, mappings=mappings)
 
-    def close(self):
-        self.client.close()
-
     def _field_mapping_for_annotation(self, annotation_task: Annotation):
         settings_type = annotation_task.settings.get("type")
 
@@ -60,7 +57,7 @@ class ElasticSearchEngine:
             raise ValueError(f"ES mappings for Annotation of type {settings_type} cannot be generated")
 
 
-def get_engine():
+async def get_engine():
     config = dict(
         hosts=settings.elasticsearch,
         verify_certs=settings.elasticsearch_ssl_verify,
@@ -72,4 +69,4 @@ def get_engine():
     try:
         yield search_engine
     finally:
-        search_engine.close()
+        await search_engine.client.close()

--- a/src/argilla/server/elasticsearch.py
+++ b/src/argilla/server/elasticsearch.py
@@ -57,7 +57,7 @@ class ElasticSearchEngine:
             raise ValueError(f"ES mappings for Annotation of type {settings_type} cannot be generated")
 
 
-async def get_engine():
+async def get_search_engine():
     config = dict(
         hosts=settings.elasticsearch,
         verify_certs=settings.elasticsearch_ssl_verify,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,13 +61,13 @@ def is_running_elasticsearch() -> bool:
 
 
 @pytest.fixture(scope="session")
-def es_config():
+def elasticsearch_config():
     return {"hosts": settings.elasticsearch}
 
 
 @pytest.fixture(scope="session")
-def elasticsearch(es_config):
-    client = Elasticsearch(**es_config)
+def elasticsearch(elasticsearch_config):
+    client = Elasticsearch(**elasticsearch_config)
     yield client
 
     for index_info in client.cat.indices(index="ar.*,rg.*", format="json"):

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -1043,7 +1043,7 @@ def test_publish_dataset_with_error_on_index_creation(
     admin_auth_header: dict,
 ):
     dataset = DatasetFactory.create()
-    AnnotationFactory.create(dataset=dataset)
+    AnnotationFactory.create(settings={"type": "invalid"}, dataset=dataset)
 
     response = client.put(f"/api/v1/datasets/{dataset.id}/publish", headers=admin_auth_header)
 

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -575,10 +575,7 @@ def test_create_dataset_rating_annotation_with_invalid_settings_options_values(
     assert db.query(Annotation).count() == 0
 
 
-@pytest.mark.skipif(
-    condition=not is_running_elasticsearch(),
-    reason="Test only running with elasticsearch backend",
-)
+@pytest.mark.skipif(condition=not is_running_elasticsearch(), reason="Test only running with elasticsearch backend")
 def test_publish_dataset(
     client: TestClient,
     db: Session,
@@ -599,6 +596,7 @@ def test_publish_dataset(
     assert elasticsearch.indices.exists(index=f"rg.{dataset.id}")
 
 
+@pytest.mark.skipif(condition=not is_running_elasticsearch(), reason="Test only running with elasticsearch backend")
 def test_publish_dataset_with_error_on_index_creation(
     client: TestClient,
     db: Session,

--- a/tests/server/test_elasticsearch.py
+++ b/tests/server/test_elasticsearch.py
@@ -16,41 +16,15 @@ import random
 
 import pytest
 from argilla.server.elasticsearch import ElasticSearchEngine
-from argilla.server.models import AnnotationType
-from argilla.server.settings import settings
 from elasticsearch import BadRequestError, Elasticsearch
-from opensearchpy import OpenSearch
 from sqlalchemy.orm import Session
 
+from tests.conftest import is_running_elasticsearch
 from tests.factories import (
-    AnnotationFactory,
     DatasetFactory,
     RatingAnnotationFactory,
     TextAnnotationFactory,
 )
-
-
-def _running_with_elasticsearch() -> str:
-    open_search = OpenSearch(hosts=settings.elasticsearch)
-
-    info = open_search.info(format="json")
-    version_info = info["version"]
-
-    return "distribution" not in version_info
-
-
-@pytest.fixture(scope="session")
-def es_config():
-    return {"hosts": settings.elasticsearch}
-
-
-@pytest.fixture(scope="session")
-def elasticsearch(es_config):
-    client = Elasticsearch(**es_config)
-    yield client
-
-    for index_info in client.cat.indices(index="ar.*,rg.*", format="json"):
-        client.indices.delete(index=index_info["index"])
 
 
 @pytest.fixture(scope="session")
@@ -58,68 +32,58 @@ def search_engine(es_config):
     return ElasticSearchEngine(config=es_config)
 
 
-@pytest.mark.skipif(
-    condition=not _running_with_elasticsearch(),
-    reason="Test only running with elasticsearch backend",
-)
-def test_create_index_for_dataset(search_engine: ElasticSearchEngine, elasticsearch: Elasticsearch):
-    dataset = DatasetFactory.create()
-    search_engine.create_index(dataset)
+@pytest.mark.skipif(condition=not is_running_elasticsearch(), reason="Test only running with elasticsearch backend")
+@pytest.mark.asyncio
+class ElasticSearchEngineTestSuite:
+    async def test_create_index_for_dataset(self, search_engine: ElasticSearchEngine, elasticsearch: Elasticsearch):
+        dataset = DatasetFactory.create()
+        await search_engine.create_index(dataset)
 
-    index_name = f"rg.{dataset.id}"
-    assert elasticsearch.indices.exists(index=index_name)
+        index_name = f"rg.{dataset.id}"
+        assert elasticsearch.indices.exists(index=index_name)
 
-    index = elasticsearch.indices.get(index=index_name)[index_name]
-    assert index["mappings"] == {"dynamic": "strict"}
+        index = elasticsearch.indices.get(index=index_name)[index_name]
+        assert index["mappings"] == {"dynamic": "strict"}
 
+    @pytest.mark.parametrize(
+        argnames=("text_ann_size", "rating_ann_size"),
+        argvalues=[(random.randint(1, 9), random.randint(1, 9)) for _ in range(1, 5)],
+    )
+    async def test_create_index_for_dataset_with_annotations(
+        self,
+        search_engine: ElasticSearchEngine,
+        elasticsearch: Elasticsearch,
+        db: Session,
+        text_ann_size: int,
+        rating_ann_size: int,
+    ):
+        text_annotations = TextAnnotationFactory.create_batch(size=text_ann_size)
+        rating_annotations = RatingAnnotationFactory.create_batch(size=rating_ann_size)
 
-@pytest.mark.skipif(
-    condition=not _running_with_elasticsearch(),
-    reason="Test only running with elasticsearch backend",
-)
-@pytest.mark.parametrize(
-    argnames=("text_ann_size", "rating_ann_size"),
-    argvalues=[(random.randint(1, 9), random.randint(1, 9)) for _ in range(1, 5)],
-)
-def test_create_index_for_dataset_with_annotations(
-    search_engine: ElasticSearchEngine,
-    elasticsearch: Elasticsearch,
-    db: Session,
-    text_ann_size: int,
-    rating_ann_size: int,
-):
-    text_annotations = TextAnnotationFactory.create_batch(size=text_ann_size)
-    rating_annotations = RatingAnnotationFactory.create_batch(size=rating_ann_size)
+        dataset = DatasetFactory.create(annotations=text_annotations + rating_annotations)
 
-    dataset = DatasetFactory.create(annotations=text_annotations + rating_annotations)
+        await search_engine.create_index(dataset)
 
-    search_engine.create_index(dataset)
+        index_name = f"rg.{dataset.id}"
+        assert elasticsearch.indices.exists(index=index_name)
 
-    index_name = f"rg.{dataset.id}"
-    assert elasticsearch.indices.exists(index=index_name)
+        index = elasticsearch.indices.get(index=index_name)[index_name]
+        assert index["mappings"] == {
+            "dynamic": "strict",
+            "properties": {
+                **{annotation.name: {"type": "text"} for annotation in text_annotations},
+                **{annotation.name: {"type": "integer"} for annotation in rating_annotations},
+            },
+        }
 
-    index = elasticsearch.indices.get(index=index_name)[index_name]
-    assert index["mappings"] == {
-        "dynamic": "strict",
-        "properties": {
-            **{annotation.name: {"type": "text"} for annotation in text_annotations},
-            **{annotation.name: {"type": "integer"} for annotation in rating_annotations},
-        },
-    }
+    async def test_create_index_with_existing_index(
+        self, search_engine: ElasticSearchEngine, elasticsearch: Elasticsearch, db: Session
+    ):
+        dataset = DatasetFactory.create()
+        await search_engine.create_index(dataset)
 
+        index_name = f"rg.{dataset.id}"
+        assert elasticsearch.indices.exists(index=index_name)
 
-@pytest.mark.skipif(
-    condition=not _running_with_elasticsearch(),
-    reason="Test only running with elasticsearch backend",
-)
-def test_create_index_with_existing_index(
-    search_engine: ElasticSearchEngine, elasticsearch: Elasticsearch, db: Session
-):
-    dataset = DatasetFactory.create()
-    search_engine.create_index(dataset)
-
-    index_name = f"rg.{dataset.id}"
-    assert elasticsearch.indices.exists(index=index_name)
-
-    with pytest.raises(BadRequestError, match="'resource_already_exists_exception', 'index"):
-        search_engine.create_index(dataset)
+        with pytest.raises(BadRequestError, match="'resource_already_exists_exception', 'index"):
+            await search_engine.create_index(dataset)

--- a/tests/server/test_elasticsearch.py
+++ b/tests/server/test_elasticsearch.py
@@ -29,8 +29,8 @@ from tests.factories import (
 
 
 @pytest_asyncio.fixture()
-async def search_engine(es_config):
-    engine = ElasticSearchEngine(config=es_config)
+async def search_engine(elasticsearch_config):
+    engine = ElasticSearchEngine(config=elasticsearch_config)
     yield engine
 
     await engine.client.close()


### PR DESCRIPTION
A basic integration with elasticsearch when a dataset is published. At this point, the elasticsearch index will be created based on dataset configuration.

A DB rollback is executed if some problem is found creating the index. If the error is raised from the commit statement, index creation should be reverted, or another mechanism to recreate the index should be provided through the API endpoint (and extra param with `force_recreate` or just `force`). But this won't be tackled in this PR.

Edit: Also, the elasticsearch client deps are reviewed. Now, the named 8x version is used. This allows us more control over the `es` client version to use, and it can suppress installation conflicts in an environment with a preview es client package installed. 

