### PR TITLE
Using an already setup httpx client in sdk modules

### DIFF
--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -224,42 +224,45 @@ class Argilla:
             A list of `WorkspaceModel` objects, containing the workspace
             attributes: name, id, created_at, and updated_at.
         """
-        return workspaces_api.list_workspaces(client=self._client).parsed
+        return workspaces_api.list_workspaces(client=self._client.httpx).parsed
 
     def list_datasets(self) -> List[FeedbackDatasetModel]:
-        return datasets_api_v1.list_datasets(client=self._client).parsed
+        return datasets_api_v1.list_datasets(client=self._client.httpx).parsed
 
-    def create_dataset(self, name: str, workspace_id: str, guidelines: Optional[str] = None) -> httpx.Response:
+    def create_dataset(self, name: str, workspace_id: str, guidelines: Optional[str] = None) -> FeedbackDatasetModel:
         return datasets_api_v1.create_dataset(
-            client=self._client, name=name, workspace_id=workspace_id, guidelines=guidelines
+            client=self._client.httpx,
+            name=name,
+            workspace_id=workspace_id,
+            guidelines=guidelines,
         ).parsed
 
     def get_dataset(self, id: str) -> FeedbackDatasetModel:
-        return datasets_api_v1.get_dataset(client=self._client, id=id).parsed
+        return datasets_api_v1.get_dataset(client=self._client.httpx, id=id).parsed
 
     def delete_dataset(self, id: str) -> httpx.Response:
-        return datasets_api_v1.delete_dataset(client=self._client, id=id)
+        return datasets_api_v1.delete_dataset(client=self._client.httpx, id=id)
 
     def publish_dataset(self, id: str) -> FeedbackDatasetModel:
-        return datasets_api_v1.publish_dataset(client=self._client, id=id).parsed
+        return datasets_api_v1.publish_dataset(client=self._client.httpx, id=id).parsed
 
     def get_records(self, id: str, offset: int = 0, limit: int = 50) -> FeedbackRecordsModel:
-        return datasets_api_v1.get_records(client=self._client, id=id, offset=offset, limit=limit).parsed
+        return datasets_api_v1.get_records(client=self._client.httpx, id=id, offset=offset, limit=limit).parsed
 
     def add_records(self, id: str, records: List[Dict[str, Any]]) -> None:
-        return datasets_api_v1.add_records(client=self._client, id=id, records=records)
+        datasets_api_v1.add_records(client=self._client.httpx, id=id, records=records)
 
     def get_fields(self, id: str) -> List[FeedbackFieldModel]:
-        return datasets_api_v1.get_fields(client=self._client, id=id).parsed
+        return datasets_api_v1.get_fields(client=self._client.httpx, id=id).parsed
 
     def add_field(self, id: str, field: Dict[str, Any]) -> httpx.Response:
-        return datasets_api_v1.add_field(client=self._client, id=id, field=field)
+        return datasets_api_v1.add_field(client=self._client.httpx, id=id, field=field)
 
     def get_questions(self, id: str) -> List[FeedbackQuestionModel]:
-        return datasets_api_v1.get_questions(client=self._client, id=id).parsed
+        return datasets_api_v1.get_questions(client=self._client.httpx, id=id).parsed
 
     def add_question(self, id: str, question: Dict[str, Any]) -> httpx.Response:
-        return datasets_api_v1.add_question(client=self._client, id=id, question=question)
+        return datasets_api_v1.add_question(client=self._client.httpx, id=id, question=question)
 
     def copy(self, dataset: str, name_of_copy: str, workspace: str = None):
         """Creates a copy of a dataset including its tags and metadata

--- a/src/argilla/client/sdk/client.py
+++ b/src/argilla/client/sdk/client.py
@@ -47,6 +47,10 @@ class _ClientCommonDefaults:
     def get_timeout(self) -> float:
         return self.timeout
 
+    @property
+    def httpx(self):
+        return self.__httpx__
+
 
 @dataclasses.dataclass
 class _Client:

