### PR TITLE
Fix some type-validations in `pydantic.BaseModel` schemas for `FeedbackDataset`

### DIFF
--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -178,7 +178,6 @@ class FeedbackDataset:
         >>> import argilla as rg
         >>> rg.init(api_url="...", api_key="...")
         >>> dataset = rg.FeedbackDataset(
-        ...     guidelines="These are the annotation guidelines.",
         ...     fields=[
         ...         rg.TextField(name="text", required=True),
         ...         rg.TextField(name="label", required=True),
@@ -196,6 +195,7 @@ class FeedbackDataset:
         ...             values=[1, 2, 3, 4, 5],
         ...         ),
         ...     ],
+        ...     guidelines="These are the annotation guidelines.",
         ... )
         >>> dataset.guidelines
         "These are the annotation guidelines."
@@ -229,30 +229,29 @@ class FeedbackDataset:
     def __init__(
         self,
         *,
-        guidelines: str,
         fields: List[FieldSchema],
         questions: List[QuestionSchema],
+        guidelines: Optional[str] = None,
     ) -> None:
         """Initializes a `FeedbackDataset` instance locally.
 
         Args:
-            guidelines: contains the guidelines for annotating the dataset.
             fields: contains the fields that will define the schema of the records in the dataset.
             questions: contains the questions that will be used to annotate the dataset.
+            guidelines: contains the guidelines for annotating the dataset. Defaults to `None`.
 
         Raises:
-            TypeError: if `guidelines` is not a string.
-            ValueError: if `guidelines` is an empty string.
             TypeError: if `fields` is not a list of `FieldSchema`.
             ValueError: if `fields` does not contain at least one required field.
             TypeError: if `questions` is not a list of `QuestionSchema`.
             ValueError: if `questions` does not contain at least one required question.
+            TypeError: if `guidelines` is not None and not a string.
+            ValueError: if `guidelines` is an empty string.
 
         Examples:
             >>> import argilla as rg
             >>> rg.init(api_url="...", api_key="...")
             >>> dataset = rg.FeedbackDataset(
-            ...     guidelines="These are the annotation guidelines.",
             ...     fields=[
             ...         rg.TextField(name="text", required=True),
             ...         rg.TextField(name="label", required=True),
@@ -270,14 +269,9 @@ class FeedbackDataset:
             ...             values=[1, 2, 3, 4, 5],
             ...         ),
             ...     ],
+            ...     guidelines="These are the annotation guidelines.",
             ... )
         """
-        if not isinstance(guidelines, str):
-            raise TypeError(f"Expected `guidelines` to be a string, got {type(guidelines)} instead.")
-        if len(guidelines) < 1:
-            raise ValueError("Expected `guidelines` to be a non-empty string, minimum length is 1.")
-        self.__guidelines = guidelines
-
         if not isinstance(fields, list):
             raise TypeError(f"Expected `fields` to be a list, got {type(fields)} instead.")
         any_required = False
@@ -302,6 +296,17 @@ class FeedbackDataset:
         if not any_required:
             raise ValueError("At least one `QuestionSchema` in `questions` must be required (`required=True`).")
         self.__questions = questions
+
+        if guidelines is not None:
+            if not isinstance(guidelines, str):
+                raise TypeError(
+                    f"Expected `guidelines` to be either None (default) or a string, got {type(guidelines)} instead."
+                )
+            if len(guidelines) < 1:
+                raise ValueError(
+                    "Expected `guidelines` to be either None (default) or a non-empty string, minimum length is 1."
+                )
+        self.__guidelines = guidelines
 
         self.__records = []
         self.__new_records = []
@@ -653,7 +658,6 @@ class FeedbackDataset:
 
         cls.argilla_id = existing_dataset.id
         self = cls(
-            guidelines=existing_dataset.guidelines,
             fields=[
                 FieldSchema.construct(**field.dict())
                 for field in datasets_api_v1.get_fields(client=httpx_client, id=existing_dataset.id).parsed
@@ -662,6 +666,7 @@ class FeedbackDataset:
                 QuestionSchema.construct(**question.dict())
                 for question in datasets_api_v1.get_questions(client=httpx_client, id=existing_dataset.id).parsed
             ],
+            guidelines=existing_dataset.guidelines or None,
         )
         if with_records:
             self.fetch_records()
