### PR TITLE
fix : repare shortcut text2text

### DIFF
--- a/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
+++ b/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
@@ -216,7 +216,7 @@ export default {
     document.removeEventListener("keydown", this.onPressKeyboardShortCut);
   },
   methods: {
-    onPressKeyboardShortCut({ code, ctrlKey }) {
+    onPressKeyboardShortCut({ code, shiftKey }) {
       switch (code) {
         case "Enter": {
           const elem = this.$refs.submitButton.$el;
@@ -225,7 +225,7 @@ export default {
         }
         case "Space": {
           const elem = this.$refs.clearButton.$el;
-          ctrlKey && elem.click();
+          shiftKey && elem.click();
           break;
         }
         case "Backspace": {

--- a/frontend/components/commons/forms/questions-form/fields/text-area/TextArea.component.vue
+++ b/frontend/components/commons/forms/questions-form/fields/text-area/TextArea.component.vue
@@ -22,13 +22,12 @@
     </div>
 
     <div class="container" :class="isFocused ? '--focused' : null">
-      <Text2TextContentEditable
+      <ContentEditableFeedbackTask
         class="textarea"
         :annotationEnabled="true"
         :annotations="[]"
         :defaultText="initialOptions.text"
         :placeholder="placeholder"
-        :isShortcutToSave="false"
         @change-text="onChangeTextArea"
         @on-change-focus="setFocus"
       />

--- a/frontend/components/text2text/results/ContentEditableFeedbackTask.vue
+++ b/frontend/components/text2text/results/ContentEditableFeedbackTask.vue
@@ -1,0 +1,130 @@
+<template>
+  <span>
+    <div class="content__edition-area">
+      <transition appear name="fade">
+        <p
+          ref="text"
+          id="contentId"
+          class="content__text"
+          :class="textIsEdited ? '--edited-text' : null"
+          :contenteditable="annotationEnabled"
+          :placeholder="placeholder"
+          @input="onInputText"
+          v-html="editableText"
+          @focus="setFocus(true)"
+          @blur="setFocus(false)"
+          @keydown.shift.enter.exact="looseFocus"
+          @keydown.shift.backspace.exact="looseFocus"
+          @keydown.shift.space.exact="looseFocus"
+          @keydown.arrow-right.stop=""
+          @keydown.arrow-left.stop=""
+          @keydown.delete.exact.stop=""
+          @keydown.enter.exact.stop=""
+        />
+      </transition>
+    </div>
+  </span>
+</template>
+
+<script>
+export default {
+  name: "ContentEditableFeedbackTask",
+  props: {
+    annotationEnabled: {
+      type: Boolean,
+      required: true,
+    },
+    annotations: {
+      type: Array,
+      required: true,
+    },
+    defaultText: {
+      type: String,
+      required: true,
+    },
+    placeholder: {
+      type: String,
+      default: "",
+    },
+  },
+  data: () => {
+    return {
+      editableText: null,
+      focus: false,
+    };
+  },
+  computed: {
+    textIsEdited() {
+      return (
+        this.defaultText !== this.editableText ||
+        this.defaultText === this.annotations[0]?.text
+      );
+    },
+  },
+  mounted() {
+    if (this.defaultText) {
+      this.editableText = this.defaultText;
+    } else {
+      this.editableText = this.text;
+    }
+
+    this.textAreaWrapper = document.getElementById("contentId");
+  },
+  methods: {
+    looseFocus() {
+      this.textAreaWrapper.blur();
+    },
+    onInputText(event) {
+      this.$emit("change-text", event.target.innerText);
+    },
+    setFocus(status) {
+      this.focus = status;
+      this.$emit("on-change-focus", status);
+    },
+  },
+};
+</script>
+<style lang="scss" scoped>
+[contenteditable="true"] {
+  padding: 0.6em;
+  outline: none;
+  &:focus + span {
+    display: block;
+  }
+}
+[contenteditable="true"]:empty:before {
+  content: attr(placeholder);
+  color: $black-37;
+  pointer-events: none;
+  display: block; /* For Firefox */
+}
+.content {
+  &__edition-area {
+    position: relative;
+    width: 100%;
+    span {
+      position: absolute;
+      top: 100%;
+      right: 0;
+      @include font-size(12px);
+      color: palette(grey, verylight);
+      margin-top: 0.5em;
+      display: none;
+    }
+  }
+  &__text {
+    display: inline-block;
+    width: 100%;
+    min-height: 30px;
+    height: 100%;
+    color: $black-87;
+    white-space: pre-wrap;
+    margin: 0;
+    word-break: break-word;
+    font-style: italic;
+    &.--edited-text {
+      font-style: normal;
+    }
+  }
+}
+</style>

--- a/frontend/components/text2text/results/Text2TextContentEditable.vue
+++ b/frontend/components/text2text/results/Text2TextContentEditable.vue
@@ -15,7 +15,7 @@
           @blur="setFocus(false)"
           @keydown.shift.enter.exact="looseFocus"
           @keydown.shift.backspace.exact="looseFocus"
-          @keydown.ctrl.space.exact="looseFocus"
+          @keydown.shift.space.exact="looseFocus"
           @keydown.arrow-right.stop=""
           @keydown.arrow-left.stop=""
           @keydown.delete.exact.stop=""

--- a/frontend/components/text2text/results/Text2TextContentEditable.vue
+++ b/frontend/components/text2text/results/Text2TextContentEditable.vue
@@ -13,7 +13,6 @@
           v-html="editableText"
           @focus="setFocus(true)"
           @blur="setFocus(false)"
-          @keydown.shift.enter.exact="looseFocus"
           @keydown.shift.backspace.exact="looseFocus"
           @keydown.shift.space.exact="looseFocus"
           @keydown.arrow-right.stop=""


### PR DESCRIPTION
# Description
The stop event in Text2TextContentEditable.vue implemented to be able to use shortcut while component have focus broke the shortcut in text2text to save (shift+enter)

TODO : 
- add new component editable for feedback task and remove unecessary logics
- replace component in textArea.component.vue
- remove the keydown.stop event which break the shortcut in text2text

**Type of change**

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**


- Only feedback task
