### PR TITLE
Add new include query param to list dataset records so responses can be optionally included

### DIFF
--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -16,7 +16,6 @@ from typing import List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Security, status
-from pydantic import parse_obj_as
 from sqlalchemy.orm import Session
 
 from argilla.server.contexts import datasets
@@ -104,7 +103,7 @@ def list_dataset_records(
         )
 
     return Records(
-        items=[parse_obj_as(Record, record.__dict__) for record in records],
+        items=[record.__dict__ for record in records],
         total=datasets.count_records_by_dataset_id(db, dataset_id),
     )
 

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -12,10 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import List
+from typing import List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Security, status
+from pydantic import parse_obj_as
 from sqlalchemy.orm import Session
 
 from argilla.server.contexts import datasets
@@ -27,6 +28,8 @@ from argilla.server.schemas.v1.datasets import (
     AnnotationCreate,
     Dataset,
     DatasetCreate,
+    Record,
+    RecordInclude,
     Records,
     RecordsCreate,
 )
@@ -78,11 +81,12 @@ def list_dataset_annotations(
     return dataset.annotations
 
 
-@router.get("/datasets/{dataset_id}/records", response_model=Records)
+@router.get("/datasets/{dataset_id}/records", response_model=Records, response_model_exclude_unset=True)
 def list_dataset_records(
     *,
     db: Session = Depends(get_db),
     dataset_id: UUID,
+    include: Optional[List[RecordInclude]] = Query([]),
     offset: int = 0,
     limit: int = Query(default=LIST_DATASET_RECORDS_LIMIT_DEFAULT, lte=LIST_DATASET_RECORDS_LIMIT_LTE),
     current_user: User = Security(auth.get_current_user),
@@ -91,8 +95,16 @@ def list_dataset_records(
 
     authorize(current_user, DatasetPolicyV1.get(dataset))
 
+    records = []
+    if current_user.is_admin:
+        records = datasets.list_records_by_dataset_id(db, dataset_id, include=include, offset=offset, limit=limit)
+    else:
+        records = datasets.list_records_by_dataset_id_and_user_id(
+            db, dataset_id, current_user.id, include=include, offset=offset, limit=limit
+        )
+
     return Records(
-        items=datasets.list_records_by_dataset_id(db, dataset_id, offset=offset, limit=limit),
+        items=[parse_obj_as(Record, record.__dict__) for record in records],
         total=datasets.count_records_by_dataset_id(db, dataset_id),
     )
 

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 from datetime import datetime
+from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
@@ -103,10 +104,15 @@ class Response(BaseModel):
         orm_mode = True
 
 
+class RecordInclude(str, Enum):
+    responses = "responses"
+
+
 class Record(BaseModel):
     id: UUID
     fields: Dict[str, Any]
     external_id: Optional[str]
+    responses: Optional[List[Response]]
     inserted_at: datetime
     updated_at: datetime
 


### PR DESCRIPTION
# Description

This PR adds an optional `includes` parameter that can have the `responses` value to include record responses in the listing.

An example of request is the following:

`GET` `/api/datasets/{dataset_id}/records?include=responses`

Notes:
* When an admin is using the `include=responses` query parameter listed records will include all the responses from all users.
* When an annotator is using the `include=responses` query parameter listed records will include only the responses for the annotator doing the request. (the `responses` field will only include one element as maximum).
* When `include=responses` is not used the `responses` field is not present on the record object.