### PR TITLE
fix : update condition to disable submit button

### DIFF
--- a/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
+++ b/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
@@ -75,7 +75,7 @@
           name="submitButton"
           value="submitButton"
           class="primary"
-          :disabled="isFormUntouched || isSomeRequiredQuestionHaveNoAnswer"
+          :disabled="disableSubmitButton"
         >
           <span v-text="'Submit'" />
         </BaseButton>
@@ -163,6 +163,30 @@ export default {
     },
     isRecordDiscarded() {
       return this.recordStatus === RECORD_STATUS.DISCARDED;
+    },
+    isRecordPending() {
+      return this.recordStatus === RECORD_STATUS.PENDING;
+    },
+    isRecordSubmitted() {
+      return this.recordStatus === RECORD_STATUS.SUBMITTED;
+    },
+    disableSubmitButton() {
+      let isButtonDisable = false;
+      switch (true) {
+        case this.isRecordSubmitted:
+          if (this.isFormUntouched || this.isSomeRequiredQuestionHaveNoAnswer) {
+            isButtonDisable = true;
+          }
+          break;
+        case this.isRecordDiscarded:
+        case this.isRecordPending:
+          if (this.isSomeRequiredQuestionHaveNoAnswer) isButtonDisable = true;
+          break;
+        default:
+          isButtonDisable = false;
+      }
+
+      return isButtonDisable;
     },
   },
   watch: {


### PR DESCRIPTION
# Description
Update condition to disable submit button

On a submitted record : 
=> the button **submit** is **disable** if **the form is untouched** or  if **one of the required question does not have answer**

On a discarded/pending record:
=> the button submit  is **disable** ONLY if **one of the required question does not have answer**

Closes #2881 

**Type of change**

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

- only feedback task submit button
