### PR TITLE
Add new endpoint to get current user dataset metrics

### DIFF
--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -29,6 +29,7 @@ from argilla.server.schemas.v1.datasets import (
     Field,
     FieldCreate,
     Fields,
+    Metrics,
     Question,
     QuestionCreate,
     Questions,
@@ -138,6 +139,29 @@ def get_dataset(
     authorize(current_user, DatasetPolicyV1.get(dataset))
 
     return dataset
+
+
+@router.get("/me/datasets/{dataset_id}/metrics", response_model=Metrics)
+def get_current_user_dataset_metrics(
+    *,
+    db: Session = Depends(get_db),
+    dataset_id: UUID,
+    current_user: User = Security(auth.get_current_user),
+):
+    dataset = _get_dataset(db, dataset_id)
+
+    authorize(current_user, DatasetPolicyV1.get(dataset))
+
+    return {
+        "records": {
+            "count": datasets.count_records_by_dataset_id(db, dataset_id),
+        },
+        "responses": {
+            "count": datasets.count_responses_by_dataset_id_and_user_id(db, dataset_id, current_user.id),
+            "submitted": datasets.count_submitted_responses_by_dataset_id_and_user_id(db, dataset_id, current_user.id),
+            "discarded": datasets.count_discarded_responses_by_dataset_id_and_user_id(db, dataset_id, current_user.id),
+        },
+    }
 
 
 @router.post("/datasets", status_code=status.HTTP_201_CREATED, response_model=Dataset)

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -23,6 +23,7 @@ from argilla.server.models import (
     Question,
     Record,
     Response,
+    ResponseStatus,
 )
 from argilla.server.schemas.v1.datasets import (
     DatasetCreate,
@@ -254,6 +255,33 @@ def get_response_by_record_id_and_user_id(db: Session, record_id: UUID, user_id:
 
 def list_responses_by_record_id(db: Session, record_id: UUID):
     return db.query(Response).filter_by(record_id=record_id).order_by(Response.inserted_at.asc()).all()
+
+
+def count_responses_by_dataset_id_and_user_id(db: Session, dataset_id: UUID, user_id: UUID):
+    return (
+        db.query(func.count(Response.id))
+        .join(Record, and_(Record.id == Response.record_id, Record.dataset_id == dataset_id))
+        .filter(Response.user_id == user_id)
+        .scalar()
+    )
+
+
+def count_submitted_responses_by_dataset_id_and_user_id(db: Session, dataset_id: UUID, user_id: UUID):
+    return (
+        db.query(func.count(Response.id))
+        .join(Record, and_(Record.id == Response.record_id, Record.dataset_id == dataset_id))
+        .filter(Response.user_id == user_id, Response.status == ResponseStatus.submitted)
+        .scalar()
+    )
+
+
+def count_discarded_responses_by_dataset_id_and_user_id(db: Session, dataset_id: UUID, user_id: UUID):
+    return (
+        db.query(func.count(Response.id))
+        .join(Record, and_(Record.id == Response.record_id, Record.dataset_id == dataset_id))
+        .filter(Response.user_id == user_id, Response.status == ResponseStatus.discarded)
+        .scalar()
+    )
 
 
 def create_response(db: Session, record: Record, user: User, response_create: ResponseCreate):

--- a/src/argilla/server/models.py
+++ b/src/argilla/server/models.py
@@ -45,6 +45,7 @@ class QuestionType(str, Enum):
 
 class ResponseStatus(str, Enum):
     submitted = "submitted"
+    discarded = "discarded"
 
 
 class DatasetStatus(str, Enum):

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -61,6 +61,21 @@ class DatasetCreate(BaseModel):
     workspace_id: UUID
 
 
+class RecordMetrics(BaseModel):
+    count: int
+
+
+class ResponseMetrics(BaseModel):
+    count: int
+    submitted: int
+    discarded: int
+
+
+class Metrics(BaseModel):
+    records: RecordMetrics
+    responses: ResponseMetrics
+
+
 class TextFieldSettings(BaseModel):
     type: Literal[FieldType.text]
 

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -24,6 +24,7 @@ from argilla.server.models import (
     Question,
     Record,
     Response,
+    ResponseStatus,
     User,
     Workspace,
 )
@@ -706,6 +707,102 @@ def test_get_dataset_with_nonexistent_dataset_id(client: TestClient, db: Session
     DatasetFactory.create()
 
     response = client.get(f"/api/v1/datasets/{uuid4()}", headers=admin_auth_header)
+
+    assert response.status_code == 404
+
+
+def test_get_current_user_dataset_metrics(client: TestClient, db: Session, admin: User, admin_auth_header: dict):
+    dataset = DatasetFactory.create()
+    record_a = RecordFactory.create(dataset=dataset)
+    record_b = RecordFactory.create(dataset=dataset)
+    record_c = RecordFactory.create(dataset=dataset)
+    RecordFactory.create_batch(3, dataset=dataset)
+    ResponseFactory.create(record=record_a, user=admin)
+    ResponseFactory.create(record=record_b, user=admin, status=ResponseStatus.discarded)
+    ResponseFactory.create(record=record_c, user=admin, status=ResponseStatus.discarded)
+
+    other_dataset = DatasetFactory.create()
+    other_record_a = RecordFactory.create(dataset=other_dataset)
+    other_record_b = RecordFactory.create(dataset=other_dataset)
+    other_record_c = RecordFactory.create(dataset=other_dataset)
+    RecordFactory.create_batch(2, dataset=other_dataset)
+    ResponseFactory.create(record=other_record_a, user=admin)
+    ResponseFactory.create(record=other_record_b)
+    ResponseFactory.create(record=other_record_c, status=ResponseStatus.discarded)
+
+    response = client.get(f"/api/v1/me/datasets/{dataset.id}/metrics", headers=admin_auth_header)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "records": {
+            "count": 6,
+        },
+        "responses": {
+            "count": 3,
+            "submitted": 1,
+            "discarded": 2,
+        },
+    }
+
+
+def test_get_current_user_dataset_metrics_without_authentication(client: TestClient, db: Session):
+    dataset = DatasetFactory.create()
+
+    response = client.get(f"/api/v1/me/datasets/{dataset.id}/metrics")
+
+    assert response.status_code == 401
+
+
+def test_get_current_user_dataset_metrics_as_annotator(client: TestClient, db: Session):
+    dataset = DatasetFactory.create()
+    annotator = AnnotatorFactory.create(workspaces=[dataset.workspace])
+    record_a = RecordFactory.create(dataset=dataset)
+    record_b = RecordFactory.create(dataset=dataset)
+    record_c = RecordFactory.create(dataset=dataset)
+    RecordFactory.create_batch(2, dataset=dataset)
+    ResponseFactory.create(record=record_a, user=annotator)
+    ResponseFactory.create(record=record_b, user=annotator)
+    ResponseFactory.create(record=record_c, user=annotator, status=ResponseStatus.discarded)
+
+    other_dataset = DatasetFactory.create()
+    other_record_a = RecordFactory.create(dataset=other_dataset)
+    other_record_b = RecordFactory.create(dataset=other_dataset)
+    other_record_c = RecordFactory.create(dataset=other_dataset)
+    RecordFactory.create_batch(3, dataset=other_dataset)
+    ResponseFactory.create(record=other_record_a, user=annotator)
+    ResponseFactory.create(record=other_record_b)
+    ResponseFactory.create(record=other_record_c, status=ResponseStatus.discarded)
+
+    response = client.get(f"/api/v1/me/datasets/{dataset.id}/metrics", headers={API_KEY_HEADER_NAME: annotator.api_key})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "records": {
+            "count": 5,
+        },
+        "responses": {
+            "count": 3,
+            "submitted": 2,
+            "discarded": 1,
+        },
+    }
+
+
+def test_get_current_user_dataset_metrics_annotator_from_different_workspace(client: TestClient, db: Session):
+    dataset = DatasetFactory.create()
+    annotator = AnnotatorFactory.create(workspaces=[WorkspaceFactory.build()])
+
+    response = client.get(f"/api/v1/me/datasets/{dataset.id}/metrics", headers={API_KEY_HEADER_NAME: annotator.api_key})
+
+    assert response.status_code == 403
+
+
+def test_get_current_user_dataset_metrics_with_nonexistent_dataset_id(
+    client: TestClient, db: Session, admin_auth_header: dict
+):
+    DatasetFactory.create()
+
+    response = client.get(f"/api/v1/me/datasets/{uuid4()}/metrics", headers=admin_auth_header)
 
     assert response.status_code == 404
 


### PR DESCRIPTION
# Description

This endpoint adds a new endpoint that will return the metrics for the current user and for an specific dataset.

The new endpoint will be the first one for APIv1 where we are using the prefix `/me` to notice that we are returning information in the context of the current user doing the request.

The returned schema will be something like the following:
```json
{
        "records": {
            "count": 5,
        },
        "responses": {
            "count": 3,
            "submitted": 2,
            "discarded": 1,
        },
}
```

Associated issue: #2763 

