### PR TITLE
fix: When going to a page superior than maximum available page, go to first

### DIFF
--- a/frontend/components/feedback-task/footer/Pagination.component.vue
+++ b/frontend/components/feedback-task/footer/Pagination.component.vue
@@ -106,7 +106,10 @@ export default {
     },
   },
   mounted() {
-    this.currentPage = parseFloat(this.$route.query?._page) || 1;
+    this.currentPage =
+      this.currentPage > this.totalPages
+        ? parseFloat(this.$route.query?._page) || 1
+        : 1;
 
     document.addEventListener("keydown", this.onPressKeyboardShortCut);
 

--- a/frontend/components/feedback-task/footer/Pagination.component.vue
+++ b/frontend/components/feedback-task/footer/Pagination.component.vue
@@ -98,7 +98,7 @@ export default {
       return (this.pageFromQuery || this.currentPage) <= this.totalPages;
     },
     pageFromRoute() {
-      return parseFloat(this.$route.query?._page);
+      return parseFloat(this.$route.query?._page) || 1;
     },
   },
   watch: {
@@ -111,7 +111,7 @@ export default {
     },
   },
   mounted() {
-    this.currentPage = this.isPageAvailable ? this.pageFromRoute || 1 : 1;
+    this.currentPage = this.isPageAvailable ? this.pageFromRoute : 1;
     document.addEventListener("keydown", this.onPressKeyboardShortCut);
     this.onBusEventCurrentPage();
   },

--- a/frontend/components/feedback-task/footer/Pagination.component.vue
+++ b/frontend/components/feedback-task/footer/Pagination.component.vue
@@ -95,7 +95,10 @@ export default {
       return `${this.currentPage} of ${this.totalItems} records`;
     },
     isPageAvailable() {
-      return (this.$route.query?._page || this.currentPage) <= this.totalPages;
+      return (this.pageFromQuery || this.currentPage) <= this.totalPages;
+    },
+    pageFromQuery() {
+      return parseFloat(this.$route.query?._page);
     },
   },
   watch: {
@@ -108,9 +111,7 @@ export default {
     },
   },
   mounted() {
-    this.currentPage = this.isPageAvailable
-      ? parseFloat(this.$route.query?._page) || 1
-      : 1;
+    this.currentPage = this.isPageAvailable ? this.pageFromQuery || 1 : 1;
 
     document.addEventListener("keydown", this.onPressKeyboardShortCut);
 

--- a/frontend/components/feedback-task/footer/Pagination.component.vue
+++ b/frontend/components/feedback-task/footer/Pagination.component.vue
@@ -97,7 +97,7 @@ export default {
     isPageAvailable() {
       return (this.pageFromQuery || this.currentPage) <= this.totalPages;
     },
-    pageFromQuery() {
+    pageFromRoute() {
       return parseFloat(this.$route.query?._page);
     },
   },
@@ -111,7 +111,7 @@ export default {
     },
   },
   mounted() {
-    this.currentPage = this.isPageAvailable ? this.pageFromQuery || 1 : 1;
+    this.currentPage = this.isPageAvailable ? this.pageFromRoute || 1 : 1;
 
     document.addEventListener("keydown", this.onPressKeyboardShortCut);
 

--- a/frontend/components/feedback-task/footer/Pagination.component.vue
+++ b/frontend/components/feedback-task/footer/Pagination.component.vue
@@ -112,9 +112,7 @@ export default {
   },
   mounted() {
     this.currentPage = this.isPageAvailable ? this.pageFromRoute || 1 : 1;
-
     document.addEventListener("keydown", this.onPressKeyboardShortCut);
-
     this.onBusEventCurrentPage();
   },
   destroyed() {

--- a/frontend/components/feedback-task/footer/Pagination.component.vue
+++ b/frontend/components/feedback-task/footer/Pagination.component.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="pagination">
     <div class="number-of-records-by-page-area"></div>
-
     <div class="pagination__buttons">
       <BaseButton
         class="pagination__button"
@@ -95,6 +94,9 @@ export default {
     totalOfRecordMessage() {
       return `${this.currentPage} of ${this.totalItems} records`;
     },
+    isPageAvailable() {
+      return (this.$route.query?._page || this.currentPage) <= this.totalPages;
+    },
   },
   watch: {
     localCurrentPage: {
@@ -106,10 +108,9 @@ export default {
     },
   },
   mounted() {
-    this.currentPage =
-      this.currentPage > this.totalPages
-        ? parseFloat(this.$route.query?._page) || 1
-        : 1;
+    this.currentPage = this.isPageAvailable
+      ? parseFloat(this.$route.query?._page) || 1
+      : 1;
 
     document.addEventListener("keydown", this.onPressKeyboardShortCut);
 


### PR DESCRIPTION
# Description

If we go to a page number superior than the maximum page number, the ui will change to the first page to avoid to show empty page

Closes #2883

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)