@@ -708,19 +713,20 @@ def generate_pydantic_schema(fields: List[FieldSchema], name: Optional[str] = "F
 
 def create_feedback_dataset(
     name: str,
-    guidelines: str,
     fields: List[FieldSchema],
     questions: List[QuestionSchema],
     workspace: Union[str, rg.Workspace] = None,
+    guidelines: Optional[str] = None,
 ) -> FeedbackDataset:
     """Creates a `FeedbackDataset` object and pushes it to Argilla.
 
     Args:
         name: the name of dataset in Argilla (must be unique per workspace).
-        guidelines: the annotation guidelines to help the annotator understand the dataset to annotate and how to annotate it.
         fields: the list of `FieldSchema` objects to define the schema of the records pushed to Argilla.
         questions: the list of `QuestionSchema` objects to define the questions to ask to the annotator.
         workspace: the name of the workspace in Argilla where to push the dataset. Defaults to the default workspace.
+        guidelines: the annotation guidelines to help the annotator understand the dataset to annotate and how to annotate it.
+            Defaults to `None`.
 
     Returns:
         The `FeedbackDataset` object created and pushed to Argilla.
@@ -734,7 +740,6 @@ def create_feedback_dataset(
         >>> rg.init(api_url="...", api_key="...")
         >>> fds = rg.create_feedback_dataset(
         ...     name="my-dataset",
-        ...     guidelines="These are the annotation guidelines.",
         ...     fields=[
         ...         rg.TextField(name="text", required=True),
         ...         rg.TextField(name="label", required=True),
@@ -752,12 +757,13 @@ def create_feedback_dataset(
         ...             values=[1, 2, 3, 4, 5],
         ...         ),
         ...     ],
+        ...     guidelines="These are the annotation guidelines.",
         ... )
     """
     fds = FeedbackDataset(
-        guidelines=guidelines,
         fields=fields,
         questions=questions,
+        guidelines=guidelines,
     )
     fds.push_to_argilla(name=name, workspace=workspace)
     return fds

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -140,7 +140,7 @@ class TextQuestion(QuestionSchema):
 
 class RatingQuestion(QuestionSchema):
     settings: Dict[str, Any] = Field({"type": "rating"})
-    values: List[int]
+    values: List[int] = Field(unique_items=True)
 
     @validator("values", always=True)
     def update_settings_with_values(cls, v, values):

--- a/src/argilla/client/sdk/v1/datasets/models.py
+++ b/src/argilla/client/sdk/v1/datasets/models.py
@@ -29,10 +29,10 @@ class FeedbackDatasetModel(BaseModel):
     id: UUID
     name: str = Field(regex="^(?!-|_)[a-zA-Z0-9-_ ]+$")
     guidelines: Optional[str] = None
-    status: str = None
-    workspace_id: str = None
-    created_at: datetime = None
-    last_updated: datetime = None
+    status: Optional[str] = None
+    workspace_id: Optional[str] = None
+    created_at: datetime
+    last_updated: datetime
 
 
 class FeedbackValueModel(BaseModel):
@@ -79,7 +79,7 @@ class FeedbackQuestionModel(BaseModel):
     id: UUID
     name: str
     title: str
-    description: str
+    description: Optional[str] = None
     required: bool
     settings: Dict[str, Any]
     inserted_at: datetime

--- a/src/argilla/client/sdk/v1/datasets/models.py
+++ b/src/argilla/client/sdk/v1/datasets/models.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel, Field, StrictInt, StrictStr
 class FeedbackDatasetModel(BaseModel):
     id: UUID
     name: str = Field(regex="^(?!-|_)[a-zA-Z0-9-_ ]+$")
-    guidelines: str = None
+    guidelines: Optional[str] = None
     status: str = None
     workspace_id: str = None
     created_at: datetime = None

--- a/tests/client/sdk/v1/datasets/test_api.py
+++ b/tests/client/sdk/v1/datasets/test_api.py
@@ -51,7 +51,7 @@ def test_list_datasets(mocked_client, sdk_client, monkeypatch) -> None:
 
     dataset_name = "test_dataset"
     mocked_client.post(
-        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": "...", "workspace_id": workspace_id}
+        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": None, "workspace_id": workspace_id}
     )
 
     response = list_datasets(client=sdk_client)
@@ -70,7 +70,7 @@ def test_get_datasets(mocked_client, sdk_client, monkeypatch) -> None:
 
     dataset_name = "test_dataset"
     mocked_response = mocked_client.post(
-        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": "...", "workspace_id": workspace_id}
+        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": None, "workspace_id": workspace_id}
     )
     dataset_id = mocked_response.json()["id"]
 
@@ -88,7 +88,7 @@ def test_create_dataset(mocked_client, sdk_client, monkeypatch) -> None:
     workspace_id = mocked_response.json()["id"]
 
     dataset_name = "test_dataset"
-    response = create_dataset(client=sdk_client, name=dataset_name, workspace_id=workspace_id, guidelines="...")
+    response = create_dataset(client=sdk_client, name=dataset_name, workspace_id=workspace_id)
     assert response.status_code == 201
     assert isinstance(response.parsed, FeedbackDatasetModel)
     assert response.parsed.name == dataset_name
@@ -103,7 +103,7 @@ def test_delete_dataset(mocked_client, sdk_client, monkeypatch) -> None:
 
     dataset_name = "test_dataset"
     mocked_response = mocked_client.post(
-        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": "...", "workspace_id": workspace_id}
+        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": None, "workspace_id": workspace_id}
     )
     dataset_id = mocked_response.json()["id"]
 
@@ -124,7 +124,7 @@ def test_publish_dataset(mocked_client, sdk_client, monkeypatch) -> None:
 
     dataset_name = "test_dataset"
     mocked_response = mocked_client.post(
-        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": "...", "workspace_id": workspace_id}
+        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": None, "workspace_id": workspace_id}
     )
     dataset_id = mocked_response.json()["id"]
 
@@ -159,7 +159,7 @@ def test_add_field(mocked_client, sdk_client, monkeypatch) -> None:
 
     dataset_name = "test_dataset"
     mocked_response = mocked_client.post(
-        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": "...", "workspace_id": workspace_id}
+        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": None, "workspace_id": workspace_id}
     )
     dataset_id = mocked_response.json()["id"]
 
@@ -180,7 +180,7 @@ def test_get_fields(mocked_client, sdk_client, monkeypatch) -> None:
 
     dataset_name = "test_dataset"
     mocked_response = mocked_client.post(
-        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": "...", "workspace_id": workspace_id}
+        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": None, "workspace_id": workspace_id}
     )
     dataset_id = mocked_response.json()["id"]
 
@@ -205,7 +205,7 @@ def test_add_question(mocked_client, sdk_client, monkeypatch) -> None:
 
     dataset_name = "test_dataset"
     mocked_response = mocked_client.post(
-        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": "...", "workspace_id": workspace_id}
+        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": None, "workspace_id": workspace_id}
     )
     dataset_id = mocked_response.json()["id"]
 
@@ -232,7 +232,7 @@ def test_get_questions(mocked_client, sdk_client, monkeypatch) -> None:
 
     dataset_name = "test_dataset"
     mocked_response = mocked_client.post(
-        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": "...", "workspace_id": workspace_id}
+        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": None, "workspace_id": workspace_id}
     )
     dataset_id = mocked_response.json()["id"]
 
@@ -263,7 +263,7 @@ def test_add_records(mocked_client, sdk_client, monkeypatch) -> None:
 
     dataset_name = "test_dataset"
     mocked_response = mocked_client.post(
-        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": "...", "workspace_id": workspace_id}
+        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": None, "workspace_id": workspace_id}
     )
     dataset_id = mocked_response.json()["id"]
 
@@ -296,7 +296,7 @@ def test_get_records(mocked_client, sdk_client, monkeypatch) -> None:
 
     dataset_name = "test_dataset"
     mocked_response = mocked_client.post(
-        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": "...", "workspace_id": workspace_id}
+        f"/api/v1/datasets", json={"name": dataset_name, "guidelines": None, "workspace_id": workspace_id}
     )
     dataset_id = mocked_response.json()["id"]
 

--- a/tests/client/test_feedback.py
+++ b/tests/client/test_feedback.py
@@ -46,9 +46,15 @@ class TestFeedbackDataset:
 
     @pytest.mark.usefixtures("feedback_dataset_fields", "feedback_dataset_questions")
     def test_init_wrong_guidelines(self, feedback_dataset_fields: list, feedback_dataset_questions: list) -> None:
-        with pytest.raises(TypeError, match="Expected `guidelines` to be a string"):
+        with pytest.raises(TypeError, match="Expected `guidelines` to be"):
             FeedbackDataset(
-                guidelines=None,
+                guidelines=[],
+                fields=feedback_dataset_fields,
+                questions=feedback_dataset_questions,
+            )
+        with pytest.raises(ValueError, match="Expected `guidelines` to be"):
+            FeedbackDataset(
+                guidelines="",
                 fields=feedback_dataset_fields,
                 questions=feedback_dataset_questions,
             )

--- a/tests/client/test_feedback.py
+++ b/tests/client/test_feedback.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, List
 
 import pytest
 from argilla.client import api
+from pydantic import ValidationError
 
 if TYPE_CHECKING:
     from argilla.client.feedback import FieldSchema, QuestionSchema
@@ -101,6 +102,14 @@ class TestFeedbackDataset:
                 questions=[
                     TextQuestion(name="test", required=False),
                     RatingQuestion(name="test", values=[0, 1], required=False),
+                ],
+            )
+        with pytest.raises(ValidationError, match="1 validation error for RatingQuestion"):
+            FeedbackDataset(
+                guidelines=feedback_dataset_guidelines,
+                fields=feedback_dataset_fields,
+                questions=[
+                    RatingQuestion(name="test", values=[0, 0], required=True),
                 ],
             )
 


### PR DESCRIPTION
# Description

Some validations in the Python client were not compliant with the Argilla API validations, so this PR tackles that to make sure that the Python client is more robust and less prone to validation errors on the API-side (thank `pydantic`!).

Kudos again to @nataliaElv for catching some of the things tackled in this PR!

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

- [X] Added regression tests for the introduced validations

**Checklist**

- [X] I have merged the original branch into my forked branch
- [X] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works