### PR TITLE
✨ Allow users to edit Descriptions and annotations guidelines WIP.

### DIFF
--- a/frontend/components/commons/dataset-description/DatasetDescription.component.spec.js
+++ b/frontend/components/commons/dataset-description/DatasetDescription.component.spec.js
@@ -1,4 +1,4 @@
-import { shallowMount } from "@vue/test-utils";
+import { mount } from "@vue/test-utils";
 import DatasetDescription from "./DatasetDescription.component";
 import * as Mocked from "./MockedService";
 
@@ -23,14 +23,14 @@ describe("DatasetDescriptionComponent should", () => {
   })
 
   it("render the component", () => {
-    const wrapper = shallowMount(DatasetDescription, options);
+    const wrapper = mount(DatasetDescription, options);
 
     expect(wrapper.is(DatasetDescription)).toBe(true);
   });
 
   it("see the dataset description", () => {
     jest.spyOn(Mocked, "getDatasetDescription").mockReturnValue("FAKE_DESCRIPTION");
-    const wrapper = shallowMount(DatasetDescription, options);
+    const wrapper = mount(DatasetDescription, options);
 
     const description = wrapper.find(".description__markdown__viewer-text");
 
@@ -39,7 +39,7 @@ describe("DatasetDescriptionComponent should", () => {
 
   it("save description when user click on save button", async () => {
     const saveDescriptionMocked = jest.spyOn(Mocked, "saveDescription");
-    const wrapper = shallowMount(DatasetDescription, options);
+    const wrapper = mount(DatasetDescription, options);
     await wrapper.find("[name=edit-button]").trigger("on-click");
 
     await wrapper.find("[name=description-input]").setValue("NEW_DESCRIPTION")
@@ -51,7 +51,7 @@ describe("DatasetDescriptionComponent should", () => {
 
   it("discard new description if the user cancel edition", async () => {
     const saveDescriptionMocked = jest.spyOn(Mocked, "saveDescription");
-    const wrapper = shallowMount(DatasetDescription, options);
+    const wrapper = mount(DatasetDescription, options);
     await wrapper.find("[name=edit-button]").trigger("on-click");
     await wrapper.find("[name=description-input]").setValue("NEW_DESCRIPTION")
 

--- a/frontend/components/commons/dataset-description/DatasetDescription.component.spec.js
+++ b/frontend/components/commons/dataset-description/DatasetDescription.component.spec.js
@@ -4,7 +4,8 @@ import DatasetDescription from "./DatasetDescription.component";
 let wrapper = null;
 const options = {
   propsData: {
-    datasetDescription: "Lorem ipsum",
+    datasetId: "FAKE_ID",
+    datasetTask: "FAKE_TASK"
   },
 };
 beforeEach(() => {
@@ -15,8 +16,19 @@ afterEach(() => {
   wrapper.destroy();
 });
 
-describe("DatasetDescriptionComponent", () => {
+jest.mock("@/models/dataset.utilities", () => {
+  return {
+    getDatasetFromORM: jest.fn(() => ({ tags: { description: "FAKE_DESCRIPTION" } }))
+  }
+})
+describe("DatasetDescriptionComponent should", () => {
   it("render the component", () => {
     expect(wrapper.is(DatasetDescription)).toBe(true);
+  });
+
+  it("see description", () => {
+    const description = wrapper.find(".description__text");
+
+    expect(description.element.innerHTML).toBe("FAKE_DESCRIPTION")
   });
 });

--- a/frontend/components/commons/dataset-description/DatasetDescription.component.spec.js
+++ b/frontend/components/commons/dataset-description/DatasetDescription.component.spec.js
@@ -1,34 +1,36 @@
 import { shallowMount } from "@vue/test-utils";
 import DatasetDescription from "./DatasetDescription.component";
+import * as Mocked from "./MockedService";
 
-let wrapper = null;
 const options = {
   propsData: {
     datasetId: "FAKE_ID",
     datasetTask: "FAKE_TASK"
   },
 };
-beforeEach(() => {
-  wrapper = shallowMount(DatasetDescription, options);
-});
-
-afterEach(() => {
-  wrapper.destroy();
-});
-
-jest.mock("@/models/dataset.utilities", () => {
-  return {
-    getDatasetFromORM: jest.fn(() => ({ tags: { description: "FAKE_DESCRIPTION" } }))
-  }
-})
 describe("DatasetDescriptionComponent should", () => {
   it("render the component", () => {
+    const wrapper = shallowMount(DatasetDescription, options);
+
     expect(wrapper.is(DatasetDescription)).toBe(true);
   });
 
   it("see description", () => {
+    jest.spyOn(Mocked, "getDatasetDescription").mockReturnValue("FAKE_DESCRIPTION");
+    const wrapper = shallowMount(DatasetDescription, options);
+
     const description = wrapper.find(".description__text");
 
     expect(description.element.innerHTML).toBe("FAKE_DESCRIPTION")
   });
+
+  it("save description when user click on save button", async () => {
+    const saveDescriptionMocked = jest.spyOn(Mocked, "saveDescription");
+    const wrapper = shallowMount(DatasetDescription, options);
+    await wrapper.find("[name=edit-button]").trigger("on-click");
+
+    await wrapper.find("[name=save-button]").trigger("on-click");
+
+    expect(saveDescriptionMocked).toHaveBeenCalledWith("FAKE_ID", "FAKE_TASK", "TEMPORAL_TODO_REMOVE");
+  })
 });

--- a/frontend/components/commons/dataset-description/DatasetDescription.component.spec.js
+++ b/frontend/components/commons/dataset-description/DatasetDescription.component.spec.js
@@ -8,20 +8,33 @@ const options = {
     datasetTask: "FAKE_TASK"
   },
 };
+
+jest.mock("marked", () => {
+  return {
+    marked: {
+      parse: jest.fn((value) => `${value}-PARSED`)
+    }
+  }
+})
+
 describe("DatasetDescriptionComponent should", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  })
+
   it("render the component", () => {
     const wrapper = shallowMount(DatasetDescription, options);
 
     expect(wrapper.is(DatasetDescription)).toBe(true);
   });
 
-  it("see description", () => {
+  it("see the dataset description", () => {
     jest.spyOn(Mocked, "getDatasetDescription").mockReturnValue("FAKE_DESCRIPTION");
     const wrapper = shallowMount(DatasetDescription, options);
 
-    const description = wrapper.find(".description__text");
+    const description = wrapper.find(".description__markdown__viewer-text");
 
-    expect(description.element.innerHTML).toBe("FAKE_DESCRIPTION")
+    expect(description.element.innerHTML).toBe("FAKE_DESCRIPTION-PARSED")
   });
 
   it("save description when user click on save button", async () => {
@@ -29,8 +42,23 @@ describe("DatasetDescriptionComponent should", () => {
     const wrapper = shallowMount(DatasetDescription, options);
     await wrapper.find("[name=edit-button]").trigger("on-click");
 
+    await wrapper.find("[name=description-input]").setValue("NEW_DESCRIPTION")
+
     await wrapper.find("[name=save-button]").trigger("on-click");
 
-    expect(saveDescriptionMocked).toHaveBeenCalledWith("FAKE_ID", "FAKE_TASK", "TEMPORAL_TODO_REMOVE");
+    expect(saveDescriptionMocked).toHaveBeenCalledWith("FAKE_ID", "FAKE_TASK", "NEW_DESCRIPTION");
+  })
+
+  it("discard new description if the user cancel edition", async () => {
+    const saveDescriptionMocked = jest.spyOn(Mocked, "saveDescription");
+    const wrapper = shallowMount(DatasetDescription, options);
+    await wrapper.find("[name=edit-button]").trigger("on-click");
+    await wrapper.find("[name=description-input]").setValue("NEW_DESCRIPTION")
+
+    await wrapper.find("[name=close-button]").trigger("on-click");
+
+    expect(saveDescriptionMocked).toHaveBeenCalledTimes(0);
+
+    expect(wrapper.find(".description__markdown__viewer-text").element.innerHTML).toBe("FAKE_DESCRIPTION-PARSED")
   })
 });

--- a/frontend/components/commons/dataset-description/DatasetDescription.component.vue
+++ b/frontend/components/commons/dataset-description/DatasetDescription.component.vue
@@ -1,43 +1,19 @@
 <template>
-  <div class="description">
+  <div>
     <h2 class="--heading5 --semibold description__title">{{ title }}</h2>
-    <div class="description__markdown__viewer" v-if="!isEditing">
-      <span
-        class="--body1 description__markdown__viewer-text"
-        v-html="compiledDescription"
-      />
-      <BaseButton name="edit-button" @on-click="onEdit">
-        <svgicon width="15" height="15" name="pen"></svgicon
-      ></BaseButton>
-    </div>
-    <div class="description__markdown__editor" v-if="isEditing">
-      <textarea
-        name="description-input"
-        class="description__markdown__editor-input"
-        v-model="newDescription"
-      ></textarea>
-
-      <div class="description__markdown__editor-button-area">
-        <BaseButton name="save-button" class="primary small" @on-click="onSave"
-          >Save</BaseButton
-        >
-        <BaseButton
-          name="close-button"
-          class="secondary small"
-          @on-click="onClose"
-          >Discard</BaseButton
-        >
-      </div>
-    </div>
+    <EditableDescriptionMarkdown :description="description" @onSave="onSave" />
   </div>
 </template>
 
 <script>
-import { marked } from "marked";
+import EditableDescriptionMarkdown from "./EditableDescriptionMarkdown.component.vue";
 
 import { getDatasetDescription, saveDescription } from "./MockedService";
 
 export default {
+  components: {
+    EditableDescriptionMarkdown,
+  },
   props: {
     datasetId: {
       type: Array,
@@ -51,84 +27,17 @@ export default {
   data: () => {
     return {
       title: "Description and annotation guidelines",
-      isEditing: false,
-      newDescription: "",
     };
   },
   computed: {
     description() {
       return getDatasetDescription(this.datasetId, this.datasetTask);
     },
-    compiledDescription() {
-      return marked.parse(this.description);
-    },
   },
   methods: {
-    onEdit() {
-      this.newDescription = this.description;
-
-      this.isEditing = true;
-    },
-    async onSave() {
-      await saveDescription(
-        this.datasetId,
-        this.datasetTask,
-        this.newDescription
-      );
-
-      this.isEditing = false;
-    },
-    onClose() {
-      this.newDescription = "";
-
-      this.isEditing = false;
+    onSave(newDescription) {
+      saveDescription(this.datasetId, this.datasetTask, newDescription);
     },
   },
 };
 </script>
-
-<style lang="scss" scoped>
-.description {
-  &__markdown {
-    margin-bottom: 5px;
-
-    &__viewer {
-      display: flex;
-      flex-direction: row;
-      align-items: baseline;
-      justify-content: space-between;
-
-      &-text {
-        color: $black-37;
-        width: 90%;
-      }
-    }
-
-    &__editor {
-      display: flex;
-      flex-direction: column;
-      justify-content: flex-end;
-      margin-bottom: 1em;
-      gap: 20px;
-
-      &-button-area {
-        display: flex;
-        justify-content: row;
-        justify-content: flex-end;
-        gap: 5px;
-      }
-
-      &-input {
-        width: 100%;
-        min-height: 20vh;
-        padding: 12px 20px;
-        box-sizing: border-box;
-        border: 2px solid #ccc;
-        border-radius: 4px;
-        background-color: #f8f8f8;
-        resize: none;
-      }
-    }
-  }
-}
-</style>

--- a/frontend/components/commons/dataset-description/DatasetDescription.component.vue
+++ b/frontend/components/commons/dataset-description/DatasetDescription.component.vue
@@ -4,7 +4,7 @@
     <div class="description__markdown" v-if="!isEditing">
       <!-- Markdown content here  -->
       <p class="--body1 description__text" v-html="description" />
-      <BaseButton id="onEdit" @on-click="onEdit">
+      <BaseButton name="edit-button" @on-click="onEdit">
         <svgicon width="15" height="15" name="pen"></svgicon
       ></BaseButton>
     </div>
@@ -12,10 +12,13 @@
       <!-- Markdown input component here -->
 
       <div class="description__button-area">
-        <base-button id="onSave" class="primary small" @on-click="onSave"
+        <base-button name="save-button" class="primary small" @on-click="onSave"
           >Save</base-button
         >
-        <base-button id="onClose" class="secondary small" @on-click="onClose"
+        <base-button
+          name="close-button"
+          class="secondary small"
+          @on-click="onClose"
           >Discard</base-button
         >
       </div>
@@ -24,7 +27,8 @@
 </template>
 
 <script>
-import { getDatasetFromORM } from "@/models/dataset.utilities";
+import { getDatasetDescription, saveDescription } from "./MockedService";
+
 export default {
   props: {
     datasetId: {
@@ -43,18 +47,21 @@ export default {
     };
   },
   computed: {
-    dataset() {
-      return getDatasetFromORM(this.datasetId, this.datasetTask, false);
-    },
     description() {
-      return this.dataset?.tags.description;
+      return getDatasetDescription(this.datasetId, this.datasetTask, false);
     },
   },
   methods: {
     onEdit() {
       this.isEditing = true;
     },
-    onSave() {
+    async onSave() {
+      await saveDescription(
+        this.datasetId,
+        this.datasetTask,
+        "TEMPORAL_TODO_REMOVE"
+      );
+
       this.isEditing = false;
     },
     onClose() {
@@ -74,7 +81,7 @@ export default {
   &__markdown {
     display: flex;
     flex-direction: row;
-    align-items: center;
+    align-items: baseline;
     justify-content: space-between;
   }
 

--- a/frontend/components/commons/dataset-description/DatasetDescription.component.vue
+++ b/frontend/components/commons/dataset-description/DatasetDescription.component.vue
@@ -1,17 +1,23 @@
 <template>
   <div class="description">
     <h2 class="--heading5 --semibold description__title">{{ title }}</h2>
-    <div class="description__markdown" v-if="!isEditing">
-      <!-- Markdown content here  -->
-      <p class="--body1 description__text" v-html="description" />
+    <div class="description__markdown__viewer" v-if="!isEditing">
+      <span
+        class="--body1 description__markdown__viewer-text"
+        v-html="compiledDescription"
+      />
       <BaseButton name="edit-button" @on-click="onEdit">
         <svgicon width="15" height="15" name="pen"></svgicon
       ></BaseButton>
     </div>
-    <div class="description__markdown__edit" v-if="isEditing">
-      <!-- Markdown input component here -->
+    <div class="description__markdown__editor" v-if="isEditing">
+      <textarea
+        name="description-input"
+        class="description__markdown__editor-input"
+        v-model="newDescription"
+      ></textarea>
 
-      <div class="description__button-area">
+      <div class="description__markdown__editor-button-area">
         <BaseButton name="save-button" class="primary small" @on-click="onSave"
           >Save</BaseButton
         >
@@ -27,6 +33,8 @@
 </template>
 
 <script>
+import { marked } from "marked";
+
 import { getDatasetDescription, saveDescription } from "./MockedService";
 
 export default {
@@ -44,27 +52,35 @@ export default {
     return {
       title: "Description and annotation guidelines",
       isEditing: false,
+      newDescription: "",
     };
   },
   computed: {
     description() {
-      return getDatasetDescription(this.datasetId, this.datasetTask, false);
+      return getDatasetDescription(this.datasetId, this.datasetTask);
+    },
+    compiledDescription() {
+      return marked.parse(this.description);
     },
   },
   methods: {
     onEdit() {
+      this.newDescription = this.description;
+
       this.isEditing = true;
     },
     async onSave() {
       await saveDescription(
         this.datasetId,
         this.datasetTask,
-        "TEMPORAL_TODO_REMOVE"
+        this.newDescription
       );
 
       this.isEditing = false;
     },
     onClose() {
+      this.newDescription = "";
+
       this.isEditing = false;
     },
   },
@@ -73,24 +89,46 @@ export default {
 
 <style lang="scss" scoped>
 .description {
-  &__text {
-    color: $black-37;
-    width: 90%;
-  }
-
   &__markdown {
-    display: flex;
-    flex-direction: row;
-    align-items: baseline;
-    justify-content: space-between;
-  }
-
-  &__button-area {
-    display: flex;
-    justify-content: row;
-    justify-content: flex-end;
-    gap: 5px;
     margin-bottom: 5px;
+
+    &__viewer {
+      display: flex;
+      flex-direction: row;
+      align-items: baseline;
+      justify-content: space-between;
+
+      &-text {
+        color: $black-37;
+        width: 90%;
+      }
+    }
+
+    &__editor {
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      margin-bottom: 1em;
+      gap: 20px;
+
+      &-button-area {
+        display: flex;
+        justify-content: row;
+        justify-content: flex-end;
+        gap: 5px;
+      }
+
+      &-input {
+        width: 100%;
+        min-height: 20vh;
+        padding: 12px 20px;
+        box-sizing: border-box;
+        border: 2px solid #ccc;
+        border-radius: 4px;
+        background-color: #f8f8f8;
+        resize: none;
+      }
+    }
   }
 }
 </style>

--- a/frontend/components/commons/dataset-description/DatasetDescription.component.vue
+++ b/frontend/components/commons/dataset-description/DatasetDescription.component.vue
@@ -12,14 +12,14 @@
       <!-- Markdown input component here -->
 
       <div class="description__button-area">
-        <base-button name="save-button" class="primary small" @on-click="onSave"
-          >Save</base-button
+        <BaseButton name="save-button" class="primary small" @on-click="onSave"
+          >Save</BaseButton
         >
-        <base-button
+        <BaseButton
           name="close-button"
           class="secondary small"
           @on-click="onClose"
-          >Discard</base-button
+          >Discard</BaseButton
         >
       </div>
     </div>

--- a/frontend/components/commons/dataset-description/DatasetDescription.component.vue
+++ b/frontend/components/commons/dataset-description/DatasetDescription.component.vue
@@ -1,14 +1,37 @@
 <template>
   <div class="description">
     <h2 class="--heading5 --semibold description__title">{{ title }}</h2>
-    <p class="--body1 description__text">{{ datasetDescription }}</p>
+    <div class="description__markdown" v-if="!isEditing">
+      <!-- Markdown content here  -->
+      <p class="--body1 description__text" v-html="description" />
+      <BaseButton id="onEdit" @on-click="onEdit">
+        <svgicon width="15" height="15" name="pen"></svgicon
+      ></BaseButton>
+    </div>
+    <div class="description__markdown__edit" v-if="isEditing">
+      <!-- Markdown input component here -->
+
+      <div class="description__button-area">
+        <base-button id="onSave" class="primary small" @on-click="onSave"
+          >Save</base-button
+        >
+        <base-button id="onClose" class="secondary small" @on-click="onClose"
+          >Discard</base-button
+        >
+      </div>
+    </div>
   </div>
 </template>
 
 <script>
+import { getDatasetFromORM } from "@/models/dataset.utilities";
 export default {
   props: {
-    datasetDescription: {
+    datasetId: {
+      type: Array,
+      required: true,
+    },
+    datasetTask: {
       type: String,
       required: true,
     },
@@ -16,7 +39,27 @@ export default {
   data: () => {
     return {
       title: "Description and annotation guidelines",
+      isEditing: false,
     };
+  },
+  computed: {
+    dataset() {
+      return getDatasetFromORM(this.datasetId, this.datasetTask, false);
+    },
+    description() {
+      return this.dataset?.tags.description;
+    },
+  },
+  methods: {
+    onEdit() {
+      this.isEditing = true;
+    },
+    onSave() {
+      this.isEditing = false;
+    },
+    onClose() {
+      this.isEditing = false;
+    },
   },
 };
 </script>
@@ -25,6 +68,22 @@ export default {
 .description {
   &__text {
     color: $black-37;
+    width: 90%;
+  }
+
+  &__markdown {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__button-area {
+    display: flex;
+    justify-content: row;
+    justify-content: flex-end;
+    gap: 5px;
+    margin-bottom: 5px;
   }
 }
 </style>

--- a/frontend/components/commons/dataset-description/EditableDescriptionMarkdown.component.spec.js
+++ b/frontend/components/commons/dataset-description/EditableDescriptionMarkdown.component.spec.js
@@ -1,0 +1,44 @@
+import { shallowMount } from "@vue/test-utils";
+import EditableDescriptionMarkdown from "./EditableDescriptionMarkdown.component.vue";
+
+const options = {
+    propsData: {
+        description: "FAKE_DESCRIPTION"
+    },
+};
+
+jest.mock("marked", () => {
+    return {
+        marked: {
+            parse: jest.fn((value) => `${value}-PARSED`)
+        }
+    }
+})
+
+describe("EditableDescriptionMarkdown should", () => {
+    it("make editable when user clicks on pencil", async () => {
+        const wrapper = shallowMount(EditableDescriptionMarkdown, options);
+        await wrapper.find("[name=edit-button]").trigger("on-click");
+
+        expect(wrapper.vm.$data.isEditing).toBe(true)
+    })
+
+    it("make no editable when user clicks on discard", async () => {
+        const wrapper = shallowMount(EditableDescriptionMarkdown, options);
+        await wrapper.find("[name=edit-button]").trigger("on-click");
+
+        await wrapper.find("[name=close-button]").trigger("on-click");
+
+        expect(wrapper.vm.$data.isEditing).toBe(false)
+    })
+
+    it("raise onSave event when user clicks on save button", async () => {
+        const wrapper = shallowMount(EditableDescriptionMarkdown, options);
+        await wrapper.find("[name=edit-button]").trigger("on-click");
+
+        await wrapper.find("[name=save-button]").trigger("on-click");
+
+        expect(wrapper.vm.$data.isEditing).toBe(false)
+        expect(wrapper.emitted().onSave).toEqual([["FAKE_DESCRIPTION"]])
+    })
+})

--- a/frontend/components/commons/dataset-description/EditableDescriptionMarkdown.component.vue
+++ b/frontend/components/commons/dataset-description/EditableDescriptionMarkdown.component.vue
@@ -1,0 +1,117 @@
+<template>
+  <div class="description">
+    <div class="description__markdown__viewer" v-if="!isEditing">
+      <span
+        class="--body1 description__markdown__viewer-text"
+        v-html="parsedDescription"
+      />
+      <BaseButton name="edit-button" @on-click="onEdit">
+        <svgicon width="15" height="15" name="pen"></svgicon
+      ></BaseButton>
+    </div>
+    <div class="description__markdown__editor" v-if="isEditing">
+      <textarea
+        name="description-input"
+        class="description__markdown__editor-input"
+        v-model="newDescription"
+      ></textarea>
+
+      <div class="description__markdown__editor-button-area">
+        <BaseButton name="save-button" class="primary small" @on-click="onSave"
+          >Save</BaseButton
+        >
+        <BaseButton
+          name="close-button"
+          class="secondary small"
+          @on-click="onClose"
+          >Discard</BaseButton
+        >
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+import { marked } from "marked";
+
+export default {
+  props: {
+    description: {
+      type: String,
+      required: true,
+    },
+  },
+  data: () => {
+    return {
+      newDescription: "",
+      isEditing: false,
+    };
+  },
+  computed: {
+    parsedDescription() {
+      return marked.parse(this.description);
+    },
+  },
+  methods: {
+    onEdit() {
+      this.newDescription = this.description;
+
+      this.isEditing = true;
+    },
+    async onSave() {
+      this.$emit("onSave", this.newDescription);
+
+      this.isEditing = false;
+    },
+    onClose() {
+      this.newDescription = "";
+
+      this.isEditing = false;
+    },
+  },
+};
+</script>
+<style lang="scss" scoped>
+.description {
+  &__markdown {
+    margin-bottom: 5px;
+
+    &__viewer {
+      display: flex;
+      flex-direction: row;
+      align-items: baseline;
+      justify-content: space-between;
+
+      &-text {
+        color: $black-37;
+        width: 90%;
+      }
+    }
+
+    &__editor {
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      margin-bottom: 1em;
+      gap: 20px;
+
+      &-button-area {
+        display: flex;
+        justify-content: row;
+        justify-content: flex-end;
+        gap: 5px;
+      }
+
+      &-input {
+        width: 100%;
+        min-height: 20vh;
+        padding: 12px 20px;
+        box-sizing: border-box;
+        border: 2px solid #ccc;
+        border-radius: 4px;
+        background-color: #f8f8f8;
+        resize: none;
+      }
+    }
+  }
+}
+</style>

--- a/frontend/components/commons/dataset-description/MockedService.js
+++ b/frontend/components/commons/dataset-description/MockedService.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 
-const FAKE_DESCRIPTION = `# Title 
+const FAKE_DESCRIPTION = `# Title
 
 ## Subtitle`;
 

--- a/frontend/components/commons/dataset-description/MockedService.js
+++ b/frontend/components/commons/dataset-description/MockedService.js
@@ -1,0 +1,13 @@
+const FAKE_DESCRIPTION = `<h1 class="code-line" data-line-start=0 data-line-end=1 ><a id="Lorem_Ipsum_0"></a>Lorem Ipsum</h1>
+<p class="has-line-data" data-line-start="1" data-line-end="2">Es simplemente el texto de relleno de las imprentas y archivos de texto. Lorem Ipsum ha sido el texto de relleno estándar de las industrias desde el año 1500, cuando un impresor (N. del T. persona que se dedica a la imprenta) desconocido usó una galería de textos y los mezcló de tal manera que logró hacer un libro de textos especimen. No sólo sobrevivió 500 años, sino que tambien ingresó como texto de relleno en documentos electrónicos, quedando esencialmente igual al original. Fue popularizado en los 60s con la creación de las hojas “Letraset”, las cuales contenian pasajes de Lorem Ipsum, y más recientemente con software de autoedición, como por ejemplo Aldus PageMaker, el cual incluye versiones de Lorem Ipsum.</p>
+<h2 class="code-line" data-line-start=3 data-line-end=4 ><a id="Code_3"></a>Code</h2>
+<pre><code class="has-line-data" data-line-start="5" data-line-end="7" class="language-js">Test
+</code></pre>`;
+
+export const getDatasetDescription = (datasetId, datasetTask) => {
+    return FAKE_DESCRIPTION
+}
+
+export const saveDescription = (datasetId, datasetTask, newDescription) => {
+    return Promise.resolve();
+}

--- a/frontend/components/commons/dataset-description/MockedService.js
+++ b/frontend/components/commons/dataset-description/MockedService.js
@@ -1,13 +1,19 @@
-const FAKE_DESCRIPTION = `<h1 class="code-line" data-line-start=0 data-line-end=1 ><a id="Lorem_Ipsum_0"></a>Lorem Ipsum</h1>
-<p class="has-line-data" data-line-start="1" data-line-end="2">Es simplemente el texto de relleno de las imprentas y archivos de texto. Lorem Ipsum ha sido el texto de relleno estándar de las industrias desde el año 1500, cuando un impresor (N. del T. persona que se dedica a la imprenta) desconocido usó una galería de textos y los mezcló de tal manera que logró hacer un libro de textos especimen. No sólo sobrevivió 500 años, sino que tambien ingresó como texto de relleno en documentos electrónicos, quedando esencialmente igual al original. Fue popularizado en los 60s con la creación de las hojas “Letraset”, las cuales contenian pasajes de Lorem Ipsum, y más recientemente con software de autoedición, como por ejemplo Aldus PageMaker, el cual incluye versiones de Lorem Ipsum.</p>
-<h2 class="code-line" data-line-start=3 data-line-end=4 ><a id="Code_3"></a>Code</h2>
-<pre><code class="has-line-data" data-line-start="5" data-line-end="7" class="language-js">Test
-</code></pre>`;
+import Vue from 'vue'
+
+const FAKE_DESCRIPTION = `# Title 
+
+## Subtitle`;
+
+const fakeDataset = Vue.observable({
+    description: FAKE_DESCRIPTION
+})
 
 export const getDatasetDescription = (datasetId, datasetTask) => {
-    return FAKE_DESCRIPTION
+    return fakeDataset.description;
 }
 
 export const saveDescription = (datasetId, datasetTask, newDescription) => {
+    fakeDataset.description = newDescription;
+
     return Promise.resolve();
 }

--- a/frontend/components/page-contents/dataset-settings/LeftDatasetSettings.content.vue
+++ b/frontend/components/page-contents/dataset-settings/LeftDatasetSettings.content.vue
@@ -16,7 +16,10 @@
       </base-action-tooltip>
     </div>
     <div class="dataset-description-component left-content-item">
-      <DatasetDescriptionComponent :datasetDescription="settingsDescription" />
+      <DatasetDescriptionComponent
+        :datasetId="datasetId"
+        :datasetTask="datasetTask"
+      />
     </div>
     <div
       class="labels-edition-component left-content-item"
@@ -76,9 +79,6 @@ export default {
     },
     isTaskTextClassification() {
       return this.datasetTask === "TextClassification";
-    },
-    settingsDescription() {
-      return "Soon you will be able to edit your information";
     },
     isLoading() {
       return this.$fetchState.pending;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "@vuex-orm/plugin-axios": "^0.9.3",
     "core-js": "^3.6.5",
     "js-base64": "^3.7.2",
+    "marked": "^5.0.2",
     "moment-timezone": "^0.5.33",
     "nuxt": "^2.15.8",
     "nuxt-highlightjs": "^1.0.2",


### PR DESCRIPTION
# Description
**Allow users to create or edit the Description and annotation guidelines.**
I'm trying to implement the feature that allow the users to create or edit the descriptions and annotations.
I want to validate the first approach and look and feel of this request, and also I need some help to decide which markdown component to use here.

![Description and annotation V1](https://github.com/argilla-io/argilla/assets/7398909/37040694-e0d0-4869-ac8d-b5760754518e)

**Type of change**
- [ ] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**
- [ ] DatasetDescriptionComponent unit test

**Checklist**
- [ ] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)