### PR TITLE
Add attribute total counting number of records to dataset records APIv1 endpoint response

### DIFF
--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -91,7 +91,10 @@ def list_dataset_records(
 
     authorize(current_user, DatasetPolicyV1.get(dataset))
 
-    return Records(items=datasets.list_records(db, dataset, offset=offset, limit=limit))
+    return Records(
+        items=datasets.list_records_by_dataset_id(db, dataset_id, offset=offset, limit=limit),
+        total=datasets.count_records_by_dataset_id(db, dataset_id),
+    )
 
 
 @router.get("/datasets/{dataset_id}", response_model=Dataset)

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -125,15 +125,19 @@ def get_record_by_id(db: Session, record_id: UUID):
     return db.get(Record, record_id)
 
 
-def list_records(db: Session, dataset: Dataset, offset: int = 0, limit: int = LIST_RECORDS_LIMIT):
+def list_records_by_dataset_id(db: Session, dataset_id: UUID, offset: int = 0, limit: int = LIST_RECORDS_LIMIT):
     return (
         db.query(Record)
-        .filter(Record.dataset_id == dataset.id)
+        .filter_by(dataset_id=dataset_id)
         .order_by(Record.inserted_at.asc())
         .offset(offset)
         .limit(limit)
         .all()
     )
+
+
+def count_records_by_dataset_id(db: Session, dataset_id: UUID):
+    return db.query(func.count(Record.id)).filter_by(dataset_id=dataset_id).scalar()
 
 
 def create_records(db: Session, dataset: Dataset, user: User, records_create: RecordsCreate):

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -107,6 +107,7 @@ class Record(BaseModel):
 
 class Records(BaseModel):
     items: List[Record]
+    total: int
 
 
 class ResponseCreate(BaseModel):

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -42,7 +42,6 @@ from tests.factories import (
     DatasetFactory,
     RatingAnnotationFactory,
     RecordFactory,
-    ResponseFactory,
     TextAnnotationFactory,
     WorkspaceFactory,
 )
@@ -206,6 +205,8 @@ def test_list_dataset_records(client: TestClient, admin_auth_header: dict):
     record_b = RecordFactory.create(fields={"record_b": "value_b"}, dataset=dataset)
     record_c = RecordFactory.create(fields={"record_c": "value_c"}, dataset=dataset)
 
+    RecordFactory.create_batch(size=2)
+
     response = client.get(f"/api/v1/datasets/{dataset.id}/records", headers=admin_auth_header)
 
     assert response.status_code == 200
@@ -232,7 +233,8 @@ def test_list_dataset_records(client: TestClient, admin_auth_header: dict):
                 "inserted_at": record_c.inserted_at.isoformat(),
                 "updated_at": record_c.updated_at.isoformat(),
             },
-        ]
+        ],
+        "total": 3,
     }
 
 
