### PR TITLE
Add max length limits to text fields

### DIFF
--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -23,13 +23,22 @@ from typing_extensions import Annotated, Literal
 
 from argilla.server.models import DatasetStatus, FieldType, QuestionType, ResponseStatus
 
+DATASET_CREATE_GUIDELINES_MIN_LENGTH = 1
+DATASET_CREATE_GUIDELINES_MAX_LENGTH = 10000
+
 FIELD_CREATE_NAME_REGEX = r"^(?=.*[a-z0-9])[a-z0-9_-]+$"
 FIELD_CREATE_NAME_MIN_LENGTH = 1
 FIELD_CREATE_NAME_MAX_LENGTH = 200
+FIELD_CREATE_TITLE_MIN_LENGTH = 1
+FIELD_CREATE_TITLE_MAX_LENGTH = 500
 
 QUESTION_CREATE_NAME_REGEX = r"^(?=.*[a-z0-9])[a-z0-9_-]+$"
 QUESTION_CREATE_NAME_MIN_LENGTH = 1
 QUESTION_CREATE_NAME_MAX_LENGTH = 200
+QUESTION_CREATE_TITLE_MIN_LENGTH = 1
+QUESTION_CREATE_TITLE_MAX_LENGTH = 500
+QUESTION_CREATE_DESCRIPTION_MIN_LENGTH = 1
+QUESTION_CREATE_DESCRIPTION_MAX_LENGTH = 1000
 
 RATING_OPTIONS_MIN_ITEMS = 2
 RATING_OPTIONS_MAX_ITEMS = 100
@@ -57,7 +66,12 @@ class Datasets(BaseModel):
 
 class DatasetCreate(BaseModel):
     name: str
-    guidelines: Optional[str]
+    guidelines: Optional[
+        constr(
+            min_length=DATASET_CREATE_GUIDELINES_MIN_LENGTH,
+            max_length=DATASET_CREATE_GUIDELINES_MAX_LENGTH,
+        )
+    ]
     workspace_id: UUID
 
 
@@ -103,7 +117,10 @@ class FieldCreate(BaseModel):
         min_length=FIELD_CREATE_NAME_MIN_LENGTH,
         max_length=FIELD_CREATE_NAME_MAX_LENGTH,
     )
-    title: str
+    title: constr(
+        min_length=FIELD_CREATE_TITLE_MIN_LENGTH,
+        max_length=FIELD_CREATE_TITLE_MAX_LENGTH,
+    )
     required: Optional[bool]
     settings: TextFieldSettings
 
@@ -149,8 +166,16 @@ class QuestionCreate(BaseModel):
         min_length=QUESTION_CREATE_NAME_MIN_LENGTH,
         max_length=QUESTION_CREATE_NAME_MAX_LENGTH,
     )
-    title: str
-    description: Optional[str]
+    title: constr(
+        min_length=QUESTION_CREATE_TITLE_MIN_LENGTH,
+        max_length=QUESTION_CREATE_TITLE_MAX_LENGTH,
+    )
+    description: Optional[
+        constr(
+            min_length=QUESTION_CREATE_DESCRIPTION_MIN_LENGTH,
+            max_length=QUESTION_CREATE_DESCRIPTION_MAX_LENGTH,
+        )
+    ]
     required: Optional[bool]
     settings: Union[TextQuestionSettings, RatingQuestionSettings] = ModelField(..., discriminator="type")
 

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -30,7 +30,10 @@ from argilla.server.models import (
 )
 from argilla.server.schemas.v1.datasets import (
     FIELD_CREATE_NAME_MAX_LENGTH,
+    FIELD_CREATE_TITLE_MAX_LENGTH,
+    QUESTION_CREATE_DESCRIPTION_MAX_LENGTH,
     QUESTION_CREATE_NAME_MAX_LENGTH,
+    QUESTION_CREATE_TITLE_MAX_LENGTH,
     RATING_OPTIONS_MAX_ITEMS,
     RATING_OPTIONS_MIN_ITEMS,
     RECORDS_CREATE_MAX_ITEMS,
@@ -1244,6 +1247,20 @@ def test_create_dataset_field_with_invalid_max_length_name(client: TestClient, d
     assert db.query(Field).count() == 0
 
 
+def test_create_dataset_field_with_invalid_max_length_title(client: TestClient, db: Session, admin_auth_header: dict):
+    dataset = DatasetFactory.create()
+    field_json = {
+        "name": "name",
+        "title": "a" * (FIELD_CREATE_TITLE_MAX_LENGTH + 1),
+        "settings": {"type": "text"},
+    }
+
+    response = client.post(f"/api/v1/datasets/{dataset.id}/fields", headers=admin_auth_header, json=field_json)
+
+    assert response.status_code == 422
+    assert db.query(Field).count() == 0
+
+
 def test_create_dataset_field_with_existent_name(client: TestClient, db: Session, admin_auth_header: dict):
     field = FieldFactory.create(name="name")
     field_json = {
@@ -1414,6 +1431,39 @@ def test_create_dataset_question_with_invalid_max_length_name(client: TestClient
     question_json = {
         "name": "a" * (QUESTION_CREATE_NAME_MAX_LENGTH + 1),
         "title": "title",
+        "settings": {"type": "text"},
+    }
+
+    response = client.post(f"/api/v1/datasets/{dataset.id}/questions", headers=admin_auth_header, json=question_json)
+
+    assert response.status_code == 422
+    assert db.query(Question).count() == 0
+
+
+def test_create_dataset_question_with_invalid_max_length_title(
+    client: TestClient, db: Session, admin_auth_header: dict
+):
+    dataset = DatasetFactory.create()
+    question_json = {
+        "name": "name",
+        "title": "a" * (QUESTION_CREATE_TITLE_MAX_LENGTH + 1),
+        "settings": {"type": "text"},
+    }
+
+    response = client.post(f"/api/v1/datasets/{dataset.id}/questions", headers=admin_auth_header, json=question_json)
+
+    assert response.status_code == 422
+    assert db.query(Question).count() == 0
+
+
+def test_create_dataset_question_with_invalid_max_length_description(
+    client: TestClient, db: Session, admin_auth_header: dict
+):
+    dataset = DatasetFactory.create()
+    question_json = {
+        "name": "name",
+        "title": "title",
+        "description": "a" * (QUESTION_CREATE_DESCRIPTION_MAX_LENGTH + 1),
         "settings": {"type": "text"},
     }
 


### PR DESCRIPTION
# Description

This PR adds schema validations for some textual fields such as:

- dataset guidelines
- dataset text field title
- dataset question title and description

Closes #2796 

