### PR TITLE
Fix `log_batch` return type-hint

### DIFF
--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -357,7 +357,7 @@ class Argilla:
                 max_tries=max_retries,
                 backoff_log_level=logging.DEBUG,
             )
-            def log_batch(batch_info: Tuple[int, list]) -> Union[Tuple[int, int]]:
+            def log_batch(batch_info: Tuple[int, list]) -> Tuple[int, int]:
                 batch_id, batch = batch_info
 
                 bulk_result = bulk(


### PR DESCRIPTION
# Description

`Union` was not required, since the function just returns a `Tuple` or an exception, not `None`.

**Type of change**

- [X] Minor fix

**How Has This Been Tested**

Didn't run any, since it doesn't introduce any functional change, just a type-hint fix, that just affects static type-checking (e.g. `mypy`).

**Checklist**

- [ ] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)