### PR TITLE
List responses for a record v1 endpoint

### DIFF
--- a/src/argilla/server/apis/v1/handlers/records.py
+++ b/src/argilla/server/apis/v1/handlers/records.py
@@ -33,6 +33,7 @@ def _get_record(db: Session, record_id: UUID):
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Record with id `{record_id}` not found",
         )
+
     return record
 
 

--- a/src/argilla/server/apis/v1/handlers/records.py
+++ b/src/argilla/server/apis/v1/handlers/records.py
@@ -11,7 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Security, status
@@ -21,10 +20,37 @@ from argilla.server.contexts import datasets
 from argilla.server.database import get_db
 from argilla.server.models import User
 from argilla.server.policies import RecordPolicyV1, authorize
-from argilla.server.schemas.v1.records import Response, ResponseCreate
+from argilla.server.schemas.v1.records import Response, ResponseCreate, Responses
 from argilla.server.security import auth
 
 router = APIRouter(tags=["records"])
+
+
+def _get_record(db: Session, record_id: UUID):
+    record = datasets.get_record_by_id(db, record_id)
+    if not record:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Record with id `{record_id}` not found",
+        )
+    return record
+
+
+@router.get("/records/{record_id}/responses", response_model=Responses)
+def list_record_responses(
+    *,
+    db: Session = Depends(get_db),
+    record_id: UUID,
+    current_user: User = Security(auth.get_current_user),
+):
+    record = _get_record(db, record_id)
+
+    authorize(current_user, RecordPolicyV1.get(record))
+
+    if current_user.is_admin:
+        return Responses(items=datasets.list_responses_by_record_id(db, record.id))
+    else:
+        return Responses(items=[datasets.get_response_by_record_id_and_user_id(db, record.id, current_user.id)])
 
 
 @router.post("/records/{record_id}/responses", status_code=status.HTTP_201_CREATED, response_model=Response)
@@ -35,12 +61,7 @@ def create_record_response(
     response_create: ResponseCreate,
     current_user: User = Security(auth.get_current_user),
 ):
