### PR TITLE
feat: integrate new instruction task in datasets list page

### DIFF
--- a/frontend/components/page-contents/feedback-task-content/CenterFeedbackTask.content.vue
+++ b/frontend/components/page-contents/feedback-task-content/CenterFeedbackTask.content.vue
@@ -248,7 +248,7 @@ export default {
       },
       {
         id: "id_7",
-         name:"nameOfQuestion_id_7",
+        name: "nameOfQuestion_id_7",
         question: "Comment",
         placeholder: "this is the placeholder",
         options: [

--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -830,7 +830,7 @@ const actions = {
           task: "FeedbackTask",
           created_at: feedbackTask.inserted_at,
           last_updated: feedbackTask.updated_at,
-          workspace: feedbackTask.workspace_id,
+          workspace: feedbackTask.id,
           metadata: feedbackTask.metadata ?? {},
           tags: feedbackTask.tags ?? [],
           viewSettings: {},

--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -33,7 +33,7 @@ import {
   isLabelTextExistInGlobalLabel,
   isLabelTextExistInGlobalLabelAndSavedInBack,
 } from "@/models/globalLabel.queries";
-import { getDatasetFromORM, upsertDataset } from "@/models/dataset.utilities";
+import { getDatasetFromORM } from "@/models/dataset.utilities";
 
 const isObject = (obj) => obj && typeof obj === "object";
 
@@ -818,28 +818,9 @@ const actions = {
     /**
      * Fetch all observation datasets from backend
      */
-    const previousDatasets = await ObservationDataset.api().get("/datasets/", {
-      persistBy: "create",
-    });
+    const { data } = await this.$axios.get("/datasets/");
 
-    const feedbackTaskDatasets = await this.$axios.get("v1/datasets");
-    const formattedDatasetsObj = feedbackTaskDatasets.data.map(
-      (feedbackTask) => {
-        return {
-          ...feedbackTask,
-          task: "FeedbackTask",
-          created_at: feedbackTask.inserted_at,
-          last_updated: feedbackTask.updated_at,
-          workspace: feedbackTask.id,
-          metadata: feedbackTask.metadata ?? {},
-          tags: feedbackTask.tags ?? [],
-          viewSettings: {},
-        };
-      }
-    );
-    upsertDataset(formattedDatasetsObj);
-
-    return previousDatasets;
+    return data;
   },
   async fetchByName(_, name) {
     /**

--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -831,8 +831,8 @@ const actions = {
           created_at: feedbackTask.inserted_at,
           last_updated: feedbackTask.updated_at,
           workspace: feedbackTask.workspace_id,
-          metadata: {},
-          tags: [],
+          metadata: feedbackTask.metadata ?? {},
+          tags: feedbackTask.tags ?? [],
           viewSettings: {},
         };
       }

--- a/frontend/database/modules/datasets.js
+++ b/frontend/database/modules/datasets.js
@@ -33,7 +33,7 @@ import {
   isLabelTextExistInGlobalLabel,
   isLabelTextExistInGlobalLabelAndSavedInBack,
 } from "@/models/globalLabel.queries";
-import { getDatasetFromORM } from "@/models/dataset.utilities";
+import { getDatasetFromORM, upsertDataset } from "@/models/dataset.utilities";
 
 const isObject = (obj) => obj && typeof obj === "object";
 
@@ -818,10 +818,28 @@ const actions = {
     /**
      * Fetch all observation datasets from backend
      */
-
-    return await ObservationDataset.api().get("/datasets/", {
+    const previousDatasets = await ObservationDataset.api().get("/datasets/", {
       persistBy: "create",
     });
+
+    const feedbackTaskDatasets = await this.$axios.get("v1/datasets");
+    const formattedDatasetsObj = feedbackTaskDatasets.data.map(
+      (feedbackTask) => {
+        return {
+          ...feedbackTask,
+          task: "FeedbackTask",
+          created_at: feedbackTask.inserted_at,
+          last_updated: feedbackTask.updated_at,
+          workspace: feedbackTask.workspace_id,
+          metadata: {},
+          tags: [],
+          viewSettings: {},
+        };
+      }
+    );
+    upsertDataset(formattedDatasetsObj);
+
+    return previousDatasets;
   },
   async fetchByName(_, name) {
     /**

--- a/frontend/models/dataset.utilities.js
+++ b/frontend/models/dataset.utilities.js
@@ -53,4 +53,8 @@ const getTaskDatasetById = (datasetId, datasetTask, isWithViewSettings) => {
   return datasetById;
 };
 
-export { getDatasetFromORM, getDatasetTaskById };
+const upsertDataset = (datasetObj) => {
+  ObservationDataset.insertOrUpdate({ data: datasetObj });
+};
+
+export { getDatasetFromORM, getDatasetTaskById, upsertDataset };

--- a/frontend/models/feedback-task-model/feedback-dataset/feedbackDataset.queries.js
+++ b/frontend/models/feedback-task-model/feedback-dataset/feedbackDataset.queries.js
@@ -6,6 +6,9 @@ const upsertFeedbackDataset = (feedbackDataset) => {
 };
 
 // GET
+const getAllFeedbackDatasets = () => {
+  return FeedbackDatasetModel.all();
+};
 const getFeedbackDatasetNameById = (datasetId) => {
   return FeedbackDatasetModel.query().whereId(datasetId).first()?.name || null;
 };
@@ -18,6 +21,7 @@ const getFeedbackDatasetWorkspaceNameById = (datasetId) => {
 
 export {
   upsertFeedbackDataset,
+  getAllFeedbackDatasets,
   getFeedbackDatasetNameById,
   getFeedbackDatasetWorkspaceNameById,
 };

--- a/frontend/pages/datasets/index.vue
+++ b/frontend/pages/datasets/index.vue
@@ -189,6 +189,7 @@ export default {
       });
     },
     formattedFeedbackTaskDatasets() {
+      // TODO - when workspace object will be include in the API call, replace line197 by the workspace
       return getAllFeedbackDatasets().map((dataset) => {
         return {
           ...dataset,
@@ -232,8 +233,6 @@ export default {
       return _tags;
     },
     workspace() {
-      // THIS IS WRONG !!!
-      this.$route.query.workspace;
       return currentWorkspace(this.$route);
     },
   },

--- a/frontend/pages/datasets/index.vue
+++ b/frontend/pages/datasets/index.vue
@@ -228,11 +228,25 @@ export default {
       }
     },
     datasetWorkspace(dataset) {
-      var workspace = dataset.workspace;
+      const { name, workspace, task } = dataset;
+      let datasetWorkspace = workspace;
       if (workspace === null || workspace === "null") {
-        workspace = this.workspace;
+        datasetWorkspace = this.workspace;
       }
-      return `/datasets/${workspace}/${dataset.name}`;
+      const feedbackTaskPath = {
+        name: "dataset-id-annotation-mode",
+        params: {
+          id: datasetWorkspace,
+        },
+      };
+      const path = {
+        name: "datasets-workspace-dataset",
+        params: {
+          dataset: name,
+          workspace: datasetWorkspace,
+        },
+      };
+      return task === "FeedbackTask" ? feedbackTaskPath : path;
     },
     onActionClicked(action, dataset) {
       switch (action) {

--- a/frontend/pages/datasets/index.vue
+++ b/frontend/pages/datasets/index.vue
@@ -152,7 +152,7 @@ export default {
 
     // UPSERT all kinds of dataset (Text2Text, TextClassification, TokenClassification AND FeedbackDataset) into the old orm
     upsertDataset([...oldDatasets, ...formattedFeedbackDatasetsObj]);
-    
+
     // UPSERT FeedbackDataset into the new orm for this task
     upsertFeedbackDataset(feedbackTaskDatasets);
   },


### PR DESCRIPTION
# Description
Integrate feedback task into dataset list


Closes #2719 

**Type of change**
- [x] call new api to get feedback task list
- [x] format and inject feedback task object into old dataset table
- [x] go to the new page for Feedback task if the dataset have a "FeedbackTask" type 


(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [x] datasets list => now we can see dataset with "FeedbackTask" type
- [x] on click to a feedback task dataset, user will be redirect to /dataset/{datasetId}/annotation-mode
- [x] on click to a previous dataset, user will be redirect to the previous page of dataset regarding the type of tthe dataset

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)