### PR TITLE
feat : update shortcuts for discard/clear/submit responses

### DIFF
--- a/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
+++ b/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
@@ -169,19 +169,19 @@ export default {
     document.removeEventListener("keydown", this.onPressKeyboardShortCut);
   },
   methods: {
-    onPressKeyboardShortCut({ code, ctrlKey }) {
+    onPressKeyboardShortCut({ code, shiftKey }) {
       switch (code) {
         case "Enter": {
           const elem = this.$refs.submitButton.$el;
           elem.click();
           break;
         }
-        case "Space": {
+        case "Backspace": {
           const elem = this.$refs.clearButton.$el;
-          ctrlKey && elem.click();
+          shiftKey && elem.click();
           break;
         }
-        case "Backspace": {
+        case "KeyD": {
           const elem = this.$refs.discardButton.$el;
           elem.click();
           break;

--- a/frontend/components/feedback-task/footer/Pagination.component.vue
+++ b/frontend/components/feedback-task/footer/Pagination.component.vue
@@ -5,12 +5,13 @@
     <div class="pagination__buttons">
       <BaseButton
         class="pagination__button"
-        @click="onClickPrev"
+        ref="prevButton"
+        @click="onPaginate(onClickPrev)"
         :disabled="currentPage === 1"
-        ><svgicon name="chevron-left" width="8" height="8" />{{
-          prevButtonMessage
-        }}</BaseButton
       >
+        <svgicon name="chevron-left" width="8" height="8" />
+        {{ prevButtonMessage }}
+      </BaseButton>
 
       <div class="pagination__page-number-area" v-if="showPageNumber">
         <BaseButton
@@ -26,7 +27,8 @@
 
       <BaseButton
         class="pagination__button"
-        @click="onClickNext"
+        ref="nextButton"
+        @click="onPaginate(onClickNext)"
         :disabled="currentPage >= totalPages"
       >
         {{ nextButtonMessage }}
@@ -41,6 +43,8 @@
 </template>
 
 <script>
+import { Notification } from "@/models/Notifications";
+
 export default {
   name: "PaginationComponent",
   props: {
@@ -63,6 +67,12 @@ export default {
     showPageNumber: {
       type: Boolean,
       default: false,
+    },
+    notificationParams: {
+      type: Object | null,
+    },
+    conditionToShowNotificationComponentOnPagination: {
+      type: Function | null,
     },
   },
   data() {
@@ -110,19 +120,65 @@ export default {
     onPressKeyboardShortCut({ code }) {
       switch (code) {
         case "ArrowRight": {
-          this.onClickNext();
+          const elem = this.$refs.nextButton.$el;
+          elem.click();
           break;
         }
         case "ArrowLeft": {
-          this.onClickPrev();
+          const elem = this.$refs.prevButton.$el;
+          elem.click();
           break;
         }
         default:
+          // Do nothing => the code is not registered as shortcut
       }
     },
     onBusEventCurrentPage() {
       this.$root.$on("current-page", (currentPage) => {
         this.currentPage = currentPage;
+      });
+    },
+    onPaginate(eventToFire) {
+      if (this.isNotificationComponentForThisPage()) {
+        const { message, buttonMessage, typeOfToast } = this.notificationParams;
+        this.showNotificationBeforePaginate({
+          eventToFire,
+          message,
+          buttonMessage,
+          typeOfToast,
+        });
+      } else {
+        eventToFire();
+      }
+    },
+    isNotificationComponentForThisPage() {
+      if (
+        this.notificationParams &&
+        this.conditionToShowNotificationComponentOnPagination
+      ) {
+        const showNotification =
+          this.conditionToShowNotificationComponentOnPagination(
+            this.currentPage
+          );
+
+        return showNotification;
+      }
+      return false;
+    },
+    showNotificationBeforePaginate({
+      eventToFire,
+      message,
+      buttonMessage,
+      typeOfToast,
+    }) {
+      Notification.dispatch("notify", {
+        message: message ?? "",
+        numberOfChars: 20000,
+        type: typeOfToast ?? "warning",
+        buttonText: buttonMessage ?? "",
+        async onClick() {
+          eventToFire();
+        },
       });
     },
     onClickPrev() {

--- a/frontend/components/feedback-task/footer/Pagination.component.vue
+++ b/frontend/components/feedback-task/footer/Pagination.component.vue
@@ -130,7 +130,7 @@ export default {
           break;
         }
         default:
-          // Do nothing => the code is not registered as shortcut
+        // Do nothing => the code is not registered as shortcut
       }
     },
     onBusEventCurrentPage() {

--- a/frontend/components/feedback-task/footer/PaginationFeedbackTask.component.vue
+++ b/frontend/components/feedback-task/footer/PaginationFeedbackTask.component.vue
@@ -3,12 +3,19 @@
     v-if="totalRecord"
     :showPageNumber="false"
     :totalItems="totalRecord"
+    :notificationParams="paginationNotificationParams"
+    :conditionToShowNotificationComponentOnPagination="
+      conditionToShowNotificationComponent
+    "
     @on-paginate="onPaginate"
   />
 </template>
 
 <script>
 import { getTotalRecordByDatasetId } from "@/models/feedback-task-model/feedback-dataset/feedbackDataset.queries";
+import { getRecordStatusByDatasetIdAndRecordIndex } from "@/models/feedback-task-model/record/record.queries";
+import { RECORD_STATUS } from "@/models/feedback-task-model/record/record.queries";
+
 export default {
   name: "PaginationFeedbackTaskComponent",
   props: {
@@ -16,6 +23,13 @@ export default {
       type: String,
       required: true,
     },
+  },
+  created() {
+    this.paginationNotificationParams = {
+      message: "Pending actions will be lost when the page is refreshed",
+      buttonMessage: "Ok, got it!",
+      typeOfToast: "warning",
+    };
   },
   computed: {
     totalRecord() {
@@ -28,6 +42,31 @@ export default {
     },
     onEmitCurrentPageByBusEvent(currentPage) {
       this.$root.$emit("current-page", currentPage);
+    },
+    conditionToShowNotificationComponent(currentPage) {
+      // NOTE 1 - this method have to be passed to the generic pagination component to keep it 'stupid'
+      // NOTE 2 - this function is only validate if one record is showned
+      // NOTE 3 - record_index start at 0 and page at 1.
+      const recordIndex = currentPage - 1;
+      const recordStatusOfTheCurrentRecord =
+        getRecordStatusByDatasetIdAndRecordIndex(this.datasetId, recordIndex);
+
+      let showNotification = false;
+      switch (recordStatusOfTheCurrentRecord) {
+        case RECORD_STATUS.PENDING:
+          showNotification = true;
+          break;
+        case RECORD_STATUS.SUBMITTED:
+        case RECORD_STATUS.DISCARDED:
+          showNotification = false;
+          break;
+        default:
+          console.log(
+            `The status ${recordStatusOfTheCurrentRecord} is unknown`
+          );
+      }
+
+      return showNotification;
     },
   },
   destroyed() {

--- a/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
+++ b/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
@@ -154,12 +154,7 @@ export default {
     factoryRecordsForOrm(records) {
       return records.map(
         (
-          {
-            id: recordId,
-            responses: recordResponses,
-            fields: recordFields,
-            recordStatus,
-          },
+          { id: recordId, responses: recordResponses, fields: recordFields },
           index
         ) => {
           const formattedRecordFields = this.factoryRecordFieldsForOrm(
@@ -167,7 +162,8 @@ export default {
             recordId
           );
 
-          const formattedRecordResponsesForOrm =
+          // NOTE - the record status come from the corresponding responses
+          const { formattedRecordResponsesForOrm, recordStatus } =
             this.factoryRecordResponsesForOrm({ recordId, recordResponses });
 
           return {
@@ -195,7 +191,11 @@ export default {
     },
     factoryRecordResponsesForOrm({ recordId, recordResponses }) {
       const formattedRecordResponsesForOrm = [];
+      // NOTE - by default, recordStatus is at "PENDING"
+      let recordStatus = RECORD_STATUS.PENDING;
+
       recordResponses.forEach((responsesByRecordAndUser) => {
+        recordStatus = responsesByRecordAndUser.status ?? RECORD_STATUS.PENDING;
         Object.entries(responsesByRecordAndUser.values).forEach(
           ([questionName, recordResponseByQuestionName]) => {
             let formattedOptionsWithRecordResponse = [];
@@ -253,7 +253,7 @@ export default {
         );
       });
 
-      return formattedRecordResponsesForOrm;
+      return { formattedRecordResponsesForOrm, recordStatus };
     },
   },
 };

--- a/frontend/components/text2text/results/Text2TextContentEditable.vue
+++ b/frontend/components/text2text/results/Text2TextContentEditable.vue
@@ -15,10 +15,11 @@
           @blur="setFocus(false)"
           @keydown.shift.enter.exact="looseFocus"
           @keydown.shift.backspace.exact="looseFocus"
-          @keydown.ctrl.space.exact="looseFocus"
+          @keydown.ctrl.1.exact="looseFocus"
           @keydown.arrow-right.stop=""
           @keydown.arrow-left.stop=""
           @keydown.delete.exact.stop=""
+          @keydown.d.exact.stop=""
           @keydown.enter.exact.stop=""
         />
       </transition>

--- a/frontend/models/feedback-task-model/record/record.queries.js
+++ b/frontend/models/feedback-task-model/record/record.queries.js
@@ -37,6 +37,11 @@ const getRecordWithFieldsAndResponsesByUserId = (
 const getRecordIndexByRecordId = (recordId) => {
   return RecordModel.query().whereId(recordId).first()?.record_index;
 };
+const getRecordStatusByDatasetIdAndRecordIndex = (datasetId, recordIndex) =>
+  RecordModel.query()
+    .where("dataset_id", datasetId)
+    .where("record_index", recordIndex)
+    .first()?.record_status;
 
 // EXIST
 const isRecordWithRecordIndexByDatasetIdExists = (datasetId, recordIndex) => {
@@ -58,6 +63,7 @@ export {
   RECORD_STATUS,
   upsertRecords,
   getRecordWithFieldsAndResponsesByUserId,
+  getRecordStatusByDatasetIdAndRecordIndex,
   getRecordIndexByRecordId,
   updateRecordStatusByRecordId,
   isRecordWithRecordIndexByDatasetIdExists,


### PR DESCRIPTION
# Description
Updates shortcuts for : 
clear : shift + backspace
submit : enter
discard : keyD

When text component have focus : 
clear : shift + backspace
submit : shift + enter
discard : ctrl + keyD 

**WARNING** a better shortcut needs to be define for discard, since ctrl+keyD is a shortcut in chrome (save url as favori) 


**Type of change**

- New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- Only feedback task

