### PR TITLE
chore: added very rough outline prepare_for_training with FeedbackDat…

### DIFF
--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -34,6 +34,7 @@ from pydantic import (
 from tqdm import tqdm
 
 import argilla as rg
+from argilla.client.models import Framework
 from argilla.client.sdk.v1.datasets import api as datasets_api_v1
 
 if TYPE_CHECKING:
@@ -150,6 +151,21 @@ class RatingQuestion(QuestionSchema):
 
     class Config:
         validate_assignment = True
+
+
+class TrainingDataForLLMFineTuningGeneric(BaseModel):
+    text: Union[TextQuestion, TextField]
+
+
+class TrainingDataForLLMFineTuningChat(BaseModel):
+    prompt: Union[TextField, TextQuestion]
+    context: Union[TextField, TextQuestion]
+    response: Union[TextField, TextQuestion]
+
+
+class TrainingDataForTextClassification(BaseModel):
+    text: Union[TextQuestion, TextField]
+    label: RatingQuestion
 
 
 class FeedbackDataset:
@@ -672,6 +688,80 @@ class FeedbackDataset:
             self.fetch_records()
         return self
 
+    def prepare_for_training(
+        self,
+        framework: Union[Framework, str],
+        training_data: Union[
+            TrainingDataForTextClassification, TrainingDataForLLMFineTuningChat, TrainingDataForLLMFineTuningChat
+        ],
+        train_size: Optional[float] = 1,
+        test_size: Optional[float] = None,
+        seed: Optional[int] = None,
+        fetch_records: bool = True,
+    ):
+        if isinstance(framework, str):
+            framework = Framework(framework)
+
+        if fetch_records:
+            self.fetch_records()
+
+        relevant_data = self.get_relevant_data_for_training(training_data, "FCFS")
+
+        if framework == Framework.AUTOTRAIN:
+            import pandas as pd
+
+            return pd.DataFrame(relevant_data)
+
+        else:
+            raise NotImplementedError(f"Framework {framework} is not supported yet")
+
+    def get_relevant_data_for_training(self, training_data, strategy="FCFS"):
+        # TODO: implement other strategies besides first come first serve
+        # TODO: think about ID usage per field and response
+        relevant_fields = list([getattr(training_data, field).name for field in training_data.__fields__])
+
+        total_data = []
+        for rec in self.records:
+            # get relevant (fixed) fields
+            relevant_data = {k: v for k, v in rec["fields"].items() if k in relevant_fields}
+
+            # check if we require responses
+            missing_fields = set(relevant_fields) - set(relevant_data.keys())
+
+            if not missing_fields:
+                total_data.append(relevant_data)
+                continue
+            else:
+                # check if there are responses
+                if not rec["responses"]:
+                    continue
+                for res in rec["responses"]:
+                    for missing_field in missing_fields:
+                        value = res["values"].get(missing_field, {})
+                        if value.get("value"):
+                            relevant_data[missing_field] = value["value"]
+                if missing_fields - set(relevant_data.keys()):
+                    continue
+                else:
+                    total_data.append(relevant_data)
+        return total_data
+
+    def prepare_for_training_with_autotrain(
+        self,
+        training_data: TrainingDataForTextClassification,
+        train_size: Optional[float] = 1,
+        test_size: Optional[float] = None,
+        seed: Optional[int] = None,
+    ):
+        relevant_fields = ["id"] + list(training_data.__fields__.keys())
+        total_data = []
+        for rec in self.records:
+            relevant_data = {k: v for k, v in rec["fields"].items() if k in relevant_fields}
+            relevant_data["id"] = rec["id"]
+            total_data.append(relevant_data)
+
+        return total_data
+
 
 def generate_pydantic_schema(fields: List[FieldSchema], name: Optional[str] = "FieldsSchema") -> BaseModel:
     """Generates a `pydantic.BaseModel` schema from a list of `FieldSchema` objects to validate
@@ -827,5 +917,5 @@ def feedback_dataset_in_argilla(
     else:
         try:
             return (True, datasets_api_v1.get_dataset(client=httpx_client, id=id).parsed)
-        except Exception as e:
+        except Exception:
             return (False, None)

--- a/src/argilla/client/models.py
+++ b/src/argilla/client/models.py
@@ -43,6 +43,7 @@ class Framework(Enum):
     SPAN_MARKER = "span_marker"
     SPARK_NLP = "spark-nlp"
     OPENAI = "openai"
+    AUTOTRAIN = "autotrain"
 
     @classmethod
     def _missing_(cls, value):


### PR DESCRIPTION
…aset

# Description

I added a very rough outline of my ideation behind `prepare_for_training` with the new `FeedbackDataset`. As discussed there are 3 complexities:

- How to resolve annotator alignment?
- How to resolve optional fields, which have not been filled out? e.g., "Please provide a correction for prompt 1?".
- How handle potential concatenation of fields? 

To make it modular I created a step-wise approach.

1. `Pydantic` Models that map and verify data fields, like so. By doing this we keep the flexibility to allow for other tasks like TextClassification and this ensures we can directly use `datasets.field` and `dataset.questions` for defining training. We could also use the `name` values from the fields/questions, but this might be more error prone.
2. `get_relevant_data_for_training()` in `List[dict]` format with all relevant fields from the Pydantic model. **annotator alignment issue**. For now I opted for choosing the first non-zero value.
3. Forward the `List[dict]` to a similar flow we previously had.
4. Also add `dataset.unify_responses(question, Enum(strategy))`-method


```python
class TrainingDataForTextClassification(BaseModel):
    text: TextField
    label: Union[RatingQuestion, SingleLabelQuestion, MultiLabelQuestion]
    label_unifier: Enum(strategies)
    # TODO: validation for strategy against question type
```

```python 
import os

import argilla as rg
from argilla.client.feedback import (
    TrainingDataForLLMFineTuningChat,
)

rg.init(api_url=os.environ.get("ARGILLA_API_URL_DEV"), api_key=os.environ.get("ARGILLA_API_KEY_DEV_PRE"))

dataset = rg.FeedbackDataset.from_argilla(
    name="test_feedback_dataset-natalia",
    workspace="workspace-0",
    with_records=False,
)

fields = dataset.fields
questions = dataset.questions
# property method for field
training_data = TrainingDataForLLMFineTuningChat(prompt=fields[0], context=fields[1], response=questions[4])
print(training_data)

print(
    dataset.prepare_for_training(
        framework="autotrain",
        training_data=training_data,
        train_size=0.8,
    )
)
```

Closes #2954

**Type of change**

- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)