### PR TITLE
Relax `codecov/patch` threshold to avoid failures

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,3 +6,7 @@ coverage:
       default:
         target: auto
         threshold: 2%
+    patch:
+      default:
+        target: auto
+        threshold: 2%


### PR DESCRIPTION
# Description

Relax the `codecov/patch` threshold to avoid CI from failing too often due to small code coverage percentage changes.

Closes #2985