### PR TITLE
feat : update toast messages

### DIFF
--- a/frontend/components/feedback-task/footer/PaginationFeedbackTask.component.vue
+++ b/frontend/components/feedback-task/footer/PaginationFeedbackTask.component.vue
@@ -24,8 +24,8 @@ export default {
   },
   created() {
     this.paginationNotificationParams = {
-      message: "Pending actions will be lost when the page is refreshed",
-      buttonMessage: "Ok, got it!",
+      message: "Your changes will be lost if you move to another page",
+      buttonMessage: "Ok, continue.",
       typeOfToast: "warning",
     };
 

--- a/frontend/components/page-contents/feedback-task-content/CenterFeedbackTask.content.vue
+++ b/frontend/components/page-contents/feedback-task-content/CenterFeedbackTask.content.vue
@@ -97,9 +97,8 @@ export default {
     },
   },
   created() {
-    this.toastMessage =
-      "Pending actions will be lost when the page is refreshed";
-    this.buttonMessage = "Ok, got it!";
+    this.toastMessage = "Your changes will be lost if you move to another view";
+    this.buttonMessage = "Ok, continue.";
     this.typeOfToast = "warning";
   },
   methods: {

--- a/frontend/pages/dataset/_id/annotation-mode/index.vue
+++ b/frontend/pages/dataset/_id/annotation-mode/index.vue
@@ -99,9 +99,8 @@ export default {
   },
   created() {
     this.checkIfUrlHaveRecordStatusOrInitiateQueryParams();
-    this.toastMessage =
-      "Pending actions will be lost when the page is refreshed";
-    this.buttonMessage = "Ok, got it!";
+    this.toastMessage = "Your changes will be lost if you refresh the page";
+    this.buttonMessage = "Ok, continue.";
     this.typeOfToast = "warning";
   },
   methods: {


### PR DESCRIPTION
# Description
Update toast messages if the form have been touched before: 
- refresh
- pagination
- switching to another view (status pending, discarded, submitted)

**Type of change**

- New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- Only feedback task messages on the 3 toasts
