### PR TITLE
feat : front support tooltip for configuration

### DIFF
--- a/frontend/components/base/BaseIconWithBadge.vue
+++ b/frontend/components/base/BaseIconWithBadge.vue
@@ -14,7 +14,7 @@
         borderColor: badgeBorderColor,
       }"
     >
-      <svgicon :name="icon" width="22" height="22" color="white" />
+      <svgicon :name="icon" width="22" height="22" :color="iconColor" />
     </i>
   </BaseButton>
 </template>
@@ -27,6 +27,10 @@ export default {
     },
     icon: {
       type: String,
+    },
+    iconColor: {
+      type: String,
+      default: () => "white",
     },
     tooltip: {
       type: String,

--- a/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
+++ b/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
@@ -10,8 +10,8 @@
           :placeholder="input.placeholder"
           :initialOptions="input.options[0]"
           :isRequired="input.is_required"
-          :isIcon="!!input.tooltip_message"
-          :tooltipMessage="input.tooltip_message"
+          :isIcon="!!input.description"
+          :tooltipMessage="input.description"
           :colorHighlight="colorAsterisk"
           @on-change-text-area="
             onChange({ newOptions: $event, idComponent: input.id })
@@ -24,8 +24,8 @@
           :title="input.question"
           :initialOptions="input.options"
           :isRequired="input.is_required"
-          :isIcon="!!input.tooltip_message"
-          :tooltipMessage="input.tooltip_message"
+          :isIcon="!!input.description"
+          :tooltipMessage="input.description"
           :colorHighlight="colorAsterisk"
           @on-change-single-label="
             onChange({ newOptions: $event, idComponent: input.id })
@@ -38,8 +38,8 @@
           :title="input.question"
           :initialOptions="input.options"
           :isRequired="input.is_required"
-          :isIcon="!!input.tooltip_message"
-          :tooltipMessage="input.tooltip_message"
+          :isIcon="!!input.description"
+          :tooltipMessage="input.description"
           :colorHighlight="colorAsterisk"
           @on-change-rating="
             onChange({ newOptions: $event, idComponent: input.id })

--- a/frontend/components/commons/forms/questions-form/fields/mono-selection/MonoSelection.component.vue
+++ b/frontend/components/commons/forms/questions-form/fields/mono-selection/MonoSelection.component.vue
@@ -9,6 +9,7 @@
 
       <BaseIconWithBadge
         class="icon-info"
+        v-if="isIcon"
         icon="info"
         :id="`${title}MonoSelection`"
         :show-badge="false"

--- a/frontend/components/commons/forms/questions-form/fields/mono-selection/MonoSelection.component.vue
+++ b/frontend/components/commons/forms/questions-form/fields/mono-selection/MonoSelection.component.vue
@@ -6,14 +6,18 @@
         v-text="title"
         v-optional-field="isRequired ? false : true"
       />
-      <TooltipComponent
-        class="info-icon"
-        v-if="isIcon"
-        :message="tooltipMessage"
-        direction="bottom"
-      >
-        <svgicon class="icon" name="info" width="22" height="22" />
-      </TooltipComponent>
+
+      <BaseIconWithBadge
+        class="icon-info"
+        icon="info"
+        :id="`${title}MonoSelection`"
+        :show-badge="false"
+        iconColor="rgba(0, 0, 0, 0.37)"
+        badge-vertical-position="top"
+        badge-horizontal-position="right"
+        badge-border-color="white"
+        v-tooltip="{ content: tooltipMessage, backgroundColor: '#FFF' }"
+      />
     </div>
     <div class="container">
       <div class="inputs-area">
@@ -183,5 +187,19 @@ input {
 
 span {
   word-break: break-word;
+}
+
+.icon-info {
+  margin: 0;
+  padding: 0;
+  overflow: inherit;
+  &[data-title] {
+    position: relative;
+    overflow: visible;
+    &:before,
+    &:after {
+      margin-top: 0;
+    }
+  }
 }
 </style>

--- a/frontend/components/commons/forms/questions-form/fields/text-area/TextArea.component.vue
+++ b/frontend/components/commons/forms/questions-form/fields/text-area/TextArea.component.vue
@@ -9,6 +9,7 @@
 
       <BaseIconWithBadge
         class="icon-info"
+        v-if="isIcon"
         icon="info"
         :id="`${title}TextArea`"
         :show-badge="false"
@@ -65,7 +66,7 @@ export default {
     },
     isIcon: {
       type: Boolean,
-      default: false,
+      default: () => false,
     },
     tooltipMessage: {
       type: String,

--- a/frontend/components/commons/forms/questions-form/fields/text-area/TextArea.component.vue
+++ b/frontend/components/commons/forms/questions-form/fields/text-area/TextArea.component.vue
@@ -7,13 +7,17 @@
         v-optional-field="isRequired ? false : true"
       />
 
-      <TooltipComponent
-        v-if="isIcon"
-        :message="tooltipMessage"
-        direction="bottom"
-      >
-        <svgicon class="icon" name="info" width="22" height="22" />
-      </TooltipComponent>
+      <BaseIconWithBadge
+        class="icon-info"
+        icon="info"
+        :id="`${title}TextArea`"
+        :show-badge="false"
+        iconColor="rgba(0, 0, 0, 0.37)"
+        badge-vertical-position="top"
+        badge-horizontal-position="right"
+        badge-border-color="white"
+        v-tooltip="{ content: tooltipMessage, backgroundColor: '#FFF' }"
+      />
     </div>
 
     <div class="container" :class="isFocused ? '--focused' : null">
@@ -134,5 +138,19 @@ export default {
 .textarea {
   display: flex;
   flex: 0 0 100%;
+}
+
+.icon-info {
+  margin: 0;
+  padding: 0;
+  overflow: inherit;
+  &[data-title] {
+    position: relative;
+    overflow: visible;
+    &:before,
+    &:after {
+      margin-top: 0;
+    }
+  }
 }
 </style>

--- a/frontend/components/page-contents/feedback-task-content/CenterFeedbackTask.content.vue
+++ b/frontend/components/page-contents/feedback-task-content/CenterFeedbackTask.content.vue
@@ -116,6 +116,7 @@ export default {
             title: questionTitle,
             required: isRequired,
             settings: questionSettings,
+            description: questionDescription,
           },
           index
         ) => {
@@ -141,7 +142,7 @@ export default {
             is_required: isRequired,
             component_type: componentType,
             placeholder: questionSettings?.placeholder ?? null,
-            tooltip_message: questionSettings?.tooltip ?? null,
+            description: questionDescription ?? null,
           };
         }
       );

--- a/frontend/models/feedback-task-model/dataset-question/DatasetQuestion.model.js
+++ b/frontend/models/feedback-task-model/dataset-question/DatasetQuestion.model.js
@@ -14,7 +14,7 @@ class DatasetQuestion extends Model {
       placeholder: this.string(null).nullable(),
       is_required: this.boolean(false),
       component_type: this.string(null).nullable(),
-      tooltip_message: this.string(null).nullable(),
+      description: this.string(null).nullable(),
     };
   }
 }

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -71,6 +71,7 @@ export default {
     { src: "~/plugins/custom-directives/circle.directive.js" },
     { src: "~/plugins/custom-directives/required-field.directive.js" },
     { src: "~/plugins/custom-directives/optional-field.directive.js" },
+    { src: "~/plugins/custom-directives/tooltip.directive.js" },
   ],
 
   // Auto import components (https://go.nuxtjs.dev/config-components)


### PR DESCRIPTION
# Description
Front part to support support tooltip configuration

TODO : 
- [x] renaming attribute orm 'tooltip_message' by generic one (description as in the back end)
- [x] get and pass to the question components (rating, etc) this description attribute from the corresponding orm
- [x] render the tooltip
- [x] modify the tooltip from question components to be a new directive instead of a component => the tooltip will open on click and close on clickOutside or click on close button
- [ ] custom css of the tooltip directive => This part will be tackle in an other issue to update css

Bonus
- [x] Replace TooltipComponent by BaseIconWithBadge component and add to this component the new tooltip directive


**Type of change**

- New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- Only feedback task 
