### PR TITLE
Refactor : Stop using total records in front end

### DIFF
--- a/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
+++ b/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
@@ -145,7 +145,6 @@ export default {
   data() {
     return {
       inputs: [],
-      formData: {},
       renderForm: 0,
       isError: false,
     };
@@ -297,7 +296,7 @@ export default {
           RECORD_STATUS.DISCARDED
         );
 
-        this.emitBusEventGoToRecordIndex();
+        this.$emit("on-discard-responses");
 
         // TODO - reset only when we know that we fetch and computed all the necessary records data
         this.onReset();
@@ -326,16 +325,13 @@ export default {
           RECORD_STATUS.SUBMITTED
         );
 
-        this.emitBusEventGoToRecordIndex();
+        this.$emit("on-submit-responses");
 
         // TODO - reset only when we know that we fetch and computed all the necessary records data
         this.onReset();
       } catch (error) {
         console.log(error);
       }
-    },
-    emitBusEventGoToRecordIndex() {
-      this.$root.$emit("go-to-record-index", this.recordIdIndex + 1);
     },
     async onClear() {
       try {
@@ -531,6 +527,8 @@ export default {
       });
     },
     emitIsQuestionsFormUntouchedByBusEvent(isFormUntouched) {
+      this.$emit("on-question-form-touched", !isFormUntouched);
+      // TODO: Once notifications are centralized in one single point, we can remove this.
       this.$root.$emit("are-responses-untouched", isFormUntouched);
     },
   },

--- a/frontend/components/feedback-task/DatasetFilters.component.vue
+++ b/frontend/components/feedback-task/DatasetFilters.component.vue
@@ -46,6 +46,14 @@ export default {
       selectedStatus: null,
     };
   },
+  mounted() {
+    this.selectedStatus = this.selectedStatus || this.statusFromRoute;
+
+    this.$root.$on("reset-status-filter", () => {
+      this.selectedStatus = this.statusFromRoute;
+    });
+  },
+
   computed: {
     filtersFromVuex() {
       return getFiltersByDatasetId(
@@ -64,8 +72,8 @@ export default {
     },
   },
   watch: {
-    statusFromRoute() {
-      this.selectedStatus = this.statusFromRoute;
+    selectedStatus(newValue) {
+      this.$root.$emit("status-filter-changed", newValue);
     },
   },
   created() {
@@ -142,6 +150,9 @@ export default {
         }
       );
     },
+  },
+  beforeDestroy() {
+    this.$root.$off("reset-status-filter");
   },
 };
 </script>

--- a/frontend/components/feedback-task/StatusFilter.vue
+++ b/frontend/components/feedback-task/StatusFilter.vue
@@ -20,7 +20,7 @@
     <RadioButtonsSelectBase
       :options="options"
       :selected-option="selectedOption"
-      @change="changeOption"
+      @change="onChangeOption"
     />
   </div>
 </template>
@@ -41,15 +41,8 @@ export default {
     event: "change",
   },
   methods: {
-    changeOption(id) {
-      this.$emit("change", id);
-      this.updateRouteQuery(id);
-    },
-    updateRouteQuery(query) {
-      const currentQuery = this.$route.query;
-      this.$router.push({
-        query: { ...currentQuery, _status: query },
-      });
+    onChangeOption(option) {
+      this.$emit("change", option);
     },
   },
 };

--- a/frontend/components/feedback-task/footer/Pagination.component.vue
+++ b/frontend/components/feedback-task/footer/Pagination.component.vue
@@ -1,57 +1,34 @@
 <template>
   <div class="pagination">
-    <div class="number-of-records-by-page-area"></div>
     <div class="pagination__buttons">
       <BaseButton
         class="pagination__button"
         ref="prevButton"
-        @click="onPaginate(onClickPrev)"
-        :disabled="currentPage === 1"
+        @click="onClickPrev"
+        :disabled="isFirstPage"
       >
         <svgicon name="chevron-left" width="8" height="8" />
         {{ prevButtonMessage }}
       </BaseButton>
 
-      <div class="pagination__page-number-area" v-if="showPageNumber">
-        <BaseButton
-          v-for="page in totalPages"
-          :key="page"
-          class="pagination__button"
-          @click="onClickNumber(page)"
-          :disabled="isCurrentPage(page)"
-        >
-          {{ page }}
-        </BaseButton>
-      </div>
-
       <BaseButton
         class="pagination__button"
         ref="nextButton"
-        @click="onPaginate(onClickNext)"
-        :disabled="currentPage >= totalPages"
+        @click="onClickNext"
+        :disabled="false"
       >
         {{ nextButtonMessage }}
         <svgicon name="chevron-right" width="8" height="8" />
       </BaseButton>
     </div>
-    <!-- NOTE: HIDDEN FOR MVP
-    <div class="total-records-area">
-      <span v-text="totalOfRecordMessage" />
-    </div> -->
   </div>
 </template>
 
 <script>
-import { Notification } from "@/models/Notifications";
-
 export default {
   name: "PaginationComponent",
   props: {
-    totalItems: {
-      type: Number,
-      required: true,
-    },
-    numberOfItemsByPage: {
+    currentPage: {
       type: Number,
       default: () => 1,
     },
@@ -63,59 +40,21 @@ export default {
       type: String,
       default: () => "Prev",
     },
-    showPageNumber: {
-      type: Boolean,
-      default: false,
-    },
-    notificationParams: {
-      type: Object | null,
-    },
-    conditionToShowNotificationComponentOnPagination: {
-      type: Function | null,
-    },
-  },
-  data() {
-    return {
-      localCurrentPage: 1,
-    };
   },
   computed: {
-    currentPage: {
-      get() {
-        return this.localCurrentPage;
-      },
-      set(newCurrentPage) {
-        this.localCurrentPage = +newCurrentPage;
-      },
+    isFirstPage() {
+      return this.currentPage === 1;
     },
-    totalPages() {
-      return Math.ceil(this.totalItems / this.numberOfItemsByPage);
-    },
-    totalOfRecordMessage() {
-      return `${this.currentPage} of ${this.totalItems} records`;
-    },
-    isPageAvailable() {
-      return this.pageFromRoute <= this.totalPages;
-    },
+    // TODO: Move to the parent
     pageFromRoute() {
       return parseFloat(this.$route.query?._page) || 1;
     },
   },
-  watch: {
-    localCurrentPage: {
-      immediate: true,
-      handler(newCurrentPage) {
-        this.emitCurrentPage();
-        this.updateUrlParams(newCurrentPage);
-      },
-    },
-  },
   mounted() {
-    this.currentPage = this.isPageAvailable ? this.pageFromRoute : 1;
     document.addEventListener("keydown", this.onPressKeyboardShortCut);
-    this.onBusEventCurrentPage();
   },
   destroyed() {
+    // TODO: Move this to the parent
     document.removeEventListener("keydown", this.onPressKeyboardShortCut);
   },
   methods: {
@@ -135,72 +74,11 @@ export default {
         // Do nothing => the code is not registered as shortcut
       }
     },
-    onBusEventCurrentPage() {
-      this.$root.$on("current-page", (currentPage) => {
-        this.currentPage = currentPage;
-      });
-    },
-    onPaginate(eventToFire) {
-      if (this.isNotificationComponentForThisPage()) {
-        const { message, buttonMessage, typeOfToast } = this.notificationParams;
-        this.showNotificationBeforePaginate({
-          eventToFire,
-          message,
-          buttonMessage,
-          typeOfToast,
-        });
-      } else {
-        eventToFire();
-      }
-    },
-    isNotificationComponentForThisPage() {
-      if (
-        this.notificationParams &&
-        this.conditionToShowNotificationComponentOnPagination
-      ) {
-        const showNotification =
-          this.conditionToShowNotificationComponentOnPagination();
-
-        return showNotification;
-      }
-      return false;
-    },
-    showNotificationBeforePaginate({
-      eventToFire,
-      message,
-      buttonMessage,
-      typeOfToast,
-    }) {
-      Notification.dispatch("notify", {
-        message: message ?? "",
-        numberOfChars: 500,
-        type: typeOfToast ?? "warning",
-        buttonText: buttonMessage ?? "",
-        async onClick() {
-          eventToFire();
-        },
-      });
-    },
     onClickPrev() {
-      this.currentPage > 1 && this.currentPage--;
+      this.$emit("on-click-prev");
     },
     onClickNext() {
-      this.currentPage < this.totalPages && this.currentPage++;
-    },
-    onClickNumber(pageValue) {
-      this.currentPage = pageValue;
-    },
-    emitCurrentPage() {
-      this.$emit("on-paginate", this.currentPage);
-    },
-    isCurrentPage(page) {
-      return this.currentPage === page;
-    },
-    updateUrlParams(currentPage) {
-      this.$router.push({
-        path: this.$route.path,
-        query: { ...this.$route.query, _page: currentPage },
-      });
+      this.$emit("on-click-next");
     },
   },
 };

--- a/frontend/components/page-contents/feedback-task-content/CenterFeedbackTask.content.vue
+++ b/frontend/components/page-contents/feedback-task-content/CenterFeedbackTask.content.vue
@@ -25,9 +25,6 @@ export default {
       required: true,
     },
   },