@@ -242,12 +244,15 @@ def test_list_dataset_records_with_offset(client: TestClient, admin_auth_header:
     RecordFactory.create(fields={"record_b": "value_b"}, dataset=dataset)
     record_c = RecordFactory.create(fields={"record_c": "value_c"}, dataset=dataset)
 
+    RecordFactory.create_batch(size=2)
+
     response = client.get(f"/api/v1/datasets/{dataset.id}/records", headers=admin_auth_header, params={"offset": 2})
 
     assert response.status_code == 200
 
     response_body = response.json()
     assert [item["id"] for item in response_body["items"]] == [str(record_c.id)]
+    assert response_body["total"] == 3
 
 
 def test_list_dataset_records_with_limit(client: TestClient, admin_auth_header: dict):
@@ -256,12 +261,15 @@ def test_list_dataset_records_with_limit(client: TestClient, admin_auth_header: 
     RecordFactory.create(fields={"record_b": "value_b"}, dataset=dataset)
     RecordFactory.create(fields={"record_c": "value_c"}, dataset=dataset)
 
+    RecordFactory.create_batch(size=2)
+
     response = client.get(f"/api/v1/datasets/{dataset.id}/records", headers=admin_auth_header, params={"limit": 1})
 
     assert response.status_code == 200
 
     response_body = response.json()
     assert [item["id"] for item in response_body["items"]] == [str(record_a.id)]
+    assert response_body["total"] == 3
 
 
 def test_list_dataset_records_with_offset_and_limit(client: TestClient, admin_auth_header: dict):
@@ -269,6 +277,8 @@ def test_list_dataset_records_with_offset_and_limit(client: TestClient, admin_au
     RecordFactory.create(fields={"record_a": "value_a"}, dataset=dataset)
     record_c = RecordFactory.create(fields={"record_b": "value_b"}, dataset=dataset)
     RecordFactory.create(fields={"record_c": "value_c"}, dataset=dataset)
+
+    RecordFactory.create_batch(size=2)
 
     response = client.get(
         f"/api/v1/datasets/{dataset.id}/records", headers=admin_auth_header, params={"offset": 1, "limit": 1}
@@ -278,6 +288,7 @@ def test_list_dataset_records_with_offset_and_limit(client: TestClient, admin_au
 
     response_body = response.json()
     assert [item["id"] for item in response_body["items"]] == [str(record_c.id)]
+    assert response_body["total"] == 3
 
 
 def test_list_dataset_records_without_authentication(client: TestClient):
@@ -295,6 +306,8 @@ def test_list_dataset_records_as_annotator(client: TestClient, admin: User, db: 
     record_a = RecordFactory.create(fields={"record_a": "value_a"}, dataset=dataset)
     record_b = RecordFactory.create(fields={"record_b": "value_b"}, dataset=dataset)
     record_c = RecordFactory.create(fields={"record_c": "value_c"}, dataset=dataset)
+
+    RecordFactory.create_batch(size=2)
 
     response = client.get(f"/api/v1/datasets/{dataset.id}/records", headers={API_KEY_HEADER_NAME: annotator.api_key})
 
@@ -322,7 +335,8 @@ def test_list_dataset_records_as_annotator(client: TestClient, admin: User, db: 
                 "inserted_at": record_c.inserted_at.isoformat(),
                 "updated_at": record_c.updated_at.isoformat(),
             },
-        ]
+        ],
+        "total": 3,
     }
 
 

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -205,7 +205,8 @@ def test_list_dataset_records(client: TestClient, admin_auth_header: dict):
     record_b = RecordFactory.create(fields={"record_b": "value_b"}, dataset=dataset)
     record_c = RecordFactory.create(fields={"record_c": "value_c"}, dataset=dataset)
 
-    RecordFactory.create_batch(size=2)
+    other_dataset = DatasetFactory.create()
+    RecordFactory.create_batch(size=2, dataset=other_dataset)
 
     response = client.get(f"/api/v1/datasets/{dataset.id}/records", headers=admin_auth_header)
 
@@ -244,7 +245,8 @@ def test_list_dataset_records_with_offset(client: TestClient, admin_auth_header:
     RecordFactory.create(fields={"record_b": "value_b"}, dataset=dataset)
     record_c = RecordFactory.create(fields={"record_c": "value_c"}, dataset=dataset)
 
-    RecordFactory.create_batch(size=2)
+    other_dataset = DatasetFactory.create()
+    RecordFactory.create_batch(size=2, dataset=other_dataset)
 
     response = client.get(f"/api/v1/datasets/{dataset.id}/records", headers=admin_auth_header, params={"offset": 2})
 
@@ -261,7 +263,8 @@ def test_list_dataset_records_with_limit(client: TestClient, admin_auth_header: 
     RecordFactory.create(fields={"record_b": "value_b"}, dataset=dataset)
     RecordFactory.create(fields={"record_c": "value_c"}, dataset=dataset)
 
-    RecordFactory.create_batch(size=2)
+    other_dataset = DatasetFactory.create()
+    RecordFactory.create_batch(size=2, dataset=other_dataset)
 
     response = client.get(f"/api/v1/datasets/{dataset.id}/records", headers=admin_auth_header, params={"limit": 1})
 
@@ -278,7 +281,8 @@ def test_list_dataset_records_with_offset_and_limit(client: TestClient, admin_au
     record_c = RecordFactory.create(fields={"record_b": "value_b"}, dataset=dataset)
     RecordFactory.create(fields={"record_c": "value_c"}, dataset=dataset)
 
-    RecordFactory.create_batch(size=2)
+    other_dataset = DatasetFactory.create()
+    RecordFactory.create_batch(size=2, dataset=other_dataset)
 
     response = client.get(
         f"/api/v1/datasets/{dataset.id}/records", headers=admin_auth_header, params={"offset": 1, "limit": 1}
@@ -307,7 +311,8 @@ def test_list_dataset_records_as_annotator(client: TestClient, admin: User, db: 
     record_b = RecordFactory.create(fields={"record_b": "value_b"}, dataset=dataset)
     record_c = RecordFactory.create(fields={"record_c": "value_c"}, dataset=dataset)
 
-    RecordFactory.create_batch(size=2)
+    other_dataset = DatasetFactory.create()
+    RecordFactory.create_batch(size=2, dataset=other_dataset)
 
     response = client.get(f"/api/v1/datasets/{dataset.id}/records", headers={API_KEY_HEADER_NAME: annotator.api_key})
 


### PR DESCRIPTION
# Description

This PR add a new `total` value the listing records for datasets on APIv1 endpoint.

With this change we are allowing classic pagination on the frontend so the pages can be calculated.

Notes:
* I'm adding `RecordFactory.create_batch(size=2)` to some tests so we can be sure that we have records for other datasets apart from the one that we are requesting.