### PR TITLE
Add new APIv1 update response endpoint

### DIFF
--- a/src/argilla/server/apis/v1/handlers/responses.py
+++ b/src/argilla/server/apis/v1/handlers/responses.py
@@ -1,0 +1,47 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Security, status
+from sqlalchemy.orm import Session
+
+from argilla.server.contexts import datasets
+from argilla.server.database import get_db
+from argilla.server.models import User
+from argilla.server.policies import ResponsePolicyV1, authorize
+from argilla.server.schemas.v1.responses import Response, ResponseUpdate
+from argilla.server.security import auth
+
+router = APIRouter(tags=["responses"])
+
+
+@router.put("/responses/{response_id}", response_model=Response)
+def update_response(
+    *,
+    db: Session = Depends(get_db),
+    response_id: UUID,
+    response_update: ResponseUpdate,
+    current_user: User = Security(auth.get_current_user),
+):
+    response = datasets.get_response_by_id(db, response_id)
+    if not response:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Response with id `{response_id}` not found",
+        )
+
+    authorize(current_user, ResponsePolicyV1.update(response))
+
+    return datasets.update_response(db, response, response_update)

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -21,6 +21,7 @@ from argilla.server.schemas.v1.datasets import (
     RecordsCreate,
 )
 from argilla.server.schemas.v1.records import ResponseCreate
+from argilla.server.schemas.v1.responses import ResponseUpdate
 from argilla.server.security.model import User
 from sqlalchemy import func
 from sqlalchemy.orm import Session
@@ -157,6 +158,10 @@ def create_records(db: Session, dataset: Dataset, user: User, records_create: Re
     db.commit()
 
 
+def get_response_by_id(db: Session, response_id: UUID):
+    return db.get(Response, response_id)
+
+
 def get_response_by_record_id_and_user_id(db: Session, record_id: UUID, user_id: UUID):
     return db.query(Response).filter_by(record_id=record_id, user_id=user_id).first()
 
@@ -169,6 +174,15 @@ def create_response(db: Session, record: Record, user: User, response_create: Re
     )
 
     db.add(response)
+    db.commit()
+    db.refresh(response)
+
+    return response
+
+
+def update_response(db: Session, response: Response, response_update: ResponseUpdate):
+    response.values = response_update.values
+
     db.commit()
     db.refresh(response)
 

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -21,6 +21,7 @@ from argilla.server.errors import ForbiddenOperationError
 from argilla.server.models import (
     Dataset,
     Record,
+    Response,
     User,
     UserRole,
     Workspace,
@@ -186,6 +187,12 @@ class RecordPolicyV1:
                 )
             )
         )
+
+
+class ResponsePolicyV1:
+    @classmethod
+    def update(cls, response: Response) -> PolicyAction:
+        return lambda actor: actor.is_admin or actor.id == response.user_id
 
 
 class DatasetSettingsPolicy:

--- a/src/argilla/server/routes.py
+++ b/src/argilla/server/routes.py
@@ -36,6 +36,7 @@ from argilla.server.apis.v0.handlers import (
 from argilla.server.apis.v1.handlers import annotations as annotations_v1
 from argilla.server.apis.v1.handlers import datasets as datasets_v1
 from argilla.server.apis.v1.handlers import records as records_v1
+from argilla.server.apis.v1.handlers import responses as responses_v1
 from argilla.server.apis.v1.handlers import workspaces as workspaces_v1
 from argilla.server.errors.base_errors import __ALL__
 
@@ -64,3 +65,4 @@ api_router.include_router(datasets_v1.router, prefix="/v1")
 api_router.include_router(workspaces_v1.router, prefix="/v1")
 api_router.include_router(annotations_v1.router, prefix="/v1")
 api_router.include_router(records_v1.router, prefix="/v1")
+api_router.include_router(responses_v1.router, prefix="/v1")

--- a/src/argilla/server/schemas/v1/responses.py
+++ b/src/argilla/server/schemas/v1/responses.py
@@ -22,6 +22,8 @@ from pydantic import BaseModel
 class Response(BaseModel):
     id: UUID
     values: Dict[str, Any]
+    record_id: UUID
+    user_id: UUID
     inserted_at: datetime
     updated_at: datetime
 

--- a/src/argilla/server/schemas/v1/responses.py
+++ b/src/argilla/server/schemas/v1/responses.py
@@ -1,0 +1,33 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from datetime import datetime
+from typing import Any, Dict
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class Response(BaseModel):
+    id: UUID
+    values: Dict[str, Any]
+    inserted_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class ResponseUpdate(BaseModel):
+    values: Dict[str, Any]

--- a/tests/server/api/v1/test_responses.py
+++ b/tests/server/api/v1/test_responses.py
@@ -52,6 +52,8 @@ def test_update_response(client: TestClient, db: Session, admin_auth_header: dic
             "input_ok": {"value": "yes"},
             "output_ok": {"value": "yes"},
         },
+        "record_id": str(response.record_id),
+        "user_id": str(response.user_id),
         "inserted_at": response.inserted_at.isoformat(),
         "updated_at": datetime.fromisoformat(resp_body["updated_at"]).isoformat(),
     }
@@ -113,6 +115,8 @@ def test_update_response_as_annotator(client: TestClient, db: Session):
             "input_ok": {"value": "yes"},
             "output_ok": {"value": "yes"},
         },