--- a/src/argilla/client/sdk/v1/datasets/api.py
+++ b/src/argilla/client/sdk/v1/datasets/api.py
@@ -33,24 +33,18 @@ from argilla.client.sdk.v1.datasets.models import (
 
 
 def create_dataset(
-    client: AuthenticatedClient,
+    client: httpx.Client,
     name: str,
     workspace_id: str,
     guidelines: Optional[str] = None,
 ) -> Response[Union[FeedbackDatasetModel, ErrorMessage, HTTPValidationError]]:
-    url = "{}/api/v1/datasets".format(client.base_url)
+    url = "/api/v1/datasets"
 
     body = {"name": name, "workspace_id": workspace_id}
     if guidelines is not None:
         body.update({"guidelines": guidelines})
 
-    response = httpx.post(
-        url=url,
-        json=body,
-        headers=client.get_headers(),
-        cookies=client.get_cookies(),
-        timeout=client.get_timeout(),
-    )
+    response = client.post(url=url, json=body)
 
     if response.status_code == 201:
         parsed_response = FeedbackDatasetModel.construct(**response.json())
@@ -64,17 +58,12 @@ def create_dataset(
 
 
 def get_dataset(
-    client: AuthenticatedClient,
+    client: httpx.Client,
     id: str,
 ) -> Response[Union[FeedbackDatasetModel, ErrorMessage, HTTPValidationError]]:
-    url = "{}/api/v1/datasets/{id}".format(client.base_url, id=id)
+    url = "/api/v1/datasets/{id}".format(id=id)
 
-    response = httpx.get(
-        url=url,
-        headers=client.get_headers(),
-        cookies=client.get_cookies(),
-        timeout=client.get_timeout(),
-    )
+    response = client.get(url=url)
 
     if response.status_code == 200:
         parsed_response = FeedbackDatasetModel.construct(**response.json())
@@ -88,17 +77,12 @@ def get_dataset(
 
 
 def delete_dataset(
-    client: AuthenticatedClient,
+    client: httpx.Client,
     id: str,
 ) -> Response:
-    url = "{}/api/v1/datasets/{id}".format(client.base_url, id=id)
+    url = "/api/v1/datasets/{id}".format(id=id)
 
-    response = httpx.delete(
-        url=url,
-        headers=client.get_headers(),
-        cookies=client.get_cookies(),
-        timeout=client.get_timeout(),
-    )
+    response = client.delete(url=url)
 
     if response.status_code == 200:
         return Response(
@@ -110,17 +94,12 @@ def delete_dataset(
 
 
 def publish_dataset(
-    client: AuthenticatedClient,
+    client: httpx.Client,
     id: str,
 ) -> Response[Union[FeedbackDatasetModel, ErrorMessage, HTTPValidationError]]:
-    url = "{}/api/v1/datasets/{id}/publish".format(client.base_url, id=id)
+    url = "/api/v1/datasets/{id}/publish".format(id=id)
 
-    response = httpx.put(
-        url=url,
-        headers=client.get_headers(),
-        cookies=client.get_cookies(),
-        timeout=client.get_timeout(),
-    )
+    response = client.put(url=url)
 
     if response.status_code == 200:
         parsed_response = FeedbackDatasetModel.construct(**response.json())
@@ -134,16 +113,11 @@ def publish_dataset(
 
 
 def list_datasets(
-    client: AuthenticatedClient,
+    client: httpx.Client,
 ) -> Response[Union[List[FeedbackDatasetModel], ErrorMessage, HTTPValidationError]]:
     url = "{}/api/v1/me/datasets".format(client.base_url)
 
-    response = httpx.get(
-        url=url,
-        headers=client.get_headers(),
-        cookies=client.get_cookies(),
-        timeout=client.get_timeout(),
-    )
+    response = client.get(url=url)
 
     if response.status_code == 200:
         parsed_response = [FeedbackDatasetModel.construct(**dataset) for dataset in response.json()["items"]]
@@ -157,19 +131,16 @@ def list_datasets(
 
 
 def get_records(
-    client: AuthenticatedClient,
+    client: httpx.Client,
     id: str,
     offset: int = 0,
     limit: int = 50,
 ) -> Response[Union[FeedbackRecordsModel, ErrorMessage, HTTPValidationError]]:
-    url = "{}/api/v1/me/datasets/{id}/records".format(client.base_url, id=id)
+    url = "/api/v1/me/datasets/{id}/records".format(id=id)
 
-    response = httpx.get(
+    response = client.get(
         url=url,
         params={"include": "responses", "offset": offset, "limit": limit},
-        headers=client.get_headers(),
-        cookies=client.get_cookies(),
-        timeout=client.get_timeout(),
     )
 
     if response.status_code == 200:
@@ -184,19 +155,13 @@ def get_records(
 
 
 def add_records(
-    client: AuthenticatedClient,
+    client: httpx.Client,
     id: str,
     records: List[Dict[str, Any]],
 ) -> Response[Union[ErrorMessage, HTTPValidationError]]:
-    url = "{}/api/v1/datasets/{id}/records".format(client.base_url, id=id)
+    url = "/api/v1/datasets/{id}/records".format(id=id)
 
-    response = httpx.post(
-        url=url,
-        json={"items": records},
-        headers=client.get_headers(),
-        cookies=client.get_cookies(),
-        timeout=client.get_timeout(),
-    )
+    response = client.post(url=url, json={"items": records})
 
     if response.status_code == 204:
         return Response(
@@ -208,17 +173,12 @@ def add_records(
 
 
 def get_fields(
-    client: AuthenticatedClient,
+    client: httpx.Client,
     id: str,
 ) -> Response[Union[List[FeedbackFieldModel], ErrorMessage, HTTPValidationError]]:
-    url = "{}/api/v1/datasets/{id}/fields".format(client.base_url, id=id)
+    url = "/api/v1/datasets/{id}/fields".format(id=id)
 
-    response = httpx.get(
-        url=url,
-        headers=client.get_headers(),
-        cookies=client.get_cookies(),
-        timeout=client.get_timeout(),
-    )
+    response = client.get(url=url)
 
     if response.status_code == 200:
         parsed_response = [FeedbackFieldModel.construct(**item) for item in response.json()["items"]]
@@ -232,19 +192,13 @@ def get_fields(
 
 
 def add_field(
-    client: AuthenticatedClient,
+    client: httpx.Client,
     id: str,
     field: Dict[str, Any],
 ) -> Response[Union[ErrorMessage, HTTPValidationError]]:
-    url = "{}/api/v1/datasets/{id}/fields".format(client.base_url, id=id)
+    url = "/api/v1/datasets/{id}/fields".format(id=id)
 
-    response = httpx.post(
-        url=url,
-        json=field,
-        headers=client.get_headers(),
-        cookies=client.get_cookies(),
-        timeout=client.get_timeout(),
-    )
+    response = client.post(url=url, json=field)
 
     if response.status_code == 201:
         return Response(
@@ -256,17 +210,12 @@ def add_field(
 
 
 def get_questions(
-    client: AuthenticatedClient,
+    client: httpx.Client,
     id: str,
 ) -> Response[Union[List[FeedbackQuestionModel], ErrorMessage, HTTPValidationError]]:
-    url = "{}/api/v1/datasets/{id}/questions".format(client.base_url, id=id)
+    url = "/api/v1/datasets/{id}/questions".format(id=id)
 
-    response = httpx.get(
-        url=url,
-        headers=client.get_headers(),
-        cookies=client.get_cookies(),
-        timeout=client.get_timeout(),
-    )
+    response = client.get(url=url)
 
     if response.status_code == 200:
         parsed_response = [FeedbackQuestionModel.construct(**item) for item in response.json()["items"]]
@@ -280,19 +229,13 @@ def get_questions(
 
 
 def add_question(
-    client: AuthenticatedClient,
+    client: httpx.Client,
     id: str,
     question: Dict[str, Any],
 ) -> Response[Union[ErrorMessage, HTTPValidationError]]:
-    url = "{}/api/v1/datasets/{id}/questions".format(client.base_url, id=id)
+    url = "/api/v1/datasets/{id}/questions".format(id=id)
 
-    response = httpx.post(
-        url=url,
-        json=question,
-        headers=client.get_headers(),
-        cookies=client.get_cookies(),
-        timeout=client.get_timeout(),
-    )
+    response = client.post(url=url, json=question)
 
     if response.status_code == 201:
         return Response(

--- a/src/argilla/client/sdk/workspaces/api.py
+++ b/src/argilla/client/sdk/workspaces/api.py
@@ -27,9 +27,7 @@ from argilla.client.sdk.commons.models import (
 from argilla.client.sdk.workspaces.models import WorkspaceModel
 
 
-def list_workspaces(
-    client: AuthenticatedClient,
-) -> Response[Union[List[WorkspaceModel], ErrorMessage, HTTPValidationError]]:
+def list_workspaces(client: httpx.Client) -> Response[Union[List[WorkspaceModel], ErrorMessage, HTTPValidationError]]:
     """Sends a requet to `GET /api/workspaces` to list all the workspaces in the account.
 
     Args:
@@ -39,14 +37,9 @@ def list_workspaces(
         A Response object with the parsed response, containing a `parsed` attribute with the
         parsed response if the request was successful, which is a list of `WorkspaceModel` objects.
     """
-    url = "{}/api/workspaces".format(client.base_url)
+    url = "/api/workspaces"
 
-    response = httpx.get(
-        url=url,
-        headers=client.get_headers(),
-        cookies=client.get_cookies(),
-        timeout=client.get_timeout(),
-    )
+    response = client.get(url=url)
 
     if response.status_code == 200:
         parsed_response = [WorkspaceModel(**workspace) for workspace in response.json()]

--- a/tests/client/sdk/workspaces/test_api.py
+++ b/tests/client/sdk/workspaces/test_api.py
@@ -26,13 +26,13 @@ def sdk_client():
     return AuthenticatedClient(base_url="http://localhost:6900", token=DEFAULT_API_KEY)
 
 
-def test_list_workspaces(mocked_client, sdk_client, monkeypatch) -> None:
-    monkeypatch.setattr(httpx, "get", mocked_client.get)
+def test_list_workspaces(mocked_client, sdk_client: AuthenticatedClient, monkeypatch) -> None:
+    monkeypatch.setattr(sdk_client.httpx, "get", mocked_client.get)
 
     workspace_name = "test_workspace"
     mocked_client.post(f"/api/workspaces", json={"name": workspace_name})
 
-    response = list_workspaces(client=sdk_client)
+    response = list_workspaces(client=sdk_client.httpx)
 
     assert response.status_code == 200
     assert isinstance(response.parsed, list)


### PR DESCRIPTION
# Description

Since the new SDK modules are creating a new httpx client on each request, some problems related to connection performance can be raised. In the [official docs](https://www.python-httpx.org/advanced/) you can read: 

> When you make requests using the top-level API as documented in the [Quickstart](https://www.python-httpx.org/quickstart/) guide, HTTPX has to establish a new connection for every single request (connections are not reused). As the number of requests to a host increases, this quickly becomes inefficient.
> 
> On the other hand, a Client instance uses [HTTP connection pooling](https://en.wikipedia.org/wiki/HTTP_persistent_connection). This means that when you make several requests to the same host, the Client will reuse the underlying TCP connection, instead of recreating one for every single request.

In order to better use the httpx client, this PR changes the `sdk` module to reuse the already set up httpx client in the `AuthenticatedClient` instance.

By using this client, you don't need to pass header or base URL configuration on each request, since is setup on client initialization.