### PR TITLE
fix: Destroy the notification toast when leaving the page and limit the duration

### DIFF
--- a/frontend/components/feedback-task/footer/Pagination.component.vue
+++ b/frontend/components/feedback-task/footer/Pagination.component.vue
@@ -173,7 +173,7 @@ export default {
     }) {
       Notification.dispatch("notify", {
         message: message ?? "",
-        numberOfChars: 20000,
+        numberOfChars: 500,
         type: typeOfToast ?? "warning",
         buttonText: buttonMessage ?? "",
         async onClick() {

--- a/frontend/components/page-contents/feedback-task-content/CenterFeedbackTask.content.vue
+++ b/frontend/components/page-contents/feedback-task-content/CenterFeedbackTask.content.vue
@@ -115,7 +115,7 @@ export default {
     }) {
       Notification.dispatch("notify", {
         message: message ?? "",
-        numberOfChars: 20000,
+        numberOfChars: 500,
         type: typeOfToast ?? "warning",
         buttonText: buttonMessage ?? "",
         async onClick() {

--- a/frontend/database/modules/notifications.js
+++ b/frontend/database/modules/notifications.js
@@ -29,6 +29,9 @@ const actions = {
       type: type || "default",
     });
   },
+  clear() {
+    return Vue.$toast.clear();
+  },
 };
 
 export default {

--- a/frontend/pages/dataset/_id/annotation-mode/index.vue
+++ b/frontend/pages/dataset/_id/annotation-mode/index.vue
@@ -201,7 +201,7 @@ export default {
     }) {
       Notification.dispatch("notify", {
         message: message ?? "",
-        numberOfChars: 20000,
+        numberOfChars: 500,
         type: typeOfToast ?? "warning",
         buttonText: buttonMessage ?? "",
         async onClick() {
@@ -212,6 +212,7 @@ export default {
   },
   destroyed() {
     this.$root.$off("are-responses-untouched");
+    Notification.dispatch("clear");
   },
 };
 </script>


### PR DESCRIPTION
# Description

this PR fixes the notification to be shown when leaving the page and limit its duration to 10 seconds.

Closes #2931

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)