### PR TITLE
feat : show toast on navigation when record is in pending state

### DIFF
--- a/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
+++ b/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
@@ -156,6 +156,11 @@ export default {
       );
     },
   },
+  watch: {
+    isFormUntouched(isFormUntouched) {
+      this.onEmitIsQuestionsFormUntouchedByBusEvent(isFormUntouched);
+    },
+  },
   created() {
     this.COMPONENT_TYPE = COMPONENT_TYPE;
     this.formOnErrorMessage =
@@ -435,6 +440,9 @@ export default {
         numberOfChars: message.length,
         type: typeOfToast,
       });
+    },
+    onEmitIsQuestionsFormUntouchedByBusEvent(isFormUntouched) {
+      this.$root.$emit("are-responses-untouched", isFormUntouched);
     },
   },
 };

--- a/frontend/components/feedback-task/footer/Pagination.component.vue
+++ b/frontend/components/feedback-task/footer/Pagination.component.vue
@@ -5,12 +5,13 @@
     <div class="pagination__buttons">
       <BaseButton
         class="pagination__button"
-        @click="onClickPrev"
+        ref="prevButton"
+        @click="onPaginate(onClickPrev)"
         :disabled="currentPage === 1"
-        ><svgicon name="chevron-left" width="8" height="8" />{{
-          prevButtonMessage
-        }}</BaseButton
       >
+        <svgicon name="chevron-left" width="8" height="8" />
+        {{ prevButtonMessage }}
+      </BaseButton>
 
       <div class="pagination__page-number-area" v-if="showPageNumber">
         <BaseButton
@@ -26,7 +27,8 @@
 
       <BaseButton
         class="pagination__button"
-        @click="onClickNext"
+        ref="nextButton"
+        @click="onPaginate(onClickNext)"
         :disabled="currentPage >= totalPages"
       >
         {{ nextButtonMessage }}
@@ -41,6 +43,8 @@
 </template>
 
 <script>
