### PR TITLE
fix: Reset form after submit or discard from in Feedback Task

### DIFF
--- a/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
+++ b/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
@@ -297,8 +297,8 @@ export default {
           RECORD_STATUS.DISCARDED
         );
 
-        this.onReset();
         this.emitBusEventGoToRecordIndex();
+        this.onReset();
       } catch (error) {
         console.log(error);
       }
@@ -324,8 +324,8 @@ export default {
           RECORD_STATUS.SUBMITTED
         );
 
-        this.onReset();
         this.emitBusEventGoToRecordIndex();
+        this.onReset();
       } catch (error) {
         console.log(error);
       }

--- a/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
+++ b/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
@@ -298,6 +298,8 @@ export default {
         );
 
         this.emitBusEventGoToRecordIndex();
+
+        // TODO - reset only when we know that we fetch and computed all the necessary records data
         this.onReset();
       } catch (error) {
         console.log(error);
@@ -325,6 +327,8 @@ export default {
         );
 
         this.emitBusEventGoToRecordIndex();
+
+        // TODO - reset only when we know that we fetch and computed all the necessary records data
         this.onReset();
       } catch (error) {
         console.log(error);

--- a/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
+++ b/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
@@ -297,6 +297,7 @@ export default {
           RECORD_STATUS.DISCARDED
         );
 
+        this.onReset();
         this.emitBusEventGoToRecordIndex();
       } catch (error) {
         console.log(error);
@@ -323,6 +324,7 @@ export default {
           RECORD_STATUS.SUBMITTED
         );
 
+        this.onReset();
         this.emitBusEventGoToRecordIndex();
       } catch (error) {
         console.log(error);


### PR DESCRIPTION
# Description

This PR includes a reset for update form after submit or discard the questionnaire to force the frontend to update and avoid some problems when discarding or sending the last paging record

Closes #2936

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)