### PR TITLE
fix: pagination synchronisation on change params

### DIFF
--- a/frontend/components/feedback-task/footer/Pagination.component.vue
+++ b/frontend/components/feedback-task/footer/Pagination.component.vue
@@ -79,11 +79,6 @@ export default {
         this.localCurrentPage = +newCurrentPage;
       },
     },
-    currentPageFromUrl() {
-      const currentPageFromUrl = parseFloat(this.$route.query?._page) || 1;
-      this.currentPage = currentPageFromUrl;
-      return currentPageFromUrl;
-    },
     totalPages() {
       return Math.ceil(this.totalItems / this.numberOfItemsByPage);
     },
@@ -94,7 +89,6 @@ export default {
   watch: {
     localCurrentPage: {
       immediate: true,
-      deep: true,
       handler(newCurrentPage) {
         this.emitCurrentPage();
         this.updateUrlParams(newCurrentPage);
@@ -105,9 +99,12 @@ export default {
     this.currentPage = parseFloat(this.$route.query?._page) || 1;
 
     document.addEventListener("keydown", this.onPressKeyboardShortCut);
+
+    this.onBusEventCurrentPage();
   },
   destroyed() {
     document.removeEventListener("keydown", this.onPressKeyboardShortCut);
+    this.$root.$off("current-page");
   },
   methods: {
     onPressKeyboardShortCut({ code }) {
@@ -122,6 +119,11 @@ export default {
         }
         default:
       }
+    },
+    onBusEventCurrentPage() {
+      this.$root.$on("current-page", (currentPage) => {
+        this.currentPage = currentPage;
+      });
     },
     onClickPrev() {
       this.currentPage > 1 && this.currentPage--;

--- a/frontend/components/feedback-task/footer/Pagination.component.vue
+++ b/frontend/components/feedback-task/footer/Pagination.component.vue
@@ -92,8 +92,9 @@ export default {
     },
   },
   watch: {
-    currentPage: {
+    localCurrentPage: {
       immediate: true,
+      deep: true,
       handler(newCurrentPage) {
         this.emitCurrentPage();
         this.updateUrlParams(newCurrentPage);

--- a/frontend/components/page-contents/feedback-task-content/CenterFeedbackTask.content.vue
+++ b/frontend/components/page-contents/feedback-task-content/CenterFeedbackTask.content.vue
@@ -64,9 +64,10 @@ export default {
           // NOTE - recordIndex start at 0 / page start at 1
           const pageToGo = recordIndexToGo + 1;
 
-          if (pageToGo < this.totalRecords) {
+          if (this.currentPage < this.totalRecords) {
             this.recordOffset = recordIndexToGo;
             this.currentPage = pageToGo;
+            this.$root.$emit("current-page", this.currentPage);
           }
           if (recordIndexToGo < this.totalRecords) {
             this.updatePageQueryParam(pageToGo);


### PR DESCRIPTION
# Description
There was a synchronisation problem after submitting the form with the pagination : the page number from pagination was not the good one.
To solve the problem, the function responsable of increasing the currentPage/record to go, have to $emit this new page value for the pagination component. The pagination component will listen to this page number and to compute the new localCurrentPage properties

**Type of change**

-  Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

- Only feedback task
