### PR TITLE
fix : updated_at wrong value

### DIFF
--- a/frontend/pages/datasets/index.vue
+++ b/frontend/pages/datasets/index.vue
@@ -210,7 +210,7 @@ export default {
           tags: dataset?.tags ?? {},
           task: "FeedbackTask",
           created_at: dataset.inserted_at,
-          updated_at: dataset.updated_at,
+          last_updated: dataset.updated_at, // NOTE - need to be last_updated attribute to have the same for old and new dataset
           link: this.factoryLinkForFeedbackDataset(dataset),
         };
       });


### PR DESCRIPTION
# Description
Repare wrong last update value in dataset list

Since feedback dataset and old dataset did not have the same attribute to describe the last updated date, the date in the table from dataset list was wrong.

**Type of change**

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

- Only dataset list and only last update value
