### PR TITLE
fix: Avoid rendering html for non valid html strings in Text2text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ These are the section headers that we use:
 
 - `argilla.training` bugfixes and unification ([#2665](https://github.com/argilla-io/argilla/issues/2665))
 - Resolved several small bugs in the `ArgillaTrainer`.
+- Avoid rendering html for invalid html strings in Text2text ([#2911]https://github.com/argilla-io/argilla/issues/2911)
 
 ### Deprecated
 
@@ -73,6 +74,7 @@ These are the section headers that we use:
 - Added `Argilla.training` module with support for `spacy`, `setfit`, and `transformers`. Closes [#2504](https://github.com/argilla-io/argilla/issues/2496)
 
 ### Fixes
+
 - Now the `prepare_for_training` method is working when `multi_label=True`. Closes [#2606](https://github.com/argilla-io/argilla/issues/2606)
 
 ### Changed
@@ -95,8 +97,6 @@ These are the section headers that we use:
 - The default value for old `API Key` constant. Closes [#2251](https://github.com/argilla-io/argilla/issues/2251)
 
 [#2564]: https://github.com/argilla-io/argilla/issues/2564
-
-
 
 ## [1.5.1](https://github.com/argilla-io/argilla/compare/v1.5.0...v1.5.1) - 2023-03-30
 

--- a/frontend/components/text2text/results/Text2TextContentEditable.vue
+++ b/frontend/components/text2text/results/Text2TextContentEditable.vue
@@ -3,13 +3,14 @@
     <div class="content__edition-area">
       <transition appear name="fade">
         <p
+          :key="editableText"
           ref="text"
           class="content__text"
           :class="textIsEdited ? '--edited-text' : null"
           :contenteditable="annotationEnabled"
           :placeholder="placeholder"
           @input="onInputText"
-          v-html="editableText"
+          v-html="customEditableText"
           @focus="setFocus(true)"
           @blur="setFocus(false)"
         ></p>
@@ -52,6 +53,11 @@ export default {
         this.defaultText !== this.editableText ||
         this.defaultText === this.annotations[0]?.text
       );
+    },
+    customEditableText() {
+      return this.$checkValidHtml(this.editableText)
+        ? this.editableText
+        : this.$options.filters.escape(this.editableText);
     },
   },
   mounted() {

--- a/frontend/components/text2text/results/Text2TextContentEditable.vue
+++ b/frontend/components/text2text/results/Text2TextContentEditable.vue
@@ -20,6 +20,7 @@
   </span>
 </template>
 <script>
+import { escapeHtmlChars } from "@/utils/escapeHtmlChars";
 export default {
   props: {
     annotationEnabled: {
@@ -57,7 +58,7 @@ export default {
     customEditableText() {
       return this.$checkValidHtml(this.editableText)
         ? this.editableText
-        : this.$options.filters.escape(this.editableText);
+        : escapeHtmlChars(this.editableText);
     },
   },
   mounted() {

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -65,6 +65,7 @@ export default {
     { src: "~/plugins/toast.js" },
     { src: "~/plugins/highlight-search.js" },
     { src: "~/plugins/copy-to-clipboard.js" },
+    { src: "~/plugins/check-valid-html.js" },
     { src: "~/plugins/filters.js" },
     { src: "~/plugins/variables.js" },
     { src: "~/plugins/custom-directives/badge.directive.js" },

--- a/frontend/plugins/check-valid-html.js
+++ b/frontend/plugins/check-valid-html.js
@@ -1,0 +1,27 @@
+/*
+ * coding=utf-8
+ * Copyright 2021-present, the Recognai S.L. team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default (context, inject) => {
+  const checkValidHtml = function (text) {
+    let parser = new DOMParser();
+    let doc = parser.parseFromString(text, "application/xml");
+    let errorNode = doc.querySelector("parsererror");
+    return !errorNode;
+  };
+
+  inject("checkValidHtml", checkValidHtml);
+};

--- a/frontend/plugins/filters.js
+++ b/frontend/plugins/filters.js
@@ -27,17 +27,3 @@ Vue.filter("capitalize", function (value) {
 
   return capitalize(value);
 });
-
-Vue.filter("escape", function (value) {
-  return value?.replace(
-    /[&<>'"]/g,
-    (tag) =>
-      ({
-        "&": "&amp;",
-        "<": "&lt;",
-        ">": "&gt;",
-        "'": "&#39;",
-        '"': "&quot;",
-      }[tag])
-  );
-});

--- a/frontend/plugins/filters.js
+++ b/frontend/plugins/filters.js
@@ -27,3 +27,17 @@ Vue.filter("capitalize", function (value) {
 
   return capitalize(value);
 });
+
+Vue.filter("escape", function (value) {
+  return value?.replace(
+    /[&<>'"]/g,
+    (tag) =>
+      ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        "'": "&#39;",
+        '"': "&quot;",
+      }[tag])
+  );
+});

--- a/frontend/utils/escapeHtmlChars.js
+++ b/frontend/utils/escapeHtmlChars.js
@@ -1,0 +1,15 @@
+const escapeHtmlChars = function (value) {
+  return value?.replace(
+    /[&<>'"]/g,
+    (tag) =>
+      ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        "'": "&#39;",
+        '"': "&quot;",
+      }[tag])
+  );
+};
+
+export { escapeHtmlChars };


### PR DESCRIPTION
# Description

This PR fixes html transformation for strings in frontend, in case it is not html valid, the text is escaped in the editable content component, in case it is valid the html will be visible

Closes #2911

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)