+import { Notification } from "@/models/Notifications";
+
 export default {
   name: "PaginationComponent",
   props: {
@@ -63,6 +67,12 @@ export default {
     showPageNumber: {
       type: Boolean,
       default: false,
+    },
+    notificationParams: {
+      type: Object | null,
+    },
+    conditionToShowNotificationComponentOnPagination: {
+      type: Function | null,
     },
   },
   data() {
@@ -110,19 +120,65 @@ export default {
     onPressKeyboardShortCut({ code }) {
       switch (code) {
         case "ArrowRight": {
-          this.onClickNext();
+          const elem = this.$refs.nextButton.$el;
+          elem.click();
           break;
         }
         case "ArrowLeft": {
-          this.onClickPrev();
+          const elem = this.$refs.prevButton.$el;
+          elem.click();
           break;
         }
         default:
+          // Do nothing => the code is not registered as shortcut
       }
     },
     onBusEventCurrentPage() {
       this.$root.$on("current-page", (currentPage) => {
         this.currentPage = currentPage;
+      });
+    },
+    onPaginate(eventToFire) {
+      if (this.isNotificationComponentForThisPage()) {
+        const { message, buttonMessage, typeOfToast } = this.notificationParams;
+        this.showNotificationBeforePaginate({
+          eventToFire,
+          message,
+          buttonMessage,
+          typeOfToast,
+        });
+      } else {
+        eventToFire();
+      }
+    },
+    isNotificationComponentForThisPage() {
+      if (
+        this.notificationParams &&
+        this.conditionToShowNotificationComponentOnPagination
+      ) {
+        const showNotification =
+          this.conditionToShowNotificationComponentOnPagination(
+            this.currentPage
+          );
+
+        return showNotification;
+      }
+      return false;
+    },
+    showNotificationBeforePaginate({
+      eventToFire,
+      message,
+      buttonMessage,
+      typeOfToast,
+    }) {
+      Notification.dispatch("notify", {
+        message: message ?? "",
+        numberOfChars: 20000,
+        type: typeOfToast ?? "warning",
+        buttonText: buttonMessage ?? "",
+        async onClick() {
+          eventToFire();
+        },
       });
     },
     onClickPrev() {

--- a/frontend/components/feedback-task/footer/Pagination.component.vue
+++ b/frontend/components/feedback-task/footer/Pagination.component.vue
@@ -130,7 +130,7 @@ export default {
           break;
         }
         default:
-          // Do nothing => the code is not registered as shortcut
+        // Do nothing => the code is not registered as shortcut
       }
     },
     onBusEventCurrentPage() {
@@ -157,9 +157,7 @@ export default {
         this.conditionToShowNotificationComponentOnPagination
       ) {
         const showNotification =
-          this.conditionToShowNotificationComponentOnPagination(
-            this.currentPage
-          );
+          this.conditionToShowNotificationComponentOnPagination();
 
         return showNotification;
       }

--- a/frontend/components/feedback-task/footer/PaginationFeedbackTask.component.vue
+++ b/frontend/components/feedback-task/footer/PaginationFeedbackTask.component.vue
@@ -65,5 +65,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss" scoped></style>

--- a/frontend/components/feedback-task/footer/PaginationFeedbackTask.component.vue
+++ b/frontend/components/feedback-task/footer/PaginationFeedbackTask.component.vue
@@ -47,7 +47,6 @@ export default {
     },
     onBusEventAreResponsesUntouched() {
       this.$root.$on("are-responses-untouched", (areResponsesUntouched) => {
-        console.log("are-responses-untouched", areResponsesUntouched);
         this.areResponsesUntouched = areResponsesUntouched;
       });
     },

--- a/frontend/components/feedback-task/footer/PaginationFeedbackTask.component.vue
+++ b/frontend/components/feedback-task/footer/PaginationFeedbackTask.component.vue
@@ -62,6 +62,7 @@ export default {
   },
   destroyed() {
     this.$root.$off("current-page");
+    this.$root.$off("are-responses-untouched");
   },
 };
 </script>

--- a/frontend/components/feedback-task/footer/PaginationFeedbackTask.component.vue
+++ b/frontend/components/feedback-task/footer/PaginationFeedbackTask.component.vue
@@ -3,12 +3,19 @@
     v-if="totalRecord"
     :showPageNumber="false"
     :totalItems="totalRecord"
+    :notificationParams="paginationNotificationParams"
+    :conditionToShowNotificationComponentOnPagination="
+      conditionToShowNotificationComponent
+    "
     @on-paginate="onPaginate"
   />
 </template>
 
 <script>
 import { getTotalRecordByDatasetId } from "@/models/feedback-task-model/feedback-dataset/feedbackDataset.queries";
+import { getRecordStatusByDatasetIdAndRecordIndex } from "@/models/feedback-task-model/record/record.queries";
+import { RECORD_STATUS } from "@/models/feedback-task-model/record/record.queries";
+
 export default {
   name: "PaginationFeedbackTaskComponent",
   props: {
@@ -16,6 +23,13 @@ export default {
       type: String,
       required: true,
     },
+  },
+  created() {
+    this.paginationNotificationParams = {
+      message: "Pending actions will be lost when the page is refreshed",
+      buttonMessage: "Ok, got it!",
+      typeOfToast: "warning",
+    };
   },
   computed: {
     totalRecord() {
@@ -28,6 +42,31 @@ export default {
     },
     onEmitCurrentPageByBusEvent(currentPage) {
       this.$root.$emit("current-page", currentPage);
+    },
+    conditionToShowNotificationComponent(currentPage) {
+      // NOTE 1 - this method have to be passed to the generic pagination component to keep it 'stupid'
+      // NOTE 2 - this function is only validate if one record is showned
+      // NOTE 3 - record_index start at 0 and page at 1.
+      const recordIndex = currentPage - 1;
+      const recordStatusOfTheCurrentRecord =
+        getRecordStatusByDatasetIdAndRecordIndex(this.datasetId, recordIndex);
+
+      let showNotification = false;
+      switch (recordStatusOfTheCurrentRecord) {
+        case RECORD_STATUS.PENDING:
+          showNotification = true;
+          break;
+        case RECORD_STATUS.SUBMITTED:
+        case RECORD_STATUS.DISCARDED:
+          showNotification = false;
+          break;
+        default:
+          console.log(
+            `The status ${recordStatusOfTheCurrentRecord} is unknown`
+          );
+      }
+
+      return showNotification;
     },
   },
   destroyed() {

--- a/frontend/components/feedback-task/footer/PaginationFeedbackTask.component.vue
+++ b/frontend/components/feedback-task/footer/PaginationFeedbackTask.component.vue
@@ -13,8 +13,6 @@
 
 <script>
 import { getTotalRecordByDatasetId } from "@/models/feedback-task-model/feedback-dataset/feedbackDataset.queries";
-import { getRecordStatusByDatasetIdAndRecordIndex } from "@/models/feedback-task-model/record/record.queries";
-import { RECORD_STATUS } from "@/models/feedback-task-model/record/record.queries";
 
 export default {
   name: "PaginationFeedbackTaskComponent",
@@ -30,6 +28,13 @@ export default {
       buttonMessage: "Ok, got it!",
       typeOfToast: "warning",
     };
+
+    this.onBusEventAreResponsesUntouched();
+  },
+  data() {
+    return {
+      areResponsesUntouched: true,
+    };
   },
   computed: {
     totalRecord() {
@@ -40,33 +45,20 @@ export default {
     onPaginate(currentPage) {
       this.onEmitCurrentPageByBusEvent(currentPage);
     },
+    onBusEventAreResponsesUntouched() {
+      this.$root.$on("are-responses-untouched", (areResponsesUntouched) => {
+        console.log("are-responses-untouched", areResponsesUntouched);
+        this.areResponsesUntouched = areResponsesUntouched;
+      });
+    },
     onEmitCurrentPageByBusEvent(currentPage) {
       this.$root.$emit("current-page", currentPage);
     },
-    conditionToShowNotificationComponent(currentPage) {
+    conditionToShowNotificationComponent() {
       // NOTE 1 - this method have to be passed to the generic pagination component to keep it 'stupid'
-      // NOTE 2 - this function is only validate if one record is showned
-      // NOTE 3 - record_index start at 0 and page at 1.
-      const recordIndex = currentPage - 1;
-      const recordStatusOfTheCurrentRecord =
-        getRecordStatusByDatasetIdAndRecordIndex(this.datasetId, recordIndex);
+      // NOTE 2 - return true if responses have been touched,return false in other case
 
-      let showNotification = false;
-      switch (recordStatusOfTheCurrentRecord) {
-        case RECORD_STATUS.PENDING:
-          showNotification = true;
-          break;
-        case RECORD_STATUS.SUBMITTED:
-        case RECORD_STATUS.DISCARDED:
-          showNotification = false;
-          break;
-        default:
-          console.log(
-            `The status ${recordStatusOfTheCurrentRecord} is unknown`
-          );
-      }
-
-      return showNotification;
+      return !this.areResponsesUntouched;
     },
   },
   destroyed() {

--- a/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
+++ b/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
@@ -154,12 +154,7 @@ export default {
     factoryRecordsForOrm(records) {
       return records.map(
         (
-          {
-            id: recordId,
-            responses: recordResponses,
-            fields: recordFields,
-            recordStatus,
-          },
+          { id: recordId, responses: recordResponses, fields: recordFields },
           index
         ) => {
           const formattedRecordFields = this.factoryRecordFieldsForOrm(
@@ -167,7 +162,8 @@ export default {
             recordId
           );
 
-          const formattedRecordResponsesForOrm =
+          // NOTE - the record status come from the corresponding responses
+          const { formattedRecordResponsesForOrm, recordStatus } =
             this.factoryRecordResponsesForOrm({ recordId, recordResponses });
 
           return {
@@ -195,7 +191,11 @@ export default {
     },
     factoryRecordResponsesForOrm({ recordId, recordResponses }) {
       const formattedRecordResponsesForOrm = [];
+      // NOTE - by default, recordStatus is at "PENDING"
+      let recordStatus = RECORD_STATUS.PENDING;
+
       recordResponses.forEach((responsesByRecordAndUser) => {
+        recordStatus = responsesByRecordAndUser.status ?? RECORD_STATUS.PENDING;
         Object.entries(responsesByRecordAndUser.values).forEach(
           ([questionName, recordResponseByQuestionName]) => {
             let formattedOptionsWithRecordResponse = [];
@@ -253,7 +253,7 @@ export default {
         );
       });
 
-      return formattedRecordResponsesForOrm;
+      return { formattedRecordResponsesForOrm, recordStatus };
     },
   },
 };

--- a/frontend/models/feedback-task-model/record/record.queries.js
+++ b/frontend/models/feedback-task-model/record/record.queries.js
@@ -37,11 +37,12 @@ const getRecordWithFieldsAndResponsesByUserId = (
 const getRecordIndexByRecordId = (recordId) => {
   return RecordModel.query().whereId(recordId).first()?.record_index;
 };
-const getRecordStatusByDatasetIdAndRecordIndex = (datasetId, recordIndex) =>
-  RecordModel.query()
+const getRecordStatusByDatasetIdAndRecordIndex = (datasetId, recordIndex) => {
+  return RecordModel.query()
     .where("dataset_id", datasetId)
     .where("record_index", recordIndex)
     .first()?.record_status;
+};
 
 // EXIST
 const isRecordWithRecordIndexByDatasetIdExists = (datasetId, recordIndex) => {

--- a/frontend/models/feedback-task-model/record/record.queries.js
+++ b/frontend/models/feedback-task-model/record/record.queries.js
@@ -37,6 +37,11 @@ const getRecordWithFieldsAndResponsesByUserId = (
 const getRecordIndexByRecordId = (recordId) => {
   return RecordModel.query().whereId(recordId).first()?.record_index;
 };
+const getRecordStatusByDatasetIdAndRecordIndex = (datasetId, recordIndex) =>
+  RecordModel.query()
+    .where("dataset_id", datasetId)
+    .where("record_index", recordIndex)
+    .first()?.record_status;
 
 // EXIST
 const isRecordWithRecordIndexByDatasetIdExists = (datasetId, recordIndex) => {
@@ -58,6 +63,7 @@ export {
   RECORD_STATUS,
   upsertRecords,
   getRecordWithFieldsAndResponsesByUserId,
+  getRecordStatusByDatasetIdAndRecordIndex,
   getRecordIndexByRecordId,
   updateRecordStatusByRecordId,
   isRecordWithRecordIndexByDatasetIdExists,


### PR DESCRIPTION
# Description
When record have been touched (means the form is different than his initial state) and user click on pagination, a toast need to be showned to the user to confirm action and to explain that the current modification will be lost if form is not submitted.

Note: the function which have the responsability to show or not the toast is in PaginationFeedback.component.vue and not Pagination.component.vue to keep the atomic component stupid. Later, when Pagination.component.vue will be reused, it will be more easy to change this callback from his direct parent.

Closes #2836 

**Type of change**

- New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- Only feedback task

