### PR TITLE
Using the optional postgresql deps to setup docker image

### DIFF
--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -16,10 +16,9 @@ COPY dist/*.whl /packages/
 
 RUN apt-get update && \
     apt-get install -y python-dev libpq-dev gcc && \
-    pip install psycopg2 && \
-    apt-get remove -y python-dev libpq-dev gcc && \
     chmod +x /start_argilla_server.sh && \
-    for wheel in /packages/*.whl; do pip install "$wheel"[server]; done && \
+    for wheel in /packages/*.whl; do pip install "$wheel"[server,postgresql]; done && \
+    apt-get remove -y python-dev libpq-dev gcc && \
     rm -rf /packages
 
 # Create argilla volume

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && \
     chmod +x /start_argilla_server.sh && \
     for wheel in /packages/*.whl; do pip install "$wheel"[server,postgresql]; done && \
     apt-get remove -y python-dev libpq-dev gcc && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
     rm -rf /packages
 
 # Create argilla volume


### PR DESCRIPTION
# Description

This PRs adapts changes introduced in #2820 regarding [this comment](https://github.com/argilla-io/argilla/pull/2820#discussion_r1183335987)

Now, the `postgresql` optional deps are used to install python requirements for PostgreSQL support.