### PR TITLE
feat : init front record status from backend response status

### DIFF
--- a/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
+++ b/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
@@ -154,12 +154,7 @@ export default {
     factoryRecordsForOrm(records) {
       return records.map(
         (
-          {
-            id: recordId,
-            responses: recordResponses,
-            fields: recordFields,
-            recordStatus,
-          },
+          { id: recordId, responses: recordResponses, fields: recordFields },
           index
         ) => {
           const formattedRecordFields = this.factoryRecordFieldsForOrm(
@@ -167,7 +162,8 @@ export default {
             recordId
           );
 
-          const formattedRecordResponsesForOrm =
+          // NOTE - the record status come from the corresponding responses
+          const { formattedRecordResponsesForOrm, recordStatus } =
             this.factoryRecordResponsesForOrm({ recordId, recordResponses });
 
           return {
@@ -195,7 +191,11 @@ export default {
     },
     factoryRecordResponsesForOrm({ recordId, recordResponses }) {
       const formattedRecordResponsesForOrm = [];
+      // NOTE - by default, recordStatus is at "PENDING"
+      let recordStatus = RECORD_STATUS.PENDING;
+
       recordResponses.forEach((responsesByRecordAndUser) => {
+        recordStatus = responsesByRecordAndUser.status ?? RECORD_STATUS.PENDING;
         Object.entries(responsesByRecordAndUser.values).forEach(
           ([questionName, recordResponseByQuestionName]) => {
             let formattedOptionsWithRecordResponse = [];
@@ -253,7 +253,7 @@ export default {
         );
       });
 
-      return formattedRecordResponsesForOrm;
+      return { formattedRecordResponsesForOrm, recordStatus };
     },
   },
 };


### PR DESCRIPTION
# Description

Init the record status from front orm with the status of related response (all responses from one user and one record have the same status)

Closes #2843 

**Type of change**

- New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

-  Only feedback task
