### PR TITLE
Fix delete datasets with cascade deletion

### DIFF
--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -155,9 +155,15 @@ class Dataset(Base):
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
     workspace: Mapped["Workspace"] = relationship(back_populates="datasets")
-    fields: Mapped[List["Field"]] = relationship(back_populates="dataset", order_by=Field.inserted_at.asc())
-    questions: Mapped[List["Question"]] = relationship(back_populates="dataset", order_by=Question.inserted_at.asc())
-    records: Mapped[List["Record"]] = relationship(back_populates="dataset", order_by=Record.inserted_at.asc())
+    fields: Mapped[List["Field"]] = relationship(
+        back_populates="dataset", passive_deletes=True, order_by=Field.inserted_at.asc()
+    )
+    questions: Mapped[List["Question"]] = relationship(
+        back_populates="dataset", passive_deletes=True, order_by=Question.inserted_at.asc()
+    )
+    records: Mapped[List["Record"]] = relationship(
+        back_populates="dataset", passive_deletes=True, order_by=Record.inserted_at.asc()
+    )
 
     @property
     def is_draft(self):

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -1521,18 +1521,29 @@ def test_publish_dataset_with_nonexistent_dataset_id(client: TestClient, db: Ses
     assert db.get(Dataset, dataset.id).status == "draft"
 
 
-def test_delete_dataset(client: TestClient, db: Session, admin_auth_header: dict):
+def test_delete_dataset(client: TestClient, db: Session, admin: User, admin_auth_header: dict):
     dataset = DatasetFactory.create()
     TextFieldFactory.create(dataset=dataset)
     TextQuestionFactory.create(dataset=dataset)
 
+    other_dataset = DatasetFactory.create()
+    other_field = TextFieldFactory.create(dataset=other_dataset)
+    other_question = TextQuestionFactory.create(dataset=other_dataset)
+    other_record = RecordFactory.create(dataset=other_dataset)
+    other_response = ResponseFactory.create(record=other_record, user=admin)
+
     response = client.delete(f"/api/v1/datasets/{dataset.id}", headers=admin_auth_header)
 
     assert response.status_code == 200
-    assert db.query(Dataset).count() == 0
-    assert db.query(Field).count() == 0
-    assert db.query(Question).count() == 0
-    assert db.query(Workspace).count() == 1
+    assert [dataset.id for dataset in db.query(Dataset).all()] == [other_dataset.id]
+    assert [field.id for field in db.query(Field).all()] == [other_field.id]
+    assert [question.id for question in db.query(Question).all()] == [other_question.id]
+    assert [record.id for record in db.query(Record).all()] == [other_record.id]
+    assert [response.id for response in db.query(Response).all()] == [other_response.id]
+    assert [workspace.id for workspace in db.query(Workspace).order_by(Workspace.inserted_at.asc()).all()] == [
+        dataset.workspace_id,
+        other_dataset.workspace_id,
+    ]
 
 
 def test_delete_published_dataset(client: TestClient, db: Session, admin: User, admin_auth_header: dict):
@@ -1542,15 +1553,24 @@ def test_delete_published_dataset(client: TestClient, db: Session, admin: User, 
     record = RecordFactory.create(dataset=dataset)
     ResponseFactory.create(record=record, user=admin)
 
+    other_dataset = DatasetFactory.create()
+    other_field = TextFieldFactory.create(dataset=other_dataset)
+    other_question = TextQuestionFactory.create(dataset=other_dataset)
+    other_record = RecordFactory.create(dataset=other_dataset)
+    other_response = ResponseFactory.create(record=other_record, user=admin)
+
     response = client.delete(f"/api/v1/datasets/{dataset.id}", headers=admin_auth_header)
 
     assert response.status_code == 200
-    assert db.query(Dataset).count() == 0
-    assert db.query(Field).count() == 0
-    assert db.query(Question).count() == 0
-    assert db.query(Record).count() == 0
-    assert db.query(Response).count() == 0
-    assert db.query(Workspace).count() == 1
+    assert [dataset.id for dataset in db.query(Dataset).all()] == [other_dataset.id]
+    assert [field.id for field in db.query(Field).all()] == [other_field.id]
+    assert [question.id for question in db.query(Question).all()] == [other_question.id]
+    assert [record.id for record in db.query(Record).all()] == [other_record.id]
+    assert [response.id for response in db.query(Response).all()] == [other_response.id]
+    assert [workspace.id for workspace in db.query(Workspace).order_by(Workspace.inserted_at.asc()).all()] == [
+        dataset.workspace_id,
+        other_dataset.workspace_id,
+    ]
 
 
 def test_delete_dataset_without_authentication(client: TestClient, db: Session):


### PR DESCRIPTION
# Description

There was a bug on the backend detected by @keithCuniah when a dataset with related questions is deleted giving a database error.

This was caused by SQLAlchemy default behavior trying to delete explicitly relationships rows one by one.

This default behavior can be changed setting `passive_deletes=True` on the defined model relationship. Meaning that the deletion will not be done and it will be managed by the database (if available).
