### PR TITLE
Minor fixes and improvements around `rg.FeedbackDataset`

### DIFF
--- a/docs/_source/getting_started/installation/deployments/docker-quickstart.md
+++ b/docs/_source/getting_started/installation/deployments/docker-quickstart.md
@@ -35,6 +35,6 @@ This will run the latest quickstart docker image with 2 users `admin` and `argil
   is `12345678`. By setting up a custom password you can use your own password to login into the app.
 - `LOAD_DATASETS`: This variables will allow you to load sample datasets. The default value will be `full`. The
   supported values for this variable is as follows:
-    1. `single`: Load single datasets for TextClassification task.
-    2. `full`: Load all the sample datasets for NLP tasks (TokenClassification, TextClassification, Text2Text)
+    1. `single`: Load single datasets for Feedback task.
+    2. `full`: Load all the sample datasets for NLP tasks (Feedback, TokenClassification, TextClassification, Text2Text)
     3. `none`: No datasets are loaded.

--- a/quickstart.README.md
+++ b/quickstart.README.md
@@ -128,6 +128,6 @@ This will run the latest quickstart docker image with 2 users `admin` and `argil
 - `ARGILLA_WORKSPACE`: The name of a workspace that will be created and used by default for admin and annotator users. The default value will be the one defined by `ADMIN_USERNAME` environment variable.
 - `LOAD_DATASETS`: This variables will allow you to load sample datasets. The default value will be `full`. The
   supported values for this variable is as follows:
-    1. `single`: Load single datasets for TextClassification task.
-    2. `full`: Load all the sample datasets for NLP tasks (TokenClassification, TextClassification, Text2Text)
+    1. `single`: Load single datasets for Feedback task.
+    2. `full`: Load all the sample datasets for NLP tasks (Feedback, TokenClassification, TextClassification, Text2Text)
     3. `none`: No datasets being loaded.

--- a/scripts/load_data.py
+++ b/scripts/load_data.py
@@ -146,6 +146,16 @@ class LoadDatasets:
             },
         )
 
+    @staticmethod
+    def load_sharegpt_prompt_rating_mini():
+        print("Loading sharegpt-prompt-rating-mini dataset")
+
+        # Load dataset from the hub
+        dataset = rg.FeedbackDataset.from_huggingface("argilla/sharegpt-prompt-rating-mini")
+
+        # Read in dataset, assuming it's a dataset for token classification
+        dataset.push_to_argilla(name="sharegpt-prompt-rating-mini")
+
 
 if __name__ == "__main__":
     API_KEY = sys.argv[1]
@@ -160,15 +170,15 @@ if __name__ == "__main__":
                 if response.status_code == 200:
                     ld = LoadDatasets(API_KEY)
 
-                    ld.load_sst_sentiment_explainability()
+                    ld.load_sharegpt_prompt_rating_mini()
+
                     if LOAD_DATASETS.lower() == "single":
                         break
-
                     ld.load_news_text_summarization()
                     ld.load_news_programmatic_labeling()
                     ld.load_gutenberg_spacy_ner_monitoring()
+                    ld.load_sst_sentiment_explainability()
                     break
-
             except requests.exceptions.ConnectionError:
                 pass
             except Exception as e:

--- a/src/argilla/__init__.py
+++ b/src/argilla/__init__.py
@@ -62,7 +62,6 @@ if _TYPE_CHECKING:
         RatingQuestion,
         TextField,
         TextQuestion,
-        create_feedback_dataset,
     )
     from argilla.client.models import (
         Text2TextRecord,
@@ -114,7 +113,6 @@ _import_structure = {
     ],
     "client.feedback": [
         "FeedbackDataset",
-        "create_feedback_dataset",
         "TextField",
         "TextQuestion",
         "RatingQuestion",

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -866,13 +866,18 @@ class FeedbackDataset:
                 f"Recommended `huggingface_hub` version is 0.14.0 or higher, and you have {huggingface_hub.__version__}, so in case you have any issue when pushing the dataset to the HuggingFace Hub upgrade it as `pip install huggingface_hub --upgrade`."
             )
 
-        token = kwargs.get("token") or kwargs.get("use_auth_token")
+        if "token" in kwargs:
+            token = kwargs.pop("token")
+        elif "use_auth_token" in kwargs:
+            token = kwargs.pop("use_auth_token")
+        else:
+            token = None
 
         config_path = hf_hub_download(
             repo_id=repo_id,
             filename="argilla.cfg",
             repo_type="dataset",
-            token=token if not isinstance(token, bool) else None,
+            token=token,
         )
         with open(config_path, "rb") as f:
             config = FeedbackDatasetConfig.parse_raw(f.read())
@@ -913,7 +918,7 @@ class FeedbackDataset:
                     fields={field.name: hfds[index][field.name] for field in cls.fields},
                     responses=list(responses.values()) or None,
                     external_id=hfds[index]["external_id"],
-                )
+                ).dict()
             )
         del hfds
         return cls

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -58,21 +58,17 @@ class ValueSchema(BaseModel):
 
 
 class ResponseSchema(BaseModel):
