### PR TITLE
Admin users can create records with responses for several users

### DIFF
--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -254,9 +254,7 @@ async def create_dataset_records(
     # TODO: We should split API v1 into different FastAPI apps so we can customize error management.
     #  After mapping ValueError to 422 errors for API v1 then we can remove this try except.
     try:
-        await datasets.create_records(
-            db, search_engine, dataset=dataset, user=current_user, records_create=records_create
-        )
+        await datasets.create_records(db, search_engine, dataset=dataset, records_create=records_create)
     except ValueError as err:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(err))
 

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -17,9 +17,9 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
-from pydantic import BaseModel, conlist, constr
+from pydantic import BaseModel, conlist, constr, validator
 from pydantic import Field as ModelField
-from typing_extensions import Literal
+from typing_extensions import Annotated, Literal
 
 from argilla.server.models import DatasetStatus, FieldType, QuestionType, ResponseStatus
 
@@ -204,20 +204,39 @@ class Records(BaseModel):
     total: int
 
 
-class SubmittedResponseCreate(BaseModel):
+class UserSubmittedResponseCreate(BaseModel):
+    user_id: UUID
     values: Dict[str, ResponseValueCreate]
     status: Literal[ResponseStatus.submitted]
 
 
-class DiscardedResponseCreate(BaseModel):
+class UserDiscardedResponseCreate(BaseModel):
+    user_id: UUID
     values: Optional[Dict[str, ResponseValueCreate]]
     status: Literal[ResponseStatus.discarded]
+
+
+UserResponseCreate = Annotated[
+    Union[UserSubmittedResponseCreate, UserDiscardedResponseCreate],
+    ModelField(discriminator="status"),
+]
 
 
 class RecordCreate(BaseModel):
     fields: Dict[str, Any]
     external_id: Optional[str]
-    response: Optional[Union[SubmittedResponseCreate, DiscardedResponseCreate]] = ModelField(discriminator="status")
+    responses: Optional[List[UserResponseCreate]]
+
+    @validator("responses")
+    def check_user_id_is_unique(cls, values):
+        user_ids = []
+
+        for value in values:
+            if value.user_id in user_ids:
+                raise ValueError(f"Responses contains several responses for the same user_id: {str(value.user_id)!r}")
+            user_ids.append(value.user_id)
+
+        return values
 
 
 class RecordsCreate(BaseModel):

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -1401,6 +1401,7 @@ async def test_create_dataset_records(
     search_engine: SearchEngine,
     opensearch: OpenSearch,
     db: Session,
+    admin: User,
     admin_auth_header: dict,
 ):
     dataset = DatasetFactory.create(status=DatasetStatus.ready)
