### PR TITLE
fix : update total record only once

### DIFF
--- a/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
+++ b/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
@@ -208,8 +208,9 @@ export default {
       // FORMAT records for orm
       const formattedRecords = this.factoryRecordsForOrm(records);
 
-      // UPSERT total records && records in ORM
-      updateTotalRecordsByDatasetId(this.datasetId, totalRecords);
+      // UPSERT total records (only if it's not exists in ORM) && records in ORM
+      this.totalRecords ??
+        updateTotalRecordsByDatasetId(this.datasetId, totalRecords);
       upsertRecords(formattedRecords);
     },
     async getRecords(datasetId, recordOffset, numberOfRecordsToFetch = 5) {


### PR DESCRIPTION
# Description
Update total_record in FeedbackDataset orm only if value not exists
This is for performance, in order to not always update the total_record when fetching new records

**Type of change**

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

- Only feedback tasks and only fetching records (this endpoint contains tht total_records)
