### PR TITLE
fix: Paste plain text in editable content for Feedback Task

### DIFF
--- a/frontend/components/text2text/results/ContentEditableFeedbackTask.vue
+++ b/frontend/components/text2text/results/ContentEditableFeedbackTask.vue
@@ -88,7 +88,7 @@ export default {
     pastePlainText(event) {
       if (this.focus && event.target.isContentEditable) {
         event.preventDefault();
-        const text = event.clipboardData.getData("text/plain");
+        const text = event.clipboardData?.getData("text/plain");
         document.execCommand("insertText", false, text);
       }
     },

--- a/frontend/components/text2text/results/ContentEditableFeedbackTask.vue
+++ b/frontend/components/text2text/results/ContentEditableFeedbackTask.vue
@@ -62,6 +62,7 @@ export default {
     },
   },
   mounted() {
+    window.addEventListener("paste", this.pastePlainText);
     if (this.defaultText) {
       this.editableText = this.defaultText;
     } else {
@@ -69,6 +70,9 @@ export default {
     }
 
     this.textAreaWrapper = document.getElementById("contentId");
+  },
+  destroyed() {
+    window.removeEventListener("paste", this.pastePlainText);
   },
   methods: {
     looseFocus() {
@@ -80,6 +84,13 @@ export default {
     setFocus(status) {
       this.focus = status;
       this.$emit("on-change-focus", status);
+    },
+    pastePlainText(event) {
+      if (this.focus && event.target.isContentEditable) {
+        event.preventDefault();
+        const text = event.clipboardData.getData("text/plain");
+        document.execCommand("insertText", false, text);
+      }
     },
   },
 };

--- a/frontend/components/text2text/results/ContentEditableFeedbackTask.vue
+++ b/frontend/components/text2text/results/ContentEditableFeedbackTask.vue
@@ -88,7 +88,7 @@ export default {
     pastePlainText(event) {
       if (this.focus && event.target.isContentEditable) {
         event.preventDefault();
-        const text = event.clipboardData?.getData("text/plain");
+        const text = event.clipboardData?.getData("text/plain") ?? "";
         document.execCommand("insertText", false, text);
       }
     },


### PR DESCRIPTION
# Description

This PR forces to paste plain text in the content editable area for Feedback Task to avoid breaking the area and causing strange behavior

Closes #2958

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)


**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)