### PR TITLE
[Docs] Replace labelling with labeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `quickstart.Dockerfile` image default users from `team` and `argilla` to `admin` and `annotator` including new passwords and API keys ([#2564]).
 - Datasets to be managed only by users with `admin` role ([#2564]).
 - The list of rules is now accessible while metrics are computed. Closes[#2117](https://github.com/argilla-io/argilla/issues/2117)
-- Style updates for weak labelling and adding feedback toast when delete rules. See [#2626](https://github.com/argilla-io/argilla/pull/2626) and [#2648](https://github.com/argilla-io/argilla/pull/2648)
+- Style updates for weak labeling and adding feedback toast when delete rules. See [#2626](https://github.com/argilla-io/argilla/pull/2626) and [#2648](https://github.com/argilla-io/argilla/pull/2648)
 
 ### Removed
 

--- a/docs/_source/getting_started/argilla.md
+++ b/docs/_source/getting_started/argilla.md
@@ -14,7 +14,7 @@ Deploy your own Argilla Server on Spaces with a few clicks:
 ```
 
 
-```{admonition} Semantic Search data labelling 🆕
+```{admonition} Semantic Search data labeling 🆕
 :class: important
 
 🆕 Use embeddings to find the most similar records with the UI. This feature uses vector search combined with traditional search (keyword and filter based).
@@ -39,7 +39,7 @@ Get started: [Semantic Search Deep-dive guide](../guides/label_records_with_sema
 
 ## Use cases
 
-* **Data labelling and curation**: collect labels to start a project from scratch or from existing live models.
+* **Data labeling and curation**: collect labels to start a project from scratch or from existing live models.
 * **Model monitoring and observability:** log and observe predictions of live models.
 * **Evaluation**: easily compute "live" metrics from models in production, and slice evaluation datasets to test your system under specific conditions.
 * **Model debugging**: log predictions during the development process to visually spot issues.

--- a/docs/_source/getting_started/installation/deployments/huggingface-spaces.md
+++ b/docs/_source/getting_started/installation/deployments/huggingface-spaces.md
@@ -2,7 +2,7 @@
 
 Argilla nicely integrates with the Hugging Face stack (`datasets`, `transformers`, `hub`, and `setfit`), and now it can also be deployed using the Hub's Spaces.
 
-In this guide, you'll learn to deploy your own Argilla app and use it for data labelling workflows right from the Hub.
+In this guide, you'll learn to deploy your own Argilla app and use it for data labeling workflows right from the Hub.
 
 ## Your first Argilla Space
 
@@ -75,9 +75,9 @@ rg.init(api_url="[your_space_url]", api_key="admin.apikey")
 rg.log(rg.read_datasets(dataset, task="TextClassification"), name="bankingapp_sentiment")
 ```
 
-Congrats! You now have a dataset available from the Argilla UI to start browsing and labelling. In the code above, we've used one of the many integrations with Hugging Face libraries, which let you [read hundreds of datasets](https://docs.argilla.io/en/latest/guides/features/datasets.html#Importing-a-Dataset) available on the Hub.
+Congrats! You now have a dataset available from the Argilla UI to start browsing and labeling. In the code above, we've used one of the many integrations with Hugging Face libraries, which let you [read hundreds of datasets](https://docs.argilla.io/en/latest/guides/features/datasets.html#Importing-a-Dataset) available on the Hub.
 
-### Data labelling and model training
+### Data labeling and model training
 
 At this point, you can label your data directly using your Argilla Space and read the training data to train your model of choice.
 

--- a/docs/_source/guides/how_to.ipynb
+++ b/docs/_source/guides/how_to.ipynb
@@ -931,7 +931,7 @@
    "id": "c2cbd593-e241-4f27-9a58-6932912ea9f1",
    "metadata": {},
    "source": [
-    "### 3. Weak labelling rules"
+    "### 3. Weak labeling rules"
    ]
   },
   {

--- a/docs/_source/guides/label_records_with_semanticsearch.ipynb
+++ b/docs/_source/guides/label_records_with_semanticsearch.ipynb
@@ -557,7 +557,7 @@
     "\n",
     "### Argilla UI\n",
     "\n",
-    "Within the Argilla UI, it is possible to select a record that has an attached vector to start semantic searching by clicking the \"Find similar\" button. After labelling, the \"Remove similar record filter\" button can be pressed to close the specific search and continue with your labeling session.\n",
+    "Within the Argilla UI, it is possible to select a record that has an attached vector to start semantic searching by clicking the \"Find similar\" button. After labeling, the \"Remove similar record filter\" button can be pressed to close the specific search and continue with your labeling session.\n",
     "\n",
     "![Screenshot of Argilla UI](../../_static/reference/webapp/features-similaritysearch.png)\n",
     "\n",

--- a/docs/_source/guides/log_load_and_prepare_data.ipynb
+++ b/docs/_source/guides/log_load_and_prepare_data.ipynb
@@ -152,7 +152,7 @@
     "\n",
     "### Using `rg.log`\n",
     "\n",
-    "For this example we show how to use `rg.log` to create records that will be logged into an existing dataset, with an [existing labelling schema](#define-a-labeling-schema). Note that, this needs to be defined before logging data into a dataset.\n",
+    "For this example we show how to use `rg.log` to create records that will be logged into an existing dataset, with an [existing labeling schema](#define-a-labeling-schema). Note that, this needs to be defined before logging data into a dataset.\n",
     "\n",
     "```python\n",
     "import argilla as rg\n",
@@ -474,7 +474,7 @@
    "source": [
     "### Migrating from old schema\n",
     "\n",
-    "For old Argilla versions, labels created from the UI were not included as part of a labelling schema. Instead, the UI used the dataset metadata index in Elastic Search to store \n",
+    "For old Argilla versions, labels created from the UI were not included as part of a labeling schema. Instead, the UI used the dataset metadata index in Elastic Search to store \n",
     "this information.\n",
     "\n",
     "<div class=\"alert alert-warning\">\n",

--- a/docs/_source/guides/log_model_explanations.md
+++ b/docs/_source/guides/log_model_explanations.md
@@ -47,7 +47,7 @@ It is possible to add a certainty score to each of the logged predictions. Often
 ## Metrics
 The Argilla package gets shipped with build-in metrics for `TextClassification`and `TokenClassification`. These provide insight in model performance, annotation correctness and training impact. For an overview of how to use them, take a look at our [metric](../features/metrics.ipynb) section.
 ### Weak Supervision
-![weak-labelling](../_static/reference/webapp/features-weak-labelling.png "Weak Labelling")
+![weak-labeling](../_static/reference/webapp/features-weak-labelling.png "Weak labeling")
 
 Besides our more general metrics, we also provide the option to keep track of the impact of weak supervision rules. This impact is determined by testing against verified annotated data and unannotated data, which gives you an understanding of how the rules perform in real-life and what percentage of the data is influenced by them.
 <!--

--- a/docs/_source/guides/programmatic_labeling_with_rules.ipynb
+++ b/docs/_source/guides/programmatic_labeling_with_rules.ipynb
@@ -6,7 +6,7 @@
    "id": "020957ce-46fa-4799-8321-716e62900269",
    "metadata": {},
    "source": [
-    "# 👮 Programmatic labelling with rules\n",
+    "# 👮 Programmatic labeling with rules\n",
     "\n",
     "This guide gives you a brief introduction to weak supervision with Argilla.\n",
     "\n",
@@ -25,8 +25,8 @@
     "\n",
     "The recommended workflow for weak supervision is:\n",
     "\n",
-    "- Log an unlabelled dataset into Argilla\n",
-    "- Use the `Annotate` mode for hand- and/or bulk-labelling a validation set. This validation is key to measure the quality and performance of your rules. Additionally, you need to build a test set which is not used for defining rules. This test set will be used to measure the performance of your end model, as with any other supervised model.\n",
+    "- Log an unlabeled dataset into Argilla.\n",
+    "- Use the `Annotate` mode for hand- and/or bulk-labeling a validation set. This validation is key to measure the quality and performance of your rules. Additionally, you need to build a test set which is not used for defining rules. This test set will be used to measure the performance of your end model, as with any other supervised model.\n",
     "- Use the `Define rules` mode for evaluating and defining rules. Rules are defined with search queries (using ES query string DSL). Additionally, you can use the Python client methods to add, delete, or modify rules programmatically, making them available for refinement in the UI.\n",
     "- Use the Python client for reading rules, defining additional rules if needed, and train a label (for building a training set) or a downstream model (for building an end classifier).\n",
     "\n",
@@ -90,7 +90,7 @@
     "\n",
     "1. Defined using the no-code feature of the UI (see the [Define rules mode](../../reference/webapp/pages.html#modes) reference).\n",
     "2. `Rule` objects can be created using Python as shown above. These objects can be either applied locally by developers (which might be interested for testing without overloading the server) or added to the dataset in the Argilla server, making these rules available from the UI. \n",
-    "3. Python functions cannot be defined with the no-code feature and can only be applied locally but not added to the dataset in the Argilla server. Data teams can use these Python labelling functions to add extra heuristics before building a weakly labelled dataset. This functions should be used for heuristics which are not possible to define using ES queries.\n",
+    "3. Python functions cannot be defined with the no-code feature and can only be applied locally but not added to the dataset in the Argilla server. Data teams can use these Python labeling functions to add extra heuristics before building a weakly labelled dataset. This functions should be used for heuristics which are not possible to define using ES queries.\n",
     "\n",
     "\n",
     "\n",
@@ -881,7 +881,7 @@
    "id": "d8d9d3f9",
    "metadata": {},
    "source": [
-    "Lets load the rules again and apply weak labelling"
+    "Lets load the rules again and apply weak labeling"
    ]
   },
   {

--- a/docs/_source/reference/webapp/features.md
+++ b/docs/_source/reference/webapp/features.md
@@ -126,17 +126,17 @@ There you will find the progress of your annotation session, the distribution of
 You can find more information about the metrics in our dedicated [metrics guide](view_dataset_metrics.md).
 
 
-## Weak labelling
+## Weak labeling
 
-![Weak labelling](../../_static/reference/webapp/features-weak-labelling.png)
+![Weak labeling](../../_static/reference/webapp/features-weak-labelling.png)
 
 The Argilla UI has a dedicated mode to find good **heuristic rules**, also often referred to as _labeling functions_, for a [weak supervision](https://www.snorkel.org/blog/weak-supervision) workflow.
 As shown in our [guide](../../guides/weak-supervision.ipynb) and [tutorial](../../tutorials/labelling-textclassification-sentencetransformers-weaksupervision.ipynb), these rules allow you to quickly annotate your data with noisy labels in a semiautomatic way.
 
-You can access the _Weak labelling_ mode via the sidebar of the [Dataset page](dataset.md).
+You can access the _Weak labeling_ mode via the sidebar of the [Dataset page](dataset.md).
 
 ```{note}
-The _Weak labelling_ mode is only available for text classification datasets.
+The _Weak labeling_ mode is only available for text classification datasets.
 ```
 
 ### Query plus labels
@@ -343,7 +343,7 @@ Argilla metrics are very convenient in terms of assesing the status of the datas
 
 ### How to use Metrics
 
-Metrics are composed of two submenus: **Progress** and **Stats**. These submenus might be different for **Token** and **Text Classification** tasks, as well as for the different modes (especially the **Weak labelling mode**).
+Metrics are composed of two submenus: **Progress** and **Stats**. These submenus might be different for **Token** and **Text Classification** tasks, as well as for the different modes (especially the **Weak labeling mode**).
 
 #### Progress
 
@@ -354,7 +354,7 @@ This submenu is useful when users need to know how many records have been annota
 When clicking on this menu, not only the progress is shown. The number of records is also displayed, as well as the number of labeled records or entities that are **validated** or **discarded**.
 
 
-##### Weak labelling mode
+##### Weak labeling mode
 
 In this mode, **progress** is related to the coverage of the rules. It shows the **model coverage** and the **annotated coverage**, and also the **precision average** and the number of correct and incorrect results.
 
@@ -366,7 +366,7 @@ In the **total rules** section, users can find the number of rules related to th
 
 This submenu allows users to know more about the keywords of the dataset.
 
-##### Explore and Weak labelling mode
+##### Explore and Weak labeling mode
 
 In both modes, the **Keywords** list displays a list of relevant words and the number of occurrences.
 

--- a/docs/_source/reference/webapp/pages.md
+++ b/docs/_source/reference/webapp/pages.md
@@ -108,8 +108,8 @@ The right sidebar is divided into three sections.
 
 This section of the sidebar lets you switch between the different Argilla modes that are covered extensively in their respective guides:
 
-- **Hand labelling**: this mode lets you conveniently [annotate your data](./features.md#annotate-records)
-- **Weak labelling**: this mode helps you to [define rules](./features.md#weak-labelling) to automatically label your data (Text Classification only)
+- **Hand labeling**: this mode lets you conveniently [annotate your data](./features.md#annotate-records)
+- **Weak labeling**: this mode helps you to [define rules](./features.md#weak-labeling) to automatically label your data (Text Classification only)
 - **Explore**: this mode is for [exploring your dataset](./features.md#explore-records) and gain valuable insights
 
 

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-gpt3-fewshot.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-gpt3-fewshot.ipynb
@@ -5204,7 +5204,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.12"
   },
   "vscode": {
    "interpreter": {

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-sentence-transformers-semantic.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-sentence-transformers-semantic.ipynb
@@ -7,10 +7,10 @@
    "source": [
     "# 💨 Label data with semantic search and Sentence Transformers\n",
     "\n",
-    "In this tutorial, you'll learn to use Sentence Transformer embeddings and semantic search to make data labelling significantly faster. It will walk you through the following steps:\n",
+    "In this tutorial, you'll learn to use Sentence Transformer embeddings and semantic search to make data labeling significantly faster. It will walk you through the following steps:\n",
     "\n",
     "- 💾 use sentence transformers to generate embeddings of a dataset with banking customer requests\n",
-    "- 🙃 upload the dataset into Argilla for data labelling\n",
+    "- 🙃 upload the dataset into Argilla for data labeling\n",
     "- 🏷 use the similarity search feature to efficiently find an label bulks of semantically-related examples\n",
     "\n",
     "<img src=\"../../_static/tutorials/labelling-textclassification-sentence-transformers-semantic/4.png\" alt=\"Similarity search\" style=\"width: 1100px;\">"
@@ -23,9 +23,9 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "In this tutorial, we'll use the power of embeddings to make data labelling (and curation) more efficient. The idea of exploiting embeddings for labelling is not new, and there are several cool, standalone libraries to label data using embeddings.\n",
+    "In this tutorial, we'll use the power of embeddings to make data labeling (and curation) more efficient. The idea of exploiting embeddings for labeling is not new, and there are several cool, standalone libraries to label data using embeddings.\n",
     "\n",
-    "Since `1.2.0`, Argilla gives you a way to leverage embedding-based similarity together with all other workflows already provided: search-based bulk labelling, programmatic labelling using search queries, model pre-annotation, and human-in-the-loop workflows. This also means you can combine keyword search and filters with this new similarity search feature. All these without any vendor or model lock-in, you can use ANY embedding or encoding method, including but not limited to `Sentence Transformers`, `OpenAI`, or `Co:here`. If you want a deep-dive, you can check the [Semantic similarity deep-dive](../../guides/features/semantic-search.ipynb), but this tutorial will show you the basics to get started. \n",
+    "Since `1.2.0`, Argilla gives you a way to leverage embedding-based similarity together with all other workflows already provided: search-based bulk labeling, programmatic labeling using search queries, model pre-annotation, and human-in-the-loop workflows. This also means you can combine keyword search and filters with this new similarity search feature. All these without any vendor or model lock-in, you can use ANY embedding or encoding method, including but not limited to `Sentence Transformers`, `OpenAI`, or `Co:here`. If you want a deep-dive, you can check the [Semantic similarity deep-dive](../../guides/features/semantic-search.ipynb), but this tutorial will show you the basics to get started. \n",
     "\n",
     "Let's do it!"
    ]
@@ -148,7 +148,7 @@
    "source": [
     "## 💾 Downloading and embedding your dataset\n",
     "\n",
-    "The code below will load the banking customer requests dataset from the Hub, encode the `text` field, and create the `vectors` field which will contain only one key (`mini-lm-sentence-transformers`). For the purposes of labelling the dataset from scratch, it will also remove the `label` field, which contains original intent labels."
+    "The code below will load the banking customer requests dataset from the Hub, encode the `text` field, and create the `vectors` field which will contain only one key (`mini-lm-sentence-transformers`). For the purposes of labeling the dataset from scratch, it will also remove the `label` field, which contains original intent labels."
    ]
   },
   {
@@ -170,7 +170,7 @@
     "    batched=True\n",
     ")\n",
     "\n",
-    "# Removes the original labels because you'll be labelling from scratch\n",
+    "# Removes the original labels because you'll be labeling from scratch\n",
     "dataset = dataset.remove_columns(\"label\")\n",
     "\n",
     "# Turn vectors into a dictionary\n",
@@ -279,7 +279,7 @@
    "source": [
     "## 🙃 Upload dataset into Argilla\n",
     "\n",
-    "The original `banking77` dataset is a intent classification dataset with dozens of labels (`lost_card`, `card_arrival`, etc.). To keep this tutorial simple, we define a simplified labelling scheme with higher level classes: `[\"change_details\", \"card\", \"atm\", \"top_up\", \"balance\", \"transfer\", \"exchange_rate\", \"pin\"]`.\n",
+    "The original `banking77` dataset is a intent classification dataset with dozens of labels (`lost_card`, `card_arrival`, etc.). To keep this tutorial simple, we define a simplified labeling scheme with higher level classes: `[\"change_details\", \"card\", \"atm\", \"top_up\", \"balance\", \"transfer\", \"exchange_rate\", \"pin\"]`.\n",
     "\n",
     "Let's define the dataset settings, configure the dataset, and upload our dataset with vectors."
    ]
@@ -292,7 +292,7 @@
    "source": [
     "rg_ds = rg.DatasetForTextClassification.from_datasets(dataset)\n",
     "\n",
-    "# Our labelling scheme\n",
+    "# Our labeling scheme\n",
     "settings = rg.TextClassificationSettings(\n",
     "    label_schema=[\"change_details\", \"card\", \"atm\", \"top_up\", \"balance\", \"transfer\", \"exchange_rate\", \"pin\"]\n",
     ")\n",
@@ -311,7 +311,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 🏷 Bulk labelling with the `find similar` action\n",
+    "## 🏷 Bulk labeling with the `find similar` action\n",
     "\n",
     "Now that our `banking77-topics` is available from the Argilla UI. We can start annotating our data leveraging semantic similarity search. The workflow is following:\n",
     "\n",
@@ -324,9 +324,9 @@
     "\n",
     "\n",
     "### Label a record\n",
-    "Using the hand-labelling mode, you can label a record like the one below:\n",
+    "Using the hand-labeling mode, you can label a record like the one below:\n",
     "\n",
-    "![labelling-textclassification-sentence-transformers-semantic](../../_static/tutorials/labelling-textclassification-sentence-transformers-semantic/6.png)\n",
+    "![labeling-textclassification-sentence-transformers-semantic](../../_static/tutorials/labelling-textclassification-sentence-transformers-semantic/6.png)\n",
     "\n",
     "Now if you want to find semantically similar or even duplicates of this record you can use the Find similar button. \n",
     "\n",
@@ -342,19 +342,19 @@
     "    \n",
     "</div>\n",
     "\n",
-    "![labelling-textclassification-sentence-transformers-semantic](../../_static/tutorials/labelling-textclassification-sentence-transformers-semantic/4.png)\n",
+    "![labeling-textclassification-sentence-transformers-semantic](../../_static/tutorials/labelling-textclassification-sentence-transformers-semantic/4.png)\n",
     "\n",
     "As you can see the model is effectively capturing similar meaning without the need of explicit shared words: e.g., `details` vs `information`.\n",
     "\n",
     "### Review records\n",
-    "At this point, you can label the records one by one or scroll-down to review them before using the bulk-labelling button on the top of the records list.\n",
+    "At this point, you can label the records one by one or scroll-down to review them before using the bulk-labeling button on the top of the records list.\n",
     "\n",
     "\n",
-    "![labelling-textclassification-sentence-transformers-semantic](../../_static/tutorials/labelling-textclassification-sentence-transformers-semantic/3.png)\n",
+    "![labeling-textclassification-sentence-transformers-semantic](../../_static/tutorials/labelling-textclassification-sentence-transformers-semantic/3.png)\n",
     "\n",
     "### Bulk label\n",
     "\n",
-    "For this tutorial, our labels are sufficiently fine-grained for the embeddings to group records that fall under the same topic. So in this case, it is safe to use the bulk labelling feature directly, effectively labelling 50 semantically-similar examples after a quick revision.\n",
+    "For this tutorial, our labels are sufficiently fine-grained for the embeddings to group records that fall under the same topic. So in this case, it is safe to use the bulk labeling feature directly, effectively labeling 50 semantically-similar examples after a quick revision.\n",
     "\n",
     "<div class=\"alert alert-warning\">\n",
     "\n",
@@ -363,9 +363,9 @@
     "For other use cases, you might need to be more careful and combine this feature with search queries and filters. For quick experimentation, you can also assume you'll make some labelling errors and then use tools like `cleanlab` for detecting label errors.\n",
     "</div>\n",
     "\n",
-    "![labelling-textclassification-sentence-transformers-semantic](../../_static/tutorials/labelling-textclassification-sentence-transformers-semantic/2.png)\n",
+    "![labeling-textclassification-sentence-transformers-semantic](../../_static/tutorials/labelling-textclassification-sentence-transformers-semantic/2.png)\n",
     "\n",
-    "![labelling-textclassification-sentence-transformers-semantic](../../_static/tutorials/labelling-textclassification-sentence-transformers-semantic/1.png)\n",
+    "![labeling-textclassification-sentence-transformers-semantic](../../_static/tutorials/labelling-textclassification-sentence-transformers-semantic/1.png)\n",
     "\n",
     "\n",
     "\n",
@@ -379,7 +379,7 @@
    "source": [
     "## Summary\n",
     "\n",
-    "In this tutorial, you learned to use similarity search for data labelling with Argilla by using Sentence Transformers to embed your raw data."
+    "In this tutorial, you learned to use similarity search for data labeling with Argilla by using Sentence Transformers to embed your raw data."
    ]
   }
  ],

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-sentencetransformers-semantic.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-sentencetransformers-semantic.ipynb
@@ -7,14 +7,14 @@
         "id": "5PwXNf1WNYm4"
       },
       "source": [
-        "# 📸 Bulk Labelling Multimodal Data\n",
+        "# 📸 Bulk Labeling Multimodal Data\n",
         "\n",
         "\n",
         "In this tutorial, we will work with multimodal data of images and text. It will walk you through the following steps:\n",
         "\n",
         "- Load a dataset with images and text of electronic products.\n",
         "- Experiment with zero shot image and text classification.\n",
-        "- Label the data using the bulk labelling with image and text embeddings.\n",
+        "- Label the data using the bulk labeling with image and text embeddings.\n",
         "- Train a SetFit classification model on the labelled data.\n",
         "\n",
         "<img src=\"../../_static/tutorials/labelling-textclassification-sentencetransformers-semantic/argilla_image_cables.png\" alt=\"Argilla with images tutorial\" style=\"width: 1100px;\">\n"
@@ -653,7 +653,7 @@
         "id": "s_ecJF0ZNYnI"
       },
       "source": [
-        "## Consolidate data labelling\n",
+        "## Consolidate data labeling\n",
         "\n",
         "The above scores from two zero shot classification approaches reveal that the task is possible but challenging using a zero shot approach. \n",
         "\n",
@@ -667,7 +667,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "## Bulk Labelling with embeddings\n"
+        "## Bulk Labeling with embeddings\n"
       ]
     },
     {

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-sentencetransformers-weaksupervision.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-sentencetransformers-weaksupervision.ipynb
@@ -31,6 +31,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "442d9748",
    "metadata": {
@@ -39,11 +40,11 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "Labelling functions normally have high precision, but low coverage. Only records that strictly match the conditions determined by a given function will be labelled, while other potential candidates will be left out. \n",
+    "Labeling functions normally have high precision, but low coverage. Only records that strictly match the conditions determined by a given function will be labelled, while other potential candidates will be left out. \n",
     "\n",
-    "Building on [the findings of the Hazy Research group](https://github.com/HazyResearch/epoxy), we present a way to solve this problem by extending the weak labels produced by our labelling functions with sentence embeddings. \n",
+    "Building on [the findings of the Hazy Research group](https://github.com/HazyResearch/epoxy), we present a way to solve this problem by extending the weak labels produced by our labeling functions with sentence embeddings. \n",
     "\n",
-    "We extend the coverage of our labelling functions by giving unlabelled records the same label as their nearest labelled neighbor in the embedding space if the cosine similarity between them scores above a certain threshold.    \n",
+    "We extend the coverage of our labeling functions by giving unlabelled records the same label as their nearest labelled neighbor in the embedding space if the cosine similarity between them scores above a certain threshold.    \n",
     "\n",
     "We will show in this tutorial that, by adjusting these similarity thresholds and selecting proper sentence embeddings, we are able to significantly improve the accuracy of the downstream classifiers produced by our weak supervision workflows."
    ]

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-setfit-zeroshot.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-setfit-zeroshot.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "Xmp2vWHTXywC"
@@ -8,7 +9,7 @@
    "source": [
     "# 🔫 Zero-shot and few-shot classification with SetFit\n",
     "\n",
-    "In this tutorial, you'll learn to use Sentence Transformer embeddings and SetFit's zero-shot and few-shot capabilities to make data labelling significantly faster. It will walk you through the following steps:\n",
+    "In this tutorial, you'll learn to use Sentence Transformer embeddings and SetFit's zero-shot and few-shot capabilities to make data labeling significantly faster. It will walk you through the following steps:\n",
     "\n",
     "- 💾 Use sentence transformers to generate embeddings of a dataset with banking customer requests.\n",
     "- 🔫 Use SetFit's zero-shot classifier and upload its predictions together with the embeddings.\n",
@@ -20,6 +21,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "-H8DStnBXywE"
@@ -27,7 +29,7 @@
    "source": [
     "## Introduction\n",
     "\n",
-    "In this tutorial, we'll use the power of embeddings to make data labelling (and curation) more efficient. Combined with SetFit's zero and few-shot capabilities, this approach will greatly reduce the time to get a good quality model with your own data.\n",
+    "In this tutorial, we'll use the power of embeddings to make data labeling (and curation) more efficient. Combined with SetFit's zero and few-shot capabilities, this approach will greatly reduce the time to get a good quality model with your own data.\n",
     "\n",
     "\n",
     "Let's do it!"
@@ -163,6 +165,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "hTGCAUyxXywQ"
@@ -170,7 +173,7 @@
    "source": [
     "## 💾 Embedding your dataset\n",
     "\n",
-    "The code below will load the [banking customer requests dataset](https://huggingface.co/datasets/banking77) from the Hub, encode the `text` field, and create the `vectors` field which will contain only one key (`mini-lm-sentence-transformers`). For the purposes of labelling the dataset from scratch, it will also remove the `label` field, which contains the original intent labels."
+    "The code below will load the [banking customer requests dataset](https://huggingface.co/datasets/banking77) from the Hub, encode the `text` field, and create the `vectors` field which will contain only one key (`mini-lm-sentence-transformers`). For the purposes of labeling the dataset from scratch, it will also remove the `label` field, which contains the original intent labels."
    ]
   },
   {
@@ -194,7 +197,7 @@
     "    batched=True\n",
     ")\n",
     "\n",
-    "# Removes the original labels because you'll be labelling from scratch\n",
+    "# Removes the original labels because you'll be labeling from scratch\n",
     "dataset = dataset.remove_columns(\"label\")\n",
     "\n",
     "# Turn vectors into a dictionary\n",
@@ -384,6 +387,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "0-_YRm_GhaDT"
@@ -391,7 +395,7 @@
    "source": [
     "## 🔫 Zero-shot predictions with SetFit\n",
     "\n",
-    "The original `banking77` dataset is an intent classification dataset with dozens of labels (`lost_card`, `card_arrival`, etc.). To keep this tutorial simple, we define a simplified labelling scheme with higher level classes.\n",
+    "The original `banking77` dataset is an intent classification dataset with dozens of labels (`lost_card`, `card_arrival`, etc.). To keep this tutorial simple, we define a simplified labeling scheme with higher level classes.\n",
     "\n",
     "\n",
     "Let's set up and train our zero-shot SetFit model. Please note that SetFit's approach to zero-shot is to create a synthetic dataset of training examples, which is different from other approaches (e.g., transformers zero-shot pipelines) where \"templated\" examples with label names are used at inference time."
@@ -421,12 +425,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "Sp3oSMi9snkp"
    },
    "source": [
-    "We can use our trained zero-shot model to predict over the dataset. We'll later load these predictions into Argilla and use them to speed-up the labelling process."
+    "We can use our trained zero-shot model to predict over the dataset. We'll later load these predictions into Argilla and use them to speed-up the labeling process."
    ]
   },
   {
@@ -473,12 +478,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "Y-e_l9dtXywV"
    },
    "source": [
-    "## 🏷 Bulk labelling with the `find similar` and zero-shot predictions\n",
+    "## 🏷 Bulk labeling with the `find similar` and zero-shot predictions\n",
     "Now that our `banking77-topics-setfit` is available from the Argilla UI. You can start annotating the data by leveraging similarity search and our zero-shot predictions. After going to your Argilla UI URL, the workflow is following:\n",
     "\n",
     "1. Label a record (e.g., label \"Change my information\" as `change details`) and then click on Find similar on the top-right of your record.\n",
@@ -486,10 +492,11 @@
     "3. You can now review the predictions, validate them, or correct them.\n",
     "\n",
     "\n",
-    "After labelling around 200 records, we're ready to evaluate our zero-shot model, let's see how! "
+    "After labeling around 200 records, we're ready to evaluate our zero-shot model, let's see how! "
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "668C81adsaLK"
@@ -497,7 +504,7 @@
    "source": [
     "## 📏 Evaluate the zero-shot model\n",
     "\n",
-    "We can use Argilla's built-in metrics to compute `f1` based on (1) the predictions of the zero-shot model we stored at the beginning of the tutorial, and (2) the manual annotations. Please note that during the labelling process, we've added a new label `Other` to account for examples that didn't fall into our predefined categories. This highlights the importance of iterating early on during project definition. Argilla gives users a lot of flexibility, features like predictions and similarity search can help to surface potential issues and refinements much faster than with traditional data annotation tools. "
+    "We can use Argilla's built-in metrics to compute `f1` based on (1) the predictions of the zero-shot model we stored at the beginning of the tutorial, and (2) the manual annotations. Please note that during the labeling process, we've added a new label `Other` to account for examples that didn't fall into our predefined categories. This highlights the importance of iterating early on during project definition. Argilla gives users a lot of flexibility, features like predictions and similarity search can help to surface potential issues and refinements much faster than with traditional data annotation tools. "
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-sklearn-weaksupervision.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-sklearn-weaksupervision.ipynb
@@ -2441,12 +2441,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1a95ac66-480b-4bf2-b35c-e548df16a084",
    "metadata": {},
    "source": [
     "After uploading the dataset, we can explore and inspect it to find good heuristic rules.\n",
-    "For this we highly recommend the dedicated [*Define rules* mode](../../reference/webapp/features.html#weak-labelling) of the Argilla web app, that allows you to quickly iterate over heuristic rules, compute their metrics and save them.\n",
+    "For this we highly recommend the dedicated [*Define rules* mode](../../reference/webapp/features.html#weak-labeling) of the Argilla web app, that allows you to quickly iterate over heuristic rules, compute their metrics and save them.\n",
     "\n",
     "Here we copy our rules found via the web app to the notebook for you to easily follow along the tutorial."
    ]

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-snorkel-weaksupervision.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-snorkel-weaksupervision.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "The following diagram shows the overall process for using Weak supervision with Argilla:\n",
     "\n",
-    "![labelling-textclassification-snorkel-weaksupervision](../../_static/tutorials/labelling-textclassification-snorkel-weaksupervision/labelling-textclassification-snorkel-weaksupervision.png)"
+    "![labeling-textclassification-snorkel-weaksupervision](../../_static/tutorials/labelling-textclassification-snorkel-weaksupervision/labelling-textclassification-snorkel-weaksupervision.png)"
    ]
   },
   {
@@ -379,11 +379,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "62724abf",
    "metadata": {},
    "source": [
-    "Rules can be defined and managed (1) using the UI, and (2) using the Python client. We will add some rules with the Python Client that will be available in the UI where we can start our interactive weak labelling."
+    "Rules can be defined and managed (1) using the UI, and (2) using the Python client. We will add some rules with the Python Client that will be available in the UI where we can start our interactive weak labeling."
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/labelling-tokenclassification-basics.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-tokenclassification-basics.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "2. we can split our dataset into different datasets that have the records assigned to each user and log them in their personal workspaces.\n",
     "\n",
-    "You may want to use option 1 if you want to keep the whole dataset available to see and explore for every team member but still you want them to focus on a set of records when they annotate. This can be interesting if your annotators will also make weak labelling rules based on the annotations of the whole team.\n",
+    "You may want to use option 1 if you want to keep the whole dataset available to see and explore for every team member but still you want them to focus on a set of records when they annotate. This can be interesting if your annotators will also make weak labeling rules based on the annotations of the whole team.\n",
     "\n",
     "Option 2 is better if you want each team member to work independently and not see the records that other teammates are working on. This can be interesting if you want to measure annotator agreement afterwards.\n",
     "\n",

--- a/docs/_source/tutorials/notebooks/labelling-tokenclassification-skweak-weaksupervision.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-tokenclassification-skweak-weaksupervision.ipynb
@@ -388,11 +388,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1ba8dec6",
    "metadata": {},
    "source": [
-    "Heuristic rules in `skweak` are applied through labelling functions. Each of these functions must yield the start and end index of the annotated [span](https://spacy.io/api/span) followed by its assigned label. "
+    "Heuristic rules in `skweak` are applied through labeling functions. Each of these functions must yield the start and end index of the annotated [span](https://spacy.io/api/span) followed by its assigned label. "
    ]
   },
   {
@@ -463,13 +464,14 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "973742e2",
    "metadata": {},
    "source": [
-    "Let's encapsulate our heuristic rules as labelling functions. \n",
+    "Let's encapsulate our heuristic rules as labeling functions. \n",
     "\n",
-    "Labelling functions are defined as [FunctionAnnotator](https://github.com/NorskRegnesentral/skweak/wiki/Step-1:-Labelling-functions#heuristicsfunctionannotator) objects, and multiple functions can be grouped inside a single [CombinedAnnotator](https://github.com/NorskRegnesentral/skweak/wiki/Step-1:-Labelling-functions#applying-labelling-functions)."
+    "Labeling functions are defined as [FunctionAnnotator](https://github.com/NorskRegnesentral/skweak/wiki/Step-1:-Labelling-functions#heuristicsfunctionannotator) objects, and multiple functions can be grouped inside a single [CombinedAnnotator](https://github.com/NorskRegnesentral/skweak/wiki/Step-1:-Labelling-functions#applying-labelling-functions)."
    ]
   },
   {
@@ -706,15 +708,16 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9f8c5df7",
    "metadata": {},
    "source": [
     "### Logging to Argilla   \n",
     "\n",
-    "After defining our labelling functions, it's time to effectively annotate our documents.    \n",
+    "After defining our labeling functions, it's time to effectively annotate our documents.    \n",
     "\n",
-    "First we annotate the development set with gold labels, and add the weak labels of our labelling functions."
+    "First we annotate the development set with gold labels, and add the weak labels of our labeling functions."
    ]
   },
   {
@@ -741,14 +744,15 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e0e76b13-8b24-4eed-afde-e36ade6dd2e6",
    "metadata": {},
    "source": [
-    "Then we will log records to Argilla, for which any of the labelling functions triggered a weak label, or for which we have a gold annotation. \n",
-    "In this way we will be able to quickly visualize any bugs or missing edge cases which may not yet be covered by our labelling functions. \n",
+    "Then we will log records to Argilla, for which any of the labeling functions triggered a weak label, or for which we have a gold annotation. \n",
+    "In this way we will be able to quickly visualize any bugs or missing edge cases which may not yet be covered by our labeling functions. \n",
     "\n",
-    "We also add a metadata `doc_index` that will allow us to group distinct labelling functions for the same document."
+    "We also add a metadata `doc_index` that will allow us to group distinct labeling functions for the same document."
    ]
   },
   {
@@ -775,7 +779,7 @@
     "            else:\n",
     "                predictions[labelling_function] = unroll_spans(span_list)\n",
     "\n",
-    "        # add records for each labelling function, if they made a prediction\n",
+    "        # add records for each labeling function, if they made a prediction\n",
     "        for agent, prediction in predictions.items():\n",
     "            if prediction:\n",
     "                yield rg.TokenClassificationRecord(\n",
@@ -787,7 +791,7 @@
     "                    metadata={\"doc_index\": idx},\n",
     "                )\n",
     "\n",
-    "        # add records with annotations, for which no labelling function triggered\n",
+    "        # add records with annotations, for which no labeling function triggered\n",
     "        if not any(predictions.values()) and annotations:\n",
     "            yield rg.TokenClassificationRecord(\n",
     "                text=\" \".join(tokens),\n",
@@ -1057,6 +1061,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a95d3b8a",
    "metadata": {},
@@ -1067,7 +1072,7 @@
     "\n",
     "After carefully considering which rules are appropriate for our dataset, we will annotate the training data and then aggregate our annotations into a single layer. \n",
     "\n",
-    "`skweak` includes an aggregation model called **majority voter**. It considers each labelling function as a voter and outputs the most frequent label. We will utilize this majority voter to produce a single set of annotations for our documents, and then we will log the results to Argilla.\n",
+    "`skweak` includes an aggregation model called **majority voter**. It considers each labeling function as a voter and outputs the most frequent label. We will utilize this majority voter to produce a single set of annotations for our documents, and then we will log the results to Argilla.\n",
     "\n",
     "The majority voter is particularly useful when annotating for multiple labels, as in this case the annotations produced by the heuristic rules may not only overlap and but also conflict with each other. However, as we are annotating only for the `ORG` label, we won't need the majority voter to resolve any conflicts: it will simply merge the labels from each annotator into the `maj_voter` field."
    ]
@@ -1110,11 +1115,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "cdd6a6ef",
    "metadata": {},
    "source": [
-    "Although here we are using the majority voter in a rather simple way to vote for a single `ORG` label, it is possible to attribute weights to the vote of each labelling function and even define complex hierarchies between labels. These details are explained in the majority voter [documentation](https://github.com/NorskRegnesentral/skweak/wiki/Step-2:-Aggregation) and [code](https://github.com/NorskRegnesentral/skweak/blob/de888c26d7faaa7fe15746f2aed5e574685bbfad/skweak/aggregation.py#L193) on the skweak repository."
+    "Although here we are using the majority voter in a rather simple way to vote for a single `ORG` label, it is possible to attribute weights to the vote of each labeling function and even define complex hierarchies between labels. These details are explained in the majority voter [documentation](https://github.com/NorskRegnesentral/skweak/wiki/Step-2:-Aggregation) and [code](https://github.com/NorskRegnesentral/skweak/blob/de888c26d7faaa7fe15746f2aed5e574685bbfad/skweak/aggregation.py#L193) on the skweak repository."
    ]
   },
   {
@@ -1293,27 +1299,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001B[38;5;4mℹ Saving to output directory: /tmp/model\u001B[0m\n",
-      "\u001B[38;5;4mℹ Using CPU\u001B[0m\n",
-      "\u001B[1m\n",
-      "=========================== Initializing pipeline ===========================\u001B[0m\n",
+      "\u001b[38;5;4mℹ Saving to output directory: /tmp/model\u001b[0m\n",
+      "\u001b[38;5;4mℹ Using CPU\u001b[0m\n",
+      "\u001b[1m\n",
+      "=========================== Initializing pipeline ===========================\u001b[0m\n",
       "[2022-01-27 12:38:58,091] [INFO] Set up nlp object from config\n",
       "[2022-01-27 12:38:58,102] [INFO] Pipeline: ['tok2vec', 'ner']\n",
       "[2022-01-27 12:38:58,107] [INFO] Created vocabulary\n",
       "[2022-01-27 12:38:59,423] [INFO] Added vectors: en_core_web_lg\n",
       "[2022-01-27 12:39:00,729] [INFO] Finished initializing nlp object\n",
       "[2022-01-27 12:39:23,582] [INFO] Initialized pipeline components: ['tok2vec', 'ner']\n",
-      "\u001B[38;5;2m✔ Initialized pipeline\u001B[0m\n",
-      "\u001B[1m\n",
-      "============================= Training pipeline =============================\u001B[0m\n",
-      "\u001B[38;5;4mℹ Pipeline: ['tok2vec', 'ner']\u001B[0m\n",
-      "\u001B[38;5;4mℹ Initial learn rate: 0.001\u001B[0m\n",
+      "\u001b[38;5;2m✔ Initialized pipeline\u001b[0m\n",
+      "\u001b[1m\n",
+      "============================= Training pipeline =============================\u001b[0m\n",
+      "\u001b[38;5;4mℹ Pipeline: ['tok2vec', 'ner']\u001b[0m\n",
+      "\u001b[38;5;4mℹ Initial learn rate: 0.001\u001b[0m\n",
       "E    #       LOSS TOK2VEC  LOSS NER  ENTS_F  ENTS_P  ENTS_R  SCORE \n",
       "---  ------  ------------  --------  ------  ------  ------  ------\n",
       "  0       0          0.00     39.17    2.97    2.26    4.33    0.03\n",
       "  0     200         69.40   1239.88   36.93   91.72   23.12    0.37\n",
       "  1     400         15.18    280.61   43.67   78.79   30.20    0.44\n",
-      "\u001B[38;5;2m✔ Saved pipeline to output directory\u001B[0m\n",
+      "\u001b[38;5;2m✔ Saved pipeline to output directory\u001b[0m\n",
       "/tmp/model/model-last\n"
      ]
     }

--- a/docs/_source/tutorials/notebooks/training-textclassification-setfit-fewshot.ipynb
+++ b/docs/_source/tutorials/notebooks/training-textclassification-setfit-fewshot.ipynb
@@ -169,11 +169,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "574c9c3c-c841-43da-b5f0-16947cb261a4",
    "metadata": {},
    "source": [
-    "## Manual labelling\n",
+    "## Manual labeling\n",
     "\n",
     "In this step, we create the labels `pos` and `neg` using the same label scheme as the original dataset. Then we use the UI to sequentially label a few examples. For the example, we spent literally 15 minutes."
    ]

--- a/docs/_source/tutorials/notebooks/training-textclassification-setfit-sentiment.ipynb
+++ b/docs/_source/tutorials/notebooks/training-textclassification-setfit-sentiment.ipynb
@@ -345,11 +345,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4950ad03-68ca-4b4b-9a8c-681aa39d3761",
    "metadata": {},
    "source": [
-    "## 2. Hand labelling\n",
+    "## 2. Hand labeling\n",
     "\n",
     "In this step, you can use Argilla UI to label a few examples (e.g., 50 examples).\n",
     "\n",

--- a/docs/_source/tutorials/notebooks/training-textclassification-transformers-pretrained.ipynb
+++ b/docs/_source/tutorials/notebooks/training-textclassification-transformers-pretrained.ipynb
@@ -856,7 +856,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.7.12"
   },
   "vscode": {
    "interpreter": {

--- a/docs/_source/tutorials/steps/1_labelling.md
+++ b/docs/_source/tutorials/steps/1_labelling.md
@@ -1,4 +1,4 @@
-## 🏷 Labelling
+## 🏷 Labeling
 
 ````{grid} 1 1 2 2
 :class-container: tuto-section-2 tuto-list


### PR DESCRIPTION
Closes #2803

# Description

I've replaced `labelling` (2 L's) with `labeling` throughout the documentation. Note that there are still *many* occurrences of `labelling` (2 L's) as many files are named with 2 L's. If we edit these, old links from outside of Argilla pointing to Argilla docs will stop working.
As a result, I left these for now. Perhaps that's something for 2.0? @nataliaElv 

I tried to be careful to not introduce any breaking links.

**Type of change**

- [x] Documentation update

**How Has This Been Tested**

N\A

**Checklist**

- [x] I have merged the original branch into my forked branch
- [x] I added relevant documentation
- [x] follows the style guidelines of this project
- ~I did a self-review of my code~
- [x] I made corresponding changes to the documentation
- ~My changes generate no new warnings~
- ~I have added tests that prove my fix is effective or that my feature works~
- ~I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)~

---

- Tom Aarsen