@@ -1417,13 +1418,13 @@ async def test_create_dataset_records(
             {
                 "fields": {"input": "Say Hello", "output": "Hello"},
                 "external_id": "1",
-                "response": {
-                    "values": {
-                        "input_ok": {"value": "yes"},
-                        "output_ok": {"value": "yes"},
-                    },
-                    "status": "submitted",
-                },
+                "responses": [
+                    {
+                        "values": {"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}},
+                        "status": "submitted",
+                        "user_id": str(admin.id),
+                    }
+                ],
             },
             {
                 "fields": {"input": "Say Hello", "output": "Hi"},
@@ -1431,26 +1432,32 @@ async def test_create_dataset_records(
             {
                 "fields": {"input": "Say Pello", "output": "Hello World"},
                 "external_id": "3",
-                "response": {
-                    "values": {
-                        "input_ok": {"value": "no"},
-                        "output_ok": {"value": "no"},
-                    },
-                    "status": "submitted",
-                },
+                "responses": [
+                    {
+                        "values": {"input_ok": {"value": "no"}, "output_ok": {"value": "no"}},
+                        "status": "submitted",
+                        "user_id": str(admin.id),
+                    }
+                ],
             },
             {
                 "fields": {"input": "Say Hello", "output": "Good Morning"},
-                "response": {
-                    "values": {"input_ok": {"value": "yes"}, "output_ok": {"value": "no"}},
-                    "status": "discarded",
-                },
+                "responses": [
+                    {
+                        "values": {"input_ok": {"value": "yes"}, "output_ok": {"value": "no"}},
+                        "status": "discarded",
+                        "user_id": str(admin.id),
+                    }
+                ],
             },
             {
                 "fields": {"input": "Say Hello", "output": "Say Hello"},
-                "response": {
-                    "status": "discarded",
-                },
+                "responses": [
+                    {
+                        "user_id": str(admin.id),
+                        "status": "discarded",
+                    }
+                ],
             },
         ]
     }
@@ -1482,6 +1489,168 @@ async def test_create_dataset_records(
             "responses": {"admin": {"values": None, "status": "discarded"}},
         },
     ]
+
+
+@pytest.mark.asyncio
+async def test_create_dataset_records_with_response_for_multiple_users(
+    client: TestClient,
+    search_engine: SearchEngine,
+    opensearch: OpenSearch,
+    db: Session,
+    admin: User,
+    admin_auth_header: dict,
+):
+    workspace = WorkspaceFactory.create()
+
+    dataset = DatasetFactory.create(status=DatasetStatus.ready, workspace=workspace)
+    TextFieldFactory.create(name="input", dataset=dataset)
+    TextFieldFactory.create(name="output", dataset=dataset)
+    TextQuestionFactory.create(name="input_ok", dataset=dataset)
+    TextQuestionFactory.create(name="output_ok", dataset=dataset)
+
+    annotator = AnnotatorFactory.create(workspaces=[workspace])
+
+    # Prepare dataset and es index
+    await search_engine.create_index(dataset)
+
+    records_json = {
+        "items": [
+            {
+                "fields": {"input": "Say Hello", "output": "Hello"},
+                "external_id": "1",
+                "responses": [
+                    {
+                        "values": {"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}},
+                        "status": "submitted",
+                        "user_id": str(admin.id),
+                    },
+                    {
+                        "status": "discarded",
+                        "user_id": str(annotator.id),
+                    },
+                ],
+            },
+            {
+                "fields": {"input": "Say Pello", "output": "Hello World"},
+                "external_id": "3",
+                "responses": [
+                    {
+                        "values": {"input_ok": {"value": "no"}, "output_ok": {"value": "no"}},
+                        "status": "submitted",
+                        "user_id": str(annotator.id),
+                    }
+                ],
+            },
+        ]
+    }
+
+    response = client.post(f"/api/v1/datasets/{dataset.id}/records", headers=admin_auth_header, json=records_json)
+
+    assert response.status_code == 204, response.json()
+    assert db.query(Record).count() == 2
+    assert db.query(Response).filter(Response.user_id == annotator.id).count() == 2
+    assert db.query(Response).filter(Response.user_id == admin.id).count() == 1
+
+
+@pytest.mark.asyncio
+async def test_create_dataset_records_with_response_for_unknown_user(
+    client: TestClient,
+    search_engine: SearchEngine,
+    opensearch: OpenSearch,
+    db: Session,
+    admin_auth_header: dict,
+):
+    dataset = DatasetFactory.create(status=DatasetStatus.ready)
+    TextFieldFactory.create(name="input", dataset=dataset)
+    TextFieldFactory.create(name="output", dataset=dataset)
+    TextQuestionFactory.create(name="input_ok", dataset=dataset)
+    TextQuestionFactory.create(name="output_ok", dataset=dataset)
+
+    # Prepare dataset and es index
+    await search_engine.create_index(dataset)
+
+    records_json = {
+        "items": [
+            {
+                "fields": {"input": "Say Hello", "output": "Hello"},
+                "external_id": "1",
+                "responses": [
+                    {
+                        "values": {"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}},
+                        "status": "submitted",
+                        "user_id": str(uuid4()),
+                    },
+                ],
+            },
+        ]
+    }
+
+    response = client.post(f"/api/v1/datasets/{dataset.id}/records", headers=admin_auth_header, json=records_json)
+
+    assert response.status_code == 422, response.json()
+    assert db.query(Record).count() == 0
+    assert db.query(Response).count() == 0
+
+
+@pytest.mark.asyncio
+async def test_create_dataset_records_with_duplicated_response_for_an_user(
+    client: TestClient,
+    search_engine: SearchEngine,
+    opensearch: OpenSearch,
+    db: Session,
+    admin: User,
+    admin_auth_header: dict,
+):
+    dataset = DatasetFactory.create(status=DatasetStatus.ready)
+    TextFieldFactory.create(name="input", dataset=dataset)
+    TextFieldFactory.create(name="output", dataset=dataset)
+    TextQuestionFactory.create(name="input_ok", dataset=dataset)
+    TextQuestionFactory.create(name="output_ok", dataset=dataset)
+
+    # Prepare dataset and es index
+    await search_engine.create_index(dataset)
+
+    records_json = {
+        "items": [
+            {
+                "fields": {"input": "Say Hello", "output": "Hello"},
+                "external_id": "1",
+                "responses": [
+                    {
+                        "values": {"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}},
+                        "status": "submitted",
+                        "user_id": str(admin.id),
+                    },
+                    {
+                        "values": {"input_ok": {"value": "no"}, "output_ok": {"value": "no"}},
+                        "status": "submitted",
+                        "user_id": str(admin.id),
+                    },
+                ],
+            },
+        ]
+    }
+
+    response = client.post(f"/api/v1/datasets/{dataset.id}/records", headers=admin_auth_header, json=records_json)
+
+    assert response.status_code == 422, response.json()
+    assert response.json() == {
+        "detail": {
+            "code": "argilla.api.errors::ValidationError",
+            "params": {
+                "model": "Request",
+                "errors": [
+                    {
+                        "loc": ["body", "items", 0, "responses"],
+                        "msg": f"Responses contains several responses for the same user_id: {str(admin.id)!r}",
+                        "type": "value_error",
+                    }
+                ],
+            },
+        }
+    }
+    assert db.query(Record).count() == 0
+    assert db.query(Response).count() == 0
 
 
 def test_create_dataset_records_with_missing_required_fields(
@@ -1611,10 +1780,7 @@ def test_create_dataset_records_without_authentication(client: TestClient, db: S
                 "fields": {"input": "Say Hello", "ouput": "Hello"},
                 "external_id": "1",
                 "response": {
-                    "values": {
-                        "input_ok": {"value": "yes"},
-                        "output_ok": {"value": "yes"},
-                    },
+                    "values": {"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}},
                     "status": "submitted",
                 },
             },
@@ -1662,6 +1828,7 @@ async def test_create_dataset_records_with_submitted_response(
     db: Session,
     search_engine: SearchEngine,
     opensearch: OpenSearch,
+    admin: User,
     admin_auth_header: dict,
 ):
     dataset = DatasetFactory.create(status=DatasetStatus.ready)
@@ -1678,13 +1845,13 @@ async def test_create_dataset_records_with_submitted_response(
         "items": [
             {
                 "fields": {"input": "Say Hello", "output": "Hello"},
-                "response": {
-                    "values": {
-                        "input_ok": {"value": "yes"},
-                        "output_ok": {"value": "yes"},
-                    },
-                    "status": "submitted",
-                },
+                "responses": [
+                    {
+                        "values": {"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}},
+                        "status": "submitted",
+                        "user_id": str(admin.id),
+                    }
+                ],
             },
         ]
     }
@@ -1697,7 +1864,10 @@ async def test_create_dataset_records_with_submitted_response(
 
 
 def test_create_dataset_records_with_submitted_response_without_values(
-    client: TestClient, db: Session, admin_auth_header: dict
+    client: TestClient,
+    db: Session,
+    admin: User,
+    admin_auth_header: dict,
 ):
     dataset = DatasetFactory.create(status=DatasetStatus.ready)
 
@@ -1705,9 +1875,12 @@ def test_create_dataset_records_with_submitted_response_without_values(
         "items": [
             {
                 "fields": {"input": "Say Hello", "ouput": "Hello"},
-                "response": {
-                    "status": "submitted",
-                },
+                "responses": [
+                    {
+                        "user_id": str(admin.id),
+                        "status": "submitted",
+                    }
+                ],
             },
         ]
     }
@@ -1725,6 +1898,7 @@ async def test_create_dataset_records_with_discarded_response(
     db: Session,
     search_engine: SearchEngine,
     opensearch: OpenSearch,
+    admin: User,
     admin_auth_header: dict,
 ):
     dataset = DatasetFactory.create(status=DatasetStatus.ready)
@@ -1740,13 +1914,13 @@ async def test_create_dataset_records_with_discarded_response(
         "items": [
             {
                 "fields": {"input": "Say Hello", "output": "Hello"},
-                "response": {
-                    "values": {
-                        "input_ok": {"value": "yes"},
-                        "output_ok": {"value": "yes"},
-                    },
-                    "status": "discarded",
-                },
+                "responses": [
+                    {
+                        "values": {"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}},
+                        "status": "discarded",
+                        "user_id": str(admin.id),
+                    }
+                ],
             },
         ]
     }
@@ -1758,19 +1932,24 @@ async def test_create_dataset_records_with_discarded_response(
     assert db.query(Response).filter(Response.status == ResponseStatus.discarded).count() == 1
 
 
-def test_create_dataset_records_with_invalid_response_status(client: TestClient, db: Session, admin_auth_header: dict):
+def test_create_dataset_records_with_invalid_response_status(
+    client: TestClient,
+    db: Session,
+    admin: User,
+    admin_auth_header: dict,
+):
     dataset = DatasetFactory.create(status=DatasetStatus.ready)
     records_json = {
         "items": [
             {
                 "fields": {"input": "Say Hello", "ouput": "Hello"},
-                "response": {
-                    "values": {
-                        "input_ok": {"value": "yes"},
-                        "output_ok": {"value": "yes"},
-                    },
-                    "status": "invalid",
-                },
+                "responses": [
+                    {
+                        "values": {"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}},
+                        "status": "invalid",
+                        "user_id": str(admin.id),
+                    }
+                ],
             },
         ]
     }
@@ -1788,6 +1967,7 @@ async def test_create_dataset_records_with_discarded_response_without_values(
     db: Session,
     search_engine: SearchEngine,
     opensearch: OpenSearch,
+    admin: User,
     admin_auth_header: dict,
 ):
     dataset = DatasetFactory.create(status=DatasetStatus.ready)
@@ -1803,9 +1983,12 @@ async def test_create_dataset_records_with_discarded_response_without_values(
         "items": [
             {
                 "fields": {"input": "Say Hello", "output": "Hello"},
-                "response": {
-                    "status": "discarded",
-                },
+                "responses": [
+                    {
+                        "status": "discarded",
+                        "user_id": str(admin.id),
+                    }
+                ],
             },
         ]
     }
@@ -1821,17 +2004,7 @@ def test_create_dataset_records_with_non_published_dataset(client: TestClient, d
     dataset = DatasetFactory.create(status=DatasetStatus.draft)
     records_json = {
         "items": [
-            {
-                "fields": {"input": "Say Hello", "ouput": "Hello"},
-                "external_id": "1",
-                "response": {
-                    "values": {
-                        "input_ok": {"value": "yes"},
-                        "output_ok": {"value": "yes"},
-                    },
-                    "status": "submitted",
-                },
-            },
+            {"fields": {"input": "Say Hello", "ouput": "Hello"}, "external_id": "1"},
         ],
     }
 


### PR DESCRIPTION
# Description

WARNING !!! This PR changes the records creation endpoint.

Instead of passing a single response, now the endpoint accepts a list of user responses. This allows admins to restore a backup of the dataset.

@alvarobartt  Once this PR is merged in the feature branch, you should adapt the add_records method to accept a list of users' responses. See [here](https://github.com/argilla-io/argilla/blob/6fe3d3c2f9c958435e660d192e081203453bf1cb/src/argilla/server/schemas/v1/datasets.py#L228) for the schema definition.

Closes #2903
