### PR TITLE
fix: Remove current-page event destruction to get correct records

### DIFF
--- a/frontend/components/feedback-task/footer/Pagination.component.vue
+++ b/frontend/components/feedback-task/footer/Pagination.component.vue
@@ -114,7 +114,6 @@ export default {
   },
   destroyed() {
     document.removeEventListener("keydown", this.onPressKeyboardShortCut);
-    this.$root.$off("current-page");
   },
   methods: {
     onPressKeyboardShortCut({ code }) {

--- a/frontend/components/feedback-task/footer/PaginationFeedbackTask.component.vue
+++ b/frontend/components/feedback-task/footer/PaginationFeedbackTask.component.vue
@@ -61,7 +61,6 @@ export default {
     },
   },
   destroyed() {
-    this.$root.$off("current-page");
     this.$root.$off("are-responses-untouched");
   },
 };

--- a/frontend/pages/dataset/_id/annotation-mode/index.vue
+++ b/frontend/pages/dataset/_id/annotation-mode/index.vue
@@ -209,7 +209,7 @@ export default {
     },
   },
   destroyed() {
-    this.$root.$off("current-page");
+    this.$root.$off("are-responses-untouched");
   },
 };
 </script>


### PR DESCRIPTION
# Description

When we change the status selector from one empty to one with records, the record offset is not correct. Removing the destruction of the `current-page` event in pagination, we can get the correct record offset. 

Closes #2880

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)