### PR TITLE
Add dataset fields

### DIFF
--- a/src/argilla/server/alembic/versions/ae5522b4c674_create_fields_table.py
+++ b/src/argilla/server/alembic/versions/ae5522b4c674_create_fields_table.py
@@ -1,0 +1,49 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""create fields table
+
+Revision ID: ae5522b4c674
+Revises: e402e9d9245e
+Create Date: 2023-04-21 16:10:27.320399
+
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.sql import expression
+
+# revision identifiers, used by Alembic.
+revision = "ae5522b4c674"
+down_revision = "e402e9d9245e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "fields",
+        sa.Column("id", sa.Uuid, primary_key=True),
+        sa.Column("name", sa.String, nullable=False, index=True),
+        sa.Column("title", sa.Text, nullable=False),
+        sa.Column("required", sa.Boolean, nullable=False, server_default=expression.false()),
+        sa.Column("settings", sa.JSON, nullable=False),
+        sa.Column("dataset_id", sa.Uuid, sa.ForeignKey("datasets.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column("inserted_at", sa.DateTime, nullable=False),
+        sa.Column("updated_at", sa.DateTime, nullable=False),
+        sa.UniqueConstraint("name", "dataset_id", name="field_name_dataset_id_uq"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("fields")

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -29,6 +29,7 @@ from argilla.server.schemas.v1.datasets import (
     Dataset,
     DatasetCreate,
     Datasets,
+    Fields,
     RecordInclude,
     Records,
     RecordsCreate,
@@ -65,6 +66,20 @@ def list_datasets(
         return Datasets(items=datasets.list_datasets(db))
     else:
         return Datasets(items=current_user.datasets)
+
+
+@router.get("/datasets/{dataset_id}/fields", response_model=Fields)
+def list_dataset_fields(
+    *,
+    db: Session = Depends(get_db),
+    dataset_id: UUID,
+    current_user: User = Security(auth.get_current_user),
+):
+    dataset = _get_dataset(db, dataset_id)
+
+    authorize(current_user, DatasetPolicyV1.get(dataset))
+
+    return Fields(items=dataset.fields)
 
 
 @router.get("/datasets/{dataset_id}/annotations", response_model=Annotations)

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -34,6 +34,10 @@ def default_inserted_at(context):
     return context.get_current_parameters()["inserted_at"]
 
 
+class FieldType(str, Enum):
+    text = "text"
+
+
 class AnnotationType(str, Enum):
     text = "text"
     rating = "rating"
@@ -47,6 +51,29 @@ class DatasetStatus(str, Enum):
 class UserRole(str, Enum):
     admin = "admin"
     annotator = "annotator"
+
+
+class Field(Base):
+    __tablename__ = "fields"
+
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    name: Mapped[str]
+    title: Mapped[str] = mapped_column(Text)
+    required: Mapped[bool] = mapped_column(default=False)
+    settings: Mapped[dict] = mapped_column(JSON, default={})
+    dataset_id: Mapped[UUID] = mapped_column(ForeignKey("datasets.id"))
+
+    inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
+
+    dataset: Mapped["Dataset"] = relationship(back_populates="fields")
+
+    def __repr__(self):
+        return (
+            f"Field(id={str(self.id)!r}, name={self.name!r}, required={self.required!r}, "
+            f"dataset_id={str(self.dataset_id)!r}, "
+            f"inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+        )
 
 
 class Annotation(Base):
@@ -127,6 +154,7 @@ class Dataset(Base):
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
     workspace: Mapped["Workspace"] = relationship(back_populates="datasets")
+    fields: Mapped[List["Field"]] = relationship(back_populates="dataset", order_by=Field.inserted_at.asc())
     annotations: Mapped[List["Annotation"]] = relationship(
         back_populates="dataset", order_by=Annotation.inserted_at.asc()
     )

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -17,10 +17,11 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
-from pydantic import BaseModel, Field, conlist, constr
+from pydantic import BaseModel, conlist, constr
+from pydantic import Field as ModelField
 from typing_extensions import Literal
 
-from argilla.server.models import AnnotationType, DatasetStatus
+from argilla.server.models import AnnotationType, DatasetStatus, FieldType
 
 ANNOTATION_CREATE_NAME_REGEX = r"^(?=.*[a-z0-9])[a-z0-9_-]+$"
 
@@ -57,6 +58,27 @@ class DatasetCreate(BaseModel):
     workspace_id: UUID
 
 
+class TextFieldSettings(BaseModel):
+    type: Literal[FieldType.text]
+
+
+class Field(BaseModel):
+    id: UUID
+    name: str
+    title: str
+    required: bool
+    settings: TextFieldSettings
+    inserted_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class Fields(BaseModel):
+    items: List[Field]
+
+
 class TextAnnotationSettings(BaseModel):
     type: Literal[AnnotationType.text]
 
@@ -79,7 +101,7 @@ class Annotation(BaseModel):
     name: str
     title: str
     required: bool
-    settings: Union[TextAnnotationSettings, RatingAnnotationSettings] = Field(..., discriminator="type")
+    settings: Union[TextAnnotationSettings, RatingAnnotationSettings] = ModelField(..., discriminator="type")
     inserted_at: datetime
     updated_at: datetime
 
@@ -99,7 +121,7 @@ class AnnotationCreate(BaseModel):
     )
     title: str
     required: Optional[bool]
-    settings: Union[TextAnnotationSettings, RatingAnnotationSettings] = Field(..., discriminator="type")
+    settings: Union[TextAnnotationSettings, RatingAnnotationSettings] = ModelField(..., discriminator="type")
 
 
 class Response(BaseModel):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -18,6 +18,8 @@ from argilla.server.models import (
     Annotation,
     AnnotationType,
     Dataset,
+    Field,
+    FieldType,
     Record,
     Response,
     User,
@@ -102,6 +104,21 @@ class ResponseFactory(factory.alchemy.SQLAlchemyModelFactory):
     }
     record = factory.SubFactory(RecordFactory)
     user = factory.SubFactory(UserFactory)
+
+
+class FieldFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        model = Field
+        sqlalchemy_session = Session
+        sqlalchemy_session_persistence = "commit"
+
+    name = factory.Sequence(lambda n: f"field-{n}")
+    title = "Field Title"
+    dataset = factory.SubFactory(DatasetFactory)
+
+
+class TextFieldFactory(FieldFactory):
+    settings = {"type": FieldType.text.value}
 
 
 class AnnotationFactory(factory.alchemy.SQLAlchemyModelFactory):

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -46,6 +46,7 @@ from tests.factories import (
     RecordFactory,
     ResponseFactory,
     TextAnnotationFactory,
+    TextFieldFactory,
     WorkspaceFactory,
 )
 
@@ -111,6 +112,83 @@ def test_list_datasets_as_annotator(client: TestClient, db: Session):
 
     response_body = response.json()
     assert [dataset["name"] for dataset in response_body["items"]] == ["dataset-a", "dataset-b"]
+
+
+def test_list_dataset_fields(client: TestClient, db: Session, admin_auth_header: dict):
+    dataset = DatasetFactory.create()
+    text_field_a = TextFieldFactory.create(name="text-field-a", title="Text Field A", required=True, dataset=dataset)
+    text_field_b = TextFieldFactory.create(name="text-field-b", title="Text Field B", dataset=dataset)
+
+    other_dataset = DatasetFactory.create()
+    TextFieldFactory.create_batch(size=2, dataset=other_dataset)
+
+    response = client.get(f"/api/v1/datasets/{dataset.id}/fields", headers=admin_auth_header)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "items": [
+            {
+                "id": str(text_field_a.id),
+                "name": "text-field-a",
+                "title": "Text Field A",
+                "required": True,
+                "settings": {"type": "text"},
+                "inserted_at": text_field_a.inserted_at.isoformat(),
+                "updated_at": text_field_a.updated_at.isoformat(),
+            },
+            {
+                "id": str(text_field_b.id),
+                "name": "text-field-b",
+                "title": "Text Field B",
+                "required": False,
+                "settings": {"type": "text"},
+                "inserted_at": text_field_b.inserted_at.isoformat(),
+                "updated_at": text_field_b.updated_at.isoformat(),
+            },
+        ],
+    }
+
+
+def test_list_dataset_fields_without_authentication(client: TestClient, db: Session):
+    dataset = DatasetFactory.create()
+
+    response = client.get(f"/api/v1/datasets/{dataset.id}/fields")
+
+    assert response.status_code == 401
+
+
+def test_list_dataset_fields_as_annotator(client: TestClient, db: Session):
+    dataset = DatasetFactory.create()
+    annotator = AnnotatorFactory.create(workspaces=[dataset.workspace])
+    TextFieldFactory.create(name="text-field-a", dataset=dataset)
+    TextFieldFactory.create(name="text-field-b", dataset=dataset)
+
+    other_dataset = DatasetFactory.create()
+    TextFieldFactory.create_batch(size=2, dataset=other_dataset)
+
+    response = client.get(f"/api/v1/datasets/{dataset.id}/fields", headers={API_KEY_HEADER_NAME: annotator.api_key})
+
+    assert response.status_code == 200
+
+    response_body = response.json()
+    assert [field["name"] for field in response_body["items"]] == ["text-field-a", "text-field-b"]
+
+
+def test_list_dataset_fields_as_annotator_from_different_workspace(client: TestClient, db: Session):
+    dataset = DatasetFactory.create()
+    annotator = AnnotatorFactory.create(workspaces=[WorkspaceFactory.build()])
+
+    response = client.get(f"/api/v1/datasets/{dataset.id}/fields", headers={API_KEY_HEADER_NAME: annotator.api_key})
+
+    assert response.status_code == 403
+
+
+def test_list_dataset_fields_with_nonexistent_dataset_id(client: TestClient, db: Session, admin_auth_header: dict):
+    DatasetFactory.create()
+
+    response = client.get(f"/api/v1/datasets/{uuid4()}/fields", headers=admin_auth_header)
+
+    assert response.status_code == 404
 
 
 def test_list_dataset_annotations(client: TestClient, db: Session, admin_auth_header: dict):


### PR DESCRIPTION
# Description

This PR adds the following changes:
* Add a new database migration creating `fields` table.
* Add a SQLAlchemy `Field` model.
* Add a first endpoint to list fields for a specific dataset `GET /api/v1/datasets/{dataset_id}/fields`

Notes:
* I have finally used `fields` instead of `field_settings` because the naming started to feel strange when creating things like Pydantic schemas. I'm open to suggestions for changing it.
* I didn't add an `Union` for `settings` on `Field` schema. It's because right now it only has one type that is `text`. We can add the `Union` and discriminator once that we have more than one type of field.

Closes #2750
