### PR TITLE
Add regex constraint for annotation name

### DIFF
--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -16,10 +16,15 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
-from pydantic import BaseModel, Field, conlist
+from pydantic import BaseModel, Field, conlist, constr
 from typing_extensions import Literal
 
 from argilla.server.models import AnnotationType, DatasetStatus
+
+ANNOTATION_CREATE_NAME_REGEX = r"^(?=.*[a-z0-9])[a-z0-9_-]+$"
+
+ANNOTATION_CREATE_NAME_MIN_LENGTH = 1
+ANNOTATION_CREATE_NAME_MAX_LENGTH = 200
 
 RATING_OPTIONS_MIN_ITEMS = 2
 RATING_OPTIONS_MAX_ITEMS = 100
@@ -78,7 +83,11 @@ class Annotation(BaseModel):
 
 
 class AnnotationCreate(BaseModel):
-    name: str
+    name: constr(
+        regex=ANNOTATION_CREATE_NAME_REGEX,
+        min_length=ANNOTATION_CREATE_NAME_MIN_LENGTH,
+        max_length=ANNOTATION_CREATE_NAME_MAX_LENGTH,
+    )
     title: str
     required: Optional[bool]
     settings: Union[TextAnnotationSettings, RatingAnnotationSettings] = Field(..., discriminator="type")

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -26,6 +26,7 @@ from argilla.server.models import (
     User,
 )
 from argilla.server.schemas.v1.datasets import (
+    ANNOTATION_CREATE_NAME_MAX_LENGTH,
     RATING_OPTIONS_MAX_ITEMS,
     RATING_OPTIONS_MIN_ITEMS,
     RECORDS_CREATE_MAX_ITEMS,
@@ -514,6 +515,22 @@ def test_create_dataset_annotation_with_invalid_name(
     dataset = DatasetFactory.create()
     annotation_json = {
         "name": invalid_name,
+        "title": "title",
+        "settings": {"type": "text"},
+    }
+
+    response = client.post(
+        f"/api/v1/datasets/{dataset.id}/annotations", headers=admin_auth_header, json=annotation_json
+    )
+
+    assert response.status_code == 422
+    assert db.query(Annotation).count() == 0
+
+
+def test_create_annotation_with_invalid_max_length_name(client: TestClient, db: Session, admin_auth_header: dict):
+    dataset = DatasetFactory.create()
+    annotation_json = {
+        "name": "a" * (ANNOTATION_CREATE_NAME_MAX_LENGTH + 1),
         "title": "title",
         "settings": {"type": "text"},
     }

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -507,6 +507,25 @@ def test_create_dataset_annotation_as_annotator(client: TestClient, db: Session)
     assert db.query(Annotation).count() == 0
 
 
+@pytest.mark.parametrize("invalid_name", ["", " ", "  ", "-", "--", "_", "__", "A", "AA", "invalid_nAmE"])
+def test_create_dataset_annotation_with_invalid_name(
+    client: TestClient, db: Session, admin_auth_header: dict, invalid_name: str
+):
+    dataset = DatasetFactory.create()
+    annotation_json = {
+        "name": invalid_name,
+        "title": "title",
+        "settings": {"type": "text"},
+    }
+
+    response = client.post(
+        f"/api/v1/datasets/{dataset.id}/annotations", headers=admin_auth_header, json=annotation_json
+    )
+
+    assert response.status_code == 422
+    assert db.query(Annotation).count() == 0
+
+
 def test_create_dataset_annotation_with_existent_name(client: TestClient, db: Session, admin_auth_header: dict):
     annotation = AnnotationFactory.create(name="name")
     annotation_json = {


### PR DESCRIPTION
# Description

Annotation names will be used on search queries and written into our search engine. For this reason we need to add a constraint to `name` attribute for annotations so only some patterns are allowed.

I have added the following constraints for annotation `name` attribute when they are created:
* The minimum number of characters is `1`.
* The maximum number of characters is `200`.
* It needs to match a regular expression with the following rules:
  * Can only contains lowercase letters, digits, hyphens or underscores.
  * It must contains at least one lowercase letter or digit.