### PR TITLE
Remove `total` field from output payload of listing records endpoints

### DIFF
--- a/src/argilla/client/sdk/v1/datasets/models.py
+++ b/src/argilla/client/sdk/v1/datasets/models.py
@@ -59,10 +59,6 @@ class FeedbackItemModel(BaseModel):
 
 class FeedbackRecordsModel(BaseModel):
     items: List[FeedbackItemModel]
-    total: Optional[int] = None
-
-    class Config:
-        fields = {"total": {"exclude": True}}
 
 
 class FeedbackFieldModel(BaseModel):

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -119,16 +119,7 @@ def list_current_user_dataset_records(
         db, dataset_id, current_user.id, include=include, response_status=response_status, offset=offset, limit=limit
     )
 
-    if response_status == ResponseStatusFilter.missing:
-        total = datasets.count_records_with_missing_responses_by_dataset_id_and_user_id(db, dataset_id, current_user.id)
-    elif response_status == ResponseStatusFilter.submitted:
-        total = datasets.count_submitted_responses_by_dataset_id_and_user_id(db, dataset_id, current_user.id)
-    elif response_status == ResponseStatusFilter.discarded:
-        total = datasets.count_discarded_responses_by_dataset_id_and_user_id(db, dataset_id, current_user.id)
-    else:
-        total = datasets.count_records_by_dataset_id(db, dataset_id)
-
-    return Records(items=[record.__dict__ for record in records], total=total)
+    return Records(items=[record.__dict__ for record in records])
 
 
 @router.get("/datasets/{dataset_id}/records", response_model=Records, response_model_exclude_unset=True)
@@ -147,10 +138,7 @@ def list_dataset_records(
 
     records = datasets.list_records_by_dataset_id(db, dataset_id, include=include, offset=offset, limit=limit)
 
-    return Records(
-        items=[record.__dict__ for record in records],
-        total=datasets.count_records_by_dataset_id(db, dataset_id),
-    )
+    return Records(items=[record.__dict__ for record in records])
 
 
 @router.get("/datasets/{dataset_id}", response_model=Dataset)

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -230,7 +230,6 @@ class Record(BaseModel):
 
 class Records(BaseModel):
     items: List[Record]
-    total: int
 
 
 class UserSubmittedResponseCreate(BaseModel):

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -337,7 +337,6 @@ def test_list_dataset_records(client: TestClient, admin_auth_header: dict):
                 "updated_at": record_c.updated_at.isoformat(),
             },
         ],
-        "total": 3,
     }
 
 
@@ -442,7 +441,6 @@ def test_list_dataset_records_with_include_responses(client: TestClient, admin_a
                 "updated_at": record_c.updated_at.isoformat(),
             },
         ],
-        "total": 3,
     }
 
 
@@ -461,7 +459,6 @@ def test_list_dataset_records_with_offset(client: TestClient, admin_auth_header:
 
     response_body = response.json()
     assert [item["id"] for item in response_body["items"]] == [str(record_c.id)]
-    assert response_body["total"] == 3
 
 
 def test_list_dataset_records_with_limit(client: TestClient, admin_auth_header: dict):
@@ -479,7 +476,6 @@ def test_list_dataset_records_with_limit(client: TestClient, admin_auth_header: 
 
     response_body = response.json()
     assert [item["id"] for item in response_body["items"]] == [str(record_a.id)]
-    assert response_body["total"] == 3
 
 
 def test_list_dataset_records_with_offset_and_limit(client: TestClient, admin_auth_header: dict):
@@ -499,7 +495,6 @@ def test_list_dataset_records_with_offset_and_limit(client: TestClient, admin_au
 
     response_body = response.json()
     assert [item["id"] for item in response_body["items"]] == [str(record_c.id)]
-    assert response_body["total"] == 3
 
 
 def test_list_dataset_records_without_authentication(client: TestClient):
@@ -562,7 +557,6 @@ def test_list_current_user_dataset_records(client: TestClient, admin_auth_header
                 "updated_at": record_c.updated_at.isoformat(),
             },
         ],
-        "total": 3,
     }
 
 
@@ -670,7 +664,6 @@ def test_list_current_user_dataset_records_with_include_responses(
                 "updated_at": record_c.updated_at.isoformat(),
             },
         ],
-        "total": 3,
     }
 
 
@@ -689,7 +682,6 @@ def test_list_current_user_dataset_records_with_offset(client: TestClient, admin
 
     response_body = response.json()
     assert [item["id"] for item in response_body["items"]] == [str(record_c.id)]
-    assert response_body["total"] == 3
 
 
 def test_list_current_user_dataset_records_with_limit(client: TestClient, admin_auth_header: dict):
@@ -707,7 +699,6 @@ def test_list_current_user_dataset_records_with_limit(client: TestClient, admin_
 
     response_body = response.json()
     assert [item["id"] for item in response_body["items"]] == [str(record_a.id)]
-    assert response_body["total"] == 3
 
 
 def test_list_current_user_dataset_records_with_offset_and_limit(client: TestClient, admin_auth_header: dict):
@@ -727,7 +718,6 @@ def test_list_current_user_dataset_records_with_offset_and_limit(client: TestCli
 
     response_body = response.json()
     assert [item["id"] for item in response_body["items"]] == [str(record_c.id)]
-    assert response_body["total"] == 3
 
 
 @pytest.mark.parametrize("response_status_filter", ["missing", "discarded", "submitted"])
@@ -764,7 +754,6 @@ def test_list_current_user_dataset_records_with_response_status_filter(
     assert response.status_code == 200
     response_json = response.json()
 
-    assert response_json["total"] == num_responses_per_status
     assert len(response_json["items"]) == num_responses_per_status
 
     if response_status_filter == "missing":
@@ -819,7 +808,6 @@ def test_list_current_user_dataset_records_as_annotator(client: TestClient, admi
                 "updated_at": record_c.updated_at.isoformat(),
             },
         ],
-        "total": 3,
     }
 
 
@@ -927,7 +915,6 @@ def test_list_current_user_dataset_records_as_annotator_with_include_responses(
                 "updated_at": record_c.updated_at.isoformat(),
             },
         ],
-        "total": 3,
     }
 
 


### PR DESCRIPTION
# Description

I've removed the `total` field from the output payload of the endpoints listing records in API v1 (`GET /api/v1/datasets/{dataset_id}/records` and `GET /api/v1/me/datasets/{dataset_id}/records`), and also in the Python client (`FeedbackRecordsModel`).

Closes #2917 (backend side only)

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

All tests in `tests/server/api/v1/test_datasets.py` have passed and also the ones from `tests/client/{test_feedback.py, sdk/v1/datasets}`

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)