### PR TITLE
feat : refresh and prevent user will lost current modifications on clicking refresh button

### DIFF
--- a/frontend/components/commons/sidebar-feedback-task/SidebarFeedbackTask.component.vue
+++ b/frontend/components/commons/sidebar-feedback-task/SidebarFeedbackTask.component.vue
@@ -82,7 +82,7 @@ export default {
           console.log("change-view-mode", info);
           break;
         case "refresh":
-          console.log("refresh dataset");
+          this.$emit("refresh");
           break;
         default:
           console.warn(info);

--- a/frontend/components/commons/sidebar-feedback-task/SidebarFeedbackTask.component.vue
+++ b/frontend/components/commons/sidebar-feedback-task/SidebarFeedbackTask.component.vue
@@ -13,6 +13,7 @@
 </template>
 
 <script>
+import { SIDEBAR_GROUP } from "@/models/feedback-task-model/dataset-filter/datasetFilter.queries";
 export default {
   data: () => ({
     currentMetric: null,
@@ -74,14 +75,14 @@ export default {
   },
   methods: {
     onClickSidebarAction(group, info) {
-      switch (group) {
-        case "metrics":
+      switch (group.toUpperCase()) {
+        case SIDEBAR_GROUP.METRICS:
           this.toggleMetrics(info);
           break;
-        case "mode":
+        case SIDEBAR_GROUP.MODE:
           console.log("change-view-mode", info);
           break;
-        case "refresh":
+        case SIDEBAR_GROUP.REFRESH:
           this.$emit("refresh");
           break;
         default:

--- a/frontend/models/feedback-task-model/dataset-filter/datasetFilter.queries.js
+++ b/frontend/models/feedback-task-model/dataset-filter/datasetFilter.queries.js
@@ -1,5 +1,11 @@
 import { DatasetFilter as DatasetFilterModel } from "./DatasetFilter.model";
 
+const SIDEBAR_GROUP = Object.freeze({
+  METRICS: "METRICS",
+  MODE: "MODE",
+  REFRESH: "REFRESH",
+});
+
 // UPSERT
 const upsertDatasetFilters = (globalFilters) => {
   DatasetFilterModel.insertOrUpdate({ data: globalFilters });
@@ -18,4 +24,4 @@ const getFiltersByDatasetId = (
     .get();
 };
 
-export { upsertDatasetFilters, getFiltersByDatasetId };
+export { upsertDatasetFilters, getFiltersByDatasetId, SIDEBAR_GROUP };

--- a/frontend/models/feedback-task-model/record-field/recordField.queries.js
+++ b/frontend/models/feedback-task-model/record-field/recordField.queries.js
@@ -1,0 +1,6 @@
+import { RecordField as RecordFieldModel } from "./RecordField.model";
+
+// DELETE ALL FIELDS
+const deleteAllRecordFields = () => RecordFieldModel.deleteAll();
+
+export { deleteAllRecordFields };

--- a/frontend/models/feedback-task-model/record-response/recordResponse.queries.js
+++ b/frontend/models/feedback-task-model/record-response/recordResponse.queries.js
@@ -29,6 +29,9 @@ const deleteRecordResponsesByUserIdAndResponseId = (userId, responseId) =>
     );
   });
 
+// DELETE ALL RESPONSES
+const deleteAllRecordResponses = () => RecordResponseModel.deleteAll();
+
 // EXIST
 const isResponsesByUserIdExists = (userId, recordId) =>
   RecordResponseModel.query()
@@ -42,5 +45,6 @@ export {
   findRecordResponseByRecordIdByQuestionId,
   upsertRecordResponses,
   deleteRecordResponsesByUserIdAndResponseId,
+  deleteAllRecordResponses,
   isResponsesByUserIdExists,
 };

--- a/frontend/pages/dataset/_id/annotation-mode/index.vue
+++ b/frontend/pages/dataset/_id/annotation-mode/index.vue
@@ -8,7 +8,7 @@
       />
     </template>
     <template v-slot:sidebar-right>
-      <SidebarFeedbackTaskComponent />
+      <SidebarFeedbackTaskComponent @refresh="onRefresh()" />
     </template>
     <template v-slot:top>
       <DatasetFiltersComponent :datasetId="datasetId" />
@@ -41,6 +41,11 @@ export default {
   name: "DatasetPage",
   components: {
     HeaderAndTopAndOneColumn,
+  },
+  data: () => {
+    return {
+      areResponsesUntouched: false,
+    };
   },
   computed: {
     datasetId() {
@@ -80,12 +85,19 @@ export default {
 
       // 3- insert in ORM
       upsertFeedbackDataset({ ...dataset, workspace_name: workspace });
+
+      // Check if response is untouched
+      this.onBusEventAreResponsesUntouched();
     } catch (err) {
       this.manageErrorIfFetchNotWorking(err);
     }
   },
   created() {
     this.checkIfUrlHaveRecordStatusOrInitiateQueryParams();
+    this.toastMessage =
+      "Pending actions will be lost when the page is refreshed";
+    this.buttonMessage = "Ok, got it!";
+    this.typeOfToast = "warning";
   },
   methods: {
     checkIfUrlHaveRecordStatusOrInitiateQueryParams() {
@@ -148,6 +160,41 @@ export default {
       };
 
       Notification.dispatch("notify", paramsForNotitification);
+    },
+    async onRefresh() {
+      if (this.areResponsesUntouched) {
+        this.$fetch();
+      } else {
+        this.showNotificationBeforeRefresh({
+          eventToFireOnClick: async () => {
+            this.$fetch();
+          },
+          message: this.toastMessage,
+          buttonMessage: this.buttonMessage,
+          typeOfToast: this.typeOfToast,
+        });
+      }
+    },
+    async onBusEventAreResponsesUntouched() {
+      this.$root.$on("are-responses-untouched", (areResponsesUntouched) => {
+        this.areResponsesUntouched = areResponsesUntouched;
+      });
+    },
+    showNotificationBeforeRefresh({
+      eventToFireOnClick,
+      message,
+      buttonMessage,
+      typeOfToast,
+    }) {
+      Notification.dispatch("notify", {
+        message: message ?? "",
+        numberOfChars: 20000,
+        type: typeOfToast ?? "warning",
+        buttonText: buttonMessage ?? "",
+        async onClick() {
+          eventToFireOnClick();
+        },
+      });
     },
   },
 };

--- a/frontend/pages/dataset/_id/annotation-mode/index.vue
+++ b/frontend/pages/dataset/_id/annotation-mode/index.vue
@@ -24,7 +24,10 @@
 
 <script>
 import HeaderAndTopAndOneColumn from "@/layouts/HeaderAndTopAndOneColumn";
-import { RECORD_STATUS } from "@/models/feedback-task-model/record/record.queries";
+import {
+  RECORD_STATUS,
+  deleteAllRecords,
+} from "@/models/feedback-task-model/record/record.queries";
 import {
   upsertFeedbackDataset,
   getFeedbackDatasetNameById,
@@ -163,17 +166,21 @@ export default {
     },
     async onRefresh() {
       if (this.areResponsesUntouched) {
-        this.$fetch();
+        await this.deleteRecordsAndRefreshDataset();
       } else {
         this.showNotificationBeforeRefresh({
           eventToFireOnClick: async () => {
-            this.$fetch();
+            await this.deleteRecordsAndRefreshDataset();
           },
           message: this.toastMessage,
           buttonMessage: this.buttonMessage,
           typeOfToast: this.typeOfToast,
         });
       }
+    },
+    async deleteRecordsAndRefreshDataset() {
+      await deleteAllRecords();
+      this.$fetch();
     },
     async onBusEventAreResponsesUntouched() {
       this.$root.$on("are-responses-untouched", (areResponsesUntouched) => {
@@ -196,6 +203,9 @@ export default {
         },
       });
     },
+  },
+  destroyed() {
+    this.$root.$off("current-page");
   },
 };
 </script>

--- a/frontend/pages/dataset/_id/annotation-mode/index.vue
+++ b/frontend/pages/dataset/_id/annotation-mode/index.vue
@@ -28,6 +28,8 @@ import {
   RECORD_STATUS,
   deleteAllRecords,
 } from "@/models/feedback-task-model/record/record.queries";
+import { deleteAllRecordFields } from "@/models/feedback-task-model/record-field/recordField.queries";
+import { deleteAllRecordResponses } from "@/models/feedback-task-model/record-response/recordResponse.queries";
 import {
   upsertFeedbackDataset,
   getFeedbackDatasetNameById,
@@ -180,6 +182,8 @@ export default {
     },
     async deleteRecordsAndRefreshDataset() {
       await deleteAllRecords();
+      await deleteAllRecordFields();
+      await deleteAllRecordResponses();
       this.$fetch();
     },
     async onBusEventAreResponsesUntouched() {


### PR DESCRIPTION
# Description

This PR includes refresh dataset functionality from sidebar button and prevents user with a toast component if formular have been touched

Closes #2868

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**Checklist**

- [x] I have merged the original branch into my forked branch
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings