### PR TITLE
feat : show toast on switch route

### DIFF
--- a/frontend/pages/dataset/_id/annotation-mode/index.vue
+++ b/frontend/pages/dataset/_id/annotation-mode/index.vue
@@ -56,7 +56,7 @@ export default {
       areResponsesUntouched: false,
     };
   },
-  beforeRouteLeave(to, next) {
+  beforeRouteLeave(to, from, next) {
     if (!this.areResponsesUntouched) {
       let message = "";
       switch (to.name) {

--- a/frontend/pages/dataset/_id/annotation-mode/index.vue
+++ b/frontend/pages/dataset/_id/annotation-mode/index.vue
@@ -63,7 +63,6 @@ export default {
         case "datasets":
         case "dataset-id-settings":
         case "user-settings":
-        case "login":
           message = "Your changes will be lost if you leave the current page";
           break;
         default:

--- a/frontend/pages/dataset/_id/annotation-mode/index.vue
+++ b/frontend/pages/dataset/_id/annotation-mode/index.vue
@@ -56,6 +56,39 @@ export default {
       areResponsesUntouched: false,
     };
   },
+  beforeRouteLeave(to, next) {
+    if (!this.areResponsesUntouched) {
+      let message = "";
+      switch (to.name) {
+        case "datasets":
+          message =
+            "Your changes will be lost if you navigate throw the breadcrumb";
+          break;
+        case "dataset-id-settings":
+          message =
+            "Your changes will be lost if you go to the dataset settings page";
+          break;
+        case "user-settings":
+          message =
+            "Your changes will be lost if you go to your user settings page";
+          break;
+        case "login":
+          message = "Your changes will be lost if you logout";
+          break;
+        default:
+          message = "Your current modification will be lost";
+      }
+      this.showNotification({
+        eventToFireOnClick: async () => {
+          await next();
+        },
+        message,
+        buttonMessage: this.buttonMessage,
+      });
+    } else {
+      next();
+    }
+  },
   computed: {
     datasetId() {
       return this.$route.params.id;
@@ -173,13 +206,13 @@ export default {
       if (this.areResponsesUntouched) {
         await this.deleteRecordsAndRefreshDataset();
       } else {
-        this.showNotificationBeforeRefresh({
+        this.showNotification({
           eventToFireOnClick: async () => {
             await this.deleteRecordsAndRefreshDataset();
           },
           message: this.toastMessage,
           buttonMessage: this.buttonMessage,
-          typeOfToast: this.typeOfToast,
+          typeOfToast: "warning",
         });
       }
     },
@@ -194,7 +227,7 @@ export default {
         this.areResponsesUntouched = areResponsesUntouched;
       });
     },
-    showNotificationBeforeRefresh({
+    showNotification({
       eventToFireOnClick,
       message,
       buttonMessage,

--- a/frontend/pages/dataset/_id/annotation-mode/index.vue
+++ b/frontend/pages/dataset/_id/annotation-mode/index.vue
@@ -61,30 +61,22 @@ export default {
       let message = "";
       switch (to.name) {
         case "datasets":
-          message =
-            "Your changes will be lost if you navigate throw the breadcrumb";
-          break;
         case "dataset-id-settings":
-          message =
-            "Your changes will be lost if you go to the dataset settings page";
-          break;
         case "user-settings":
-          message =
-            "Your changes will be lost if you go to your user settings page";
-          break;
         case "login":
-          message = "Your changes will be lost if you logout";
+          message = "Your changes will be lost if you leave the current page";
           break;
         default:
-          message = "Your current modification will be lost";
+        // do nothing
       }
-      this.showNotification({
-        eventToFireOnClick: async () => {
-          await next();
-        },
-        message,
-        buttonMessage: this.buttonMessage,
-      });
+      message.length &&
+        this.showNotification({
+          eventToFireOnClick: async () => {
+            await next();
+          },
+          message,
+          buttonMessage: this.buttonMessage,
+        });
     } else {
       next();
     }


### PR DESCRIPTION
# Description
Show toast component when switching route.
When this PR will be merged, a notification component will be shown to the user : 
- on refresh : `Your changes will be lost if you refresh the page`
- on change filter status : `Your changes will be lost if you move to another view`
- on pagination : `Your changes will be lost if you move to another page`
- **(NEW)** breadcrumb navigation / setting page navigation / my settings navigation(from the badge) : `Your changes will be lost if you leave the current page`

**Type of change**

- New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

Only feedback task : 
Edit the form of a record without submit or discard, then click on : 
- on refresh
- on change filter status
- on pagination
- breadcrumb navigation 
- setting page navigation 
- my settings navigation(from the badge) 
- click on log out (from the badge)
