### PR TITLE
Increase `codecov` threshold to avoid status checks from failing due to it

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,8 @@
 comment:
   require_changes: true
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%


### PR DESCRIPTION
# Description

Tiny PR to update the `.codecov.yml` configuration file to relax the restrictions from `codecov` in the current status checks, since it's making a lot of status checks in PRs fail due to a super small code coverage change e.g. 0.1

So on, the new configuration file uses `target: auto` to compare the coverage of the current code with the previous base commit used to calculate the diff, and `threshold: 2%` to allow a 2 percent difference with respect to the base commit coverage.

**Type of change**

- [X] Improvement (change adding some improvement to an existing functionality)