### PR TITLE
feat: add v1 enpoint to set `Response` status

### DIFF
--- a/src/argilla/server/alembic/versions/e402e9d9245e_create_responses_table.py
+++ b/src/argilla/server/alembic/versions/e402e9d9245e_create_responses_table.py
@@ -36,6 +36,7 @@ def upgrade() -> None:
         sa.Column("values", sa.JSON, nullable=False),
         sa.Column("record_id", sa.Uuid, sa.ForeignKey("records.id", ondelete="CASCADE"), nullable=False, index=True),
         sa.Column("user_id", sa.Uuid, sa.ForeignKey("users.id", ondelete="SET NULL"), index=True),
+        sa.Column("status", sa.String, nullable=False, index=True),
         sa.Column("inserted_at", sa.DateTime, nullable=False),
         sa.Column("updated_at", sa.DateTime, nullable=False),
         sa.UniqueConstraint("record_id", "user_id", name="response_record_id_user_id_uq"),

--- a/src/argilla/server/apis/v1/handlers/responses.py
+++ b/src/argilla/server/apis/v1/handlers/responses.py
@@ -21,7 +21,11 @@ from argilla.server.contexts import datasets
 from argilla.server.database import get_db
 from argilla.server.models import User
 from argilla.server.policies import ResponsePolicyV1, authorize
-from argilla.server.schemas.v1.responses import Response, ResponseUpdate
+from argilla.server.schemas.v1.responses import (
+    Response,
+    ResponseStatusUpdate,
+    ResponseUpdate,
+)
 from argilla.server.security import auth
 
 router = APIRouter(tags=["responses"])
