### PR TITLE
Add response_status filter when listing dataset records for an user

### DIFF
--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -273,15 +273,8 @@ def count_responses_by_dataset_id_and_user_id(db: Session, dataset_id: UUID, use
 def count_submitted_responses_by_dataset_id_and_user_id(db: Session, dataset_id: UUID, user_id: UUID):
     return (
         db.query(func.count(Response.id))
-        .join(
-            Record,
-            and_(
-                Record.id == Response.record_id,
-                Record.dataset_id == dataset_id,
-                Response.status == ResponseStatus.submitted,
-            ),
-        )
-        .filter(Response.user_id == user_id)
+        .join(Record, and_(Record.id == Response.record_id, Record.dataset_id == dataset_id))
+        .filter(Response.user_id == user_id, Response.status == ResponseStatus.submitted)
         .scalar()
     )
 
@@ -289,15 +282,8 @@ def count_submitted_responses_by_dataset_id_and_user_id(db: Session, dataset_id:
 def count_discarded_responses_by_dataset_id_and_user_id(db: Session, dataset_id: UUID, user_id: UUID):
     return (
         db.query(func.count(Response.id))
-        .join(
-            Record,
-            and_(
-                Record.id == Response.record_id,
-                Record.dataset_id == dataset_id,
-                Response.status == ResponseStatus.discarded,
-            ),
-        )
-        .filter(Response.user_id == user_id)
+        .join(Record, and_(Record.id == Response.record_id, Record.dataset_id == dataset_id))
+        .filter(Response.user_id == user_id, Response.status == ResponseStatus.discarded)
         .scalar()
     )
 

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -179,10 +179,18 @@ class RecordInclude(str, Enum):
     responses = "responses"
 
 
+class ResponseStatusFilter(str, Enum):
+    missing = "missing"
+    submitted = "submitted"
+    discarded = "discarded"
+
+
 class Record(BaseModel):
     id: UUID
     fields: Dict[str, Any]
     external_id: Optional[str]
+    # TODO: move `responses` to `response` since contextualized endpoint will contains only the user response
+    # response: Optional[Response]
     responses: Optional[List[Response]]
     inserted_at: datetime
     updated_at: datetime


### PR DESCRIPTION
# Description

The endpoint `/api/me/v1/datasets/:dataset_id/records` accepts a query param `response_status` to filter by the user responses status. The possible values are:

- `missing`: to find records without responses for the current user.
- `submitted`: to find records with submitted responses for the current user.
- `discarded`: to find records with discarded responses.

*Note: The "pending" state corresponds, for now, to those records without a response for the user requesting them. Once we introduce new intermediate status (like `draft`), the "pending" state may include those intermediate statuses. This is the reason why the current filter is defined as `missing` instead of `pending`.*

Also, the `total` value in the response is computed based on the filter configuration.

Closes https://github.com/argilla-io/argilla/issues/2840

cc @leiyre @keithCuniah 