### PR TITLE
Fix image alignment on token classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ These are the section headers that we use:
 
 - add `max_retries` and `num_threads` parameters to `rg.log` to run data logging request concurrently with backoff retry policy. See [#2458](https://github.com/argilla-io/argilla/issues/2458) and [#2533](https://github.com/argilla-io/argilla/issues/2533)
 - `rg.load` accepts `exclude_vectors` and `exclude_metrics` when loading data. Closes [#2398](https://github.com/argilla-io/argilla/issues/2398)
+
+### Fixes
+
 - fix image alignment on token classification
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ These are the section headers that we use:
 
 - add `max_retries` and `num_threads` parameters to `rg.log` to run data logging request concurrently with backoff retry policy. See [#2458](https://github.com/argilla-io/argilla/issues/2458) and [#2533](https://github.com/argilla-io/argilla/issues/2533)
 - `rg.load` accepts `exclude_vectors` and `exclude_metrics` when loading data. Closes [#2398](https://github.com/argilla-io/argilla/issues/2398)
+- fix image alignment on token classification
 
 ### Changed
 

--- a/frontend/components/token-classifier/results/RecordTokenClassification.vue
+++ b/frontend/components/token-classifier/results/RecordTokenClassification.vue
@@ -17,10 +17,10 @@
 
 <template>
   <div class="record">
+    <div class="record--image-area" v-if="isRecordContainsImage">
+      <img :src="metadata._image_url" alt="image of the record" />
+    </div>
     <div class="content">
-      <div class="record--image-area" v-if="isRecordContainsImage">
-        <img :src="metadata._image_url" alt="image of the record" />
-      </div>
       <div class="origins">
         <text-spans-static
           v-if="record.prediction"


### PR DESCRIPTION
# Description

The new `metadata._image_url` feature to show images was a bit misaligned for token classification. The pred highlight were showing on top of the image. text classification seems to be fine.

Before (using argilla/argilla-server:v1.6.0):
![image](https://user-images.githubusercontent.com/15624271/234341992-e8ff4c19-abcb-4f02-b860-35d0c1c41b08.png)

After (with the fix):
<img width="638" alt="image" src="https://user-images.githubusercontent.com/15624271/234342040-5e9453bb-d7de-49b5-b4c1-8abfcd43bae0.png">

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
Visually with the below code:
```python
label_map={
    "A" : "location",
    "B" : "organization",
    "C" : "building",
    "D" : "vegetable"
}
labels=list(label_map.keys())
label_map_reverse={label_map[k]:k for k in label_map.keys()}
record = rg.TokenClassificationRecord(
                text='A'*len(label_map_reverse.keys()),
                tokens=["A" for ent in label_map_reverse.keys()],
                prediction=[(ent, i, i+1) for i,ent in enumerate(label_map_reverse.keys())],
                prediction_agent="fake",
                annotation=[(ent, i, i+1) for i,ent in enumerate(label_map_reverse.keys())],
                annotation_agent="fake",
                metadata= { 
                    "_image_url":"https://argilla.io/og.png",
                },
                # status='Validated', #‘Default’, ‘Edited’, ‘Discarded’, ‘Validated’
                id=0
            )
rg.log(records=record, name="test_image")
```

**Checklist**

- [ ] I have merged the original branch into my forked branch
- [x] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)