-    values: Dict[str, ValueSchema]
-    status: Literal["submitted", "missing", "discarded"]
-
-
-class OfflineFeedbackResponse(ResponseSchema):
     user_id: Optional[UUID] = None
+    values: Dict[str, ValueSchema]
+    status: Literal["submitted", "missing", "discarded"] = "submitted"
 
     @validator("user_id", always=True)
     def user_id_must_have_value(cls, v):
         if not v:
             warnings.warn(
-                "`user_id` not provided for `OfflineFeedbackResponse`. So it will be"
-                " set to `None`. Which is not an issue, even though if you're planning"
-                " to log the record in Argilla, as it will be set automatically to the"
-                " current user's id."
+                "`user_id` not provided, so it will be set to `None`. Which is not an"
+                " issue, unless if you're planning to log the response in Argilla, as "
+                " it will be automatically set to the active `user_id`."
             )
         return v
 
@@ -97,7 +93,7 @@ class FeedbackRecord(BaseModel):
 class OfflineFeedbackRecord(BaseModel):
     id: Optional[str] = None
     fields: Dict[str, str]
-    responses: List[OfflineFeedbackResponse] = []
+    responses: List[ResponseSchema] = []
     external_id: Optional[str] = None
     inserted_at: Optional[str] = None
     updated_at: Optional[str] = None

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -887,6 +887,7 @@ class FeedbackDataset:
                 raise ValueError(
                     f"Only one dataset can be loaded at a time, use `split` to select a split, available splits are: {', '.join(hfds.keys())}."
                 )
+            hfds = hfds[list(hfds.keys())[0]]
 
         for index in range(len(hfds)):
             responses = {}

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -1061,5 +1061,5 @@ def feedback_dataset_in_argilla(
     else:
         try:
             return (True, datasets_api_v1.get_dataset(client=httpx_client, id=id).parsed)
-        except Exception as e:
+        except:
             return (False, None)

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -12,8 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import logging
 import tempfile
-import warnings
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple, Union
 from uuid import UUID
 
@@ -52,6 +52,8 @@ if TYPE_CHECKING:
 FETCHING_BATCH_SIZE = 250
 PUSHING_BATCH_SIZE = 32
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class ValueSchema(BaseModel):
     value: Union[StrictStr, StrictInt]
@@ -65,7 +67,7 @@ class ResponseSchema(BaseModel):
     @validator("user_id", always=True)
     def user_id_must_have_value(cls, v):
         if not v:
-            warnings.warn(
+            _LOGGER.warning(
                 "`user_id` not provided, so it will be set to `None`. Which is not an"
                 " issue, unless if you're planning to log the response in Argilla, as "
                 " it will be automatically set to the active `user_id`."
@@ -389,7 +391,7 @@ class FeedbackDataset:
         raised and the current records will be returned instead.
         """
         if not self.argilla_id:
-            warnings.warn(
+            _LOGGER.warning(
                 "No records have been logged into neither Argilla nor HuggingFace, so"
                 " no records will be fetched. The current records will be returned"
                 " instead."
@@ -489,7 +491,7 @@ class FeedbackDataset:
 
         if not name or (not name and not workspace):
             if self.argilla_id is None:
-                warnings.warn(
+                _LOGGER.warning(
                     "No `name` or `workspace` have been provided, and no dataset has"
                     " been pushed to Argilla yet, so no records will be pushed to"
                     " Argilla."
@@ -497,7 +499,7 @@ class FeedbackDataset:
                 return
 
             if len(self.__new_records) < 1:
-                warnings.warn(
+                _LOGGER.warning(
                     "No new records have been added to the current `FeedbackTask`"
                     " dataset, so no records will be pushed to Argilla."
                 )
@@ -606,7 +608,7 @@ class FeedbackDataset:
             self.__new_records = []
 
             if self.argilla_id is not None:
-                warnings.warn(
+                _LOGGER.warning(
                     "Since the current object is already a `FeedbackDataset` pushed to"
                     " Argilla, you'll keep on interacting with the same dataset in"
                     " Argilla, even though the one you just pushed holds a different"
@@ -777,7 +779,7 @@ class FeedbackDataset:
         from packaging.version import parse as parse_version
 
         if parse_version(huggingface_hub.__version__) < parse_version("0.14.0"):
-            warnings.warn(
+            _LOGGER.warning(
                 f"Recommended `huggingface_hub` version is 0.14.0 or higher, and you have {huggingface_hub.__version__}, so in case you have any issue when pushing the dataset to the HuggingFace Hub upgrade it as `pip install huggingface_hub --upgrade`."
             )
 
@@ -860,7 +862,7 @@ class FeedbackDataset:
         from packaging.version import parse as parse_version
 
         if parse_version(huggingface_hub.__version__) < parse_version("0.14.0"):
-            warnings.warn(
+            _LOGGER.warning(
                 f"Recommended `huggingface_hub` version is 0.14.0 or higher, and you have {huggingface_hub.__version__}, so in case you have any issue when pushing the dataset to the HuggingFace Hub upgrade it as `pip install huggingface_hub --upgrade`."
             )
 

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -727,6 +727,7 @@ class FeedbackDataset:
                     {
                         "user_id": Value(dtype="string"),
                         "value": Value(dtype="string" if question.settings["type"] == "text" else "int32"),
+                        "status": Value(dtype="string"),
                     },
                     id="question",
                 )
@@ -741,7 +742,11 @@ class FeedbackDataset:
                 for question in self.questions:
                     dataset[question.name].append(
                         [
-                            {"user_id": r["user_id"], "value": r["values"][question.name]["value"]}
+                            {
+                                "user_id": r["user_id"],
+                                "value": r["values"][question.name]["value"],
+                                "status": r["status"],
+                            }
                             for r in record["responses"]
                         ]
                         or None
@@ -888,11 +893,15 @@ class FeedbackDataset:
             for question in cls.questions:
                 if hfds[index][question.name] is None or len(hfds[index][question.name]) < 1:
                     continue
-                for user_id, value in zip(hfds[index][question.name]["user_id"], hfds[index][question.name]["value"]):
+                for user_id, value, status in zip(
+                    hfds[index][question.name]["user_id"],
+                    hfds[index][question.name]["value"],
+                    hfds[index][question.name]["status"],
+                ):
                     if user_id not in responses:
                         responses[user_id] = {
                             "user_id": user_id,
-                            "status": "submitted",
+                            "status": status,
                             "values": {},
                         }
                     responses[user_id]["values"].update({question.name: {"value": value}})

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -850,11 +850,13 @@ class FeedbackDataset:
                 f"Recommended `huggingface_hub` version is 0.14.0 or higher, and you have {huggingface_hub.__version__}, so in case you have any issue when pushing the dataset to the HuggingFace Hub upgrade it as `pip install huggingface_hub --upgrade`."
             )
 
+        token = kwargs.get("token") or kwargs.get("use_auth_token")
+
         config_path = hf_hub_download(
             repo_id=repo_id,
             filename="argilla.cfg",
             repo_type="dataset",
-            token=kwargs["token"] if "token" in kwargs else None,
+            token=token,
         )
         with open(config_path, "rb") as f:
             config = FeedbackDatasetConfig.parse_raw(f.read())
@@ -865,11 +867,7 @@ class FeedbackDataset:
             guidelines=config.guidelines,
         )
 
-        if "token" in kwargs:
-            kwargs["use_auth_token"] = kwargs["token"]
-            del kwargs["token"]
-
-        hfds = load_dataset(repo_id, *args, **kwargs)
+        hfds = load_dataset(repo_id, use_auth_token=token, *args, **kwargs)
         if isinstance(hfds, DatasetDict) and "split" not in kwargs:
             if len(hfds.keys()) > 1:
                 raise ValueError(

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -154,9 +154,12 @@ class RatingQuestion(QuestionSchema):
         validate_assignment = True
 
 
+AllowedQuestionTypes = Union[TextQuestion, RatingQuestion]
+
+
 class FeedbackDatasetConfig(BaseModel):
     fields: List[FieldSchema]
-    questions: List[QuestionSchema]
+    questions: List[AllowedQuestionTypes]
     guidelines: Optional[str] = None
 
 
@@ -179,7 +182,7 @@ class FeedbackDataset:
         TypeError: if `guidelines` is not a string.
         TypeError: if `fields` is not a list of `FieldSchema`.
         ValueError: if `fields` does not contain at least one required field.
-        TypeError: if `questions` is not a list of `QuestionSchema`.
+        TypeError: if `questions` is not a list of `TextQuestion` and/or `RatingQuestion`.
         ValueError: if `questions` does not contain at least one required question.
 
     Examples:
@@ -238,7 +241,7 @@ class FeedbackDataset:
         self,
         *,
         fields: List[FieldSchema],
-        questions: List[QuestionSchema],
+        questions: List[AllowedQuestionTypes],
         guidelines: Optional[str] = None,
     ) -> None:
         """Initializes a `FeedbackDataset` instance locally.
@@ -251,7 +254,7 @@ class FeedbackDataset:
         Raises:
             TypeError: if `fields` is not a list of `FieldSchema`.
             ValueError: if `fields` does not contain at least one required field.
-            TypeError: if `questions` is not a list of `QuestionSchema`.
+            TypeError: if `questions` is not a list of `TextQuestion` and/or `RatingQuestion`.
             ValueError: if `questions` does not contain at least one required question.
             TypeError: if `guidelines` is not None and not a string.
             ValueError: if `guidelines` is an empty string.
@@ -297,12 +300,15 @@ class FeedbackDataset:
             raise TypeError(f"Expected `questions` to be a list, got {type(questions)} instead.")
         any_required = False
         for question in questions:
-            if not isinstance(question, QuestionSchema):
-                raise TypeError(f"Expected `questions` to be a list of `QuestionSchema`, got {type(question)} instead.")
+            if not isinstance(question, AllowedQuestionTypes):
+                raise TypeError(
+                    "Expected `questions` to be a list of `TextQuestion` and/or `RatingQuestion`, got a"
+                    f" question in the list with type {type(question)} instead."
+                )
             if not any_required and question.required:
                 any_required = True
         if not any_required:
-            raise ValueError("At least one `QuestionSchema` in `questions` must be required (`required=True`).")
+            raise ValueError("At least one question in `questions` must be required (`required=True`).")
         self.__questions = questions
 
         if guidelines is not None:

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -865,7 +865,7 @@ class FeedbackDataset:
             repo_id=repo_id,
             filename="argilla.cfg",
             repo_type="dataset",
-            token=token,
+            token=token if not isinstance(token, bool) else None,
         )
         with open(config_path, "rb") as f:
             config = FeedbackDatasetConfig.parse_raw(f.read())

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -314,11 +314,11 @@ class FeedbackDataset:
         if guidelines is not None:
             if not isinstance(guidelines, str):
                 raise TypeError(
-                    f"Expected `guidelines` to be either None (default) or a string, got {type(guidelines)} instead."
+                    "Expected `guidelines` to be either None (default) or a string, got" f" {type(guidelines)} instead."
                 )
             if len(guidelines) < 1:
                 raise ValueError(
-                    "Expected `guidelines` to be either None (default) or a non-empty string, minimum length is 1."
+                    "Expected `guidelines` to be either None (default) or a non-empty string, minimum length" " is 1."
                 )
         self.__guidelines = guidelines
 
@@ -723,8 +723,8 @@ class FeedbackDataset:
             for field in self.fields:
                 if field.settings["type"] not in FIELD_TYPE_TO_PYTHON_TYPE.keys():
                     raise ValueError(
-                        f"Field {field.name} has an unsupported type: {field.settings['type']}, for the moment only the"
-                        f" following types are supported: {list(FIELD_TYPE_TO_PYTHON_TYPE.keys())}"
+                        f"Field {field.name} has an unsupported type: {field.settings['type']}, for the moment"
+                        f" only the following types are supported: {list(FIELD_TYPE_TO_PYTHON_TYPE.keys())}"
                     )
                 features[field.name] = Value(dtype="string", id="field")
                 if field.name not in dataset:
@@ -786,12 +786,15 @@ class FeedbackDataset:
 
         if parse_version(huggingface_hub.__version__) < parse_version("0.14.0"):
             _LOGGER.warning(
-                f"Recommended `huggingface_hub` version is 0.14.0 or higher, and you have {huggingface_hub.__version__}, so in case you have any issue when pushing the dataset to the HuggingFace Hub upgrade it as `pip install huggingface_hub --upgrade`."
+                "Recommended `huggingface_hub` version is 0.14.0 or higher, and you have"
+                f" {huggingface_hub.__version__}, so in case you have any issue when pushing the dataset to the"
+                " HuggingFace Hub upgrade it as `pip install huggingface_hub --upgrade`."
             )
 
         if len(self) < 1:
             raise ValueError(
-                "Cannot push an empty `rg.FeedbackDataset` to the HuggingFace Hub, please make sure to add at least one record, via the method `add_records`."
+                "Cannot push an empty `rg.FeedbackDataset` to the HuggingFace Hub, please make sure to add at"
+                " least one record, via the method `add_records`."
             )
 
         hfds = self.format_as("datasets")
@@ -839,12 +842,10 @@ class FeedbackDataset:
                 "```"
             )
             card = DatasetCard(
-                (
-                    f"## Guidelines\n\n{self.guidelines}\n\n"
-                    f"{explained_fields}\n\n"
-                    f"{explained_questions}\n\n"
-                    f"{loading_guide}\n\n"
-                )
+                f"## Guidelines\n\n{self.guidelines}\n\n"
+                f"{explained_fields}\n\n"
+                f"{explained_questions}\n\n"
+                f"{loading_guide}\n\n"
             )
             card.push_to_hub(repo_id, repo_type="dataset", token=kwargs.get("token"))
 
@@ -869,7 +870,9 @@ class FeedbackDataset:
 
         if parse_version(huggingface_hub.__version__) < parse_version("0.14.0"):
             _LOGGER.warning(
-                f"Recommended `huggingface_hub` version is 0.14.0 or higher, and you have {huggingface_hub.__version__}, so in case you have any issue when pushing the dataset to the HuggingFace Hub upgrade it as `pip install huggingface_hub --upgrade`."
+                "Recommended `huggingface_hub` version is 0.14.0 or higher, and you have"
+                f" {huggingface_hub.__version__}, so in case you have any issue when pushing the dataset to the"
+                " HuggingFace Hub upgrade it as `pip install huggingface_hub --upgrade`."
             )
 
         if "token" in kwargs:
@@ -898,7 +901,8 @@ class FeedbackDataset:
         if isinstance(hfds, DatasetDict) and "split" not in kwargs:
             if len(hfds.keys()) > 1:
                 raise ValueError(
-                    f"Only one dataset can be loaded at a time, use `split` to select a split, available splits are: {', '.join(hfds.keys())}."
+                    "Only one dataset can be loaded at a time, use `split` to select a split, available splits"
+                    f" are: {', '.join(hfds.keys())}."
                 )
             hfds = hfds[list(hfds.keys())[0]]
 

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
     )
 
 FETCHING_BATCH_SIZE = 250
