### PR TITLE
2926 argilla server fails on python 310 and python 311

### DIFF
--- a/src/argilla/server/models/questions.py
+++ b/src/argilla/server/models/questions.py
@@ -12,22 +12,15 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from datetime import datetime
 from enum import Enum
 from typing import Any, List, Union
-from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field, parse_obj_as
-from sqlalchemy import JSON, ForeignKey, Text
-from sqlalchemy.orm import Mapped, mapped_column, relationship
-from typing_extensions import Annotated, Literal
+from pydantic import BaseModel, Field
 
-from argilla.client.datasets import Dataset
-from argilla.server.database import Base
-
-
-def default_inserted_at(context):
-    return context.get_current_parameters()["inserted_at"]
+try:
+    from typing import Annotated, Literal
+except ImportError:
+    from typing_extensions import Annotated, Literal
 
 
 class QuestionType(str, Enum):
@@ -70,31 +63,3 @@ class RatingQuestionSettings(BaseQuestionSettings):
 
 
 QuestionSettings = Annotated[Union[TextQuestionSettings, RatingQuestionSettings], Field(..., discriminator="type")]
-
-
-class Question(Base):
-    __tablename__ = "questions"
-
-    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
-    name: Mapped[str]
-    title: Mapped[str] = mapped_column(Text)
-    description: Mapped[str] = mapped_column(Text)
-    required: Mapped[bool] = mapped_column(default=False)
-    settings: Mapped[dict] = mapped_column(JSON, default={})
-    dataset_id: Mapped[UUID] = mapped_column(ForeignKey("datasets.id"))
-
-    inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
-    updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
-
-    dataset: Mapped["Dataset"] = relationship(back_populates="questions")
-
-    @property
-    def parsed_settings(self) -> QuestionSettings:
-        return parse_obj_as(QuestionSettings, self.settings)
-
-    def __repr__(self):
-        return (
-            f"Question(id={str(self.id)!r}, name={self.name!r}, required={self.required!r}, "
-            f"dataset_id={str(self.dataset_id)!r}, "
-            f"inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
-        )


### PR DESCRIPTION
# Description

By moving the sqlalchemy `Question` class to the `models.py` module, the error is gone described in #2926 is gone.

Closes #2926

