### PR TITLE
feat : navigate with shortcut feedback task

### DIFF
--- a/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
+++ b/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
@@ -59,6 +59,7 @@
           <span v-text="'Reset'" />
         </BaseButton>
         <BaseButton
+          ref="submitButton"
           type="submit"
           class="primary small"
           :disabled="isFormUntouched || isError"
@@ -113,12 +114,6 @@ export default {
       isError: false,
     };
   },
-  created() {
-    this.COMPONENT_TYPE = COMPONENT_TYPE;
-    this.formOnErrorMessage =
-      "One of the required field is not answered. Please, answer before validate";
-    this.onReset();
-  },
   computed: {
     userId() {
       return this.$auth.user.id;
@@ -127,7 +122,33 @@ export default {
       return isEqual(this.initialInputs, this.inputs);
     },
   },
+  created() {
+    this.COMPONENT_TYPE = COMPONENT_TYPE;
+    this.formOnErrorMessage =
+      "One of the required field is not answered. Please, answer before validate";
+    this.onReset();
+
+    document.addEventListener("keydown", this.onPressKeyboardShortCut);
+  },
+  destroyed() {
+    document.removeEventListener("keydown", this.onPressKeyboardShortCut);
+  },
   methods: {
+    onPressKeyboardShortCut({ code }) {
+      switch (code) {
+        case "Enter": {
+          const elem = this.$refs.submitButton.$el;
+          elem.click();
+          break;
+        }
+        case "Delete": {
+          console.log("onDiscard");
+          // TODO - when DISCARD feature will be implemented, add a ref in the discard button force a click
+          break;
+        }
+        default:
+      }
+    },
     onChange({ newOptions, idComponent }) {
       this.inputs = this.inputs.map((input) => {
         if (input.id === idComponent) {

--- a/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
+++ b/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
@@ -127,7 +127,8 @@ export default {
     this.formOnErrorMessage =
       "One of the required field is not answered. Please, answer before validate";
     this.onReset();
-
+  },
+  mounted() {
     document.addEventListener("keydown", this.onPressKeyboardShortCut);
   },
   destroyed() {

--- a/frontend/components/feedback-task/footer/Pagination.component.vue
+++ b/frontend/components/feedback-task/footer/Pagination.component.vue
@@ -83,8 +83,26 @@ export default {
   },
   mounted() {
     this.currentPage = parseFloat(this.$route.query?._page) || 1;
+
+    document.addEventListener("keydown", this.onPressKeyboardShortCut);
+  },
+  destroyed() {
+    document.removeEventListener("keydown", this.onPressKeyboardShortCut);
   },
   methods: {
+    onPressKeyboardShortCut({ code }) {
+      switch (code) {
+        case "ArrowRight": {
+          this.onClickNext();
+          break;
+        }
+        case "ArrowLeft": {
+          this.onClickPrev();
+          break;
+        }
+        default:
+      }
+    },
     onClickPrev() {
       this.currentPage > 1 && this.currentPage--;
     },

--- a/frontend/components/text2text/results/Text2TextContentEditable.vue
+++ b/frontend/components/text2text/results/Text2TextContentEditable.vue
@@ -4,6 +4,7 @@
       <transition appear name="fade">
         <p
           ref="text"
+          id="contentId"
           class="content__text"
           :class="textIsEdited ? '--edited-text' : null"
           :contenteditable="annotationEnabled"
@@ -12,7 +13,12 @@
           v-html="editableText"
           @focus="setFocus(true)"
           @blur="setFocus(false)"
-        ></p>
+          @keydown.shift.exact="looseFocus"
+          @keydown.arrow-right.stop=""
+          @keydown.arrow-left.stop=""
+          @keydown.delete.stop=""
+          @keydown.enter.stop=""
+        />
       </transition>
       <span v-if="isShortcutToSave"><strong>shift Enter</strong> to save</span>
     </div>
@@ -62,11 +68,14 @@ export default {
     window.addEventListener("keydown", this.keyDown);
     window.addEventListener("keyup", this.keyUp);
     window.addEventListener("paste", this.pastePlainText);
+
     if (this.defaultText) {
       this.editableText = this.defaultText;
     } else {
       this.editableText = this.text;
     }
+    
+    this.textAreaWrapper = document.getElementById("contentId");
   },
   destroyed() {
     window.removeEventListener("keydown", this.keyDown);
@@ -74,6 +83,9 @@ export default {
     window.removeEventListener("paste", this.pastePlainText);
   },
   methods: {
+    looseFocus() {
+      this.textAreaWrapper.blur();
+    },
     onInputText(event) {
       this.$emit("change-text", event.target.innerText);
     },

--- a/frontend/components/text2text/results/Text2TextContentEditable.vue
+++ b/frontend/components/text2text/results/Text2TextContentEditable.vue
@@ -16,8 +16,8 @@
           @keydown.shift.enter.exact="looseFocus"
           @keydown.arrow-right.stop=""
           @keydown.arrow-left.stop=""
-          @keydown.delete.stop=""
-          @keydown.enter.stop=""
+          @keydown.delete.exact.stop=""
+          @keydown.enter.exact.stop=""
         />
       </transition>
       <span v-if="isShortcutToSave"><strong>shift Enter</strong> to save</span>

--- a/frontend/components/text2text/results/Text2TextContentEditable.vue
+++ b/frontend/components/text2text/results/Text2TextContentEditable.vue
@@ -14,6 +14,7 @@
           @focus="setFocus(true)"
           @blur="setFocus(false)"
           @keydown.shift.enter.exact="looseFocus"
+          @keydown.shift.delete.exact="looseFocus"
           @keydown.arrow-right.stop=""
           @keydown.arrow-left.stop=""
           @keydown.delete.exact.stop=""

--- a/frontend/components/text2text/results/Text2TextContentEditable.vue
+++ b/frontend/components/text2text/results/Text2TextContentEditable.vue
@@ -13,7 +13,7 @@
           v-html="editableText"
           @focus="setFocus(true)"
           @blur="setFocus(false)"
-          @keydown.shift.exact="looseFocus"
+          @keydown.shift.enter.exact="looseFocus"
           @keydown.arrow-right.stop=""
           @keydown.arrow-left.stop=""
           @keydown.delete.stop=""
@@ -74,7 +74,7 @@ export default {
     } else {
       this.editableText = this.text;
     }
-    
+
     this.textAreaWrapper = document.getElementById("contentId");
   },
   destroyed() {

--- a/frontend/pages/dataset/_id/annotation-mode/index.vue
+++ b/frontend/pages/dataset/_id/annotation-mode/index.vue
@@ -76,7 +76,7 @@ export default {
       // TODO - remove step 2 when workspace name will be include in the getDatasetInfo API call
       // 2- fetch workspace info
       const workspace = await this.getWorkspaceInfo(dataset.workspace_id);
-      console.log(workspace);
+
       // 3- insert in ORM
       upsertFeedbackDataset({ ...dataset, workspace_name: workspace });
     } catch (err) {


### PR DESCRIPTION
# Description
Add shortcuts to actions : 
- **enter** to **submit**
- **suppr** to **discard**
- **arrow-right** to **go to next page**
- **arrow-left** to **go to previous page**

When the text component have focus 
- **shift + enter** : to **submit** 
- **shift + suppr** : to **discard**
- not possible to paginate except if the component loose focus from the text component

Closes #2767 

**WARNING** This break the shortcut **shift + enter** for **Text2Text** classification.  