-  data() {
-
-  },
   async fetch() {
     // FETCH questions AND fields by dataset
     const { items: questions } = await this.getQuestions(this.datasetId);

--- a/frontend/components/page-contents/feedback-task-content/CenterFeedbackTask.content.vue
+++ b/frontend/components/page-contents/feedback-task-content/CenterFeedbackTask.content.vue
@@ -1,30 +1,17 @@
 <template>
   <BaseLoading v-if="$fetchState.pending" />
-  <RecordFeedbackTaskAndQuestionnaireContent
-    :key="rerenderChildren"
-    v-else-if="!$fetchState.pending"
-    :datasetId="datasetId"
-    :recordOffset="recordOffset"
-    :recordStatusToFilterWith="recordStatusFilteringValue"
-  />
+  <RecordFeedbackTaskAndQuestionnaireContent v-else :datasetId="datasetId" />
 </template>
 
 <script>
-import { Notification } from "@/models/Notifications";
 import { upsertDatasetQuestions } from "@/models/feedback-task-model/dataset-question/datasetQuestion.queries";
 import { upsertDatasetFields } from "@/models/feedback-task-model/dataset-field/datasetField.queries";
-import { getTotalRecordByDatasetId } from "@/models/feedback-task-model/feedback-dataset/feedbackDataset.queries";
-import {
-  RECORD_STATUS,
-  deleteAllRecords,
-  getRecordStatusByDatasetIdAndRecordIndex,
-} from "@/models/feedback-task-model/record/record.queries";
 import {
   COMPONENT_TYPE,
   CORRESPONDING_QUESTION_COMPONENT_TYPE_FROM_API,
   CORRESPONDING_FIELD_COMPONENT_TYPE_FROM_API,
 } from "@/components/feedback-task/feedbackTask.properties";
-import { LABEL_PROPERTIES } from "@/components/feedback-task/feedbackTask.properties";
+
 const TYPE_OF_FEEDBACK = Object.freeze({
   ERROR_FETCHING_QUESTIONS: "ERROR_FETCHING_QUESTIONS",
   ERROR_FETCHING_FIELDS: "ERROR_FETCHING_FIELDS",
@@ -39,12 +26,7 @@ export default {
     },
   },
   data() {
-    return {
-      currentPage: 1,
-      recordOffset: 0,
-      rerenderChildren: 0,
-      areResponsesUntouched: true,
-    };
+
   },
   async fetch() {
     // FETCH questions AND fields by dataset
@@ -58,118 +40,9 @@ export default {
     // UPSERT formatted questions in ORM
     await upsertDatasetQuestions(formattedQuestionsForOrm);
     await upsertDatasetFields(formattedFieldsForOrm);
+  },
 
-    this.onBusEventCurrentPage();
-    this.onBusEventRecordIndexToGo();
-    this.onBusEventAreResponsesUntouched();
-  },
-  computed: {
-    totalRecords() {
-      return getTotalRecordByDatasetId(this.datasetId);
-    },
-    recordStatusFilteringValue() {
-      const { _status: recordStatus } = this.$route.query;
-      return recordStatus ?? RECORD_STATUS.PENDING.toLowerCase();
-    },
-    recordStatus() {
-      return getRecordStatusByDatasetIdAndRecordIndex(
-        this.datasetId,
-        this.recordOffset
-      );
-    },
-  },
-  watch: {
-    totalRecords(newTotalRecord) {
-      if (!newTotalRecord) this.areResponsesUntouched = true;
-    },
-    async recordStatusFilteringValue(newStatus, oldStatus) {
-      // NOTE 1 - each time the filter change, clean records orm && rerender the children component
-      !this.areResponsesUntouched ||
-        (await this.goToFirstPageAndRerenderChildren());
-
-      // NOTE 2 - if responses are untouched, toast is not shown. Else, toast is shown
-      this.checkIfAreResponsesUntouchedAndRouteStatusIsDifferent(newStatus) ||
-        this.showNotificationBeforeChangeStatus({
-          eventToFireOnClick: async () =>
-            this.goToFirstPageAndRerenderChildren(),
-          eventToFireOnClose: () =>
-            this.stayOnCurrentPageAndReplaceStatusByOldStatus(oldStatus),
-          message: this.toastMessage,
-          buttonMessage: this.buttonMessage,
-          typeOfToast: this.typeOfToast,
-        });
-    },
-  },
-  created() {
-    this.toastMessage = "Your changes will be lost if you move to another view";
-    this.buttonMessage = LABEL_PROPERTIES.CONTINUE;
-    this.typeOfToast = "warning";
-  },
   methods: {
-    showNotificationBeforeChangeStatus({
-      eventToFireOnClick,
-      eventToFireOnClose,
-      message,
-      buttonMessage,
-      typeOfToast,
-    }) {
-      Notification.dispatch("notify", {
-        message: message ?? "",
-        numberOfChars: 500,
-        type: typeOfToast ?? "warning",
-        buttonText: buttonMessage ?? "",
-        async onClick() {
-          eventToFireOnClick();
-        },
-        async onClose() {
-          eventToFireOnClose();
-        },
-      });
-    },
-    stayOnCurrentPageAndReplaceStatusByOldStatus(oldStatus) {
-      // TODO - go to previous status if user click on close button
-      this.updatePageQueryParam("_status", oldStatus);
-    },
-    async goToFirstPageAndRerenderChildren() {
-      await deleteAllRecords();
-      // Go to first page on change filter
-      this.$root.$emit("current-page", 1);
-      this.rerenderChildren++;
-    },
-    onBusEventCurrentPage() {
-      this.$root.$on("current-page", (currentPage) => {
-        this.currentPage = currentPage;
-        this.recordOffset = currentPage - 1;
-      });
-    },
-    onBusEventRecordIndexToGo() {
-      this.$root.$on("go-to-record-index", (recordIndexToGo) => {
-        if (recordIndexToGo >= 0) {
-          // NOTE - recordIndex start at 0 / page start at 1
-          const pageToGo = recordIndexToGo + 1;
-
-          if (this.currentPage < this.totalRecords) {
-            this.recordOffset = recordIndexToGo;
-            this.currentPage = pageToGo;
-            this.$root.$emit("current-page", this.currentPage);
-          }
-          if (recordIndexToGo < this.totalRecords) {
-            this.updatePageQueryParam("_page", pageToGo);
-          }
-        }
-      });
-    },
-    onBusEventAreResponsesUntouched() {
-      this.$root.$on("are-responses-untouched", (areResponsesUntouched) => {
-        this.areResponsesUntouched = areResponsesUntouched;
-      });
-    },
-    updatePageQueryParam(param, value) {
-      this.$router.push({
-        path: this.$route.path,
-        query: { ...this.$route.query, [param]: value },
-      });
-    },
     factoryQuestionsForOrm(initialQuestions) {
       return initialQuestions.map(
         (
@@ -303,12 +176,6 @@ export default {
         };
       }
     },
-    checkIfAreResponsesUntouchedAndRouteStatusIsDifferent(status) {
-      return (
-        this.areResponsesUntouched ||
-        this.recordStatus?.toLowerCase() === status
-      );
-    },
     async getFields(datasetId) {
       try {
         const { data } = await this.$axios.get(
@@ -322,10 +189,6 @@ export default {
         };
       }
     },
-  },
-  destroyed() {
-    this.$root.$off("current-page");
-    this.$root.$off("go-to-record-index");
   },
 };
 </script>

--- a/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
+++ b/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
@@ -1,9 +1,5 @@
 <template>
-  <div
-    v-if="!$fetchState.pending && !$fetchState.error"
-    :key="recordOffset"
-    class="wrapper"
-  >
+  <div v-if="!$fetchState.pending && !$fetchState.error" class="wrapper">
     <template v-if="recordId">
       <RecordFeedbackTaskComponent
         v-if="fieldsWithRecordFieldText"
@@ -11,6 +7,7 @@
         :fields="fieldsWithRecordFieldText"
       />
       <QuestionsFormComponent
+        :key="questionFormKey"
         class="question-form"
         :class="statusClass"
         v-if="questionsWithRecordAnswers && questionsWithRecordAnswers.length"
@@ -18,11 +15,15 @@
         :recordId="recordId"
         :recordStatus="record.record_status"
         :initialInputs="questionsWithRecordAnswers"
+        @on-submit-responses="onActionInResponses('SUBMIT')"
+        @on-discard-responses="onActionInResponses('DISCARD')"
+        @on-question-form-touched="onQuestionFormTouched"
       />
     </template>
+
     <div v-else class="wrapper--empty">
       <p
-        v-if="!totalRecords"
+        v-if="!hasRecords"
         class="wrapper__text --heading3"
         v-text="noRecordsMessage"
       />
@@ -32,6 +33,8 @@
 </template>
 
 <script>
+import { isNil } from "lodash";
+import { Notification } from "@/models/Notifications";
 import {
   getQuestionsByDatasetId,
   getComponentTypeOfQuestionByDatasetIdAndQuestionName,
@@ -42,14 +45,14 @@ import {
   RECORD_STATUS,
   RESPONSE_STATUS_FOR_API,
   upsertRecords,
+  deleteAllRecords,
   getRecordWithFieldsAndResponsesByUserId,
   isRecordWithRecordIndexByDatasetIdExists,
+  isAnyRecordByDatasetId,
 } from "@/models/feedback-task-model/record/record.queries";
-import {
-  updateTotalRecordsByDatasetId,
-  getTotalRecordByDatasetId,
-} from "@/models/feedback-task-model/feedback-dataset/feedbackDataset.queries";
+
 import { COMPONENT_TYPE } from "@/components/feedback-task/feedbackTask.properties";
+import { LABEL_PROPERTIES } from "../../feedback-task/feedbackTask.properties";
 
 const TYPE_OF_FEEDBACK = Object.freeze({
   ERROR_FETCHING_RECORDS: "ERROR_FETCHING_RECORDS",
@@ -59,10 +62,6 @@ export default {
   name: "RecordFeedbackTaskAndQuestionnaireComponent",
   props: {
     datasetId: {
-      type: String,
-      required: true,
-    },
-    recordStatusToFilterWith: {
       type: String,
       required: true,
     },
@@ -78,14 +77,35 @@ export default {
         return { orderFieldsBy: "order", ascendent: true };
       },
     },
-    recordOffset: {
-      type: Number,
-      required: true,
+  },
+  watch: {
+    async currentPage(newValue) {
+      await this.$router.push({
+        path: this.$route.path,
+        query: {
+          ...this.$route.query,
+          _page: newValue,
+          _status: this.recordStatusToFilterWith,
+        },
+      });
+    },
+    async recordStatusToFilterWith(newValue) {
+      await this.$router.push({
+        path: this.$route.path,
+        query: {
+          ...this.$route.query,
+          _status: newValue,
+          _page: this.currentPage,
+        },
+      });
     },
   },
   data() {
     return {
-      rerenderQuestionnaire: 1,
+      reRenderQuestionForm: 1,
+      questionFormTouched: false,
+      recordStatusToFilterWith: null,
+      currentPage: null,
     };
   },
   computed: {
@@ -111,15 +131,15 @@ export default {
       }
       return paramForUrl;
     },
-    totalRecords() {
-      return getTotalRecordByDatasetId(this.datasetId);
-    },
     record() {
       return getRecordWithFieldsAndResponsesByUserId(
         this.datasetId,
         this.userId,
-        this.recordOffset
+        this.currentPage - 1
       );
+    },
+    hasRecords() {
+      return isAnyRecordByDatasetId(this.datasetId);
     },
     recordId() {
       return this.record?.id;
@@ -180,50 +200,165 @@ export default {
     statusClass() {
       return `--${this.record.record_status.toLowerCase()}`;
     },
-  },
-  async fetch() {
-    await this.initRecordsInDatabase(this.recordOffset);
-  },
-  watch: {
-    recordOffset(newRecordOffset) {
-      const isRecordWithRecordOffsetNotExists =
-        !isRecordWithRecordIndexByDatasetIdExists(
-          this.datasetId,
-          newRecordOffset
-        );
-      if (isRecordWithRecordOffsetNotExists) {
-        this.initRecordsInDatabase(newRecordOffset);
-      }
+    questionFormKey() {
+      return `${this.currentPage}-${this.reRenderQuestionForm}`;
     },
+    statusFilterFromQuery() {
+      return this.$route.query?._status ?? RECORD_STATUS.PENDING.toLowerCase();
+    },
+    pageFromQuery() {
+      const { _page } = this.$route.query;
+      return isNil(_page) ? 1 : +_page;
+    },
+  },
+
+  async fetch() {
+    await this.initRecordsInDatabase(this.currentPage - 1);
+
+    const offset = this.currentPage - 1;
+    const isRecordExistForCurrentPage =
+      isRecordWithRecordIndexByDatasetIdExists(this.datasetId, offset);
+
+    if (!isRecordExistForCurrentPage) {
+      await this.initRecordsInDatabase(0);
+      this.currentPage = 1;
+    }
+  },
+  async created() {
+    this.noMoreDataMessage = "There is no more data";
+
+    this.recordStatusToFilterWith = this.statusFilterFromQuery;
+    this.currentPage = this.pageFromQuery;
+  },
+  mounted() {
+    this.$root.$on("go-to-next-page", () => {
+      this.setCurrentPage(this.currentPage + 1);
+    });
+    this.$root.$on("go-to-prev-page", () => {
+      this.setCurrentPage(this.currentPage - 1);
+    });
+    this.$root.$on("status-filter-changed", this.onStatusFilterChanged);
   },
   methods: {
-    async initRecordsInDatabase(recordOffset) {
-      // FETCH records from recordOffset + 5 next records
-      const { items: records, total: totalRecords } = await this.getRecords(
+    async applyStatusFilter(status) {
+      this.recordStatusToFilterWith = status;
+      this.currentPage = 1;
+
+      await deleteAllRecords();
+      await this.$fetch();
+
+      this.reRenderQuestionForm++;
+      this.questionFormTouched = false;
+    },
+    emitResetStatusFilter() {
+      this.$root.$emit("reset-status-filter");
+    },
+    async onStatusFilterChanged(newStatus) {
+      if (this.recordStatusToFilterWith === newStatus) {
+        return;
+      }
+
+      const localApplyStatusFilter = this.applyStatusFilter;
+      const localEmitResetStatusFilter = this.emitResetStatusFilter;
+
+      if (this.questionFormTouched) {
+        Notification.dispatch("notify", {
+          message: "Your changes will be lost if you move to another view",
+          numberOfChars: 500,
+          type: "warning",
+          buttonText: LABEL_PROPERTIES.CONTINUE,
+          async onClick() {
+            await localApplyStatusFilter(newStatus);
+          },
+          onClose() {
+            localEmitResetStatusFilter();
+          },
+        });
+      } else {
+        await this.applyStatusFilter(newStatus);
+      }
+    },
+    onQuestionFormTouched(isTouched) {
+      this.questionFormTouched = isTouched;
+    },
+    async setCurrentPage(newPage) {
+      const offset = newPage - 1;
+      let isNextRecordExist = isRecordWithRecordIndexByDatasetIdExists(
         this.datasetId,
-        recordOffset,
-        5
+        offset
       );
 
-      // FORMAT records for orm
-      const formattedRecords = this.factoryRecordsForOrm(records);
+      // if isNextRecordExist => move to the next one
+      // else fetch new set of records and move to next one
+      if (!isNextRecordExist) {
+        await this.initRecordsInDatabase(offset);
+        isNextRecordExist = isRecordWithRecordIndexByDatasetIdExists(
+          this.datasetId,
+          offset
+        );
+      }
 
-      // UPSERT total records && records in ORM
-      updateTotalRecordsByDatasetId(this.datasetId, totalRecords);
-      upsertRecords(formattedRecords);
+      if (isNextRecordExist) {
+        this.currentPage = newPage;
+      } else if (this.currentPage < newPage) {
+        // notify there is no more records
+        Notification.dispatch("notify", {
+          message: this.noMoreDataMessage,
+          numberOfChars: this.noMoreDataMessage.length,
+          type: "info",
+        });
+      }
     },
-    async getRecords(datasetId, recordOffset, numberOfRecordsToFetch = 5) {
+    async onActionInResponses(typeOfAction) {
+      switch (typeOfAction) {
+        case "SUBMIT":
+        case "DISCARD":
+          this.setCurrentPage(this.currentPage + 1);
+          break;
+        default:
+        // do nothing
+      }
+    },
+    async initRecordsInDatabase(
+      offset,
+      status = this.recordStatusFilterValueForGetRecords
+    ) {
+      // FETCH records from offset, status + 10 next records
+      const { items: records } = await this.getRecords(
+        this.datasetId,
+        offset,
+        status
+      );
+      // FORMAT records for orm
+      const formattedRecords = this.factoryRecordsForOrm(records, offset);
+
+      // UPSERT records in ORM
+      await upsertRecords(formattedRecords);
+    },
+    async getRecords(
+      datasetId,
+      offset,
+      responseStatus,
+      numberOfRecordsToFetch = 10
+    ) {
       try {
-        const url = `/v1/me/datasets/${datasetId}/records?include=responses&offset=${recordOffset}&limit=${numberOfRecordsToFetch}&response_status=${this.recordStatusFilterValueForGetRecords}`;
-        const { data } = await this.$axios.get(url);
+        const url = `/v1/me/datasets/${datasetId}/records`;
+        const params = {
+          include: "responses",
+          offset,
+          limit: numberOfRecordsToFetch,
+          response_status: responseStatus,
+        };
+        const { data } = await this.$axios.get(url, { params });
         return data;
       } catch (err) {
+        console.warn(err);
         throw {
           response: TYPE_OF_FEEDBACK.ERROR_FETCHING_RECORDS,
         };
       }
     },
-    factoryRecordsForOrm(records) {
+    factoryRecordsForOrm(records, offset) {
       return records.map(
         (
           { id: recordId, responses: recordResponses, fields: recordFields },
@@ -240,7 +375,7 @@ export default {
 
           return {
             id: recordId,
-            record_index: index + this.recordOffset,
+            record_index: index + offset,
             dataset_id: this.datasetId,
             record_status: recordStatus ?? RECORD_STATUS.PENDING,
             record_fields: formattedRecordFields,
@@ -343,6 +478,11 @@ export default {
 
       return { formattedRecordResponsesForOrm, recordStatus };
     },
+  },
+  beforeDestroy() {
+    this.$root.$off("go-to-next-page");
+    this.$root.$off("go-to-prev-page");
+    this.$root.$off("status-filter-changed");
   },
 };
 </script>

--- a/frontend/models/feedback-task-model/feedback-dataset/FeedbackDataset.model.js
+++ b/frontend/models/feedback-task-model/feedback-dataset/FeedbackDataset.model.js
@@ -18,7 +18,6 @@ class FeedbackDataset extends Model {
       workspace_name: this.attr(null),
       inserted_at: this.attr(null),
       updated_at: this.attr(null),
-      total_records: this.number(null).nullable(),
 
       // relationships
       dataset_questions: this.hasMany(DatasetQuestion, "dataset_id"),

--- a/frontend/models/feedback-task-model/feedback-dataset/feedbackDataset.queries.js
+++ b/frontend/models/feedback-task-model/feedback-dataset/feedbackDataset.queries.js
@@ -5,13 +5,6 @@ const upsertFeedbackDataset = (feedbackDataset) => {
   FeedbackDatasetModel.insertOrUpdate({ data: feedbackDataset });
 };
 
-const updateTotalRecordsByDatasetId = (datasetId, totalRecords) => {
-  FeedbackDatasetModel.update({
-    where: datasetId,
-    data: { total_records: totalRecords },
-  });
-};
-
 // GET
 const getAllFeedbackDatasets = () => {
   return FeedbackDatasetModel.all();
@@ -24,9 +17,6 @@ const getFeedbackDatasetWorkspaceNameById = (datasetId) => {
     FeedbackDatasetModel.query().whereId(datasetId).first()?.workspace_name ||
     null
   );
-};
-const getTotalRecordByDatasetId = (datasetId) => {
-  return FeedbackDatasetModel.query().whereId(datasetId).first()?.total_records;
 };
 const getDatasetTaskByDatasetId = (datasetId) => {
   return FeedbackDatasetModel.query().whereId(datasetId).first()?.task;
@@ -46,13 +36,11 @@ const deleteDatasetById = (datasetId) => {
 };
 export {
   upsertFeedbackDataset,
-  updateTotalRecordsByDatasetId,
   getAllFeedbackDatasets,
   getFeedbackDatasetNameById,
   getDatasetGuidelinesByDatasetId,
   getDatasetTaskByDatasetId,
   getFeedbackDatasetWorkspaceNameById,
-  getTotalRecordByDatasetId,
   isDatasetByIdExists,
   deleteDatasetById,
 };

--- a/frontend/models/feedback-task-model/record/record.queries.js
+++ b/frontend/models/feedback-task-model/record/record.queries.js
@@ -20,8 +20,8 @@ const RESPONSE_STATUS_FOR_API = Object.freeze({
 });
 
 // UPSERT
-const upsertRecords = (records) => {
-  RecordModel.insertOrUpdate({ data: records });
+const upsertRecords = async (records) => {
+  await RecordModel.insertOrUpdate({ data: records });
 };
 
 // UPDATE
@@ -73,8 +73,12 @@ const isRecordContainsAnyResponsesByUserId = (userId, recordId) => {
     .exists();
 };
 
+const isAnyRecordByDatasetId = (datasetId) => {
+  return RecordModel.query().where("dataset_id", datasetId).exists();
+};
+
 // DELETE
-const deleteAllRecords = () => RecordModel.deleteAll();
+const deleteAllRecords = async () => await RecordModel.deleteAll();
 
 export {
   RECORD_STATUS,
@@ -87,5 +91,6 @@ export {
   updateRecordStatusByRecordId,
   isRecordWithRecordIndexByDatasetIdExists,
   isRecordContainsAnyResponsesByUserId,
+  isAnyRecordByDatasetId,
   deleteAllRecords,
 };

--- a/src/argilla/client/sdk/v1/datasets/models.py
+++ b/src/argilla/client/sdk/v1/datasets/models.py
@@ -59,10 +59,6 @@ class FeedbackItemModel(BaseModel):
 
 class FeedbackRecordsModel(BaseModel):
     items: List[FeedbackItemModel]
-    total: Optional[int] = None
-
-    class Config:
-        fields = {"total": {"exclude": True}}
 
 
 class FeedbackFieldModel(BaseModel):

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -120,16 +120,7 @@ def list_current_user_dataset_records(
         db, dataset_id, current_user.id, include=include, response_status=response_status, offset=offset, limit=limit
     )
 
-    if response_status == ResponseStatusFilter.missing:
-        total = datasets.count_records_with_missing_responses_by_dataset_id_and_user_id(db, dataset_id, current_user.id)
-    elif response_status == ResponseStatusFilter.submitted:
-        total = datasets.count_submitted_responses_by_dataset_id_and_user_id(db, dataset_id, current_user.id)
-    elif response_status == ResponseStatusFilter.discarded:
-        total = datasets.count_discarded_responses_by_dataset_id_and_user_id(db, dataset_id, current_user.id)
-    else:
-        total = datasets.count_records_by_dataset_id(db, dataset_id)
-
-    return Records(items=[record.__dict__ for record in records], total=total)
+    return Records(items=[record.__dict__ for record in records])
 
 
 @router.get("/datasets/{dataset_id}/records", response_model=Records, response_model_exclude_unset=True)
@@ -148,10 +139,7 @@ def list_dataset_records(
 
     records = datasets.list_records_by_dataset_id(db, dataset_id, include=include, offset=offset, limit=limit)
 
-    return Records(
-        items=[record.__dict__ for record in records],
-        total=datasets.count_records_by_dataset_id(db, dataset_id),
-    )
+    return Records(items=[record.__dict__ for record in records])
 
 
 @router.get("/datasets/{dataset_id}", response_model=Dataset)

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -230,7 +230,6 @@ class Record(BaseModel):
 
 class Records(BaseModel):
     items: List[Record]
-    total: int
 
 
 class UserSubmittedResponseCreate(BaseModel):

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -339,7 +339,6 @@ def test_list_dataset_records(client: TestClient, admin_auth_header: dict):
                 "updated_at": record_c.updated_at.isoformat(),
             },
         ],
-        "total": 3,
     }
 
 
@@ -444,7 +443,6 @@ def test_list_dataset_records_with_include_responses(client: TestClient, admin_a
                 "updated_at": record_c.updated_at.isoformat(),
             },
         ],
-        "total": 3,
     }
 
 
@@ -463,7 +461,6 @@ def test_list_dataset_records_with_offset(client: TestClient, admin_auth_header:
 
     response_body = response.json()
     assert [item["id"] for item in response_body["items"]] == [str(record_c.id)]
-    assert response_body["total"] == 3
 
 
 def test_list_dataset_records_with_limit(client: TestClient, admin_auth_header: dict):
@@ -481,7 +478,6 @@ def test_list_dataset_records_with_limit(client: TestClient, admin_auth_header: 
 
     response_body = response.json()
     assert [item["id"] for item in response_body["items"]] == [str(record_a.id)]
-    assert response_body["total"] == 3
 
 
 def test_list_dataset_records_with_offset_and_limit(client: TestClient, admin_auth_header: dict):
@@ -501,7 +497,6 @@ def test_list_dataset_records_with_offset_and_limit(client: TestClient, admin_au
 
     response_body = response.json()
     assert [item["id"] for item in response_body["items"]] == [str(record_c.id)]
-    assert response_body["total"] == 3
 
 
 def test_list_dataset_records_without_authentication(client: TestClient):
@@ -564,7 +559,6 @@ def test_list_current_user_dataset_records(client: TestClient, admin_auth_header
                 "updated_at": record_c.updated_at.isoformat(),
             },
         ],
-        "total": 3,
     }
 
 
@@ -672,7 +666,6 @@ def test_list_current_user_dataset_records_with_include_responses(
                 "updated_at": record_c.updated_at.isoformat(),
             },
         ],
-        "total": 3,
     }
 
 
@@ -691,7 +684,6 @@ def test_list_current_user_dataset_records_with_offset(client: TestClient, admin
 
     response_body = response.json()
     assert [item["id"] for item in response_body["items"]] == [str(record_c.id)]
-    assert response_body["total"] == 3
 
 
 def test_list_current_user_dataset_records_with_limit(client: TestClient, admin_auth_header: dict):
@@ -709,7 +701,6 @@ def test_list_current_user_dataset_records_with_limit(client: TestClient, admin_
 
     response_body = response.json()
     assert [item["id"] for item in response_body["items"]] == [str(record_a.id)]
-    assert response_body["total"] == 3
 
 
 def test_list_current_user_dataset_records_with_offset_and_limit(client: TestClient, admin_auth_header: dict):
@@ -729,7 +720,6 @@ def test_list_current_user_dataset_records_with_offset_and_limit(client: TestCli
 
     response_body = response.json()
     assert [item["id"] for item in response_body["items"]] == [str(record_c.id)]
-    assert response_body["total"] == 3
 
 
 @pytest.mark.parametrize("response_status_filter", ["missing", "discarded", "submitted"])
@@ -766,7 +756,6 @@ def test_list_current_user_dataset_records_with_response_status_filter(
     assert response.status_code == 200
     response_json = response.json()
 
-    assert response_json["total"] == num_responses_per_status
     assert len(response_json["items"]) == num_responses_per_status
 
     if response_status_filter == "missing":
@@ -821,7 +810,6 @@ def test_list_current_user_dataset_records_as_annotator(client: TestClient, admi
                 "updated_at": record_c.updated_at.isoformat(),
             },
         ],
-        "total": 3,
     }
 
 
@@ -929,7 +917,6 @@ def test_list_current_user_dataset_records_as_annotator_with_include_responses(
                 "updated_at": record_c.updated_at.isoformat(),
             },
         ],
-        "total": 3,
     }
 
 


### PR DESCRIPTION
# Description
Since the `total number records` is not include anymore in the call to fetch records (See #2917) , the value have to be removed from the feedback task.

List of impacts by components/model :

1/ FeedbackPagination.component.vue :
the total_records is used to compute the number of total page
it's also used to render the pagination component (if no total_records, the component is not rendered)

2/ CenterFeedbackTask.content.vue :
when total_records change, we reinitiate the flag areResponsesUntouched to true (this help us to show are not a toast on change route or on change filter)
also used to know in which page the user is in order to allow to go to next record or not on submit/discard

3/ RecordFeedbackTaskAndQuestionnaire.content.vue :
it's where the total_records is fetch and insert in the orm
it's used as a flag to show or not a message in case there is no record

4/ FeedbackTask.model.js && feedbackTask.queries.js :
where there is the attribute total_record && queries to update/get the value from the orm

=> When the total record will be removed from the api, we have to clean the front orm and adapt the 3 components to get the toal record from the metrics instead of the previous way


**Type of change**

- Refactor (change restructuring the codebase without changing functionality)

**How Has This Been Tested**

- Feedback task only
