### PR TITLE
Add items to all APIv1 list endpoints

### DIFF
--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -25,6 +25,7 @@ from argilla.server.policies import DatasetPolicyV1, authorize
 from argilla.server.schemas.v1.datasets import (
     Annotation,
     AnnotationCreate,
+    Annotations,
     Dataset,
     DatasetCreate,
     Datasets,
@@ -65,7 +66,7 @@ def list_datasets(
         return Datasets(items=current_user.datasets)
 
 
-@router.get("/datasets/{dataset_id}/annotations", response_model=List[Annotation])
+@router.get("/datasets/{dataset_id}/annotations", response_model=Annotations)
 def list_dataset_annotations(
     *,
     db: Session = Depends(get_db),
@@ -76,7 +77,7 @@ def list_dataset_annotations(
 
     authorize(current_user, DatasetPolicyV1.get(dataset))
 
-    return dataset.annotations
+    return Annotations(items=dataset.annotations)
 
 
 @router.get("/datasets/{dataset_id}/records", response_model=Records)

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -27,6 +27,7 @@ from argilla.server.schemas.v1.datasets import (
     AnnotationCreate,
     Dataset,
     DatasetCreate,
+    Datasets,
     Records,
     RecordsCreate,
 )
@@ -50,7 +51,7 @@ def _get_dataset(db: Session, dataset_id: UUID):
     return dataset
 
 
-@router.get("/datasets", response_model=List[Dataset])
+@router.get("/datasets", response_model=Datasets)
 def list_datasets(
     *,
     db: Session = Depends(get_db),
@@ -59,9 +60,9 @@ def list_datasets(
     authorize(current_user, DatasetPolicyV1.list)
 
     if current_user.is_admin:
-        return datasets.list_datasets(db)
+        return Datasets(items=datasets.list_datasets(db))
     else:
-        return current_user.datasets
+        return Datasets(items=current_user.datasets)
 
 
 @router.get("/datasets/{dataset_id}/annotations", response_model=List[Annotation])

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -81,6 +81,10 @@ class Annotation(BaseModel):
         orm_mode = True
 
 
+class Annotations(BaseModel):
+    items: List[Annotation]
+
+
 class AnnotationCreate(BaseModel):
     name: str
     title: str

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -41,6 +41,10 @@ class Dataset(BaseModel):
         orm_mode = True
 
 
+class Datasets(BaseModel):
+    items: List[Dataset]
+
+
 class DatasetCreate(BaseModel):
     name: str
     guidelines: Optional[str]

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -42,7 +42,6 @@ from tests.factories import (
     DatasetFactory,
     RatingAnnotationFactory,
     RecordFactory,
-    ResponseFactory,
     TextAnnotationFactory,
     WorkspaceFactory,
 )
@@ -125,40 +124,42 @@ def test_list_dataset_annotations(client: TestClient, db: Session, admin_auth_he
     response = client.get(f"/api/v1/datasets/{dataset.id}/annotations", headers=admin_auth_header)
 
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": str(text_annotation.id),
-            "name": "text-annotation",
-            "title": "Text Annotation",
-            "required": True,
-            "settings": {"type": "text"},
-            "inserted_at": text_annotation.inserted_at.isoformat(),
-            "updated_at": text_annotation.updated_at.isoformat(),
-        },
-        {
-            "id": str(rating_annotation.id),
-            "name": "rating-annotation",
-            "title": "Rating Annotation",
-            "required": False,
-            "settings": {
-                "type": "rating",
-                "options": [
-                    {"value": 1},
-                    {"value": 2},
-                    {"value": 3},
-                    {"value": 4},
-                    {"value": 5},
-                    {"value": 6},
-                    {"value": 7},
-                    {"value": 8},
-                    {"value": 9},
-                    {"value": 10},
-                ],
+    assert response.json() == {
+        "items": [
+            {
+                "id": str(text_annotation.id),
+                "name": "text-annotation",
+                "title": "Text Annotation",
+                "required": True,
+                "settings": {"type": "text"},
+                "inserted_at": text_annotation.inserted_at.isoformat(),
+                "updated_at": text_annotation.updated_at.isoformat(),
             },
-            "inserted_at": rating_annotation.inserted_at.isoformat(),
-            "updated_at": rating_annotation.updated_at.isoformat(),
-        },
-    ]
+            {
+                "id": str(rating_annotation.id),
+                "name": "rating-annotation",
+                "title": "Rating Annotation",
+                "required": False,
+                "settings": {
+                    "type": "rating",
+                    "options": [
+                        {"value": 1},
+                        {"value": 2},
+                        {"value": 3},
+                        {"value": 4},
+                        {"value": 5},
+                        {"value": 6},
+                        {"value": 7},
+                        {"value": 8},
+                        {"value": 9},
+                        {"value": 10},
+                    ],
+                },
+                "inserted_at": rating_annotation.inserted_at.isoformat(),
+                "updated_at": rating_annotation.updated_at.isoformat(),
+            },
+        ]
+    }
 
 
 def test_list_dataset_annotations_without_authentication(client: TestClient, db: Session):
@@ -182,7 +183,9 @@ def test_list_dataset_annotations_as_annotator(client: TestClient, db: Session):
     )
 
     assert response.status_code == 200
-    assert [annotation["name"] for annotation in response.json()] == ["text-annotation", "rating-annotation"]
+
+    response_body = response.json()
+    assert [annotation["name"] for annotation in response_body["items"]] == ["text-annotation", "rating-annotation"]
 
 
 def test_list_dataset_annotations_as_annotator_from_different_workspace(client: TestClient, db: Session):

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -56,35 +56,37 @@ def test_list_datasets(client: TestClient, admin_auth_header: dict):
     response = client.get("/api/v1/datasets", headers=admin_auth_header)
 
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": str(dataset_a.id),
-            "name": "dataset-a",
-            "guidelines": None,
-            "status": "draft",
-            "workspace_id": str(dataset_a.workspace_id),
-            "inserted_at": dataset_a.inserted_at.isoformat(),
-            "updated_at": dataset_a.updated_at.isoformat(),
-        },
-        {
-            "id": str(dataset_b.id),
-            "name": "dataset-b",
-            "guidelines": "guidelines",
-            "status": "draft",
-            "workspace_id": str(dataset_b.workspace_id),
-            "inserted_at": dataset_b.inserted_at.isoformat(),
-            "updated_at": dataset_b.updated_at.isoformat(),
-        },
-        {
-            "id": str(dataset_c.id),
-            "name": "dataset-c",
-            "guidelines": None,
-            "status": "ready",
-            "workspace_id": str(dataset_c.workspace_id),
-            "inserted_at": dataset_c.inserted_at.isoformat(),
-            "updated_at": dataset_c.updated_at.isoformat(),
-        },
-    ]
+    assert response.json() == {
+        "items": [
+            {
+                "id": str(dataset_a.id),
+                "name": "dataset-a",
+                "guidelines": None,
+                "status": "draft",
+                "workspace_id": str(dataset_a.workspace_id),
+                "inserted_at": dataset_a.inserted_at.isoformat(),
+                "updated_at": dataset_a.updated_at.isoformat(),
+            },
+            {
+                "id": str(dataset_b.id),
+                "name": "dataset-b",
+                "guidelines": "guidelines",
+                "status": "draft",
+                "workspace_id": str(dataset_b.workspace_id),
+                "inserted_at": dataset_b.inserted_at.isoformat(),
+                "updated_at": dataset_b.updated_at.isoformat(),
+            },
+            {
+                "id": str(dataset_c.id),
+                "name": "dataset-c",
+                "guidelines": None,
+                "status": "ready",
+                "workspace_id": str(dataset_c.workspace_id),
+                "inserted_at": dataset_c.inserted_at.isoformat(),
+                "updated_at": dataset_c.updated_at.isoformat(),
+            },
+        ]
+    }
 
 
 def test_list_datasets_without_authentication(client: TestClient):
@@ -104,7 +106,9 @@ def test_list_datasets_as_annotator(client: TestClient, db: Session):
     response = client.get("/api/v1/datasets", headers={API_KEY_HEADER_NAME: annotator.api_key})
 
     assert response.status_code == 200
-    assert [dataset["name"] for dataset in response.json()] == ["dataset-a", "dataset-b"]
+
+    response_body = response.json()
+    assert [dataset["name"] for dataset in response_body["items"]] == ["dataset-a", "dataset-b"]
 
 
 def test_list_dataset_annotations(client: TestClient, db: Session, admin_auth_header: dict):


### PR DESCRIPTION
# Description

With this PR we have all the APIv1 list endpoints using the same response structure with `{"items": []}`.

We are of course only adding `total` when necessary but it's something that we can add later if necessary.