@@ -51,6 +55,21 @@ def update_response(
     authorize(current_user, ResponsePolicyV1.update(response))
 
     return datasets.update_response(db, response, response_update)
+
+
+@router.put("/responses/{response_id}/status", response_model=Response)
+def update_response_status(
+    *,
+    db: Session = Depends(get_db),
+    response_id: UUID,
+    response_status_update: ResponseStatusUpdate,
+    current_user: User = Security(auth.get_current_user),
+):
+    response = _get_response(db, response_id)
+
+    authorize(current_user, ResponsePolicyV1.update(response))
+
+    return datasets.update_response_status(db, response, response_status_update)
 
 
 @router.delete("/responses/{response_id}", response_model=Response)

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -24,7 +24,7 @@ from argilla.server.schemas.v1.datasets import (
     RecordsCreate,
 )
 from argilla.server.schemas.v1.records import ResponseCreate
-from argilla.server.schemas.v1.responses import ResponseUpdate
+from argilla.server.schemas.v1.responses import ResponseStatusUpdate, ResponseUpdate
 from argilla.server.security.model import User
 from sqlalchemy import and_, func
 from sqlalchemy.orm import Session, contains_eager, joinedload
@@ -223,6 +223,15 @@ def create_response(db: Session, record: Record, user: User, response_create: Re
 
 def update_response(db: Session, response: Response, response_update: ResponseUpdate):
     response.values = response_update.values
+
+    db.commit()
+    db.refresh(response)
+
+    return response
+
+
+def update_response_status(db: Session, response: Response, response_status_update: ResponseStatusUpdate):
+    response.status = response_status_update.status
 
     db.commit()
     db.refresh(response)

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -49,6 +49,12 @@ class UserRole(str, Enum):
     annotator = "annotator"
 
 
+class ResponseStatus(str, Enum):
+    pending = "pending"
+    submitted = "submitted"
+    discarded = "discarded"
+
+
 class Annotation(Base):
     __tablename__ = "annotations"
 
@@ -79,6 +85,7 @@ class Response(Base):
     values: Mapped[dict] = mapped_column(JSON)
     record_id: Mapped[UUID] = mapped_column(ForeignKey("records.id"))
     user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"))
+    status: Mapped[ResponseStatus] = mapped_column(default=ResponseStatus.pending, index=True, nullable=False)
 
     inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
@@ -89,7 +96,7 @@ class Response(Base):
     def __repr__(self):
         return (
             f"Response(id={str(self.id)!r}, record_id={str(self.record_id)!r}, user_id={str(self.user_id)!r}, "
-            f"inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+            f"status={self.status!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
         )
 
 

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -123,7 +123,7 @@ class Response(Base):
     def __repr__(self):
         return (
             f"Response(id={str(self.id)!r}, record_id={str(self.record_id)!r}, user_id={str(self.user_id)!r}, "
-            f"status={self.status!r}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
+            f"status={self.status}, inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
         )
 
 

--- a/src/argilla/server/schemas/v1/responses.py
+++ b/src/argilla/server/schemas/v1/responses.py
@@ -18,12 +18,15 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
+from argilla.server.models import ResponseStatus
+
 
 class Response(BaseModel):
     id: UUID
     values: Dict[str, Any]
     record_id: UUID
     user_id: UUID
+    status: ResponseStatus
     inserted_at: datetime
     updated_at: datetime
 
@@ -33,3 +36,7 @@ class Response(BaseModel):
 
 class ResponseUpdate(BaseModel):
     values: Dict[str, Any]
+
+
+class ResponseStatusUpdate(BaseModel):
+    status: ResponseStatus

--- a/tests/server/api/v1/test_responses.py
+++ b/tests/server/api/v1/test_responses.py
@@ -225,6 +225,16 @@ def test_update_response_status_with_nonexistent_response_id(client: TestClient,
     assert resp.status_code == 404
 
 
+def test_update_response_status_with_invalid_status(client: TestClient, db: Session, admin_auth_header: dict):
+    response = ResponseFactory.create()
+    response_json = {"status": "invalid"}
+
+    resp = client.put(f"/api/v1/responses/{response.id}/status", headers=admin_auth_header, json=response_json)
+
+    assert resp.status_code == 422
+    assert db.get(Response, response.id).status == "pending"
+
+
 def test_delete_response(client: TestClient, db: Session, admin_auth_header: dict):
     response = ResponseFactory.create()
 


### PR DESCRIPTION
# Description

I've added a new endpoint `PUT /api/v1/responses/{response_id}/status` that allows setting the status of a `Response`.
 
To do so, I've added a new column to the `Response` model/table called `status`, which right now has 3 possible values: `pending` (which is the default value), `submitted`, and `discarded`. I've also updated the `alembic` migrations files to include this new column, which is not `nullable` (it will have a default value always), and also an `index` will be created for it, as I suppose that we would like to filter by it and having an index will allow querying using a filter on this column faster.

Regarding the endpoint definition, I've decided to just add a new `PUT` endpoint to update the `status` of the `Response` instead of using the `PUT /v1/response/{response_id}` endpoint, because I think:

1. It makes the API's intent more explicit and easier to understand.
2. It has better separation of concerns as we can more easily optimize and scale this specific operation independently from the update response operation. Also, if in the future is needed to do something after status has been set, it will be easier this way than having an if condition in the update response endpoint that checks if the status has been updated, and if so then do something specific for when the status has changed.

As an alternative to this new endpoint, we could have:

1. Created two endpoints (`PUT /api/v1/responses/{response_id}/submit` and `PUT /api/v1/responses/{response_id}/discard`), one for submitting and one for discarding, but I think this is not a good idea, because if a new possible status is introduced, then a new endpoint has to be created and maintained. The logic of both endpoints will be exactly the same, so we would have two endpoints almost identical. Also, this approach would require the client to send a PUT request to a different endpoint depending on the status, and this can make the API harder to use.
2.  Create one endpoint very similar to the one implemented but passing the status via URL path `PUT /api/v1/responses/{response_id}/status/{status}`. This approach has the inconvenience that the client would have to send a PUT request to a different endpoint each time the status has to be changed.

Closes #2733 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

- I've added unit tests for all the possible scenarios when calling this endpoint.

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)