### PR TITLE
Ignore errors on index creation

### DIFF
--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import logging
 from uuid import UUID
 
 from argilla.server.elasticsearch import ElasticSearchEngine
@@ -27,6 +28,8 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 LIST_RECORDS_LIMIT = 20
+
+_LOGGER = logging.getLogger("argilla.server")
 
 
 def get_dataset_by_id(db: Session, dataset_id: UUID):
@@ -62,21 +65,18 @@ async def publish_dataset(db: Session, search_engine: ElasticSearchEngine, datas
     if _count_annotations_by_dataset_id(db, dataset.id) == 0:
         raise ValueError("Dataset cannot be published without annotations")
 
-    try:
-        dataset.status = DatasetStatus.ready
-        # TODO: This statement is failing in dev. I will uncomment once I resolve the problem
-        # await search_engine.create_index(dataset)
-        # TODO: DB rollback is executed if some problem is found creating the index. If the error
-        #  is raised from the commit statement, index creation should be reverted
-        #  We need a way to commit the dataset status before creating the index, and rollback the status
-        #  if something went wrong with index creation
-        db.commit()
-        db.refresh(dataset)
+    dataset.status = DatasetStatus.ready
+    db.commit()
+    db.refresh(dataset)
 
-        return dataset
-    except:
-        db.rollback()
-        raise
+    try:
+        # TODO: search engine operations won't raise errors for now.
+        #  In a next step, this action must be required to fully publish the dataset
+        await search_engine.create_index(dataset)
+    except Exception as ex:
+        _LOGGER.error(f"Search index cannot be created: {ex}")
+
+    return dataset
 
 
 def delete_dataset(db: Session, dataset: Dataset):

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -968,8 +968,7 @@ def test_create_dataset_records_with_nonexistent_dataset_id(client: TestClient, 
     assert db.query(Response).count() == 0
 
 
-# @pytest.mark.skipif(condition=not is_running_elasticsearch(), reason="Test only running with elasticsearch backend")
-@pytest.mark.skip(reason="Review index creation in DEV")
+@pytest.mark.skipif(condition=not is_running_elasticsearch(), reason="Test only running with elasticsearch backend")
 def test_publish_dataset(
     client: TestClient,
     db: Session,
@@ -990,8 +989,7 @@ def test_publish_dataset(
     assert elasticsearch.indices.exists(index=f"rg.{dataset.id}")
 
 
-# @pytest.mark.skipif(condition=not is_running_elasticsearch(), reason="Test only running with elasticsearch backend")
-@pytest.mark.skip(reason="Review index creation in DEV")
+@pytest.mark.skipif(condition=not is_running_elasticsearch(), reason="Test only running with elasticsearch backend")
 def test_publish_dataset_with_error_on_index_creation(
     client: TestClient,
     db: Session,
@@ -1003,8 +1001,8 @@ def test_publish_dataset_with_error_on_index_creation(
 
     response = client.put(f"/api/v1/datasets/{dataset.id}/publish", headers=admin_auth_header)
 
-    assert response.status_code == 422
-    assert db.get(Dataset, dataset.id).status == "draft"
+    assert response.status_code == 200
+    assert db.get(Dataset, dataset.id).status == "ready"
 
     assert not elasticsearch.indices.exists(index=f"rg.{dataset.id}")
 


### PR DESCRIPTION
This PR changes the default behavior when publishing a draft dataset, and is a temporal solution. When the search index creation raises some error, the dataset will be published and a warning will be logged into the server errors.

Once we have compatibility with our dev environments (some of them using OpenSearch) we can proceed to change this behavior.