### PR TITLE
feat: show empty message when filter status is empty

### DIFF
--- a/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
+++ b/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
@@ -21,9 +21,7 @@
       />
     </template>
     <div v-else class="wrapper--empty">
-      <p class="wrapper__text --heading3">
-        There are no {{ recordStatusToFilterWith }} records
-      </p>
+      <p class="wrapper__text --heading3" v-text="noRecordsMessage" />
     </div>
   </div>
 </template>
@@ -170,6 +168,9 @@ export default {
           };
         }
       });
+    },
+    noRecordsMessage() {
+      return `There are no ${this.recordStatusToFilterWith} records`;
     },
     statusClass() {
       return `--${this.record.record_status.toLowerCase()}`;

--- a/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
+++ b/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
@@ -1,23 +1,30 @@
 <template>
   <div
+    v-if="!$fetchState.pending && !$fetchState.error"
     :key="recordOffset"
     class="wrapper"
-    v-if="recordId && !$fetchState.pending && !$fetchState.error"
   >
-    <RecordFeedbackTaskComponent
-      v-if="fieldsWithRecordFieldText"
-      :recordStatus="record.record_status"
-      :fields="fieldsWithRecordFieldText"
-    />
-    <QuestionsFormComponent
-      class="question-form"
-      :class="statusClass"
-      v-if="questionsWithRecordAnswers && questionsWithRecordAnswers.length"
-      :datasetId="datasetId"
-      :recordId="recordId"
-      :recordStatus="record.record_status"
-      :initialInputs="questionsWithRecordAnswers"
-    />
+    <template v-if="recordId">
+      <RecordFeedbackTaskComponent
+        v-if="fieldsWithRecordFieldText"
+        :recordStatus="record.record_status"
+        :fields="fieldsWithRecordFieldText"
+      />
+      <QuestionsFormComponent
+        class="question-form"
+        :class="statusClass"
+        v-if="questionsWithRecordAnswers && questionsWithRecordAnswers.length"
+        :datasetId="datasetId"
+        :recordId="recordId"
+        :recordStatus="record.record_status"
+        :initialInputs="questionsWithRecordAnswers"
+      />
+    </template>
+    <div v-else class="wrapper--empty">
+      <p class="wrapper__text --heading3">
+        There are no {{ recordStatusToFilterWith }} records
+      </p>
+    </div>
   </div>
 </template>
 
@@ -341,6 +348,15 @@ export default {
   flex-wrap: wrap;
   gap: 2 * $base-space;
   height: 100%;
+  &__text {
+    color: $black-54;
+  }
+  &--empty {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 }
 .question-form {
   border: 1px solid transparent;


### PR DESCRIPTION
# Description

Show "There are no `<status>` records" message in case of no records

Closes #2873

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**Checklist**

- [x] I have merged the original branch into my forked branch
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings