### PR TITLE
Remove responses from records

### DIFF
--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -90,10 +90,7 @@ def list_dataset_records(
 
     authorize(current_user, DatasetPolicyV1.get(dataset))
 
-    if current_user.is_admin:
-        return Records(items=datasets.list_records(db, dataset, offset=offset, limit=limit))
-    else:
-        return Records(items=datasets.list_records_for_user(db, dataset, current_user, offset=offset, limit=limit))
+    return Records(items=datasets.list_records(db, dataset, offset=offset, limit=limit))
 
 
 @router.get("/datasets/{dataset_id}", response_model=Dataset)

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -11,7 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import List, Optional
 from uuid import UUID
 
 from argilla.server.models import Annotation, Dataset, DatasetStatus, Record, Response
@@ -22,8 +21,8 @@ from argilla.server.schemas.v1.datasets import (
 )
 from argilla.server.schemas.v1.records import ResponseCreate
 from argilla.server.security.model import User
-from sqlalchemy import and_, func
-from sqlalchemy.orm import Session, contains_eager, joinedload
+from sqlalchemy import func
+from sqlalchemy.orm import Session
 
 LIST_RECORDS_LIMIT = 20
 

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -120,20 +120,6 @@ def get_record_by_id(db: Session, record_id: UUID):
 def list_records(db: Session, dataset: Dataset, offset: int = 0, limit: int = LIST_RECORDS_LIMIT):
     return (
         db.query(Record)
-        .options(joinedload(Record.responses))
-        .filter(Record.dataset_id == dataset.id)
-        .order_by(Record.inserted_at.asc())
-        .offset(offset)
-        .limit(limit)
-        .all()
-    )
-
-
-def list_records_for_user(db: Session, dataset: Dataset, user: User, offset: int = 0, limit: int = LIST_RECORDS_LIMIT):
-    return (
-        db.query(Record)
-        .outerjoin(Response, and_(Response.record_id == Record.id, Response.user_id == user.id))
-        .options(contains_eager(Record.responses))
         .filter(Record.dataset_id == dataset.id)
         .order_by(Record.inserted_at.asc())
         .offset(offset)

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -98,7 +98,6 @@ class Record(BaseModel):
     id: UUID
     fields: Dict[str, Any]
     external_id: Optional[str]
-    responses: List[Response]
     inserted_at: datetime
     updated_at: datetime
 

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -200,13 +200,9 @@ def test_list_dataset_annotations_with_nonexistent_dataset_id(client: TestClient
 
 def test_list_dataset_records(client: TestClient, admin_auth_header: dict):
     dataset = DatasetFactory.create()
-
     record_a = RecordFactory.create(fields={"record_a": "value_a"}, dataset=dataset)
     record_b = RecordFactory.create(fields={"record_b": "value_b"}, dataset=dataset)
     record_c = RecordFactory.create(fields={"record_c": "value_c"}, dataset=dataset)
-
-    ResponseFactory.create(values={"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}}, record=record_a)
-    ResponseFactory.create(values={"input_ok": {"value": "yes"}, "output_ok": {"value": "no"}}, record=record_b)
 
     response = client.get(f"/api/v1/datasets/{dataset.id}/records", headers=admin_auth_header)
 
@@ -294,21 +290,9 @@ def test_list_dataset_records_as_annotator(client: TestClient, admin: User, db: 
     workspace = WorkspaceFactory.create()
     annotator = AnnotatorFactory.create(workspaces=[workspace])
     dataset = DatasetFactory.create(workspace=workspace)
-
     record_a = RecordFactory.create(fields={"record_a": "value_a"}, dataset=dataset)
     record_b = RecordFactory.create(fields={"record_b": "value_b"}, dataset=dataset)
     record_c = RecordFactory.create(fields={"record_c": "value_c"}, dataset=dataset)
-
-    ResponseFactory.create(
-        values={"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}}, record=record_a, user=admin
-    )
-    ResponseFactory.create(
-        values={"input_ok": {"value": "yes"}, "output_ok": {"value": "no"}}, record=record_b, user=admin
-    )
-    ResponseFactory.create(
-        values={"input_ok": {"value": "no"}, "output_ok": {"value": "no"}}, record=record_b, user=annotator
-    )
-    ResponseFactory.create(values={"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}}, record=record_b)
 
     response = client.get(f"/api/v1/datasets/{dataset.id}/records", headers={API_KEY_HEADER_NAME: annotator.api_key})
 

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -200,32 +200,13 @@ def test_list_dataset_annotations_with_nonexistent_dataset_id(client: TestClient
 
 def test_list_dataset_records(client: TestClient, admin_auth_header: dict):
     dataset = DatasetFactory.create()
+
     record_a = RecordFactory.create(fields={"record_a": "value_a"}, dataset=dataset)
     record_b = RecordFactory.create(fields={"record_b": "value_b"}, dataset=dataset)
     record_c = RecordFactory.create(fields={"record_c": "value_c"}, dataset=dataset)
 
-    response_a = ResponseFactory.create(
-        values={
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "yes"},
-        },
-        record=record_a,
-    )
-
-    response_b_1 = ResponseFactory.create(
-        values={
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "no"},
-        },
-        record=record_b,
-    )
-    response_b_2 = ResponseFactory.create(
-        values={
-            "input_ok": {"value": "no"},
-            "output_ok": {"value": "no"},
-        },
-        record=record_b,
-    )
+    ResponseFactory.create(values={"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}}, record=record_a)
+    ResponseFactory.create(values={"input_ok": {"value": "yes"}, "output_ok": {"value": "no"}}, record=record_b)
 
     response = client.get(f"/api/v1/datasets/{dataset.id}/records", headers=admin_auth_header)
 
@@ -236,17 +217,6 @@ def test_list_dataset_records(client: TestClient, admin_auth_header: dict):
                 "id": str(record_a.id),
                 "fields": {"record_a": "value_a"},
                 "external_id": record_a.external_id,
-                "responses": [
-                    {
-                        "id": str(response_a.id),
-                        "values": {
-                            "input_ok": {"value": "yes"},
-                            "output_ok": {"value": "yes"},
-                        },
-                        "inserted_at": response_a.inserted_at.isoformat(),
-                        "updated_at": response_a.updated_at.isoformat(),
-                    },
-                ],
                 "inserted_at": record_a.inserted_at.isoformat(),
                 "updated_at": record_a.updated_at.isoformat(),
             },
@@ -254,26 +224,6 @@ def test_list_dataset_records(client: TestClient, admin_auth_header: dict):
                 "id": str(record_b.id),
                 "fields": {"record_b": "value_b"},
                 "external_id": record_b.external_id,
-                "responses": [
-                    {
-                        "id": str(response_b_1.id),
-                        "values": {
-                            "input_ok": {"value": "yes"},
-                            "output_ok": {"value": "no"},
-                        },
-                        "inserted_at": response_b_1.inserted_at.isoformat(),
-                        "updated_at": response_b_1.updated_at.isoformat(),
-                    },
-                    {
-                        "id": str(response_b_2.id),
-                        "values": {
-                            "input_ok": {"value": "no"},
-                            "output_ok": {"value": "no"},
-                        },
-                        "inserted_at": response_b_2.inserted_at.isoformat(),
-                        "updated_at": response_b_2.updated_at.isoformat(),
-                    },
-                ],
                 "inserted_at": record_b.inserted_at.isoformat(),
                 "updated_at": record_b.updated_at.isoformat(),
             },
@@ -281,7 +231,6 @@ def test_list_dataset_records(client: TestClient, admin_auth_header: dict):
                 "id": str(record_c.id),
                 "fields": {"record_c": "value_c"},
                 "external_id": record_c.external_id,
-                "responses": [],
                 "inserted_at": record_c.inserted_at.isoformat(),
                 "updated_at": record_c.updated_at.isoformat(),
             },
@@ -345,42 +294,21 @@ def test_list_dataset_records_as_annotator(client: TestClient, admin: User, db: 
     workspace = WorkspaceFactory.create()
     annotator = AnnotatorFactory.create(workspaces=[workspace])
     dataset = DatasetFactory.create(workspace=workspace)
+
     record_a = RecordFactory.create(fields={"record_a": "value_a"}, dataset=dataset)
     record_b = RecordFactory.create(fields={"record_b": "value_b"}, dataset=dataset)
     record_c = RecordFactory.create(fields={"record_c": "value_c"}, dataset=dataset)
 
-    response_a_admin = ResponseFactory.create(
-        values={
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "yes"},
-        },
-        record=record_a,
-        user=admin,
+    ResponseFactory.create(
+        values={"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}}, record=record_a, user=admin
     )
-
-    response_b_admin = ResponseFactory.create(
-        values={
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "no"},
-        },
-        record=record_b,
-        user=admin,
+    ResponseFactory.create(
+        values={"input_ok": {"value": "yes"}, "output_ok": {"value": "no"}}, record=record_b, user=admin
     )
-    response_b_annotator = ResponseFactory.create(
-        values={
-            "input_ok": {"value": "no"},
-            "output_ok": {"value": "no"},
-        },
-        record=record_b,
-        user=annotator,
+    ResponseFactory.create(
+        values={"input_ok": {"value": "no"}, "output_ok": {"value": "no"}}, record=record_b, user=annotator
     )
-    response_b_other = ResponseFactory.create(
-        values={
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "yes"},
-        },
-        record=record_b,
-    )
+    ResponseFactory.create(values={"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}}, record=record_b)
 
     response = client.get(f"/api/v1/datasets/{dataset.id}/records", headers={API_KEY_HEADER_NAME: annotator.api_key})
 
@@ -391,7 +319,6 @@ def test_list_dataset_records_as_annotator(client: TestClient, admin: User, db: 
                 "id": str(record_a.id),
                 "fields": {"record_a": "value_a"},
                 "external_id": record_a.external_id,
-                "responses": [],
                 "inserted_at": record_a.inserted_at.isoformat(),
                 "updated_at": record_a.updated_at.isoformat(),
             },
@@ -399,17 +326,6 @@ def test_list_dataset_records_as_annotator(client: TestClient, admin: User, db: 
                 "id": str(record_b.id),
                 "fields": {"record_b": "value_b"},
                 "external_id": record_b.external_id,
-                "responses": [
-                    {
-                        "id": str(response_b_annotator.id),
-                        "values": {
-                            "input_ok": {"value": "no"},
-                            "output_ok": {"value": "no"},
-                        },
-                        "inserted_at": response_b_annotator.inserted_at.isoformat(),
-                        "updated_at": response_b_annotator.updated_at.isoformat(),
-                    },
-                ],
                 "inserted_at": record_b.inserted_at.isoformat(),
                 "updated_at": record_b.updated_at.isoformat(),
             },
@@ -417,7 +333,6 @@ def test_list_dataset_records_as_annotator(client: TestClient, admin: User, db: 
                 "id": str(record_c.id),
                 "fields": {"record_c": "value_c"},
                 "external_id": record_c.external_id,
-                "responses": [],
                 "inserted_at": record_c.inserted_at.isoformat(),
                 "updated_at": record_c.updated_at.isoformat(),
             },


### PR DESCRIPTION
This PR removes the responses from the record schemas. A new endpoint will be provided to retrieve the responses for a given record id. 