-    record = datasets.get_record_by_id(db, record_id)
-    if not record:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Record with id `{record_id}` not found",
-        )
+    record = _get_record(db, record_id)
 
     authorize(current_user, RecordPolicyV1.create_response(record))
 

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -161,6 +161,10 @@ def get_response_by_record_id_and_user_id(db: Session, record_id: UUID, user_id:
     return db.query(Response).filter_by(record_id=record_id, user_id=user_id).first()
 
 
+def list_responses_by_record_id(db: Session, record_id: UUID):
+    return db.query(Response).filter_by(record_id=record_id).all()
+
+
 def create_response(db: Session, record: Record, user: User, response_create: ResponseCreate):
     response = Response(
         values=response_create.values,

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -162,7 +162,7 @@ def get_response_by_record_id_and_user_id(db: Session, record_id: UUID, user_id:
 
 
 def list_responses_by_record_id(db: Session, record_id: UUID):
-    return db.query(Response).filter_by(record_id=record_id).all()
+    return db.query(Response).filter_by(record_id=record_id).order_by(Response.inserted_at.asc()).all()
 
 
 def create_response(db: Session, record: Record, user: User, response_create: ResponseCreate):

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -175,6 +175,19 @@ class AnnotationPolicyV1:
 
 class RecordPolicyV1:
     @classmethod
+    def get(cls, record: Record) -> PolicyAction:
+        return lambda actor: (
+            actor.is_admin
+            or bool(
+                accounts.get_workspace_user_by_workspace_id_and_user_id(
+                    Session.object_session(actor),
+                    record.dataset.workspace_id,
+                    actor.id,
+                )
+            )
+        )
+
+    @classmethod
     def create_response(cls, record: Record) -> PolicyAction:
         return lambda actor: (
             actor.is_admin

--- a/src/argilla/server/schemas/v1/records.py
+++ b/src/argilla/server/schemas/v1/records.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, List
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -22,6 +22,7 @@ from pydantic import BaseModel
 class Response(BaseModel):
     id: UUID
     values: Dict[str, Any]
+    user_id: UUID
     inserted_at: datetime
     updated_at: datetime
 
@@ -31,3 +32,7 @@ class Response(BaseModel):
 
 class ResponseCreate(BaseModel):
     values: Dict[str, Any]
+
+
+class Responses(BaseModel):
+    items: List[Response]

--- a/tests/server/api/v1/test_records.py
+++ b/tests/server/api/v1/test_records.py
@@ -172,17 +172,17 @@ def test_list_record_responses(client: TestClient, db: Session, admin: User, adm
         "items": [
             {
                 "id": str(response_a.id),
-                "inserted_at": response_a.inserted_at.isoformat(),
-                "updated_at": response_a.updated_at.isoformat(),
                 "values": response_a.values,
                 "user_id": str(response_a.user_id),
+                "inserted_at": response_a.inserted_at.isoformat(),
+                "updated_at": response_a.updated_at.isoformat(),
             },
             {
                 "id": str(response_b.id),
-                "inserted_at": response_b.inserted_at.isoformat(),
-                "updated_at": response_b.updated_at.isoformat(),
                 "values": response_b.values,
                 "user_id": str(response_b.user.id),
+                "inserted_at": response_b.inserted_at.isoformat(),
+                "updated_at": response_b.updated_at.isoformat(),
             },
         ]
     }
@@ -202,10 +202,10 @@ def test_list_record_responses_as_annotator(client: TestClient, db: Session, adm
         "items": [
             {
                 "id": str(response_a.id),
-                "inserted_at": response_a.inserted_at.isoformat(),
-                "updated_at": response_a.updated_at.isoformat(),
                 "values": response_a.values,
                 "user_id": str(response_a.user_id),
+                "inserted_at": response_a.inserted_at.isoformat(),
+                "updated_at": response_a.updated_at.isoformat(),
             }
         ]
     }
@@ -221,6 +221,9 @@ def test_list_record_responses_as_annotator_from_different_workspace(client: Tes
 
 
 def test_list_record_responses_with_nonexistent_record_id(client: TestClient, db: Session, admin_auth_header: dict):
+    record = RecordFactory.create()
+    ResponseFactory.create(record=record)
+
     response = client.get(f"/api/v1/records/{uuid4()}/responses", headers=admin_auth_header)
 
     assert response.status_code == 404

--- a/tests/server/api/v1/test_records.py
+++ b/tests/server/api/v1/test_records.py
@@ -28,7 +28,7 @@ from tests.factories import (
 )
 
 
-def test_create_record_response(client: TestClient, db: Session, admin_auth_header: dict):
+def test_create_record_response(client: TestClient, db: Session, admin: User, admin_auth_header: dict):
     record = RecordFactory.create()
     response_json = {
         "values": {
@@ -50,6 +50,7 @@ def test_create_record_response(client: TestClient, db: Session, admin_auth_head
             "input_ok": {"value": "yes"},
             "output_ok": {"value": "yes"},
         },
+        "user_id": str(admin.id),
         "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
         "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
     }
@@ -86,6 +87,18 @@ def test_create_record_response_as_annotator(client: TestClient, db: Session):
 
     assert response.status_code == 201
     assert db.query(Response).count() == 1
+
+    response_body = response.json()
+    assert response_body == {
+        "id": str(UUID(response_body["id"])),
+        "values": {
+            "input_ok": {"value": "yes"},
+            "output_ok": {"value": "yes"},
+        },
+        "user_id": str(annotator.id),
+        "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
+        "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
+    }
 
 
 def test_create_record_response_as_annotator_from_different_workspace(client: TestClient, db: Session):
@@ -145,3 +158,69 @@ def test_create_record_response_with_nonexistent_record_id(client: TestClient, d
 
     assert response.status_code == 404
     assert db.query(Response).count() == 0
+
+
+def test_list_record_responses(client: TestClient, db: Session, admin: User, admin_auth_header: dict):
+    record = RecordFactory.create()
+    response_a = ResponseFactory.create(record=record)
+    response_b = ResponseFactory.create(record=record)
+
+    response = client.get(f"/api/v1/records/{record.id}/responses", headers=admin_auth_header)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "items": [
+            {
+                "id": str(response_a.id),
+                "inserted_at": response_a.inserted_at.isoformat(),
+                "updated_at": response_a.updated_at.isoformat(),
+                "values": response_a.values,
+                "user_id": str(response_a.user_id),
+            },
+            {
+                "id": str(response_b.id),
+                "inserted_at": response_b.inserted_at.isoformat(),
+                "updated_at": response_b.updated_at.isoformat(),
+                "values": response_b.values,
+                "user_id": str(response_b.user.id),
+            },
+        ]
+    }
+
+
+def test_list_record_responses_as_annotator(client: TestClient, db: Session, admin: User, admin_auth_header: dict):
+    record = RecordFactory.create()
+    annotator = AnnotatorFactory.create(workspaces=[record.dataset.workspace])
+    response_a = ResponseFactory.create(record=record, user=annotator)
+    ResponseFactory.create(record=record, user=admin)
+    ResponseFactory.create(record=record)
+
+    response = client.get(f"/api/v1/records/{record.id}/responses", headers={API_KEY_HEADER_NAME: annotator.api_key})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "items": [
+            {
+                "id": str(response_a.id),
+                "inserted_at": response_a.inserted_at.isoformat(),
+                "updated_at": response_a.updated_at.isoformat(),
+                "values": response_a.values,
+                "user_id": str(response_a.user_id),
+            }
+        ]
+    }
+
+
+def test_list_record_responses_as_annotator_from_different_workspace(client: TestClient, db: Session):
+    record = RecordFactory.create()
+    annotator = AnnotatorFactory.create(workspaces=[WorkspaceFactory.build()])
+
+    response = client.get(f"/api/v1/records/{record.id}/responses", headers={API_KEY_HEADER_NAME: annotator.api_key})
+
+    assert response.status_code == 403
+
+
+def test_list_record_responses_with_nonexistent_record_id(client: TestClient, db: Session, admin_auth_header: dict):
+    response = client.get(f"/api/v1/records/{uuid4()}/responses", headers=admin_auth_header)
+
+    assert response.status_code == 404

--- a/tests/server/api/v1/test_records.py
+++ b/tests/server/api/v1/test_records.py
@@ -160,7 +160,7 @@ def test_create_record_response_with_nonexistent_record_id(client: TestClient, d
     assert db.query(Response).count() == 0
 
 
-def test_list_record_responses(client: TestClient, db: Session, admin: User, admin_auth_header: dict):
+def test_list_record_responses(client: TestClient, db: Session, admin_auth_header: dict):
     record = RecordFactory.create()
     response_a = ResponseFactory.create(record=record)
     response_b = ResponseFactory.create(record=record)


### PR DESCRIPTION
This PR adds a new endpoint to list responses for a record. The resulting responses contain the `user_id` attribute. If we want to normalize the Argilla API entities, the `record_id` should be also included. 