+        "record_id": str(response.record_id),
+        "user_id": str(response.user_id),
         "inserted_at": response.inserted_at.isoformat(),
         "updated_at": datetime.fromisoformat(resp_body["updated_at"]).isoformat(),
     }

--- a/tests/server/api/v1/test_responses.py
+++ b/tests/server/api/v1/test_responses.py
@@ -1,0 +1,167 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from datetime import datetime
+from uuid import uuid4
+
+from argilla._constants import API_KEY_HEADER_NAME
+from argilla.server.models import Response
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from tests.factories import AnnotatorFactory, ResponseFactory
+
+
+def test_update_response(client: TestClient, db: Session, admin_auth_header: dict):
+    response = ResponseFactory.create(
+        values={
+            "input_ok": {"value": "no"},
+            "output_ok": {"value": "no"},
+        },
+    )
+    response_json = {
+        "values": {
+            "input_ok": {"value": "yes"},
+            "output_ok": {"value": "yes"},
+        }
+    }
+
+    resp = client.put(f"/api/v1/responses/{response.id}", headers=admin_auth_header, json=response_json)
+
+    assert resp.status_code == 200
+    assert db.get(Response, response.id).values == {
+        "input_ok": {"value": "yes"},
+        "output_ok": {"value": "yes"},
+    }
+
+    resp_body = resp.json()
+    assert resp_body == {
+        "id": str(response.id),
+        "values": {
+            "input_ok": {"value": "yes"},
+            "output_ok": {"value": "yes"},
+        },
+        "inserted_at": response.inserted_at.isoformat(),
+        "updated_at": datetime.fromisoformat(resp_body["updated_at"]).isoformat(),
+    }
+
+
+def test_update_response_without_authentication(client: TestClient, db: Session):
+    response = ResponseFactory.create(
+        values={
+            "input_ok": {"value": "no"},
+            "output_ok": {"value": "no"},
+        },
+    )
+    response_json = {
+        "values": {
+            "input_ok": {"value": "yes"},
+            "output_ok": {"value": "yes"},
+        }
+    }
+
+    resp = client.put(f"/api/v1/responses/{response.id}", json=response_json)
+
+    assert resp.status_code == 401
+    assert db.get(Response, response.id).values == {
+        "input_ok": {"value": "no"},
+        "output_ok": {"value": "no"},
+    }
+
+
+def test_update_response_as_annotator(client: TestClient, db: Session):
+    annotator = AnnotatorFactory.create()
+    response = ResponseFactory.create(
+        values={
+            "input_ok": {"value": "no"},
+            "output_ok": {"value": "no"},
+        },
+        user=annotator,
+    )
+    response_json = {
+        "values": {
+            "input_ok": {"value": "yes"},
+            "output_ok": {"value": "yes"},
+        }
+    }
+
+    resp = client.put(
+        f"/api/v1/responses/{response.id}", headers={API_KEY_HEADER_NAME: annotator.api_key}, json=response_json
+    )
+
+    assert resp.status_code == 200
+    assert db.get(Response, response.id).values == {
+        "input_ok": {"value": "yes"},
+        "output_ok": {"value": "yes"},
+    }
+
+    resp_body = resp.json()
+    assert resp_body == {
+        "id": str(response.id),
+        "values": {
+            "input_ok": {"value": "yes"},
+            "output_ok": {"value": "yes"},
+        },
+        "inserted_at": response.inserted_at.isoformat(),
+        "updated_at": datetime.fromisoformat(resp_body["updated_at"]).isoformat(),
+    }
+
+
+def test_update_response_as_annotator_for_different_user_response(client: TestClient, db: Session):
+    annotator = AnnotatorFactory.create()
+    response = ResponseFactory.create(
+        values={
+            "input_ok": {"value": "no"},
+            "output_ok": {"value": "no"},
+        },
+    )
+    response_json = {
+        "values": {
+            "input_ok": {"value": "yes"},
+            "output_ok": {"value": "yes"},
+        }
+    }
+
+    resp = client.put(
+        f"/api/v1/responses/{response.id}", headers={API_KEY_HEADER_NAME: annotator.api_key}, json=response_json
+    )
+
+    assert resp.status_code == 403
+    assert db.get(Response, response.id).values == {
+        "input_ok": {"value": "no"},
+        "output_ok": {"value": "no"},
+    }
+
+
+def test_update_response_with_nonexistent_response_id(client: TestClient, db: Session, admin_auth_header: dict):
+    response = ResponseFactory.create(
+        values={
+            "input_ok": {"value": "no"},
+            "output_ok": {"value": "no"},
+        },
+    )
+    response_json = {
+        "values": {
+            "input_ok": {"value": "yes"},
+            "output_ok": {"value": "yes"},
+        }
+    }
+
+    resp = client.put(f"/api/v1/responses/{uuid4()}", headers=admin_auth_header, json=response_json)
+
+    assert resp.status_code == 404
+    assert db.get(Response, response.id).values == {
+        "input_ok": {"value": "no"},
+        "output_ok": {"value": "no"},
+    }


### PR DESCRIPTION
# Description

This PR adds a new endpoint to update a previously created record response:
* `PUT` `/api/v1/responses/{response_id}`

Notes:
* Admin users can update any response (even if that admin user didn't create the response in first place).
* Annotators can only update a response if the response was created by them.