+PUSHING_BATCH_SIZE = 32
 
 
 class ValueSchema(BaseModel):
@@ -507,11 +508,11 @@ class FeedbackDataset:
                 return
 
             try:
-                for i in range(0, len(self.__new_records), 32):
+                for i in range(0, len(self.__new_records), PUSHING_BATCH_SIZE):
                     datasets_api_v1.add_records(
                         client=httpx_client,
                         id=self.argilla_id,
-                        records=self.__new_records[i : i + 32],
+                        records=self.__new_records[i : i + PUSHING_BATCH_SIZE],
                     )
                 self.__records += self.__new_records
                 self.__new_records = []

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -62,7 +62,7 @@ class ValueSchema(BaseModel):
 class ResponseSchema(BaseModel):
     user_id: Optional[UUID] = None
     values: Dict[str, ValueSchema]
-    status: Literal["submitted", "missing", "discarded"] = "submitted"
+    status: Literal["submitted", "discarded"] = "submitted"
 
     @validator("user_id", always=True)
     def user_id_must_have_value(cls, v):

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -602,6 +602,9 @@ class FeedbackDataset:
                         ),
                     )
 
+            self.__records += self.__new_records
+            self.__new_records = []
+
             if self.argilla_id is not None:
                 warnings.warn(
                     "Since the current object is already a `FeedbackDataset` pushed to"
@@ -666,15 +669,15 @@ class FeedbackDataset:
         self = cls(
             fields=[
                 TextField.construct(**field.dict())
-                if field.settings.type == "text"
+                if field.settings["type"] == "text"
                 else FieldSchema.construct(**field.dict())
                 for field in datasets_api_v1.get_fields(client=httpx_client, id=existing_dataset.id).parsed
             ],
             questions=[
                 RatingQuestion.construct(**question.dict())
-                if question.settings.type == "rating"
+                if question.settings["type"] == "rating"
                 else TextQuestion.construct(**question.dict())
-                if question.settings.type == "text"
+                if question.settings["type"] == "text"
                 else QuestionSchema.construct(**question.dict())
                 for question in datasets_api_v1.get_questions(client=httpx_client, id=existing_dataset.id).parsed
             ],

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -300,7 +300,7 @@ class FeedbackDataset:
             raise TypeError(f"Expected `questions` to be a list, got {type(questions)} instead.")
         any_required = False
         for question in questions:
-            if not isinstance(question, AllowedQuestionTypes):
+            if not isinstance(question, (TextQuestion, RatingQuestion)):
                 raise TypeError(
                     "Expected `questions` to be a list of `TextQuestion` and/or `RatingQuestion`, got a"
                     f" question in the list with type {type(question)} instead."
@@ -314,11 +314,11 @@ class FeedbackDataset:
         if guidelines is not None:
             if not isinstance(guidelines, str):
                 raise TypeError(
-                    "Expected `guidelines` to be either None (default) or a string, got" f" {type(guidelines)} instead."
+                    f"Expected `guidelines` to be either None (default) or a string, got {type(guidelines)} instead."
                 )
             if len(guidelines) < 1:
                 raise ValueError(
-                    "Expected `guidelines` to be either None (default) or a non-empty string, minimum length" " is 1."
+                    "Expected `guidelines` to be either None (default) or a non-empty string, minimum length is 1."
                 )
         self.__guidelines = guidelines
 

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -665,11 +665,17 @@ class FeedbackDataset:
         cls.argilla_id = existing_dataset.id
         self = cls(
             fields=[
-                FieldSchema.construct(**field.dict())
+                TextField.construct(**field.dict())
+                if field.settings.type == "text"
+                else FieldSchema.construct(**field.dict())
                 for field in datasets_api_v1.get_fields(client=httpx_client, id=existing_dataset.id).parsed
             ],
             questions=[
-                QuestionSchema.construct(**question.dict())
+                RatingQuestion.construct(**question.dict())
+                if question.settings.type == "rating"
+                else TextQuestion.construct(**question.dict())
+                if question.settings.type == "text"
+                else QuestionSchema.construct(**question.dict())
                 for question in datasets_api_v1.get_questions(client=httpx_client, id=existing_dataset.id).parsed
             ],
             guidelines=existing_dataset.guidelines or None,

--- a/src/argilla/client/sdk/v1/datasets/api.py
+++ b/src/argilla/client/sdk/v1/datasets/api.py
@@ -243,7 +243,7 @@ def add_records(
             continue
         for response in record["responses"]:
             if response["user_id"] is None:
-                if response_without_user_id is True:
+                if response_without_user_id:
                     warnings.warn(
                         f"Multiple responses without `user_id` found in record {record}, so just the first one will be used while the rest will be ignored."
                     )

--- a/src/argilla/client/sdk/v1/datasets/api.py
+++ b/src/argilla/client/sdk/v1/datasets/api.py
@@ -17,7 +17,6 @@ from typing import Any, Dict, List, Optional, Union
 
 import httpx
 
-from argilla.client.sdk.client import AuthenticatedClient
 from argilla.client.sdk.commons.errors_handler import handle_response_error
 from argilla.client.sdk.commons.models import (
     ErrorMessage,

--- a/src/argilla/client/sdk/v1/datasets/api.py
+++ b/src/argilla/client/sdk/v1/datasets/api.py
@@ -239,6 +239,8 @@ def add_records(
     for record in records:
         cleaned_responses = []
         response_without_user_id = False
+        if "responses" not in record:
+            continue
         for response in record["responses"]:
             if response["user_id"] is None:
                 if response_without_user_id is True:

--- a/src/argilla/client/sdk/v1/datasets/api.py
+++ b/src/argilla/client/sdk/v1/datasets/api.py
@@ -234,6 +234,8 @@ def add_records(
     """
     url = "/api/v1/datasets/{id}/records".format(id=id)
 
+    active_user_id = None
+
     for record in records:
         cleaned_responses = []
         response_without_user_id = False
@@ -245,7 +247,9 @@ def add_records(
                     )
                     continue
                 else:
-                    response["user_id"] = client.get("api/me").json()["id"]
+                    if active_user_id is None:
+                        active_user_id = client.get("api/me").json()["id"]
+                    response["user_id"] = active_user_id
                     response_without_user_id = True
             cleaned_responses.append(response)
         record["responses"] = cleaned_responses

--- a/src/argilla/client/sdk/v1/datasets/models.py
+++ b/src/argilla/client/sdk/v1/datasets/models.py
@@ -42,7 +42,7 @@ class FeedbackValueModel(BaseModel):
 class FeedbackResponseModel(BaseModel):
     id: UUID
     values: Dict[str, FeedbackValueModel]
-    status: Literal["submitted", "missing", "discarded"]
+    status: Literal["submitted", "discarded"]  # API also contains "missing", but it's just a filter-status
     user_id: UUID
     inserted_at: datetime
     updated_at: datetime

--- a/tests/client/test_feedback.py
+++ b/tests/client/test_feedback.py
@@ -177,6 +177,7 @@ def test_records(
     }
     assert dataset.records[1]["responses"] == [
         {
+            "user_id": None,
             "values": {
                 "question-1": {"value": "answer"},
                 "question-2": {"value": 0},

--- a/tests/client/test_feedback.py
+++ b/tests/client/test_feedback.py
@@ -349,11 +349,11 @@ def test_push_to_argilla_and_from_argilla_without_user_ids(
             ),
         ]
     )
+
     with pytest.warns(UserWarning, match="Multiple responses without `user_id`"):
         dataset.push_to_argilla()
 
     dataset_from_argilla = FeedbackDataset.from_argilla(id=dataset.argilla_id)
-    print(dataset_from_argilla.records)
 
     assert dataset_from_argilla.guidelines == dataset.guidelines
     assert len(dataset_from_argilla.fields) == len(dataset.fields)

--- a/tests/client/test_feedback.py
+++ b/tests/client/test_feedback.py
@@ -88,19 +88,19 @@ def test_init_wrong_fields(feedback_dataset_guidelines: str, feedback_dataset_qu
 
 @pytest.mark.usefixtures("feedback_dataset_guidelines", "feedback_dataset_fields")
 def test_init_wrong_questions(feedback_dataset_guidelines: str, feedback_dataset_fields: list) -> None:
-    with pytest.raises(TypeError, match="Expected `questions` to be a list"):
+    with pytest.raises(TypeError, match="Expected `questions` to be a list, got"):
         FeedbackDataset(
             guidelines=feedback_dataset_guidelines,
             fields=feedback_dataset_fields,
             questions=None,
         )
-    with pytest.raises(TypeError, match="Expected `questions` to be a list of `QuestionSchema`"):
+    with pytest.raises(TypeError, match="Expected `questions` to be a list of `TextQuestion` and/or `RatingQuestion`"):
         FeedbackDataset(
             guidelines=feedback_dataset_guidelines,
             fields=feedback_dataset_fields,
             questions=[{"wrong": "question"}],
         )
-    with pytest.raises(ValueError, match="At least one `QuestionSchema` in `questions` must be required"):
+    with pytest.raises(ValueError, match="At least one question in `questions` must be required"):
         FeedbackDataset(
             guidelines=feedback_dataset_guidelines,
             fields=feedback_dataset_fields,

--- a/tests/client/test_feedback.py
+++ b/tests/client/test_feedback.py
@@ -269,60 +269,6 @@ def test_push_to_argilla_and_from_argilla(
 
     assert dataset.argilla_id is not None
 
-    dataset_from_argilla = FeedbackDataset.from_argilla(id=dataset.argilla_id)
-
-    assert dataset_from_argilla.guidelines == dataset.guidelines
-    assert len(dataset_from_argilla.fields) == len(dataset.fields)
-    assert [field.name for field in dataset_from_argilla.fields] == [field.name for field in dataset.fields]
-    assert len(dataset_from_argilla.questions) == len(dataset.questions)
-    assert [question.name for question in dataset_from_argilla.questions] == [
-        question.name for question in dataset.questions
-    ]
-    assert len(dataset_from_argilla.records) == len(dataset.records)
-
-
-@pytest.mark.usefixtures(
-    "feedback_dataset_guidelines",
-    "feedback_dataset_fields",
-    "feedback_dataset_questions",
-)
-def test_push_to_argilla_and_from_argilla_without_user_ids(
-    mocked_client,
-    feedback_dataset_guidelines: str,
-    feedback_dataset_fields: List["FieldSchema"],
-    feedback_dataset_questions: List["QuestionSchema"],
-) -> None:
-    api.active_api()
-    api.init(api_key="argilla.apikey")
-
-    dataset = FeedbackDataset(
-        guidelines=feedback_dataset_guidelines,
-        fields=feedback_dataset_fields,
-        questions=feedback_dataset_questions,
-    )
-    dataset.add_records(
-        [
-            FeedbackRecord(
-                fields={
-                    "text": "E",
-                    "label": "F",
-                },
-                responses=[
-                    {
-                        "values": {
-                            "question-1": {"value": "answer"},
-                            "question-2": {"value": 0},
-                        },
-                        "status": "submitted",
-                    },
-                ],
-                external_id="test-id",
-            ),
-        ]
-    )
-    dataset.push_to_argilla(name="test-dataset")
-    assert dataset.argilla_id is not None
-
     dataset.add_records(
         [
             FeedbackRecord(


### PR DESCRIPTION
# Description

As requested by @davidberenstein1957, we are now mapping the `fields` and `questions` to their `pydantic.BaseModel` schema, instead of as the default schema for both `FieldSchema` and `QuestionSchema`, respectively; just when pulling from Argilla with `rg.FeedbackDataset.from_argilla`.

Now when pushing a `FeedbackDataset` to the HuggingFace Hub with `push_to_hub`, we are not just pushing the `user_id` and the `value` in the responses, but also the `status`, which can be "submitted", "discarded", or "missing".

Now there's no need to provide the `user_id` when adding record responses, as now the active Argilla user will be used just when pushing the records to Argilla. See the following example:

```python
import argilla as rg

rg.init(api_url="...", api_key="...")

dataset = rg.FeedbackDataset(
  fields=[
    rg.TextField(name="prompt", required=True),
    rg.TextField(name="completion", required=True),
  ],
  questions=[
    rg.TextQuestion(
      name="question-1",
      description="This is the first question",
      required=True,
    ),
    rg.RatingQuestion(
      name="question-2",
      description="This is the second question",
      required=True,
      values=[1, 2, 3, 4, 5],
    ),
  ],
)

dataset.add_records([
  rg.FeedbackRecord(
    fields={
      "prompt": "The quick brown fox",
      "completion": "jumps over the lazy dog.",
    },
    responses=[
      {
        "user_id": None,
        "values": {"question-1": {"value": "Response 1"}, "question-2": {"value": 1}},
        "status": "submitted",
      },
    ],
  ),
])

dataset.push_to_argilla(name="my-dataset", workspace="my-workspace")
```

Note that in the snippet above, both `user_id` and `status` are optional, and their default values are `None` and `submitted`, respectively. So that the `user_id=None` is then transformed into the active Argilla `user_id`.

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

- [x] Added integration tests to make sure that adding a response with `user_id=None` fulfils its value to be the active user
- [x] Added integration tests to make sure that a warning is raised in case there's more than one response with `user_id=None` for the same record, and that the response is not logged into Argilla

**Checklist**

- [X] I have merged the original branch into my forked branch
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [X] I have added tests that prove my fix is effective or that my feature works