### PR TITLE
Add records and responses

### DIFF
--- a/src/argilla/server/alembic/versions/8be56284dac0_create_records_table.py
+++ b/src/argilla/server/alembic/versions/8be56284dac0_create_records_table.py
@@ -1,0 +1,45 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""create records table
+
+Revision ID: 8be56284dac0
+Revises: 3a8e2f9b5dea
+Create Date: 2023-04-13 12:56:56.456664
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "8be56284dac0"
+down_revision = "3a8e2f9b5dea"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "records",
+        sa.Column("id", sa.Uuid, primary_key=True),
+        sa.Column("fields", sa.JSON, nullable=False),
+        sa.Column("external_id", sa.String, unique=True, index=True),
+        sa.Column("dataset_id", sa.Uuid, sa.ForeignKey("datasets.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column("inserted_at", sa.DateTime, nullable=False),
+        sa.Column("updated_at", sa.DateTime, nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("records")

--- a/src/argilla/server/alembic/versions/8be56284dac0_create_records_table.py
+++ b/src/argilla/server/alembic/versions/8be56284dac0_create_records_table.py
@@ -34,10 +34,11 @@ def upgrade() -> None:
         "records",
         sa.Column("id", sa.Uuid, primary_key=True),
         sa.Column("fields", sa.JSON, nullable=False),
-        sa.Column("external_id", sa.String, unique=True, index=True),
+        sa.Column("external_id", sa.String, index=True),
         sa.Column("dataset_id", sa.Uuid, sa.ForeignKey("datasets.id", ondelete="CASCADE"), nullable=False, index=True),
         sa.Column("inserted_at", sa.DateTime, nullable=False),
         sa.Column("updated_at", sa.DateTime, nullable=False),
+        sa.UniqueConstraint("external_id", "dataset_id", name="record_external_id_dataset_id_uq"),
     )
 
 

--- a/src/argilla/server/alembic/versions/e402e9d9245e_create_responses_table.py
+++ b/src/argilla/server/alembic/versions/e402e9d9245e_create_responses_table.py
@@ -36,6 +36,8 @@ def upgrade() -> None:
         sa.Column("values", sa.JSON, nullable=False),
         sa.Column("record_id", sa.Uuid, sa.ForeignKey("records.id", ondelete="CASCADE"), nullable=False, index=True),
         sa.Column("user_id", sa.Uuid, sa.ForeignKey("users.id", ondelete="SET NULL"), index=True),
+        sa.Column("inserted_at", sa.DateTime, nullable=False),
+        sa.Column("updated_at", sa.DateTime, nullable=False),
     )
 
 

--- a/src/argilla/server/alembic/versions/e402e9d9245e_create_responses_table.py
+++ b/src/argilla/server/alembic/versions/e402e9d9245e_create_responses_table.py
@@ -1,0 +1,43 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""create responses table
+
+Revision ID: e402e9d9245e
+Revises: 8be56284dac0
+Create Date: 2023-04-13 14:48:52.462570
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e402e9d9245e"
+down_revision = "8be56284dac0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "responses",
+        sa.Column("id", sa.Uuid, primary_key=True),
+        sa.Column("values", sa.JSON, nullable=False),
+        sa.Column("record_id", sa.Uuid, sa.ForeignKey("records.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column("user_id", sa.Uuid, sa.ForeignKey("users.id", ondelete="SET NULL"), index=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("responses")

--- a/src/argilla/server/alembic/versions/e402e9d9245e_create_responses_table.py
+++ b/src/argilla/server/alembic/versions/e402e9d9245e_create_responses_table.py
@@ -38,6 +38,7 @@ def upgrade() -> None:
         sa.Column("user_id", sa.Uuid, sa.ForeignKey("users.id", ondelete="SET NULL"), index=True),
         sa.Column("inserted_at", sa.DateTime, nullable=False),
         sa.Column("updated_at", sa.DateTime, nullable=False),
+        sa.UniqueConstraint("record_id", "user_id", name="response_record_id_user_id_uq"),
     )
 
 

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -63,6 +63,20 @@ def list_datasets(
         return current_user.datasets
 
 
+@router.get("/datasets/{dataset_id}/annotations", response_model=List[Annotation])
+def list_dataset_annotations(
+    *,
+    db: Session = Depends(get_db),
+    dataset_id: UUID,
+    current_user: User = Security(auth.get_current_user),
+):
+    dataset = _get_dataset(db, dataset_id)
+
+    authorize(current_user, DatasetPolicyV1.get(dataset))
+
+    return dataset.annotations
+
+
 @router.get("/datasets/{dataset_id}/records", response_model=Records)
 def list_dataset_records(
     *,
@@ -94,22 +108,6 @@ def get_dataset(
     authorize(current_user, DatasetPolicyV1.get(dataset))
 
     return dataset
-
-
-# TODO: Change this to list_dataset_annotations and move it before list_dataset_records.
-# - Change tests names too.
-@router.get("/datasets/{dataset_id}/annotations", response_model=List[Annotation])
-def get_dataset_annotations(
-    *,
-    db: Session = Depends(get_db),
-    dataset_id: UUID,
-    current_user: User = Security(auth.get_current_user),
-):
-    dataset = _get_dataset(db, dataset_id)
-
-    authorize(current_user, DatasetPolicyV1.get(dataset))
-
-    return dataset.annotations
 
 
 @router.post("/datasets", status_code=status.HTTP_201_CREATED, response_model=Dataset)

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -154,7 +154,6 @@ def create_dataset_annotation(
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(err))
 
 
-# TODO: Returns 409 when external_id already exists?
 @router.post("/datasets/{dataset_id}/records", status_code=status.HTTP_204_NO_CONTENT)
 def create_dataset_records(
     *,
@@ -167,7 +166,12 @@ def create_dataset_records(
 
     dataset = _get_dataset(db, dataset_id)
 
-    datasets.create_records(db, dataset, current_user, records_create)
+    # TODO: We should split API v1 into different FastAPI apps so we can customize error management.
+    # After mapping ValueError to 422 errors for API v1 then we can remove this try except.
+    try:
+        datasets.create_records(db, dataset, current_user, records_create)
+    except ValueError as err:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(err))
 
 
 @router.put("/datasets/{dataset_id}/publish", response_model=Dataset)

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -130,6 +130,21 @@ def create_dataset_annotation(
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(err))
 
 
+@router.post("/datasets/{dataset_id}/records", status_code=status.HTTP_204_NO_CONTENT)
+def create_records(
+    *,
+    db: Session = Depends(get_db),
+    dataset_id: UUID,
+    records_create: RecordsCreate,
+    current_user: User = Security(auth.get_current_user),
+):
+    authorize(current_user, RecordPolicyV1.create)
+
+    dataset = _get_dataset(db, dataset_id)
+
+    datasets.create_records(db, dataset, current_user, records_create)
+
+
 @router.put("/datasets/{dataset_id}/publish", response_model=Dataset)
 def publish_dataset(
     *,

--- a/src/argilla/server/apis/v1/handlers/records.py
+++ b/src/argilla/server/apis/v1/handlers/records.py
@@ -71,21 +71,6 @@ def list_records(
     return RecordsList(total=0, items=records)
 
 
-@router.post("/datasets/{dataset_id}/records", status_code=status.HTTP_204_NO_CONTENT)
-def create_records(
-    *,
-    db: Session = Depends(get_db),
-    dataset_id: UUID,
-    records_create: RecordsCreate,
-    current_user: User = Security(auth.get_current_user),
-):
-    authorize(current_user, RecordPolicyV1.create)
-
-    dataset = _get_dataset(db, dataset_id)
-
-    datasets.create_records(db, dataset, current_user, records_create)
-
-
 @router.put("/records/{record_id}/responses", response_model=Response)
 def update_record_responses(
     *,

--- a/src/argilla/server/apis/v1/handlers/records.py
+++ b/src/argilla/server/apis/v1/handlers/records.py
@@ -49,8 +49,8 @@ def list_records(
     *,
     db: Session = Depends(get_db),
     dataset_id: UUID,
-    limit: int = Query(default=50, lte=1000),
     offset: int = 0,
+    limit: int = Query(default=50, lte=1000),
     include: Optional[List[RecordInclude]] = Query(None),
     current_user: User = Security(auth.get_current_user),
 ):
@@ -58,7 +58,7 @@ def list_records(
 
     authorize(current_user, RecordPolicyV1.get(dataset))
 
-    records = datasets.list_records(db, dataset, limit=limit, offset=offset)
+    records = datasets.list_records(db, dataset, offset=offset, limit=limit)
 
     for record in records:
         record_schema = Record(id=record.id, fields=record.fields)
@@ -102,6 +102,7 @@ def update_record_responses(
         )
 
     authorize(current_user, RecordPolicyV1.update_response(record))
+
     datasets.create_or_update_response(db, record, current_user, response_create_or_update=response)
 
     return response

--- a/src/argilla/server/apis/v1/handlers/records.py
+++ b/src/argilla/server/apis/v1/handlers/records.py
@@ -1,0 +1,53 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Security, status
+from sqlalchemy.orm import Session
+
+from argilla.server.contexts import datasets
+from argilla.server.database import get_db
+from argilla.server.policies import RecordPolicyV1, authorize
+from argilla.server.schemas.v1.records import RecordsCreate
+from argilla.server.security import auth
+from argilla.server.security.model import User
+
+router = APIRouter(tags=["records"])
+
+
+def _get_dataset(db: Session, dataset_id: UUID):
+    dataset = datasets.get_dataset_by_id(db, dataset_id)
+    if not dataset:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Dataset with id `{dataset_id}` not found",
+        )
+
+    return dataset
+
+
+@router.post("/datasets/{dataset_id}/records", status_code=status.HTTP_204_NO_CONTENT)
+def create_records(
+    *,
+    db: Session = Depends(get_db),
+    dataset_id: UUID,
+    records_create: RecordsCreate,
+    current_user: User = Security(auth.get_current_user),
+):
+    authorize(current_user, RecordPolicyV1.create)
+
+    dataset = _get_dataset(db, dataset_id)
+
+    datasets.create_records(db, dataset, records_create)

--- a/src/argilla/server/apis/v1/handlers/records.py
+++ b/src/argilla/server/apis/v1/handlers/records.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 from argilla.server.contexts import datasets
 from argilla.server.database import get_db
 from argilla.server.models import User
+from argilla.server.policies import RecordPolicyV1, authorize
 from argilla.server.schemas.v1.records import Response, ResponseCreate
 from argilla.server.security import auth
 
@@ -34,14 +35,14 @@ def create_record_response(
     response_create: ResponseCreate,
     current_user: User = Security(auth.get_current_user),
 ):
-    # TODO: Add authorize
-
     record = datasets.get_record_by_id(db, record_id)
     if not record:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Record with id `{record_id}` not found",
         )
+
+    authorize(current_user, RecordPolicyV1.create_response(record))
 
     if datasets.get_response_by_record_id_and_user_id(db, record_id, current_user.id):
         raise HTTPException(

--- a/src/argilla/server/apis/v1/handlers/records.py
+++ b/src/argilla/server/apis/v1/handlers/records.py
@@ -11,72 +11,28 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import List, Optional
+
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Security, status
+from fastapi import APIRouter, Depends, HTTPException, Security, status
 from sqlalchemy.orm import Session
 
 from argilla.server.contexts import datasets
 from argilla.server.database import get_db
-from argilla.server.policies import RecordPolicyV1, authorize
-from argilla.server.schemas.v1.records import (
-    Record,
-    RecordInclude,
-    RecordsCreate,
-    RecordsList,
-    Response,
-)
+from argilla.server.models import User
+from argilla.server.schemas.v1.records import Response, ResponseCreate
 from argilla.server.security import auth
-from argilla.server.security.model import User
 
 router = APIRouter(tags=["records"])
 
 
-def _get_dataset(db: Session, dataset_id: UUID):
-    dataset = datasets.get_dataset_by_id(db, dataset_id)
-    if not dataset:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Dataset with id `{dataset_id}` not found",
-        )
-
-    return dataset
-
-
-@router.get("/datasets/{dataset_id}/records", response_model=RecordsList)
-def list_records(
-    *,
-    db: Session = Depends(get_db),
-    dataset_id: UUID,
-    offset: int = 0,
-    limit: int = Query(default=50, lte=1000),
-    include: Optional[List[RecordInclude]] = Query(None),
-    current_user: User = Security(auth.get_current_user),
-):
-    dataset = _get_dataset(db, dataset_id)
-
-    authorize(current_user, RecordPolicyV1.get(dataset))
-
-    records = datasets.list_records(db, dataset, offset=offset, limit=limit)
-
-    for record in records:
-        record_schema = Record(id=record.id, fields=record.fields)
-        if RecordInclude.responses in include:
-            # TODO: Move this to context, please
-            response = db.query(Response).filter_by(record_id=record.id, user_id=current_user.id).first()
-            if response:
-                record_schema.responses = {current_user.username: response.values}
-
-    return RecordsList(total=0, items=records)
-
-
-@router.put("/records/{record_id}/responses", response_model=Response)
-def update_record_responses(
+# TODO: Returns 409 when a response exists for the same record and user?
+@router.post("/records/{record_id}/responses", status_code=status.HTTP_201_CREATED, response_model=Response)
+def create_record_response(
     *,
     db: Session = Depends(get_db),
     record_id: UUID,
-    response: Response,
+    response_create: ResponseCreate,
     current_user: User = Security(auth.get_current_user),
 ):
     record = datasets.get_record_by_id(db, record_id)
@@ -86,8 +42,6 @@ def update_record_responses(
             detail=f"Record with id `{record_id}` not found",
         )
 
-    authorize(current_user, RecordPolicyV1.update_response(record))
+    # TODO: Add authorize
 
-    datasets.create_or_update_response(db, record, current_user, response_create_or_update=response)
-
-    return response
+    return datasets.create_response(db, record, current_user, response_create)

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -15,11 +15,14 @@ from typing import List, Optional
 from uuid import UUID
 
 from argilla.server.models import Annotation, Dataset, DatasetStatus, Record, Response
-from argilla.server.schemas.v1.datasets import AnnotationCreate, DatasetCreate
-from argilla.server.schemas.v1.records import RecordCreate, RecordsCreate
-from argilla.server.schemas.v1.records import Response as ResponseSchema
+from argilla.server.schemas.v1.datasets import (
+    AnnotationCreate,
+    DatasetCreate,
+    RecordsCreate,
+)
+from argilla.server.schemas.v1.records import ResponseCreate
 from argilla.server.security.model import User
-from sqlalchemy import exc, func
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 
@@ -112,54 +115,46 @@ def get_record_by_id(db: Session, record_id: UUID):
     return db.get(Record, record_id)
 
 
-def list_records(db: Session, dataset: Dataset, offset: int = 0, limit: int = 50):
-    return db.query(Record).filter_by(dataset_id=dataset.id).offset(offset).limit(limit).all()
+def list_records(db: Session, dataset: Dataset, offset: int = 0, limit: int = 20):
+    return (
+        db.query(Record)
+        .filter_by(dataset_id=dataset.id)
+        .order_by(Record.inserted_at.asc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
 
 
 def create_records(db: Session, dataset: Dataset, user: User, records_create: RecordsCreate):
-    # return [create_record(db, dataset, record_create) for record_create in records_create.items]
-
-    # for record_create in records_create.items:
-
-    # errors = []
-
     if not dataset.is_ready:
         raise ValueError("Records cannot be created for a non published dataset")
 
     records = []
     for record_create in records_create.items:
-        responses = []
-        if record_create.response:
-            responses.append(Response(values={k: v.dict() for k, v in record_create.response.items()}, user_id=user.id))
-
-        records.append(
-            Record(
-                fields=record_create.fields,
-                external_id=record_create.external_id,
-                dataset_id=dataset.id,
-                responses=responses,
-            )
+        record = Record(
+            fields=record_create.fields,
+            external_id=record_create.external_id,
+            dataset_id=dataset.id,
         )
+
+        if record_create.response:
+            record.responses = [Response(values=record_create.response.values, user_id=user.id)]
+
+        records.append(record)
 
     db.add_all(records)
     db.commit()
-    # try:
-    #     with db.begin_nested():
-    #         db.add(Record(fields=record_create.fields, dataset_id=dataset.id))
-    # except exc.IntegrityError:
 
 
-def create_or_update_response(db: Session, record: Record, user: User, response_create_or_update: ResponseSchema):
-    response = db.query(Response).filter_by(record_id=record.id, user_id=user.id).first()
+def create_response(db: Session, record: Record, user: User, response_create: ResponseCreate):
+    response = Response(
+        values=response_create.values,
+        record_id=record.id,
+        user_id=user.id,
+    )
 
-    values = {k: v.dict() for k, v in response_create_or_update.items()}
-
-    if response:
-        response.values = values
-    else:
-        response = Response(record_id=record.id, user_id=user.id, values=values)
-        db.add(response)
-
+    db.add(response)
     db.commit()
     db.refresh(response)
 

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -112,8 +112,8 @@ def get_record_by_id(db: Session, record_id: UUID):
     return db.get(Record, record_id)
 
 
-def list_records(db: Session, dataset: Dataset, limit: int, offset: int = 0):
-    return db.query(Record).filter_by(dataset_id=dataset.id).limit(limit).offset(offset).all()
+def list_records(db: Session, dataset: Dataset, offset: int = 0, limit: int = 50):
+    return db.query(Record).filter_by(dataset_id=dataset.id).offset(offset).limit(limit).all()
 
 
 def create_records(db: Session, dataset: Dataset, user: User, records_create: RecordsCreate):

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -23,7 +23,7 @@ from argilla.server.schemas.v1.datasets import (
 from argilla.server.schemas.v1.records import ResponseCreate
 from argilla.server.security.model import User
 from sqlalchemy import func
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 
 def get_dataset_by_id(db: Session, dataset_id: UUID):
@@ -118,6 +118,7 @@ def get_record_by_id(db: Session, record_id: UUID):
 def list_records(db: Session, dataset: Dataset, offset: int = 0, limit: int = 20):
     return (
         db.query(Record)
+        .options(joinedload(Record.responses))
         .filter_by(dataset_id=dataset.id)
         .order_by(Record.inserted_at.asc())
         .offset(offset)

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -147,6 +147,10 @@ def create_records(db: Session, dataset: Dataset, user: User, records_create: Re
     db.commit()
 
 
+def get_response_by_record_id_and_user_id(db: Session, record_id: UUID, user_id: UUID):
+    return db.query(Response).filter_by(record_id=record_id, user_id=user_id).first()
+
+
 def create_response(db: Session, record: Record, user: User, response_create: ResponseCreate):
     response = Response(
         values=response_create.values,

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -80,7 +80,7 @@ class Record(Base):
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
     dataset: Mapped["Dataset"] = relationship(back_populates="records")
-    responses: Mapped["Response"] = relationship(back_populates="record")
+    response: Mapped["Response"] = relationship(back_populates="record")
 
     def __repr__(self):
         return f"Record(id={str(self.id)!r}, external_id={self.external_id!r},  dataset_id={str(self.dataset_id)!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
@@ -97,8 +97,8 @@ class Response(Base):
     inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
-    record = Mapped["Record"] = relationship(back_populates="responses")
-    user = Mapped["User"] = relationship(back_populates="responses")
+    record: Mapped["Record"] = relationship(back_populates="responses")
+    user: Mapped["User"] = relationship(back_populates="responses")
 
 
 class Dataset(Base):

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -68,27 +68,6 @@ class Annotation(Base):
         return f"Annotation(id={str(self.id)!r}, name={self.name!r}, required={self.required!r}, dataset_id={str(self.dataset_id)!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
 
 
-class Record(Base):
-    __tablename__ = "records"
-
-    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
-    fields: Mapped[dict] = mapped_column(JSON)
-    external_id: Mapped[Optional[str]]
-    dataset_id: Mapped[UUID] = mapped_column(ForeignKey("datasets.id"))
-
-    inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
-    updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
-
-    dataset: Mapped["Dataset"] = relationship(back_populates="records")
-    responses: Mapped[List["Response"]] = relationship(back_populates="record")
-
-    def __repr__(self):
-        return (
-            f"Record(id={str(self.id)!r}, external_id={self.external_id!r}, dataset_id={str(self.dataset_id)!r}, "
-            f"inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
-        )
-
-
 class Response(Base):
     __tablename__ = "responses"
 
@@ -106,6 +85,27 @@ class Response(Base):
     def __repr__(self):
         return (
             f"Response(id={str(self.id)!r}, record_id={str(self.record_id)!r}, user_id={str(self.user_id)!r}, "
+            f"inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        )
+
+
+class Record(Base):
+    __tablename__ = "records"
+
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    fields: Mapped[dict] = mapped_column(JSON)
+    external_id: Mapped[Optional[str]]
+    dataset_id: Mapped[UUID] = mapped_column(ForeignKey("datasets.id"))
+
+    inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
+
+    dataset: Mapped["Dataset"] = relationship(back_populates="records")
+    responses: Mapped[List["Response"]] = relationship(back_populates="record", order_by=Response.inserted_at.asc())
+
+    def __repr__(self):
+        return (
+            f"Record(id={str(self.id)!r}, external_id={self.external_id!r}, dataset_id={str(self.dataset_id)!r}, "
             f"inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
         )
 

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -80,10 +80,13 @@ class Record(Base):
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
     dataset: Mapped["Dataset"] = relationship(back_populates="records")
-    response: Mapped["Response"] = relationship(back_populates="record")
+    responses: Mapped[List["Response"]] = relationship(back_populates="record")
 
     def __repr__(self):
-        return f"Record(id={str(self.id)!r}, external_id={self.external_id!r},  dataset_id={str(self.dataset_id)!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        return (
+            f"Record(id={str(self.id)!r}, external_id={self.external_id!r}, dataset_id={str(self.dataset_id)!r},"
+            f" inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        )
 
 
 class Response(Base):
@@ -99,6 +102,12 @@ class Response(Base):
 
     record: Mapped["Record"] = relationship(back_populates="responses")
     user: Mapped["User"] = relationship(back_populates="responses")
+
+    def __repr__(self):
+        return (
+            f"Response(id={str(self.id)!r}, record_id={self.record_id!r}, user_id={str(self.user_id)!r},"
+            " inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        )
 
 
 class Dataset(Base):

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -65,7 +65,11 @@ class Annotation(Base):
     dataset: Mapped["Dataset"] = relationship(back_populates="annotations")
 
     def __repr__(self):
-        return f"Annotation(id={str(self.id)!r}, name={self.name!r}, required={self.required!r}, dataset_id={str(self.dataset_id)!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        return (
+            f"Annotation(id={str(self.id)!r}, name={self.name!r}, required={self.required!r}, "
+            f"dataset_id={str(self.dataset_id)!r}, "
+            f"inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        )
 
 
 class Response(Base):
@@ -137,7 +141,11 @@ class Dataset(Base):
         return self.status == DatasetStatus.ready
 
     def __repr__(self):
-        return f"Dataset(id={str(self.id)!r}, name={self.name!r}, guidelines={self.guidelines!r}, status={self.status.value!r}, workspace_id={str(self.workspace_id)!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        return (
+            f"Dataset(id={str(self.id)!r}, name={self.name!r}, guidelines={self.guidelines!r}, "
+            f"status={self.status.value!r}, workspace_id={str(self.workspace_id)!r}, "
+            f"inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        )
 
 
 class WorkspaceUser(Base):
@@ -154,7 +162,11 @@ class WorkspaceUser(Base):
     user: Mapped["User"] = relationship(viewonly=True)
 
     def __repr__(self):
-        return f"WorkspaceUser(id={str(self.id)!r}, workspace_id={str(self.workspace_id)!r}, user_id={str(self.user_id)!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        return (
+            f"WorkspaceUser(id={str(self.id)!r}, workspace_id={str(self.workspace_id)!r}, "
+            f"user_id={str(self.user_id)!r}, "
+            f"inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        )
 
 
 class Workspace(Base):
@@ -172,7 +184,10 @@ class Workspace(Base):
     )
 
     def __repr__(self):
-        return f"Workspace(id={str(self.id)!r}, name={self.name!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        return (
+            f"Workspace(id={str(self.id)!r}, name={self.name!r}, "
+            f"inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        )
 
 
 class User(Base):
@@ -213,4 +228,8 @@ class User(Base):
         return self.role == UserRole.annotator
 
     def __repr__(self):
-        return f"User(id={str(self.id)!r}, first_name={self.first_name!r}, last_name={self.last_name!r}, username={self.username!r}, role={self.role.value!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        return (
+            f"User(id={str(self.id)!r}, first_name={self.first_name!r}, last_name={self.last_name!r}, "
+            f"username={self.username!r}, role={self.role.value!r}, "
+            f"inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        )

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -84,8 +84,8 @@ class Record(Base):
 
     def __repr__(self):
         return (
-            f"Record(id={str(self.id)!r}, external_id={self.external_id!r}, dataset_id={str(self.dataset_id)!r},"
-            f" inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+            f"Record(id={str(self.id)!r}, external_id={self.external_id!r}, dataset_id={str(self.dataset_id)!r}, "
+            f"inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
         )
 
 
@@ -105,8 +105,8 @@ class Response(Base):
 
     def __repr__(self):
         return (
-            f"Response(id={str(self.id)!r}, record_id={self.record_id!r}, user_id={str(self.user_id)!r},"
-            " inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+            f"Response(id={str(self.id)!r}, record_id={str(self.record_id)!r}, user_id={str(self.user_id)!r}, "
+            f"inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
         )
 
 

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -140,6 +140,10 @@ class DatasetPolicyV1:
         return actor.is_admin
 
     @classmethod
+    def create_records(cls, actor: User) -> bool:
+        return actor.is_admin
+
+    @classmethod
     def publish(cls, actor: User) -> bool:
         return actor.is_admin
 
@@ -155,10 +159,6 @@ class AnnotationPolicyV1:
 
 
 class RecordPolicyV1:
-    @classmethod
-    def create(cls, actor: User) -> bool:
-        return actor.is_admin
-
     @classmethod
     def update_response(cls, record: Record) -> PolicyAction:
         return lambda actor: (

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -160,26 +160,13 @@ class AnnotationPolicyV1:
 
 class RecordPolicyV1:
     @classmethod
-    def update_response(cls, record: Record) -> PolicyAction:
+    def create_response(cls, record: Record) -> PolicyAction:
         return lambda actor: (
             actor.is_admin
             or bool(
                 accounts.get_workspace_user_by_workspace_id_and_user_id(
                     Session.object_session(actor),
                     record.dataset.workspace_id,
-                    actor.id,
-                )
-            )
-        )
-
-    @classmethod
-    def get(cls, dataset: Dataset) -> PolicyAction:
-        return lambda actor: (
-            actor.is_admin
-            or bool(
-                accounts.get_workspace_user_by_workspace_id_and_user_id(
-                    Session.object_session(actor),
-                    dataset.workspace_id,
                     actor.id,
                 )
             )

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -166,6 +166,19 @@ class RecordPolicyV1:
             )
         )
 
+    @classmethod
+    def get(cls, dataset: Dataset) -> PolicyAction:
+        return lambda actor: (
+            actor.is_admin
+            or bool(
+                accounts.get_workspace_user_by_workspace_id_and_user_id(
+                    Session.object_session(actor),
+                    dataset.workspace_id,
+                    actor.id,
+                )
+            )
+        )
+
 
 class DatasetSettingsPolicy:
     @classmethod

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -142,6 +142,12 @@ class DatasetPolicyV1:
         return actor.is_admin
 
 
+class RecordPolicyV1:
+    @classmethod
+    def create(cls, actor: User) -> bool:
+        return actor.is_admin
+
+
 class DatasetSettingsPolicy:
     @classmethod
     def list(cls, dataset: Dataset) -> PolicyAction:

--- a/src/argilla/server/routes.py
+++ b/src/argilla/server/routes.py
@@ -34,6 +34,7 @@ from argilla.server.apis.v0.handlers import (
     workspaces,
 )
 from argilla.server.apis.v1.handlers import datasets as datasets_v1
+from argilla.server.apis.v1.handlers import records as records_v1
 from argilla.server.errors.base_errors import __ALL__
 
 api_router = APIRouter(responses={error.HTTP_STATUS: error.api_documentation() for error in __ALL__})
@@ -58,3 +59,4 @@ for router in [
 
 # API v1
 api_router.include_router(datasets_v1.router, prefix="/v1")
+api_router.include_router(records_v1.router, prefix="/v1")

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -81,11 +81,21 @@ class AnnotationCreate(BaseModel):
     settings: Union[TextAnnotationSettings, RatingAnnotationSettings] = Field(..., discriminator="type")
 
 
+class Response(BaseModel):
+    id: UUID
+    values: Dict[str, Any]
+    inserted_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
 class Record(BaseModel):
     id: UUID
     fields: Dict[str, Any]
     external_id: Optional[str]
-    dataset_id: UUID  # TODO: Maybe delete this field because we are returning records for a specific dataset (same that with Annotation schema)
+    responses: List[Response]
     inserted_at: datetime
     updated_at: datetime
 

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import Optional, Union
+from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel, Field, conlist
@@ -79,3 +79,34 @@ class AnnotationCreate(BaseModel):
     title: str
     required: Optional[bool]
     settings: Union[TextAnnotationSettings, RatingAnnotationSettings] = Field(..., discriminator="type")
+
+
+class Record(BaseModel):
+    id: UUID
+    fields: Dict[str, Any]
+    external_id: Optional[str]
+    dataset_id: UUID  # TODO: Maybe delete this field because we are returning records for a specific dataset (same that with Annotation schema)
+    inserted_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class Records(BaseModel):
+    items: List[Record]
+
+
+class ResponseCreate(BaseModel):
+    values: Dict[str, Any]
+
+
+class RecordCreate(BaseModel):
+    fields: Dict[str, Any]
+    external_id: Optional[str]
+    response: Optional[ResponseCreate]
+
+
+class RecordsCreate(BaseModel):
+    # TODO: Set min and max items as constants
+    items: conlist(item_type=RecordCreate, min_items=1, max_items=1000)

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -24,6 +24,9 @@ from argilla.server.models import AnnotationType, DatasetStatus
 RATING_OPTIONS_MIN_ITEMS = 2
 RATING_OPTIONS_MAX_ITEMS = 100
 
+RECORDS_CREATE_MIN_ITEMS = 1
+RECORDS_CREATE_MAX_ITEMS = 1000
+
 
 class Dataset(BaseModel):
     id: UUID
@@ -118,5 +121,4 @@ class RecordCreate(BaseModel):
 
 
 class RecordsCreate(BaseModel):
-    # TODO: Set min and max items as constants
-    items: conlist(item_type=RecordCreate, min_items=1, max_items=1000)
+    items: conlist(item_type=RecordCreate, min_items=RECORDS_CREATE_MIN_ITEMS, max_items=RECORDS_CREATE_MAX_ITEMS)

--- a/src/argilla/server/schemas/v1/records.py
+++ b/src/argilla/server/schemas/v1/records.py
@@ -11,64 +11,23 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import json
-from enum import Enum
-from typing import Any, Dict, List, Optional
+
+from datetime import datetime
+from typing import Any, Dict
 from uuid import UUID
 
-from pydantic import BaseModel, conlist, constr
+from pydantic import BaseModel
 
 
-class AnnotationAnswer(BaseModel):
-    value: Any
-
-
-class PredictionAnswer(BaseModel):
-    value: Any
-    score: float = 0.0
-
-
-Annotation = Dict[str, AnnotationAnswer]
-Prediction = Dict[str, PredictionAnswer]
-
-
-class ResponseItem(BaseModel):
-    value: Any
-
-
-Response = Dict[constr(regex=r"^[a-z\d_-]+$"), ResponseItem]
-
-
-class Record(BaseModel):
+class Response(BaseModel):
     id: UUID
-
-    fields: Dict[str, Any]
-    responses: Optional[Dict[str, Response]]
-
-    metadata: Optional[Dict[str, Any]]
-    vectors: Optional[Dict[str, List[float]]]
+    values: Dict[str, Any]
+    inserted_at: datetime
+    updated_at: datetime
 
     class Config:
         orm_mode = True
 
 
-class RecordCreate(BaseModel):
-    fields: Dict[str, Any]
-    external_id: Optional[str]
-    response: Optional[Response]
-
-
-class RecordsCreate(BaseModel):
-    items: conlist(item_type=RecordCreate, min_items=1, max_items=1000)
-
-
-class RecordInclude(str, Enum):
-    responses = "responses"
-    suggestions = "suggestions"
-    vectors = "vectors"
-    metadata = "metadata"
-
-
-class RecordsList(BaseModel):
-    total: int
-    items: List[Record]
+class ResponseCreate(BaseModel):
+    values: Dict[str, Any]

--- a/src/argilla/server/schemas/v1/records.py
+++ b/src/argilla/server/schemas/v1/records.py
@@ -15,7 +15,7 @@
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, conlist
 
 
 class AnnotationAnswer(BaseModel):
@@ -48,3 +48,23 @@ class Record(BaseModel):
     vectors: Optional[Dict[str, List[float]]]
 
     validated_annotation: Optional[ValidatedAnnotation]
+
+
+class Response(BaseModel):
+    value: Any
+
+
+class Suggestion(BaseModel):
+    value: Any
+    score: float
+
+
+class RecordCreate(BaseModel):
+    fields: Dict[str, Any]
+    external_id: Optional[str]
+    responses: Optional[Dict[str, Response]]
+    suggestions: Optional[Dict[str, Suggestion]]
+
+
+class RecordsCreate(BaseModel):
+    items: conlist(item_type=RecordCreate, min_items=1, max_items=1000)

--- a/src/argilla/server/schemas/v1/records.py
+++ b/src/argilla/server/schemas/v1/records.py
@@ -15,7 +15,7 @@
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, conlist
+from pydantic import BaseModel, conlist, constr
 
 
 class AnnotationAnswer(BaseModel):
@@ -50,20 +50,24 @@ class Record(BaseModel):
     validated_annotation: Optional[ValidatedAnnotation]
 
 
-class Response(BaseModel):
+class Answer(BaseModel):
     value: Any
 
 
-class Suggestion(BaseModel):
+class Suggest(BaseModel):
     value: Any
     score: float
+
+
+Response = Dict[constr(regex=r"^[a-z\d_-]+$"), Answer]
+Suggestion = Dict[constr(regex=r"^[a-z\d_-]+$"), Suggest]
 
 
 class RecordCreate(BaseModel):
     fields: Dict[str, Any]
     external_id: Optional[str]
-    responses: Optional[Dict[str, Response]]
-    suggestions: Optional[Dict[str, Suggestion]]
+    response: Optional[Response]
+    suggestion: Optional[Suggestion]
 
 
 class RecordsCreate(BaseModel):

--- a/src/argilla/server/schemas/v1/records.py
+++ b/src/argilla/server/schemas/v1/records.py
@@ -11,7 +11,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import json
+from enum import Enum
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
@@ -31,44 +32,43 @@ Annotation = Dict[str, AnnotationAnswer]
 Prediction = Dict[str, PredictionAnswer]
 
 
-class ValidatedAnnotation(BaseModel):
-    reviewer: str
-    annotation: Annotation
+class ResponseItem(BaseModel):
+    value: Any
+
+
+Response = Dict[constr(regex=r"^[a-z\d_-]+$"), ResponseItem]
 
 
 class Record(BaseModel):
     id: UUID
 
     fields: Dict[str, Any]
-
-    annotations: Optional[Dict[str, Annotation]]
-    predictions: Optional[Dict[str, Prediction]]
+    responses: Optional[Dict[str, Response]]
 
     metadata: Optional[Dict[str, Any]]
     vectors: Optional[Dict[str, List[float]]]
 
-    validated_annotation: Optional[ValidatedAnnotation]
-
-
-class Answer(BaseModel):
-    value: Any
-
-
-class Suggest(BaseModel):
-    value: Any
-    score: float
-
-
-Response = Dict[constr(regex=r"^[a-z\d_-]+$"), Answer]
-Suggestion = Dict[constr(regex=r"^[a-z\d_-]+$"), Suggest]
+    class Config:
+        orm_mode = True
 
 
 class RecordCreate(BaseModel):
     fields: Dict[str, Any]
     external_id: Optional[str]
     response: Optional[Response]
-    suggestion: Optional[Suggestion]
 
 
 class RecordsCreate(BaseModel):
     items: conlist(item_type=RecordCreate, min_items=1, max_items=1000)
+
+
+class RecordInclude(str, Enum):
+    responses = "responses"
+    suggestions = "suggestions"
+    vectors = "vectors"
+    metadata = "metadata"
+
+
+class RecordsList(BaseModel):
+    total: int
+    items: List[Record]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ from argilla.server.database import SessionLocal
 from argilla.server.models import User, UserRole, Workspace, WorkspaceUser
 from starlette.testclient import TestClient
 
-from .factories import AnnotatorFactory
+from .factories import AdminFactory, AnnotatorFactory
 from .helpers import SecuredClient
 
 
@@ -50,18 +50,7 @@ def db():
 
 @pytest.fixture(scope="function")
 def admin(db):
-    user = User(
-        first_name="Admin",
-        username="admin",
-        role=UserRole.admin,
-        password_hash="$2y$05$eaw.j2Kaw8s8vpscVIZMfuqSIX3OLmxA21WjtWicDdn0losQ91Hw.",
-        api_key="admin.apikey",
-    )
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-
-    return user
+    return AdminFactory.create(first_name="Admin", username="admin", api_key="admin.apikey")
 
 
 @pytest.fixture(scope="function")

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -18,6 +18,7 @@ from argilla.server.models import (
     Annotation,
     AnnotationType,
     Dataset,
+    Record,
     User,
     UserRole,
     Workspace,
@@ -52,6 +53,19 @@ class DatasetFactory(factory.alchemy.SQLAlchemyModelFactory):
 
     name = factory.Sequence(lambda n: f"dataset-{n}")
     workspace = factory.SubFactory(WorkspaceFactory)
+
+
+class RecordFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = Record
+        sqlalchemy_session = Session
+        sqlalchemy_session_persistence = "commit"
+
+    fields = {
+        "text": "This is a text",
+        "sentiment": "neutral",
+    }
+    dataset = factory.SubFactory(DatasetFactory)
 
 
 class AnnotationFactory(factory.alchemy.SQLAlchemyModelFactory):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -19,6 +19,7 @@ from argilla.server.models import (
     AnnotationType,
     Dataset,
     Record,
+    Response,
     User,
     UserRole,
     Workspace,
@@ -66,6 +67,19 @@ class RecordFactory(factory.alchemy.SQLAlchemyModelFactory):
         "sentiment": "neutral",
     }
     dataset = factory.SubFactory(DatasetFactory)
+
+
+class ResponseFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = Response
+        sqlalchemy_session = Session
+        sqlalchemy_session_persistence = "commit"
+
+    values = {
+        "question": {"value": "LABEL"},
+        "comment": {"value": "The comment value"},
+    }
+    record = factory.SubFactory(RecordFactory)
 
 
 class AnnotationFactory(factory.alchemy.SQLAlchemyModelFactory):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -46,6 +46,26 @@ class WorkspaceFactory(factory.alchemy.SQLAlchemyModelFactory):
     name = factory.Sequence(lambda n: f"workspace-{n}")
 
 
+class UserFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = User
+        sqlalchemy_session = Session
+        sqlalchemy_session_persistence = "commit"
+
+    first_name = factory.Faker("first_name")
+    username = factory.Sequence(lambda n: f"username-{n}")
+    api_key = factory.Sequence(lambda n: f"api-key-{n}")
+    password_hash = "$2y$05$eaw.j2Kaw8s8vpscVIZMfuqSIX3OLmxA21WjtWicDdn0losQ91Hw."
+
+
+class AdminFactory(UserFactory):
+    role = UserRole.admin
+
+
+class AnnotatorFactory(UserFactory):
+    role = UserRole.annotator
+
+
 class DatasetFactory(factory.alchemy.SQLAlchemyModelFactory):
     class Meta:
         model = Dataset
@@ -66,6 +86,7 @@ class RecordFactory(factory.alchemy.SQLAlchemyModelFactory):
         "text": "This is a text",
         "sentiment": "neutral",
     }
+    external_id = factory.Sequence(lambda n: f"external-id-{n}")
     dataset = factory.SubFactory(DatasetFactory)
 
 
@@ -76,10 +97,11 @@ class ResponseFactory(factory.alchemy.SQLAlchemyModelFactory):
         sqlalchemy_session_persistence = "commit"
 
     values = {
-        "question": {"value": "LABEL"},
-        "comment": {"value": "The comment value"},
+        "question_a": {"value": "Question a response"},
+        "question_b": {"value": "Question b response"},
     }
     record = factory.SubFactory(RecordFactory)
+    user = factory.SubFactory(UserFactory)
 
 
 class AnnotationFactory(factory.alchemy.SQLAlchemyModelFactory):
@@ -113,23 +135,3 @@ class RatingAnnotationFactory(AnnotationFactory):
             {"value": 10},
         ],
     }
-
-
-class UserFactory(factory.alchemy.SQLAlchemyModelFactory):
-    class Meta:
-        model = User
-        sqlalchemy_session = Session
-        sqlalchemy_session_persistence = "commit"
-
-    first_name = factory.Faker("first_name")
-    username = factory.Sequence(lambda n: f"username-{n}")
-    api_key = factory.Sequence(lambda n: f"api-key-{n}")
-    password_hash = "$2y$05$eaw.j2Kaw8s8vpscVIZMfuqSIX3OLmxA21WjtWicDdn0losQ91Hw."
-
-
-class AdminFactory(UserFactory):
-    role = UserRole.admin
-
-
-class AnnotatorFactory(UserFactory):
-    role = UserRole.annotator

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -15,8 +15,9 @@
 from datetime import datetime
 from uuid import UUID, uuid4
 
+import pytest
 from argilla._constants import API_KEY_HEADER_NAME
-from argilla.server.models import Annotation, Dataset, DatasetStatus
+from argilla.server.models import Annotation, Dataset, DatasetStatus, Record, Response
 from argilla.server.schemas.v1.datasets import (
     RATING_OPTIONS_MAX_ITEMS,
     RATING_OPTIONS_MIN_ITEMS,
@@ -29,6 +30,7 @@ from tests.factories import (
     AnnotatorFactory,
     DatasetFactory,
     RatingAnnotationFactory,
+    RecordFactory,
     TextAnnotationFactory,
     WorkspaceFactory,
 )
@@ -91,6 +93,80 @@ def test_list_datasets_as_annotator(client: TestClient, db: Session):
 
     assert response.status_code == 200
     assert [dataset["name"] for dataset in response.json()] == ["dataset-a", "dataset-b"]
+
+
+def test_list_dataset_records(client: TestClient, admin_auth_header: dict):
+    dataset = DatasetFactory.create()
+    record_a = RecordFactory.create(fields={"record_a": "value_a"}, dataset=dataset)
+    record_b = RecordFactory.create(fields={"record_b": "value_b"}, dataset=dataset)
+    record_c = RecordFactory.create(fields={"record_c": "value_c"}, dataset=dataset)
+
+    response = client.get(f"/api/v1/datasets/{dataset.id}/records", headers=admin_auth_header)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "items": [
+            {
+                "id": str(record_a.id),
+                "fields": {"record_a": "value_a"},
+                "external_id": record_a.external_id,
+                "dataset_id": str(dataset.id),
+                "inserted_at": record_a.inserted_at.isoformat(),
+                "updated_at": record_a.updated_at.isoformat(),
+            },
+            {
+                "id": str(record_b.id),
+                "fields": {"record_b": "value_b"},
+                "external_id": record_b.external_id,
+                "dataset_id": str(dataset.id),
+                "inserted_at": record_b.inserted_at.isoformat(),
+                "updated_at": record_b.updated_at.isoformat(),
+            },
+            {
+                "id": str(record_c.id),
+                "fields": {"record_c": "value_c"},
+                "external_id": record_c.external_id,
+                "dataset_id": str(dataset.id),
+                "inserted_at": record_c.inserted_at.isoformat(),
+                "updated_at": record_c.updated_at.isoformat(),
+            },
+        ]
+    }
+
+
+@pytest.mark.skip(reason="todo")
+def test_list_dataset_records_with_offset(client: TestClient, admin_auth_header: dict):
+    pass
+
+
+@pytest.mark.skip(reason="todo")
+def test_list_dataset_records_with_limit(client: TestClient, admin_auth_header: dict):
+    pass
+
+
+@pytest.mark.skip(reason="todo")
+def test_list_dataset_records_with_offset_and_limit(client: TestClient, admin_auth_header: dict):
+    pass
+
+
+@pytest.mark.skip(reason="todo")
+def test_list_dataset_records_without_authentication(client: TestClient):
+    pass
+
+
+@pytest.mark.skip(reason="todo")
+def test_list_dataset_records_as_annotator(client: TestClient, db: Session):
+    pass
+
+
+@pytest.mark.skip(reason="todo")
+def test_list_dataset_records_as_annotator_from_different_workspace(client: TestClient, db: Session):
+    pass
+
+
+@pytest.mark.skip(reason="todo")
+def test_list_dataset_records_with_nonexistent_dataset_id(client: TestClient, db: Session, admin_auth_header: dict):
+    pass
 
 
 def test_get_dataset(client: TestClient, admin_auth_header: dict):
@@ -570,6 +646,76 @@ def test_create_dataset_rating_annotation_with_invalid_settings_options_values(
 
     assert response.status_code == 422
     assert db.query(Annotation).count() == 0
+
+
+def test_create_dataset_records(client: TestClient, db: Session, admin_auth_header: dict):
+    dataset = DatasetFactory.create(status=DatasetStatus.ready)
+    records_json = {
+        "items": [
+            {
+                "fields": {"input": "Say Hello", "ouput": "Hello"},
+                "external_id": "1",
+                "response": {
+                    "values": {"output_ok": "yes"},
+                },
+            },
+            {
+                "fields": {"input": "Say Hello", "output": "Hi"},
+                "external_id": "2",
+                "response": {
+                    "values": {"output_ok": "no"},
+                },
+            },
+            {
+                "fields": {"input": "Say Hello", "output": "Hello World"},
+                "external_id": "3",
+                "response": {
+                    "values": {"output_ok": "no"},
+                },
+            },
+        ]
+    }
+
+    response = client.post(f"/api/v1/datasets/{dataset.id}/records", headers=admin_auth_header, json=records_json)
+
+    assert response.status_code == 204
+    assert db.query(Record).count() == 3
+    assert db.query(Response).count() == 3
+
+
+@pytest.mark.skip(reason="todo")
+def test_create_dataset_records_without_authentication(client: TestClient, db: Session):
+    pass
+
+
+@pytest.mark.skip(reason="todo")
+def test_create_dataset_records_as_annotator(client: TestClient, db: Session):
+    pass
+
+
+@pytest.mark.skip(reason="todo")
+def test_create_dataset_records_with_nonexistent_dataset_id(client: TestClient, db: Session, admin_auth_header: dict):
+    pass
+
+
+@pytest.mark.skip(reason="todo")
+def test_create_dataset_records_with_less_items_than_allowed(client: TestClient, db: Session, admin_auth_header: dict):
+    pass
+
+
+@pytest.mark.skip(reason="todo")
+def test_create_dataset_records_with_more_items_than_allowed(client: TestClient, db: Session, admin_auth_header: dict):
+    pass
+
+
+@pytest.mark.skip(reason="todo")
+def test_create_dataset_records_with_duplicated_external_id(client: TestClient, db: Session, admin_auth_header: dict):
+    pass
+
+
+@pytest.mark.skip(reason="todo")
+def test_create_dataset_records_with_invalid_records(client: TestClient, db: Session, admin_auth_header: dict):
+    pass
 
 
 def test_publish_dataset(client: TestClient, db: Session, admin_auth_header: dict):

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -694,7 +694,7 @@ def test_create_dataset_records_as_annotator(client: TestClient, db: Session):
 
 
 @pytest.mark.skip(reason="todo")
-def test_create_dataset_records_with_nonexistent_dataset_id(client: TestClient, db: Session, admin_auth_header: dict):
+def test_create_dataset_records_with_non_published_dataset(client: TestClient, db: Session, admin_auth_header: dict):
     pass
 
 
@@ -715,6 +715,11 @@ def test_create_dataset_records_with_duplicated_external_id(client: TestClient, 
 
 @pytest.mark.skip(reason="todo")
 def test_create_dataset_records_with_invalid_records(client: TestClient, db: Session, admin_auth_header: dict):
+    pass
+
+
+@pytest.mark.skip(reason="todo")
+def test_create_dataset_records_with_nonexistent_dataset_id(client: TestClient, db: Session, admin_auth_header: dict):
     pass
 
 

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from uuid import UUID, uuid4
 
 from argilla._constants import API_KEY_HEADER_NAME
-from argilla.server.models import Annotation, AnnotationType, Dataset, DatasetStatus
+from argilla.server.models import Annotation, Dataset, DatasetStatus
 from argilla.server.schemas.v1.datasets import (
     RATING_OPTIONS_MAX_ITEMS,
     RATING_OPTIONS_MIN_ITEMS,

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -31,6 +31,7 @@ from tests.factories import (
     DatasetFactory,
     RatingAnnotationFactory,
     RecordFactory,
+    ResponseFactory,
     TextAnnotationFactory,
     WorkspaceFactory,
 )
@@ -101,6 +102,14 @@ def test_list_dataset_records(client: TestClient, admin_auth_header: dict):
     record_b = RecordFactory.create(fields={"record_b": "value_b"}, dataset=dataset)
     record_c = RecordFactory.create(fields={"record_c": "value_c"}, dataset=dataset)
 
+    response_b = ResponseFactory.create(
+        values={
+            "input_ok": {"value": "yes"},
+            "output_ok": {"value": "false"},
+        },
+        record=record_b,
+    )
+
     response = client.get(f"/api/v1/datasets/{dataset.id}/records", headers=admin_auth_header)
 
     assert response.status_code == 200
@@ -110,7 +119,7 @@ def test_list_dataset_records(client: TestClient, admin_auth_header: dict):
                 "id": str(record_a.id),
                 "fields": {"record_a": "value_a"},
                 "external_id": record_a.external_id,
-                "dataset_id": str(dataset.id),
+                "responses": [],
                 "inserted_at": record_a.inserted_at.isoformat(),
                 "updated_at": record_a.updated_at.isoformat(),
             },
@@ -118,7 +127,17 @@ def test_list_dataset_records(client: TestClient, admin_auth_header: dict):
                 "id": str(record_b.id),
                 "fields": {"record_b": "value_b"},
                 "external_id": record_b.external_id,
-                "dataset_id": str(dataset.id),
+                "responses": [
+                    {
+                        "id": str(response_b.id),
+                        "values": {
+                            "input_ok": {"value": "yes"},
+                            "output_ok": {"value": "false"},
+                        },
+                        "inserted_at": response_b.inserted_at.isoformat(),
+                        "updated_at": response_b.updated_at.isoformat(),
+                    },
+                ],
                 "inserted_at": record_b.inserted_at.isoformat(),
                 "updated_at": record_b.updated_at.isoformat(),
             },
@@ -126,7 +145,7 @@ def test_list_dataset_records(client: TestClient, admin_auth_header: dict):
                 "id": str(record_c.id),
                 "fields": {"record_c": "value_c"},
                 "external_id": record_c.external_id,
-                "dataset_id": str(dataset.id),
+                "responses": [],
                 "inserted_at": record_c.inserted_at.isoformat(),
                 "updated_at": record_c.updated_at.isoformat(),
             },

--- a/tests/server/api/v1/test_records.py
+++ b/tests/server/api/v1/test_records.py
@@ -25,7 +25,11 @@ def test_create_records(client: TestClient, db: Session, admin_auth_header: dict
         "items": [
             {"fields": {"input": "input-a", "output": "output-a"}, "external_id": "a"},
             {"fields": {"input": "input-b", "output": "output-b"}, "external_id": "b"},
-            {"fields": {"input": "input-c", "output": "output-c"}, "external_id": "c"},
+            {
+                "fields": {"input": "input-c", "output": "output-c"},
+                "external_id": "c",
+                "responses": {"question": {"value": True}},
+            },
         ]
     }
 

--- a/tests/server/api/v1/test_records.py
+++ b/tests/server/api/v1/test_records.py
@@ -32,8 +32,8 @@ def test_create_record_response(client: TestClient, db: Session, admin_auth_head
     record = RecordFactory.create()
     response_json = {
         "values": {
-            "input_ok": "yes",
-            "output_ok": "yes",
+            "input_ok": {"value": "yes"},
+            "output_ok": {"value": "yes"},
         },
     }
 
@@ -47,8 +47,8 @@ def test_create_record_response(client: TestClient, db: Session, admin_auth_head
     assert response_body == {
         "id": str(UUID(response_body["id"])),
         "values": {
-            "input_ok": "yes",
-            "output_ok": "yes",
+            "input_ok": {"value": "yes"},
+            "output_ok": {"value": "yes"},
         },
         "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
         "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
@@ -59,8 +59,8 @@ def test_create_record_response_without_authentication(client: TestClient, db: S
     record = RecordFactory.create()
     response_json = {
         "values": {
-            "input_ok": "yes",
-            "output_ok": "yes",
+            "input_ok": {"value": "yes"},
+            "output_ok": {"value": "yes"},
         },
     }
 
@@ -75,8 +75,8 @@ def test_create_record_response_as_annotator(client: TestClient, db: Session):
     annotator = AnnotatorFactory.create(workspaces=[record.dataset.workspace])
     response_json = {
         "values": {
-            "input_ok": "yes",
-            "output_ok": "yes",
+            "input_ok": {"value": "yes"},
+            "output_ok": {"value": "yes"},
         },
     }
 
@@ -93,8 +93,8 @@ def test_create_record_response_as_annotator_from_different_workspace(client: Te
     annotator = AnnotatorFactory.create(workspaces=[WorkspaceFactory.build()])
     response_json = {
         "values": {
-            "input_ok": "yes",
-            "output_ok": "yes",
+            "input_ok": {"value": "yes"},
+            "output_ok": {"value": "yes"},
         },
     }
 
@@ -111,8 +111,8 @@ def test_create_record_response_already_created(client: TestClient, db: Session,
     ResponseFactory.create(record=record, user=admin)
     response_json = {
         "values": {
-            "input_ok": "yes",
-            "output_ok": "yes",
+            "input_ok": {"value": "yes"},
+            "output_ok": {"value": "yes"},
         },
     }
 
@@ -136,8 +136,8 @@ def test_create_record_response_with_nonexistent_record_id(client: TestClient, d
     RecordFactory.create()
     response_json = {
         "values": {
-            "input_ok": "yes",
-            "output_ok": "yes",
+            "input_ok": {"value": "yes"},
+            "output_ok": {"value": "yes"},
         },
     }
 

--- a/tests/server/api/v1/test_records.py
+++ b/tests/server/api/v1/test_records.py
@@ -1,0 +1,35 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from argilla.server.models import DatasetStatus, Record
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from tests.factories import DatasetFactory
+
+
+def test_create_records(client: TestClient, db: Session, admin_auth_header: dict):
+    dataset = DatasetFactory.create(status=DatasetStatus.ready)
+    records_json = {
+        "items": [
+            {"fields": {"input": "input-a", "output": "output-a"}, "external_id": "a"},
+            {"fields": {"input": "input-b", "output": "output-b"}, "external_id": "b"},
+            {"fields": {"input": "input-c", "output": "output-c"}, "external_id": "c"},
+        ]
+    }
+
+    response = client.post(f"/api/v1/datasets/{dataset.id}/records", headers=admin_auth_header, json=records_json)
+
+    assert response.status_code == 204
+    assert db.query(Record).count() == 3


### PR DESCRIPTION
# Description

This PR adds several changes related with records and responses entities:
* Create `records` table and database model.
* Create `responses` table and database model.
* Add some new endpoints:
  * List records for a dataset with `GET` `/api/v1/datasets/{dataset_id}/records`.
    * Right now `admin` users will get all the responses for every record and `annotator` users the responses created by them. (This is probably gonna change in the future).
  * Create records for a dataset in bulk with `POST` `/api/v1/datasets/{dataset_id}/records`.
  * Create record responses with `POST` `/api/v1/records/{record_id}/responses`.