### PR TITLE
fix : synchronous problem when one record in dataset

### DIFF
--- a/frontend/components/page-contents/feedback-task-content/CenterFeedbackTask.content.vue
+++ b/frontend/components/page-contents/feedback-task-content/CenterFeedbackTask.content.vue
@@ -79,10 +79,14 @@ export default {
     },
   },
   watch: {
+    totalRecords(newTotalRecord) {
+      if (!newTotalRecord) this.areResponsesUntouched = true;
+    },
     async recordStatusFilteringValue(newStatus, oldStatus) {
       // NOTE 1 - each time the filter change, clean records orm && rerender the children component
       !this.areResponsesUntouched ||
         (await this.goToFirstPageAndRerenderChildren());
+
       // NOTE 2 - if responses are untouched, toast is not shown. Else, toast is shown
       this.checkIfAreResponsesUntouchedAndRouteStatusIsDifferent(newStatus) ||
         this.showNotificationBeforeChangeStatus({
@@ -302,7 +306,8 @@ export default {
     },
     checkIfAreResponsesUntouchedAndRouteStatusIsDifferent(status) {
       return (
-        this.areResponsesUntouched || this.recordStatus.toLowerCase() === status
+        this.areResponsesUntouched ||
+        this.recordStatus?.toLowerCase() === status
       );
     },
     async getFields(datasetId) {


### PR DESCRIPTION
# Description
In dataset with only one record, there was a problem of synchronisation when switching record status with record with answer which have not been submitted

a refresh was necessary to show again the good record

**Type of change**

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

- only feedback task with one record, see dataset : **feedback-task-dataset-via-sdk**

