### PR TITLE
Add a new APIv1 endpoint to create dataset fields

### DIFF
--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -72,6 +72,9 @@ async def publish_dataset(db: Session, search_engine: ElasticSearchEngine, datas
     if dataset.is_ready:
         raise ValueError("Dataset is already published")
 
+    if _count_fields_by_dataset_id(db, dataset.id) == 0:
+        raise ValueError("Dataset cannot be published without fields")
+
     if _count_annotations_by_dataset_id(db, dataset.id) == 0:
         raise ValueError("Dataset cannot be published without annotations")
 
@@ -266,6 +269,10 @@ def delete_response(db: Session, response: Response):
     db.commit()
 
     return response
+
+
+def _count_fields_by_dataset_id(db: Session, dataset_id: UUID):
+    return db.query(func.count(Field.id)).filter_by(dataset_id=dataset_id).scalar()
 
 
 def _count_annotations_by_dataset_id(db: Session, dataset_id: UUID):

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -152,6 +152,10 @@ class DatasetPolicyV1:
         return actor.is_admin
 
     @classmethod
+    def create_field(cls, actor: User) -> bool:
+        return actor.is_admin
+
+    @classmethod
     def create_annotation(cls, actor: User) -> bool:
         return actor.is_admin
 

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -23,8 +23,11 @@ from typing_extensions import Literal
 
 from argilla.server.models import AnnotationType, DatasetStatus, FieldType
 
-ANNOTATION_CREATE_NAME_REGEX = r"^(?=.*[a-z0-9])[a-z0-9_-]+$"
+FIELD_CREATE_NAME_REGEX = r"^(?=.*[a-z0-9])[a-z0-9_-]+$"
+FIELD_CREATE_NAME_MIN_LENGTH = 1
+FIELD_CREATE_NAME_MAX_LENGTH = 200
 
+ANNOTATION_CREATE_NAME_REGEX = r"^(?=.*[a-z0-9])[a-z0-9_-]+$"
 ANNOTATION_CREATE_NAME_MIN_LENGTH = 1
 ANNOTATION_CREATE_NAME_MAX_LENGTH = 200
 
@@ -77,6 +80,17 @@ class Field(BaseModel):
 
 class Fields(BaseModel):
     items: List[Field]
+
+
+class FieldCreate(BaseModel):
+    name: constr(
+        regex=FIELD_CREATE_NAME_REGEX,
+        min_length=FIELD_CREATE_NAME_MIN_LENGTH,
+        max_length=FIELD_CREATE_NAME_MAX_LENGTH,
+    )
+    title: str
+    required: Optional[bool]
+    settings: TextFieldSettings
 
 
 class TextAnnotationSettings(BaseModel):


### PR DESCRIPTION
# Description

This PR add changes to allow the creation of fields for a dataset. These fields will modelate how are the valid content of record fields accepted for this dataset.

The endpoint is the following:
* `POST` `/api/v1/datasets/{dataset_id}/fields`

Notes:
* I didn't make any change related with ElasticSearch indexing. It's something that we need to do in a different issue.

Closes #2768