### PR TITLE
Add `Workspace` class & `list_workspaces`

### DIFF
--- a/src/argilla/__init__.py
+++ b/src/argilla/__init__.py
@@ -64,6 +64,7 @@ if _TYPE_CHECKING:
         TokenClassificationRecord,
     )
     from argilla.client.nightly import FeedbackDataset, create_feedback_dataset
+    from argilla.client.workspaces import Workspace
     from argilla.datasets import (
         TextClassificationSettings,
         TokenClassificationSettings,
@@ -103,6 +104,7 @@ _import_structure = {
         "read_pandas",
     ],
     "client.nightly": ["FeedbackDataset", "create_feedback_dataset"],
+    "client.workspaces": ["Workspace"],
     "monitoring.model_monitor": ["monitor"],
     "listeners.listener": [
         "listener",

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -88,6 +88,8 @@ from argilla.client.sdk.token_classification.models import (
 )
 from argilla.client.sdk.users import api as users_api
 from argilla.client.sdk.users.models import User
+from argilla.client.sdk.workspaces import api as workspaces_api
+from argilla.client.sdk.workspaces.models import WorkspaceModel
 from argilla.utils import setup_loop_in_thread
 
 _LOGGER = logging.getLogger(__name__)
@@ -209,6 +211,9 @@ class Argilla:
             The name of the active workspace as a string.
         """
         return self._client.headers.get(WORKSPACE_HEADER_NAME)
+
+    def list_workspaces(self) -> List[WorkspaceModel]:
+        return workspaces_api.list_workspaces(client=self._client).parsed
 
     def list_datasets(self) -> List[FeedbackDatasetModel]:
         return datasets_api_v1.list_datasets(client=self._client).parsed

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -213,6 +213,12 @@ class Argilla:
         return self._client.headers.get(WORKSPACE_HEADER_NAME)
 
     def list_workspaces(self) -> List[WorkspaceModel]:
+        """Lists all the availble workspaces for the current user.
+
+        Returns:
+            A list of `WorkspaceModel` objects, containing the workspace
+            attributes: name, id, created_at, and updated_at.
+        """
         return workspaces_api.list_workspaces(client=self._client).parsed
 
     def list_datasets(self) -> List[FeedbackDatasetModel]:

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -59,6 +59,7 @@ from argilla.client.sdk.commons.errors import (
 from argilla.client.sdk.datasets import api as datasets_api
 from argilla.client.sdk.datasets.models import CopyDatasetRequest, TaskType
 from argilla.client.sdk.datasets.v1 import api as datasets_api_v1
+from argilla.client.sdk.datasets.v1.models import FeedbackDatasetModel, RecordsModel
 from argilla.client.sdk.metrics import api as metrics_api
 from argilla.client.sdk.metrics.models import MetricInfo
 from argilla.client.sdk.text2text.models import (
@@ -209,34 +210,34 @@ class Argilla:
         """
         return self._client.headers.get(WORKSPACE_HEADER_NAME)
 
-    def list_datasets(self) -> httpx.Response:
-        return datasets_api_v1.list_datasets(client=self._client)
+    def list_datasets(self) -> List[FeedbackDatasetModel]:
+        return datasets_api_v1.list_datasets(client=self._client).parsed
 
     def create_dataset(self, name: str, workspace_id: str, guidelines: Optional[str] = None) -> httpx.Response:
         return datasets_api_v1.create_dataset(
             client=self._client, name=name, workspace_id=workspace_id, guidelines=guidelines
-        )
+        ).parsed
 
-    def get_dataset(self, id: str) -> httpx.Response:
-        return datasets_api_v1.get_dataset(client=self._client, id=id)
+    def get_dataset(self, id: str) -> FeedbackDatasetModel:
+        return datasets_api_v1.get_dataset(client=self._client, id=id).parsed
 
-    def publish_dataset(self, id: str) -> httpx.Response:
-        return datasets_api_v1.publish_dataset(client=self._client, id=id)
+    def publish_dataset(self, id: str) -> FeedbackDatasetModel:
+        return datasets_api_v1.publish_dataset(client=self._client, id=id).parsed
 
-    def get_records(self, id: str, offset: int = 0, limit: int = 50) -> httpx.Response:
-        return datasets_api_v1.get_records(client=self._client, id=id, offset=offset, limit=limit)
+    def get_records(self, id: str, offset: int = 0, limit: int = 50) -> RecordsModel:
+        return datasets_api_v1.get_records(client=self._client, id=id, offset=offset, limit=limit).parsed
 
     def add_record(self, id: str, record: Dict[str, Any]) -> httpx.Response:
         return datasets_api_v1.add_record(client=self._client, id=id, record=record)
 
-    def get_fields(self, id: str) -> httpx.Response:
-        return datasets_api_v1.get_fields(client=self._client, id=id)
+    def get_fields(self, id: str) -> List[Dict[str, Any]]:
+        return datasets_api_v1.get_fields(client=self._client, id=id).parsed
 
     def add_field(self, id: str, field: Dict[str, Any]) -> httpx.Response:
         return datasets_api_v1.add_field(client=self._client, id=id, field=field)
 
-    def get_questions(self, id: str) -> httpx.Response:
-        return datasets_api_v1.get_questions(client=self._client, id=id)
+    def get_questions(self, id: str) -> List[Dict[str, Any]]:
+        return datasets_api_v1.get_questions(client=self._client, id=id).parsed
 
     def add_question(self, id: str, question: Dict[str, Any]) -> httpx.Response:
         return datasets_api_v1.add_question(client=self._client, id=id, question=question)

--- a/src/argilla/client/nightly.py
+++ b/src/argilla/client/nightly.py
@@ -210,13 +210,13 @@ class FeedbackDataset:
         self.__del__()
 
     @property
-    def fields(self) -> List[FieldSchema]:
+    def fields(self) -> List[OnlineFieldSchema]:
         if self.__fields is None or len(self.__fields) < 1:
             self.__fields = [OnlineFieldSchema(**field) for field in self.client.get_fields(id=self.id).parsed["items"]]
         return self.__fields
 
     @property
-    def questions(self) -> List[QuestionSchema]:
+    def questions(self) -> List[OnlineQuestionSchema]:
         if self.__questions is None or len(self.__questions) < 1:
             self.__questions = [
                 OnlineQuestionSchema(**question) for question in self.client.get_questions(id=self.id).parsed["items"]

--- a/src/argilla/client/sdk/datasets/v1/api.py
+++ b/src/argilla/client/sdk/datasets/v1/api.py
@@ -26,7 +26,8 @@ from argilla.client.sdk.commons.models import (
     Response,
 )
 from argilla.client.sdk.datasets.v1.models import (
-    FeedbackDataset,
+    FeedbackDatasetModel,
+    RecordsModel,
 )
 
 
@@ -35,7 +36,7 @@ def create_dataset(
     name: str,
     workspace_id: str,
     guidelines: Optional[str] = None,
-) -> Response[Union[FeedbackDataset, ErrorMessage, HTTPValidationError]]:
+) -> Response[Union[FeedbackDatasetModel, ErrorMessage, HTTPValidationError]]:
     url = "{}/api/v1/datasets".format(client.base_url)
 
     body = {"name": name, "workspace_id": workspace_id}
@@ -51,7 +52,7 @@ def create_dataset(
     )
 
     if response.status_code == 201:
-        parsed_response = FeedbackDataset(**response.json())
+        parsed_response = FeedbackDatasetModel(**response.json())
         return Response(
             status_code=response.status_code,
             content=response.content,
@@ -65,7 +66,7 @@ def create_dataset(
 def get_dataset(
     client: AuthenticatedClient,
     id: str,
-) -> Response[Union[FeedbackDataset, ErrorMessage, HTTPValidationError]]:
+) -> Response[Union[FeedbackDatasetModel, ErrorMessage, HTTPValidationError]]:
     url = "{}/api/v1/datasets/{id}".format(client.base_url, id=id)
 
     response = httpx.get(
@@ -76,7 +77,7 @@ def get_dataset(
     )
 
     if response.status_code == 200:
-        parsed_response = FeedbackDataset(**response.json())
+        parsed_response = FeedbackDatasetModel(**response.json())
         return Response(
             status_code=response.status_code,
             content=response.content,
@@ -89,7 +90,7 @@ def get_dataset(
 def publish_dataset(
     client: AuthenticatedClient,
     id: str,
-) -> Response[Union[FeedbackDataset, ErrorMessage, HTTPValidationError]]:
+) -> Response[Union[FeedbackDatasetModel, ErrorMessage, HTTPValidationError]]:
     url = "{}/api/v1/datasets/{id}/publish".format(client.base_url, id=id)
 
     response = httpx.put(
@@ -100,7 +101,7 @@ def publish_dataset(
     )
 
     if response.status_code == 200:
-        parsed_response = FeedbackDataset(**response.json())
+        parsed_response = FeedbackDatasetModel(**response.json())
         return Response(
             status_code=response.status_code,
             content=response.content,
@@ -112,7 +113,7 @@ def publish_dataset(
 
 def list_datasets(
     client: AuthenticatedClient,
-) -> Response[Union[List[FeedbackDataset], ErrorMessage, HTTPValidationError]]:
+) -> Response[Union[List[FeedbackDatasetModel], ErrorMessage, HTTPValidationError]]:
     url = "{}/api/v1/me/datasets".format(client.base_url)
 
     response = httpx.get(
@@ -123,7 +124,7 @@ def list_datasets(
     )
 
     if response.status_code == 200:
-        parsed_response = [FeedbackDataset(**dataset) for dataset in response.json()["items"]]
+        parsed_response = [FeedbackDatasetModel(**dataset) for dataset in response.json()["items"]]
         return Response(
             status_code=response.status_code,
             content=response.content,
@@ -138,7 +139,7 @@ def get_records(
     id: str,
     offset: int = 0,
     limit: int = 50,
-) -> Response[Union[Dict[str, Any], ErrorMessage, HTTPValidationError]]:
+) -> Response[Union[RecordsModel, ErrorMessage, HTTPValidationError]]:
     url = "{}/api/v1/me/datasets/{id}/records".format(client.base_url, id=id)
 
     response = httpx.get(
@@ -150,11 +151,12 @@ def get_records(
     )
 
     if response.status_code == 200:
+        parsed_response = RecordsModel(**response.json())
         return Response(
             status_code=response.status_code,
             content=response.content,
             headers=response.headers,
-            parsed=response.json(),
+            parsed=parsed_response,
         )
     return handle_response_error(response)
 
@@ -201,7 +203,7 @@ def get_fields(
             status_code=response.status_code,
             content=response.content,
             headers=response.headers,
-            parsed=response.json(),
+            parsed=response.json()["items"],
         )
     return handle_response_error(response)
 
@@ -248,7 +250,7 @@ def get_questions(
             status_code=response.status_code,
             content=response.content,
             headers=response.headers,
-            parsed=response.json(),
+            parsed=response.json()["items"],
         )
     return handle_response_error(response)
 

--- a/src/argilla/client/sdk/datasets/v1/models.py
+++ b/src/argilla/client/sdk/datasets/v1/models.py
@@ -18,15 +18,11 @@ from typing import Any, Dict
 
 from pydantic import BaseModel, Field
 
+from uuid import UUID
 
-class BaseDatasetModel(BaseModel):
-    tags: Dict[str, str] = Field(default_factory=dict)
-    metadata: Dict[str, Any] = Field(default_factory=dict)
+class FeedbackDatasetModel(BaseModel):
+    id: UUID
     name: str = Field(regex="^(?!-|_)[a-zA-Z0-9-_ ]+$")
-
-
-class FeedbackDataset(BaseDatasetModel):
-    id: str
     guidelines: str = None
     status: str = None
     workspace_id: str = None

--- a/src/argilla/client/sdk/datasets/v1/models.py
+++ b/src/argilla/client/sdk/datasets/v1/models.py
@@ -14,11 +14,11 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, List
+from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-from uuid import UUID
 
 class FeedbackDatasetModel(BaseModel):
     id: UUID
@@ -28,3 +28,8 @@ class FeedbackDatasetModel(BaseModel):
     workspace_id: str = None
     created_at: datetime = None
     last_updated: datetime = None
+
+
+class RecordsModel(BaseModel):
+    items: List[Dict[str, Any]]
+    total: int

--- a/src/argilla/client/sdk/workspaces/__init__.py
+++ b/src/argilla/client/sdk/workspaces/__init__.py
@@ -1,0 +1,14 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/src/argilla/client/sdk/workspaces/api.py
+++ b/src/argilla/client/sdk/workspaces/api.py
@@ -30,6 +30,15 @@ from argilla.client.sdk.workspaces.models import WorkspaceModel
 def list_workspaces(
     client: AuthenticatedClient,
 ) -> Response[Union[List[WorkspaceModel], ErrorMessage, HTTPValidationError]]:
+    """Sends a requet to `GET /api/workspaces` to list all the workspaces in the account.
+
+    Args:
+        client: the authenticated Argilla client to be used to send the request to the API.
+
+    Returns:
+        A Response object with the parsed response, containing a `parsed` attribute with the
+        parsed response if the request was successful, which is a list of `WorkspaceModel` objects.
+    """
     url = "{}/api/workspaces".format(client.base_url)
 
     response = httpx.get(

--- a/src/argilla/client/sdk/workspaces/api.py
+++ b/src/argilla/client/sdk/workspaces/api.py
@@ -1,0 +1,50 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import List, Union
+
+import httpx
+
+from argilla.client.sdk.client import AuthenticatedClient
+from argilla.client.sdk.commons.errors_handler import handle_response_error
+from argilla.client.sdk.commons.models import (
+    ErrorMessage,
+    HTTPValidationError,
+    Response,
+)
+from argilla.client.sdk.workspaces.models import WorkspaceModel
+
+
+def list_workspaces(
+    client: AuthenticatedClient,
+) -> Response[Union[List[WorkspaceModel], ErrorMessage, HTTPValidationError]]:
+    url = "{}/api/workspaces".format(client.base_url)
+
+    response = httpx.get(
+        url=url,
+        headers=client.get_headers(),
+        cookies=client.get_cookies(),
+        timeout=client.get_timeout(),
+    )
+
+    if response.status_code == 200:
+        parsed_response = [WorkspaceModel(**workspace) for workspace in response.json()]
+        return Response(
+            status_code=response.status_code,
+            content=response.content,
+            headers=response.headers,
+            parsed=parsed_response,
+        )
+    return handle_response_error(response)

--- a/src/argilla/client/sdk/workspaces/models.py
+++ b/src/argilla/client/sdk/workspaces/models.py
@@ -1,0 +1,25 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class WorkspaceModel(BaseModel):
+    id: str
+    name: str
+    inserted_at: datetime
+    updated_at: datetime

--- a/src/argilla/client/workspaces.py
+++ b/src/argilla/client/workspaces.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import warnings
 from typing import TYPE_CHECKING, Optional
 
 import argilla as rg
@@ -30,35 +31,50 @@ class Workspace:
     Args:
         name: the name of the workspace to be managed. If not provided, the current
             workspace will be used.
+        id: the ID of the workspace to be managed.
 
     Raises:
         ValueError: if the workspace does not exist in the current Argilla account.
 
     Examples:
         >>> from argilla import rg
-        >>> workspace = rg.Workspace("my-workspace")
+        >>> workspace = rg.Workspace.from_name("my-workspace")
         >>> workspace.id
     """
 
-    def __init__(self, name: Optional[str] = None) -> None:
+    def __init__(self, name: str, *, id: Optional[str] = None) -> None:
         """Initializes a new `Workspace` instance using the provided name. If no name
         is provided, the current workspace will be used.
 
         Args:
             name: the name of the workspace to be managed. If not provided, the current
                 workspace will be used.
+            id: the ID of the workspace to be managed.
+        """
+        self.name = name
+        self.id = id or None
+
+        if self.id is None:
+            warnings.warn(
+                f"The `rg.Workspace` doesn't exist yet, you need to create it in advance. Otherwise, use `rg.Workspace.from_name` to make sure that the workspace exists."
+            )
+
+    @classmethod
+    def from_name(cls, name: str) -> "Workspace":
+        """Class method to create a new `rg.Workspace` instance using the provided
+        name, if it exists.
+
+        Args:
+            name: the name of the workspace to be managed.
+
+        Returns:
+            A new `rg.Workspace` instance.
 
         Raises:
             ValueError: if the workspace does not exist in the current Argilla account.
-
         """
-        self.client: "Argilla" = rg.active_client()
-
-        self.name = name or self.client.get_workspace()
-        self.id = None
-        for workspace in self.client.list_workspaces():
-            if workspace.name == self.name:
-                self.id = workspace.id
-                break
-        if self.id is None:
-            raise ValueError(f"Workspace {self.name} not found in the current Argilla account.")
+        client: "Argilla" = rg.active_client()
+        for workspace in client.list_workspaces():
+            if workspace.name == name:
+                return cls(name, id=workspace.id)
+        raise ValueError(f"Workspace {name} not found in the current Argilla account.")

--- a/src/argilla/client/workspaces.py
+++ b/src/argilla/client/workspaces.py
@@ -1,0 +1,35 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import TYPE_CHECKING, Optional
+
+import argilla as rg
+
+if TYPE_CHECKING:
+    from argilla.client.api import Argilla
+
+
+class Workspace:
+    def __init__(self, name: Optional[str] = None) -> None:
+        self.client: "Argilla" = rg.active_client()
+
+        self.name = name or self.client.get_workspace()
+        self.id = None
+        for workspace in self.client.list_workspaces():
+            if workspace.name == self.name:
+                self.id = workspace.id
+                break
+        if self.id is None:
+            raise ValueError(f"Workspace {self.name} not found in the current Argilla account.")

--- a/src/argilla/client/workspaces.py
+++ b/src/argilla/client/workspaces.py
@@ -22,7 +22,36 @@ if TYPE_CHECKING:
 
 
 class Workspace:
+    """The `Workspace` class is used to manage workspaces in Argilla. The main
+    purpose of this class is to ease the conversion from name to ID, since the
+    workspace name is known to the user while the ID is not. Also, it helps checking
+    whether the workspace exists or not.
+
+    Args:
+        name: the name of the workspace to be managed. If not provided, the current
+            workspace will be used.
+
+    Raises:
+        ValueError: if the workspace does not exist in the current Argilla account.
+
+    Examples:
+        >>> from argilla import rg
+        >>> workspace = rg.Workspace("my-workspace")
+        >>> workspace.id
+    """
+
     def __init__(self, name: Optional[str] = None) -> None:
+        """Initializes a new `Workspace` instance using the provided name. If no name
+        is provided, the current workspace will be used.
+
+        Args:
+            name: the name of the workspace to be managed. If not provided, the current
+                workspace will be used.
+
+        Raises:
+            ValueError: if the workspace does not exist in the current Argilla account.
+
+        """
         self.client: "Argilla" = rg.active_client()
 
         self.name = name or self.client.get_workspace()

--- a/tests/client/sdk/workspaces/__init__.py
+++ b/tests/client/sdk/workspaces/__init__.py
@@ -1,0 +1,14 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/client/sdk/workspaces/test_api.py
+++ b/tests/client/sdk/workspaces/test_api.py
@@ -1,0 +1,40 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import httpx
+import pytest
+from argilla._constants import DEFAULT_API_KEY
+from argilla.client.sdk.client import AuthenticatedClient
+from argilla.client.sdk.workspaces.api import list_workspaces
+from argilla.client.sdk.workspaces.models import WorkspaceModel
+
+
+@pytest.fixture
+def sdk_client():
+    return AuthenticatedClient(base_url="http://localhost:6900", token=DEFAULT_API_KEY)
+
+
+def test_list_workspaces(mocked_client, sdk_client, monkeypatch) -> None:
+    monkeypatch.setattr(httpx, "get", mocked_client.get)
+
+    workspace_name = "test_workspace"
+    mocked_client.post(f"/api/workspaces", json={"name": workspace_name})
+
+    response = list_workspaces(client=sdk_client)
+
+    assert response.status_code == 200
+    assert isinstance(response.parsed, list)
+    assert len(response.parsed) > 0
+    assert isinstance(response.parsed[0], WorkspaceModel)

--- a/tests/client/sdk/workspaces/test_models.py
+++ b/tests/client/sdk/workspaces/test_models.py
@@ -1,0 +1,20 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from argilla.client.sdk.workspaces.models import WorkspaceModel as ClientSchema
+from argilla.server.apis.v1.handlers.workspaces import Workspace as ServerSchema
+
+
+def test_users_schema(helpers):
+    assert helpers.are_compatible_api_schemas(ClientSchema.schema(), ServerSchema.schema())

--- a/tests/client/test_workspaces.py
+++ b/tests/client/test_workspaces.py
@@ -1,0 +1,32 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+from argilla.client import api
+from argilla.client.workspaces import Workspace
+
+
+def test_workspace_cls_init(mocked_client):
+    the_api = api.active_api()
+    workspace = the_api.http_client.post("/api/workspaces", json={"name": "test_workspace"})
+    assert workspace["name"] == "test_workspace"
+
+    api.init(api_key="argilla.apikey")
+    workspace = Workspace("test_workspace")
+    assert workspace.name == "test_workspace"
+    assert isinstance(workspace.id, str)
+
+    with pytest.raises(ValueError):
+        Workspace("this_workspace_does_not_exist")

--- a/tests/client/test_workspaces.py
+++ b/tests/client/test_workspaces.py
@@ -24,9 +24,9 @@ def test_workspace_cls_init(mocked_client):
     assert workspace["name"] == "test_workspace"
 
     api.init(api_key="argilla.apikey")
-    workspace = Workspace("test_workspace")
+    workspace = Workspace.from_name("test_workspace")
     assert workspace.name == "test_workspace"
     assert isinstance(workspace.id, str)
 
     with pytest.raises(ValueError):
-        Workspace("this_workspace_does_not_exist")
+        Workspace.from_name("this_workspace_does_not_exist")


### PR DESCRIPTION
# Description

This PR has been created on top of #2827 to add a `Workspace` class so that we can easily convert workspace names (human readable format) to workspace IDs (transparent to the user). This is just covering the basic functionality which is to `list_workspaces` to get all the available workspaces for the current user, so that when instantiating `Workspace` we can know whether that workspace exists and is available for the current user or not.

Besides that, the main reason behind this PR is because the `/api/v1` and `/api/v1/me` endpoints expect the workspace ID, not the workspace name, as opposed to the former `/api` (v0) which was using names not IDs.

> :warning: Note that this may be extended in the future to cover all the `Workspace` functionalities provided by Argilla, but for the moment, we're keeping it simple since it's just going to be used for name to ID conversation and workspace validation.

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [X] Add unit tests for `list_datasets` and `Workspace`

**Checklist**

- [X] I have merged the original branch into my forked branch
- [X] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works