### PR TITLE
feat: use different database for unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ These are the section headers that we use:
 - Added boolean `use_markdown` property to `TextFieldSettings` model.
 - Added boolean `use_markdown` property to `TextQuestionSettings` model.
 
+## Changed
+
+- Database setup for unit tests. Now the unit tests use a different database than the one used by the local Argilla server ([#2987]).
+
 ## [1.8.0-dev](https://github.com/argilla-io/argilla/compare/v1.7.0...v1.8.0)
 
 ## Added

--- a/src/argilla/__main__.py
+++ b/src/argilla/__main__.py
@@ -16,14 +16,14 @@
 
 import typer
 
-from .tasks import database, server, training, users
+from .tasks import database_app, server_app, training_app, users_app
 
 app = typer.Typer(rich_help_panel=True, help="Argilla CLI", no_args_is_help=True)
 
-app.add_typer(users, name="users")
-app.add_typer(database, name="database")
-app.add_typer(training, name="train")
-app.add_typer(server, name="server")
+app.add_typer(users_app, name="users")
+app.add_typer(database_app, name="database")
+app.add_typer(training_app, name="train")
+app.add_typer(server_app, name="server")
 
 if __name__ == "__main__":
     app()

--- a/src/argilla/server/commons/telemetry.py
+++ b/src/argilla/server/commons/telemetry.py
@@ -16,9 +16,8 @@ import dataclasses
 import logging
 import platform
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
-import httpx
 from fastapi import Request
 
 from argilla.server.commons.models import TaskType

--- a/src/argilla/server/database.py
+++ b/src/argilla/server/database.py
@@ -14,6 +14,7 @@
 
 import os
 from sqlite3 import Connection as SQLite3Connection
+from typing import TYPE_CHECKING, Generator
 
 import alembic.config
 from sqlalchemy import create_engine, event
@@ -21,6 +22,9 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
 from argilla.server.settings import settings
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 
 @event.listens_for(Engine, "connect")
@@ -35,7 +39,7 @@ engine = create_engine(settings.database_url)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
-def get_db():
+def get_db() -> Generator["Session", None, None]:
     try:
         db = SessionLocal()
         yield db

--- a/src/argilla/server/models/models.py
+++ b/src/argilla/server/models/models.py
@@ -19,7 +19,7 @@ from typing import List, Optional
 from uuid import UUID, uuid4
 
 from pydantic import parse_obj_as
-from sqlalchemy import JSON, ForeignKey, Text, and_
+from sqlalchemy import JSON, ForeignKey, Index, Text, UniqueConstraint, and_
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from argilla.server.database import Base
@@ -59,16 +59,18 @@ class Field(Base):
     __tablename__ = "fields"
 
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
-    name: Mapped[str]
+    name: Mapped[str] = mapped_column(Text, index=True)
     title: Mapped[str] = mapped_column(Text)
     required: Mapped[bool] = mapped_column(default=False)
     settings: Mapped[dict] = mapped_column(JSON, default={})
-    dataset_id: Mapped[UUID] = mapped_column(ForeignKey("datasets.id"))
+    dataset_id: Mapped[UUID] = mapped_column(ForeignKey("datasets.id", ondelete="CASCADE"), index=True)
 
     inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
     dataset: Mapped["Dataset"] = relationship(back_populates="fields")
+
+    __table_args__ = (UniqueConstraint("name", "dataset_id", name="field_name_dataset_id_uq"),)
 
     def __repr__(self):
         return (
@@ -83,15 +85,17 @@ class Response(Base):
 
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
     values: Mapped[Optional[dict]] = mapped_column(JSON)
-    status: Mapped[ResponseStatus] = mapped_column(default=ResponseStatus.submitted)
-    record_id: Mapped[UUID] = mapped_column(ForeignKey("records.id"))
-    user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"))
+    status: Mapped[ResponseStatus] = mapped_column(default=ResponseStatus.submitted, index=True)
+    record_id: Mapped[UUID] = mapped_column(ForeignKey("records.id", ondelete="CASCADE"), index=True)
+    user_id: Mapped[Optional[UUID]] = mapped_column(ForeignKey("users.id", ondelete="SET NULL"), index=True)
 
     inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
     record: Mapped["Record"] = relationship(back_populates="responses")
     user: Mapped["User"] = relationship(back_populates="responses")
+
+    __table_args__ = (UniqueConstraint("record_id", "user_id", name="response_record_id_user_id_uq"),)
 
     @property
     def is_submitted(self):
@@ -108,15 +112,17 @@ class Record(Base):
     __tablename__ = "records"
 
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
-    fields: Mapped[dict] = mapped_column(JSON)
-    external_id: Mapped[Optional[str]]
-    dataset_id: Mapped[UUID] = mapped_column(ForeignKey("datasets.id"))
+    fields: Mapped[dict] = mapped_column(JSON, default={})
+    external_id: Mapped[Optional[str]] = mapped_column(index=True)
+    dataset_id: Mapped[UUID] = mapped_column(ForeignKey("datasets.id", ondelete="CASCADE"), index=True)
 
     inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
     dataset: Mapped["Dataset"] = relationship(back_populates="records")
     responses: Mapped[List["Response"]] = relationship(back_populates="record", order_by=Response.inserted_at.asc())
+
+    __table_args__ = (UniqueConstraint("external_id", "dataset_id", name="record_external_id_dataset_id_uq"),)
 
     def __repr__(self):
         return (
@@ -129,17 +135,19 @@ class Question(Base):
     __tablename__ = "questions"
 
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
-    name: Mapped[str]
+    name: Mapped[str] = mapped_column(index=True)
     title: Mapped[str] = mapped_column(Text)
-    description: Mapped[str] = mapped_column(Text)
+    description: Mapped[str] = mapped_column(Text, nullable=True)
     required: Mapped[bool] = mapped_column(default=False)
     settings: Mapped[dict] = mapped_column(JSON, default={})
-    dataset_id: Mapped[UUID] = mapped_column(ForeignKey("datasets.id"))
+    dataset_id: Mapped[UUID] = mapped_column(ForeignKey("datasets.id", ondelete="CASCADE"), index=True)
 
     inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
     dataset: Mapped["Dataset"] = relationship(back_populates="questions")
+
+    __table_args__ = (UniqueConstraint("name", "dataset_id", name="question_name_dataset_id_uq"),)
 
     @property
     def parsed_settings(self) -> QuestionSettings:
@@ -157,10 +165,10 @@ class Dataset(Base):
     __tablename__ = "datasets"
 
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
-    name: Mapped[str]
+    name: Mapped[str] = mapped_column(index=True)
     guidelines: Mapped[Optional[str]] = mapped_column(Text)
-    status: Mapped[DatasetStatus] = mapped_column(default=DatasetStatus.draft)
-    workspace_id: Mapped[UUID] = mapped_column(ForeignKey("workspaces.id"))
+    status: Mapped[DatasetStatus] = mapped_column(default=DatasetStatus.draft, index=True)
+    workspace_id: Mapped[UUID] = mapped_column(ForeignKey("workspaces.id", ondelete="CASCADE"), index=True)
 
     inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
@@ -175,6 +183,8 @@ class Dataset(Base):
     records: Mapped[List["Record"]] = relationship(
         back_populates="dataset", passive_deletes=True, order_by=Record.inserted_at.asc()
     )
+
+    __table_args__ = (UniqueConstraint("name", "workspace_id", name="dataset_name_workspace_id_uq"),)
 
     @property
     def is_draft(self):
@@ -196,14 +206,16 @@ class WorkspaceUser(Base):
     __tablename__ = "workspaces_users"
 
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
-    workspace_id: Mapped[UUID] = mapped_column(ForeignKey("workspaces.id"))
-    user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id"))
+    workspace_id: Mapped[UUID] = mapped_column(ForeignKey("workspaces.id", ondelete="CASCADE"), index=True)
+    user_id: Mapped[UUID] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), index=True)
 
     inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
 
     workspace: Mapped["Workspace"] = relationship(viewonly=True)
     user: Mapped["User"] = relationship(viewonly=True)
+
+    __table_args__ = (UniqueConstraint("workspace_id", "user_id", name="workspace_id_user_id_uq"),)
 
     def __repr__(self):
         return (
@@ -217,7 +229,7 @@ class Workspace(Base):
     __tablename__ = "workspaces"
 
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
-    name: Mapped[str] = mapped_column(unique=True)
+    name: Mapped[str] = mapped_column(unique=True, index=True)
 
     inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(default=default_inserted_at, onupdate=datetime.utcnow)
@@ -240,9 +252,9 @@ class User(Base):
     id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
     first_name: Mapped[str]
     last_name: Mapped[Optional[str]]
-    username: Mapped[str] = mapped_column(unique=True)
-    role: Mapped[UserRole] = mapped_column(default=UserRole.annotator)
-    api_key: Mapped[str] = mapped_column(Text, unique=True, default=generate_user_api_key)
+    username: Mapped[str] = mapped_column(unique=True, index=True)
+    role: Mapped[UserRole] = mapped_column(default=UserRole.annotator, index=True)
+    api_key: Mapped[str] = mapped_column(Text, unique=True, index=True, default=generate_user_api_key)
     password_hash: Mapped[str] = mapped_column(Text)
 
     inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)

--- a/src/argilla/tasks/__init__.py
+++ b/src/argilla/tasks/__init__.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from .database import app as database
-from .server import app as server
-from .training import app as training
-from .users import app as users
+from .database import app as database_app
+from .server import app as server_app
+from .training import app as training_app
+from .users import app as users_app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,12 +154,6 @@ def test_telemetry(mocker) -> MagicMock:
     return mocker.spy(telemetry._CLIENT, "track_data")
 
 
-# @pytest.fixture(scope="session")
-# def test_client():
-#     with TestClient(app) as client:
-#         yield client
-
-
 @pytest.fixture
 def api() -> Argilla:
     return Argilla()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,12 +11,13 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import tempfile
+from typing import TYPE_CHECKING, Dict, Generator
 from unittest.mock import MagicMock
 
 import argilla as rg
 import httpx
 import pytest
-from argilla import app
 from argilla._constants import API_KEY_HEADER_NAME, DEFAULT_API_KEY
 from argilla.client.api import active_api
 from argilla.client.apis.datasets import TextClassificationSettings
@@ -24,33 +25,61 @@ from argilla.client.client import Argilla
 from argilla.client.sdk.users import api as users_api
 from argilla.server.commons import telemetry
 from argilla.server.commons.telemetry import TelemetryClient
-from argilla.server.database import SessionLocal
-from argilla.server.models import User, UserRole, Workspace, WorkspaceUser
+from argilla.server.database import Base, get_db
+from argilla.server.models import User, UserRole, Workspace
+from argilla.server.server import app, argilla_app
 from argilla.server.settings import settings
+from fastapi.testclient import TestClient
 from opensearchpy import OpenSearch
-from starlette.testclient import TestClient
+from sqlalchemy import create_engine
 
-from .factories import AdminFactory, AnnotatorFactory
-from .helpers import SecuredClient
+from tests.database import TestSession
+from tests.factories import AdminFactory, AnnotatorFactory, UserFactory
+from tests.helpers import SecuredClient
+
+if TYPE_CHECKING:
+    from sqlalchemy import Connection
+    from sqlalchemy.orm import Session
 
 
 @pytest.fixture(scope="session")
-def client():
-    with TestClient(app) as c:
-        yield c
+def connection() -> Generator["Connection", None, None]:
+    # Create a temp directory to store a SQLite database used for testing
+    with tempfile.TemporaryDirectory() as tmpdir:
+        database_url = f"sqlite:///{tmpdir}/test.db"
+        engine = create_engine(database_url, connect_args={"check_same_thread": False})
+        conn = engine.connect()
+        TestSession.configure(bind=conn)
+        Base.metadata.create_all(conn)
+
+        yield conn
+
+        Base.metadata.drop_all(conn)
+        conn.close()
+        engine.dispose()
 
 
-@pytest.fixture(scope="function")
-def db():
-    session = SessionLocal()
-    # test_seeds(session)  # without a session, rollback is not working when some error occurs in a test
+@pytest.fixture(autouse=True)
+def db(connection: "Connection") -> Generator["Session", None, None]:
+    session = TestSession()
 
     yield session
 
-    session.query(User).delete()
-    session.query(Workspace).delete()
-    session.query(WorkspaceUser).delete()
-    session.commit()
+    session.close()
+    connection.rollback()
+
+
+@pytest.fixture(scope="function")
+def client() -> Generator[TestClient, None, None]:
+    def override_get_db():
+        yield TestSession()
+
+    argilla_app.dependency_overrides[get_db] = override_get_db
+
+    with TestClient(app) as client:
+        yield client
+
+    argilla_app.dependency_overrides.clear()
 
 
 def is_running_elasticsearch() -> bool:
@@ -77,44 +106,33 @@ def opensearch(elasticsearch_config):
 
 
 @pytest.fixture(scope="function")
-def admin(db):
+def admin() -> User:
     return AdminFactory.create(first_name="Admin", username="admin", api_key="admin.apikey")
 
 
 @pytest.fixture(scope="function")
-def annotator(db):
+def annotator() -> User:
     return AnnotatorFactory.create(first_name="Annotator", username="annotator", api_key="annotator.apikey")
 
 
-@pytest.fixture
-def mock_user(db):
-    user = User(
+@pytest.fixture(scope="function")
+def mock_user() -> User:
+    return UserFactory.create(
         first_name="Mock",
         username="mock-user",
         password_hash="$2y$05$eaw.j2Kaw8s8vpscVIZMfuqSIX3OLmxA21WjtWicDdn0losQ91Hw.",
         api_key="mock-user.apikey",
     )
 
-    db.add(user)
-    db.commit()
-    db.refresh(user)
-
-    return user
-
 
 @pytest.fixture(scope="function")
-def admin_auth_header(db, admin):
+def admin_auth_header(admin: User) -> Dict[str, str]:
     return {API_KEY_HEADER_NAME: admin.api_key}
 
 
-@pytest.fixture(scope="function")
-def argilla_auth_header(db, argilla_user):
-    return {API_KEY_HEADER_NAME: argilla_user.api_key}
-
-
 @pytest.fixture
-def argilla_user(db):
-    user = User(
+def argilla_user(db: "Session") -> User:
+    return UserFactory.create(
         first_name="Argilla",
         username="argilla",
         role=UserRole.admin,
@@ -123,11 +141,10 @@ def argilla_user(db):
         workspaces=[Workspace(name="argilla")],
     )
 
-    db.add(user)
-    db.commit()
-    db.refresh(user)
 
-    return user
+@pytest.fixture(scope="function")
+def argilla_auth_header(argilla_user: User) -> Dict[str, str]:
+    return {API_KEY_HEADER_NAME: argilla_user.api_key}
 
 
 @pytest.fixture
@@ -137,14 +154,14 @@ def test_telemetry(mocker) -> MagicMock:
     return mocker.spy(telemetry._CLIENT, "track_data")
 
 
-@pytest.fixture(scope="session")
-def test_client():
-    with TestClient(app) as client:
-        yield client
+# @pytest.fixture(scope="session")
+# def test_client():
+#     with TestClient(app) as client:
+#         yield client
 
 
 @pytest.fixture
-def api():
+def api() -> Argilla:
     return Argilla()
 
 

--- a/tests/database.py
+++ b/tests/database.py
@@ -14,4 +14,4 @@
 
 from sqlalchemy import orm
 
-TestSession = orm.scoped_session(orm.sessionmaker(join_transaction_mode="create_savepoint"))
+TestSession = orm.scoped_session(orm.sessionmaker())

--- a/tests/database.py
+++ b/tests/database.py
@@ -1,0 +1,17 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from sqlalchemy import orm
+
+TestSession = orm.scoped_session(orm.sessionmaker(join_transaction_mode="create_savepoint"))

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 import factory
-from argilla.server.database import SessionLocal
 from argilla.server.models import (
     Dataset,
     Field,
@@ -27,32 +26,31 @@ from argilla.server.models import (
     Workspace,
     WorkspaceUser,
 )
-from sqlalchemy import orm
 
-Session = orm.scoped_session(SessionLocal)
+from tests.database import TestSession
 
 
-class WorkspaceUserFactory(factory.alchemy.SQLAlchemyModelFactory):
+class BaseFactory(factory.alchemy.SQLAlchemyModelFactory):
+    class Meta:
+        sqlalchemy_session = TestSession
+        sqlalchemy_session_persistence = "flush"
+
+
+class WorkspaceUserFactory(BaseFactory):
     class Meta:
         model = WorkspaceUser
-        sqlalchemy_session = Session
-        sqlalchemy_session_persistence = "commit"
 
 
-class WorkspaceFactory(factory.alchemy.SQLAlchemyModelFactory):
+class WorkspaceFactory(BaseFactory):
     class Meta:
         model = Workspace
-        sqlalchemy_session = Session
-        sqlalchemy_session_persistence = "commit"
 
     name = factory.Sequence(lambda n: f"workspace-{n}")
 
 
-class UserFactory(factory.alchemy.SQLAlchemyModelFactory):
+class UserFactory(BaseFactory):
     class Meta:
         model = User
-        sqlalchemy_session = Session
-        sqlalchemy_session_persistence = "commit"
 
     first_name = factory.Faker("first_name")
     username = factory.Sequence(lambda n: f"username-{n}")
@@ -68,21 +66,17 @@ class AnnotatorFactory(UserFactory):
     role = UserRole.annotator
 
 
-class DatasetFactory(factory.alchemy.SQLAlchemyModelFactory):
+class DatasetFactory(BaseFactory):
     class Meta:
         model = Dataset
-        sqlalchemy_session = Session
-        sqlalchemy_session_persistence = "commit"
 
     name = factory.Sequence(lambda n: f"dataset-{n}")
     workspace = factory.SubFactory(WorkspaceFactory)
 
 
-class RecordFactory(factory.alchemy.SQLAlchemyModelFactory):
+class RecordFactory(BaseFactory):
     class Meta:
         model = Record
-        sqlalchemy_session = Session
-        sqlalchemy_session_persistence = "commit"
 
     fields = {
         "text": "This is a text",
@@ -92,21 +86,17 @@ class RecordFactory(factory.alchemy.SQLAlchemyModelFactory):
     dataset = factory.SubFactory(DatasetFactory)
 
 
-class ResponseFactory(factory.alchemy.SQLAlchemyModelFactory):
+class ResponseFactory(BaseFactory):
     class Meta:
         model = Response
-        sqlalchemy_session = Session
-        sqlalchemy_session_persistence = "commit"
 
     record = factory.SubFactory(RecordFactory)
     user = factory.SubFactory(UserFactory)
 
 
-class FieldFactory(factory.alchemy.SQLAlchemyModelFactory):
+class FieldFactory(BaseFactory):
     class Meta:
         model = Field
-        sqlalchemy_session = Session
-        sqlalchemy_session_persistence = "commit"
 
     name = factory.Sequence(lambda n: f"field-{n}")
     title = "Field Title"
@@ -117,14 +107,13 @@ class TextFieldFactory(FieldFactory):
     settings = {"type": FieldType.text.value}
 
 
-class QuestionFactory(factory.alchemy.SQLAlchemyModelFactory):
+class QuestionFactory(BaseFactory):
     class Meta:
         model = Question
-        sqlalchemy_session = Session
-        sqlalchemy_session_persistence = "commit"
 
     name = factory.Sequence(lambda n: f"question-{n}")
     title = "Question Title"
+    description = "Question Description"
     dataset = factory.SubFactory(DatasetFactory)
 
 

--- a/tests/server/api/__init__.py
+++ b/tests/server/api/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -18,7 +18,6 @@ from uuid import UUID, uuid4
 
 import pytest
 from argilla._constants import API_KEY_HEADER_NAME
-from argilla.server.commons.telemetry import TelemetryClient
 from argilla.server.models import (
     Dataset,
     DatasetStatus,
@@ -109,7 +108,7 @@ def test_list_current_user_datasets_without_authentication(client: TestClient):
     assert response.status_code == 401
 
 
-def test_list_current_user_datasets_as_annotator(client: TestClient, db: Session):
+def test_list_current_user_datasets_as_annotator(client: TestClient):
     workspace = WorkspaceFactory.create()
     annotator = AnnotatorFactory.create(workspaces=[workspace])
 
@@ -125,8 +124,8 @@ def test_list_current_user_datasets_as_annotator(client: TestClient, db: Session
     assert [dataset["name"] for dataset in response_body["items"]] == ["dataset-a", "dataset-b"]
 
 
-def test_list_dataset_fields(client: TestClient, db: Session, admin_auth_header: dict):
-    dataset = DatasetFactory.create()
+def test_list_dataset_fields(client: TestClient, admin_auth_header: dict):
+    dataset = DatasetFactory.build()
     text_field_a = TextFieldFactory.create(name="text-field-a", title="Text Field A", required=True, dataset=dataset)
     text_field_b = TextFieldFactory.create(name="text-field-b", title="Text Field B", dataset=dataset)
 
@@ -160,7 +159,7 @@ def test_list_dataset_fields(client: TestClient, db: Session, admin_auth_header:
     }
 
 
-def test_list_dataset_fields_without_authentication(client: TestClient, db: Session):
+def test_list_dataset_fields_without_authentication(client: TestClient):
     dataset = DatasetFactory.create()
 
     response = client.get(f"/api/v1/datasets/{dataset.id}/fields")
@@ -168,7 +167,7 @@ def test_list_dataset_fields_without_authentication(client: TestClient, db: Sess
     assert response.status_code == 401
 
 
-def test_list_dataset_fields_as_annotator(client: TestClient, db: Session):
+def test_list_dataset_fields_as_annotator(client: TestClient):
     dataset = DatasetFactory.create()
     annotator = AnnotatorFactory.create(workspaces=[dataset.workspace])
     TextFieldFactory.create(name="text-field-a", dataset=dataset)
@@ -185,7 +184,7 @@ def test_list_dataset_fields_as_annotator(client: TestClient, db: Session):
     assert [field["name"] for field in response_body["items"]] == ["text-field-a", "text-field-b"]
 
 
-def test_list_dataset_fields_as_annotator_from_different_workspace(client: TestClient, db: Session):
+def test_list_dataset_fields_as_annotator_from_different_workspace(client: TestClient):
     dataset = DatasetFactory.create()
     annotator = AnnotatorFactory.create(workspaces=[WorkspaceFactory.build()])
 
@@ -194,7 +193,7 @@ def test_list_dataset_fields_as_annotator_from_different_workspace(client: TestC
     assert response.status_code == 403
 
 
-def test_list_dataset_fields_with_nonexistent_dataset_id(client: TestClient, db: Session, admin_auth_header: dict):
+def test_list_dataset_fields_with_nonexistent_dataset_id(client: TestClient, admin_auth_header: dict):
     DatasetFactory.create()
 
     response = client.get(f"/api/v1/datasets/{uuid4()}/fields", headers=admin_auth_header)
@@ -202,7 +201,7 @@ def test_list_dataset_fields_with_nonexistent_dataset_id(client: TestClient, db:
     assert response.status_code == 404
 
 
-def test_list_dataset_questions(client: TestClient, db: Session, admin_auth_header: dict):
+def test_list_dataset_questions(client: TestClient, admin_auth_header: dict):
     dataset = DatasetFactory.create()
     text_question = TextQuestionFactory.create(
         name="text-question",
@@ -228,7 +227,7 @@ def test_list_dataset_questions(client: TestClient, db: Session, admin_auth_head
                 "id": str(text_question.id),
                 "name": "text-question",
                 "title": "Text Question",
-                "description": None,
+                "description": "Question Description",
                 "required": True,
                 "settings": {"type": "text"},
                 "inserted_at": text_question.inserted_at.isoformat(),
@@ -262,7 +261,7 @@ def test_list_dataset_questions(client: TestClient, db: Session, admin_auth_head
     }
 
 
-def test_list_dataset_questions_without_authentication(client: TestClient, db: Session):
+def test_list_dataset_questions_without_authentication(client: TestClient):
     dataset = DatasetFactory.create()
 
     response = client.get(f"/api/v1/datasets/{dataset.id}/questions")
@@ -270,7 +269,7 @@ def test_list_dataset_questions_without_authentication(client: TestClient, db: S
     assert response.status_code == 401
 
 
-def test_list_dataset_questions_as_annotator(client: TestClient, db: Session):
+def test_list_dataset_questions_as_annotator(client: TestClient):
     dataset = DatasetFactory.create()
     annotator = AnnotatorFactory.create(workspaces=[dataset.workspace])
     TextQuestionFactory.create(name="text-question", dataset=dataset)
@@ -286,7 +285,7 @@ def test_list_dataset_questions_as_annotator(client: TestClient, db: Session):
     assert [question["name"] for question in response_body["items"]] == ["text-question", "rating-question"]
 
 
-def test_list_dataset_questions_as_annotator_from_different_workspace(client: TestClient, db: Session):
+def test_list_dataset_questions_as_annotator_from_different_workspace(client: TestClient):
     dataset = DatasetFactory.create()
     annotator = AnnotatorFactory.create(workspaces=[WorkspaceFactory.build()])
 
@@ -295,7 +294,7 @@ def test_list_dataset_questions_as_annotator_from_different_workspace(client: Te
     assert response.status_code == 403
 
 
-def test_list_dataset_questions_with_nonexistent_dataset_id(client: TestClient, db: Session, admin_auth_header: dict):
+def test_list_dataset_questions_with_nonexistent_dataset_id(client: TestClient, admin_auth_header: dict):
     DatasetFactory.create()
 
     response = client.get(f"/api/v1/datasets/{uuid4()}/questions", headers=admin_auth_header)
@@ -772,7 +771,7 @@ def test_list_current_user_dataset_records_without_authentication(client: TestCl
     assert response.status_code == 401
 
 
-def test_list_current_user_dataset_records_as_annotator(client: TestClient, admin: User, db: Session):
+def test_list_current_user_dataset_records_as_annotator(client: TestClient, admin: User):
     workspace = WorkspaceFactory.create()
     annotator = AnnotatorFactory.create(workspaces=[workspace])
     dataset = DatasetFactory.create(workspace=workspace)
@@ -813,9 +812,7 @@ def test_list_current_user_dataset_records_as_annotator(client: TestClient, admi
     }
 
 
-def test_list_current_user_dataset_records_as_annotator_with_include_responses(
-    client: TestClient, admin: User, db: Session
-):
+def test_list_current_user_dataset_records_as_annotator_with_include_responses(client: TestClient, admin: User):
     dataset = DatasetFactory.create()
     annotator = AnnotatorFactory.create(workspaces=[dataset.workspace])
     record_a = RecordFactory.create(fields={"record_a": "value_a"}, dataset=dataset)
@@ -920,7 +917,7 @@ def test_list_current_user_dataset_records_as_annotator_with_include_responses(
     }
 
 
-def test_list_current_user_dataset_records_as_annotator_from_different_workspace(client: TestClient, db: Session):
+def test_list_current_user_dataset_records_as_annotator_from_different_workspace(client: TestClient):
     dataset = DatasetFactory.create()
     annotator = AnnotatorFactory.create(workspaces=[WorkspaceFactory.build()])
 
@@ -929,9 +926,7 @@ def test_list_current_user_dataset_records_as_annotator_from_different_workspace
     assert response.status_code == 403
 
 
-def test_list_current_user_dataset_records_with_nonexistent_dataset_id(
-    client: TestClient, db: Session, admin_auth_header: dict
-):
+def test_list_current_user_dataset_records_with_nonexistent_dataset_id(client: TestClient, admin_auth_header: dict):
     DatasetFactory.create()
 
     response = client.get(f"/api/v1/me/datasets/{uuid4()}/records", headers=admin_auth_header)
@@ -956,7 +951,7 @@ def test_get_dataset(client: TestClient, admin_auth_header: dict):
     }
 
 
-def test_get_dataset_without_authentication(client: TestClient, db: Session):
+def test_get_dataset_without_authentication(client: TestClient):
     dataset = DatasetFactory.create()
 
     response = client.get(f"/api/v1/datasets/{dataset.id}")
@@ -964,7 +959,7 @@ def test_get_dataset_without_authentication(client: TestClient, db: Session):
     assert response.status_code == 401
 
 
-def test_get_dataset_as_annotator(client: TestClient, db: Session):
+def test_get_dataset_as_annotator(client: TestClient):
     dataset = DatasetFactory.create(name="dataset")
     annotator = AnnotatorFactory.create(workspaces=[dataset.workspace])
 
@@ -974,7 +969,7 @@ def test_get_dataset_as_annotator(client: TestClient, db: Session):
     assert response.json()["name"] == "dataset"
 
 
-def test_get_dataset_as_annotator_from_different_workspace(client: TestClient, db: Session):
+def test_get_dataset_as_annotator_from_different_workspace(client: TestClient):
     dataset = DatasetFactory.create()
     annotator = AnnotatorFactory.create(workspaces=[WorkspaceFactory.build()])
 
@@ -983,7 +978,7 @@ def test_get_dataset_as_annotator_from_different_workspace(client: TestClient, d
     assert response.status_code == 403
 
 
-def test_get_dataset_with_nonexistent_dataset_id(client: TestClient, db: Session, admin_auth_header: dict):
+def test_get_dataset_with_nonexistent_dataset_id(client: TestClient, admin_auth_header: dict):
     DatasetFactory.create()
 
     response = client.get(f"/api/v1/datasets/{uuid4()}", headers=admin_auth_header)
@@ -991,7 +986,7 @@ def test_get_dataset_with_nonexistent_dataset_id(client: TestClient, db: Session
     assert response.status_code == 404
 
 
-def test_get_current_user_dataset_metrics(client: TestClient, db: Session, admin: User, admin_auth_header: dict):
+def test_get_current_user_dataset_metrics(client: TestClient, admin: User, admin_auth_header: dict):
     dataset = DatasetFactory.create()
     record_a = RecordFactory.create(dataset=dataset)
     record_b = RecordFactory.create(dataset=dataset)
@@ -1025,7 +1020,7 @@ def test_get_current_user_dataset_metrics(client: TestClient, db: Session, admin
     }
 
 
-def test_get_current_user_dataset_metrics_without_authentication(client: TestClient, db: Session):
+def test_get_current_user_dataset_metrics_without_authentication(client: TestClient):
     dataset = DatasetFactory.create()
 
     response = client.get(f"/api/v1/me/datasets/{dataset.id}/metrics")
@@ -1033,7 +1028,7 @@ def test_get_current_user_dataset_metrics_without_authentication(client: TestCli
     assert response.status_code == 401
 
 
-def test_get_current_user_dataset_metrics_as_annotator(client: TestClient, db: Session):
+def test_get_current_user_dataset_metrics_as_annotator(client: TestClient):
     dataset = DatasetFactory.create()
     annotator = AnnotatorFactory.create(workspaces=[dataset.workspace])
     record_a = RecordFactory.create(dataset=dataset)
@@ -1068,7 +1063,7 @@ def test_get_current_user_dataset_metrics_as_annotator(client: TestClient, db: S
     }
 
 
-def test_get_current_user_dataset_metrics_annotator_from_different_workspace(client: TestClient, db: Session):
+def test_get_current_user_dataset_metrics_annotator_from_different_workspace(client: TestClient):
     dataset = DatasetFactory.create()
     annotator = AnnotatorFactory.create(workspaces=[WorkspaceFactory.build()])
 
@@ -1077,9 +1072,7 @@ def test_get_current_user_dataset_metrics_annotator_from_different_workspace(cli
     assert response.status_code == 403
 
 
-def test_get_current_user_dataset_metrics_with_nonexistent_dataset_id(
-    client: TestClient, db: Session, admin_auth_header: dict
-):
+def test_get_current_user_dataset_metrics_with_nonexistent_dataset_id(client: TestClient, admin_auth_header: dict):
     DatasetFactory.create()
 
     response = client.get(f"/api/v1/me/datasets/{uuid4()}/metrics", headers=admin_auth_header)

--- a/tests/server/api/v1/test_responses.py
+++ b/tests/server/api/v1/test_responses.py
@@ -41,7 +41,7 @@ def test_update_response(client: TestClient, db: Session, admin_auth_header: dic
             "input_ok": {"value": "no"},
             "output_ok": {"value": "no"},
         },
-        status="submitted",
+        status=ResponseStatus.submitted,
     )
     response_json = {
         "values": {

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -112,11 +112,11 @@ def uri_2_path(uri: str):
     return os.path.abspath(os.path.join(p.netloc, p.path))
 
 
-def test_docs_redirect(test_client: TestClient):
-    response = test_client.get("/docs", follow_redirects=False)
+def test_docs_redirect(client: TestClient):
+    response = client.get("/docs", follow_redirects=False)
     assert response.status_code == 307
     assert response.next_request.url.path == "/api/docs"
 
-    response = test_client.get("/api", follow_redirects=False)
+    response = client.get("/api", follow_redirects=False)
     assert response.status_code == 307
     assert response.next_request.url.path == "/api/docs"

--- a/tests/server/text_classification/test_api_settings.py
+++ b/tests/server/text_classification/test_api_settings.py
@@ -134,21 +134,21 @@ def log_some_data(mocked_client, name):
 # TODO: These tests are the same for token an text classification. We will move them to a common test_dataset_settings
 #  module where settings will be tested in a per-task fashion.
 @pytest.mark.parametrize("task", [TaskType.text_classification, TaskType.token_classification])
-def test_save_settings_as_annotator(test_client: TestClient, argilla_auth_header: dict, task: TaskType):
+def test_save_settings_as_annotator(client: TestClient, argilla_auth_header: dict, task: TaskType):
     dataset_name = "test_save_settings_as_annotator"
     workspace_name = "workspace-a"
     annotator = AnnotatorFactory.create(workspaces=[WorkspaceFactory.build(name=workspace_name)])
 
-    test_client.delete(f"/api/datasets/{dataset_name}?workspace={workspace_name}", headers=argilla_auth_header)
+    client.delete(f"/api/datasets/{dataset_name}?workspace={workspace_name}", headers=argilla_auth_header)
 
-    response = test_client.post(
+    response = client.post(
         "/api/datasets",
         json={"name": dataset_name, "task": task, "workspace": workspace_name},
         headers=argilla_auth_header,
     )
     assert response.status_code == 200
 
-    response = test_client.put(
+    response = client.put(
         f"/api/datasets/{dataset_name}/{task}/settings?workspace={workspace_name}",
         json={"label_schema": {"labels": ["Label1", "Label2"]}},
         headers={API_KEY_HEADER_NAME: annotator.api_key},
@@ -164,21 +164,21 @@ def test_save_settings_as_annotator(test_client: TestClient, argilla_auth_header
 
 
 @pytest.mark.parametrize("task", [TaskType.text_classification, TaskType.token_classification])
-def test_delete_settings_as_annotator(test_client: TestClient, argilla_auth_header: dict, task: TaskType):
+def test_delete_settings_as_annotator(client: TestClient, argilla_auth_header: dict, task: TaskType):
     dataset_name = "test_delete_settings_as_annotator"
     workspace_name = "workspace-a"
     annotator = AnnotatorFactory.create(workspaces=[WorkspaceFactory.build(name=workspace_name)])
 
-    test_client.delete(f"/api/datasets/{dataset_name}?workspace={workspace_name}", headers=argilla_auth_header)
+    client.delete(f"/api/datasets/{dataset_name}?workspace={workspace_name}", headers=argilla_auth_header)
 
-    response = test_client.post(
+    response = client.post(
         "/api/datasets",
         json={"name": dataset_name, "task": task, "workspace": workspace_name},
         headers=argilla_auth_header,
     )
     assert response.status_code == 200
 
-    response = test_client.delete(
+    response = client.delete(
         f"/api/datasets/{dataset_name}/{task}/settings?workspace={workspace_name}",
         headers={API_KEY_HEADER_NAME: annotator.api_key},
     )
@@ -193,28 +193,28 @@ def test_delete_settings_as_annotator(test_client: TestClient, argilla_auth_head
 
 
 @pytest.mark.parametrize("task", [TaskType.text_classification, TaskType.token_classification])
-def test_get_settings_as_annotator(test_client: TestClient, argilla_auth_header: dict, task: TaskType):
+def test_get_settings_as_annotator(client: TestClient, argilla_auth_header: dict, task: TaskType):
     dataset_name = "test_get_settings_as_annotator"
     workspace_name = "workspace-a"
     annotator = AnnotatorFactory.create(workspaces=[WorkspaceFactory.build(name=workspace_name)])
 
-    test_client.delete(f"/api/datasets/{dataset_name}?workspace={workspace_name}", headers=argilla_auth_header)
+    client.delete(f"/api/datasets/{dataset_name}?workspace={workspace_name}", headers=argilla_auth_header)
 
-    response = test_client.post(
+    response = client.post(
         "/api/datasets",
         json={"name": dataset_name, "task": task, "workspace": workspace_name},
         headers=argilla_auth_header,
     )
     assert response.status_code == 200
 
-    response = test_client.put(
+    response = client.put(
         f"/api/datasets/{dataset_name}/{task}/settings?workspace={workspace_name}",
         json={"label_schema": {"labels": ["Label1", "Label2"]}},
         headers=argilla_auth_header,
     )
 
     stored_settings = response.json()
-    response = test_client.get(
+    response = client.get(
         f"/api/datasets/{dataset_name}/{task}/settings?workspace={workspace_name}",
         headers={API_KEY_HEADER_NAME: annotator.api_key},
     )

--- a/tests/server/token_classification/test_api_settings.py
+++ b/tests/server/token_classification/test_api_settings.py
@@ -11,10 +11,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
 import argilla as rg
-import pytest
-from argilla.client.sdk.commons.errors import ForbiddenApiError
-from argilla.server.apis.v0.models.dataset_settings import TextClassificationSettings
 from argilla.server.commons.models import TaskType
 
 

--- a/tests/tasks/users/conftest.py
+++ b/tests/tasks/users/conftest.py
@@ -1,0 +1,29 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+    from sqlalchemy.orm import Session
+
+
+@pytest.fixture(autouse=True)
+def mock_session_local(mocker: "MockerFixture", db: "Session") -> None:
+    mocker.patch.object(db, "close", side_effect=lambda: None)
+    mocker.patch("argilla.tasks.users.create.SessionLocal", return_value=db)
+    mocker.patch("argilla.tasks.users.create_default.SessionLocal", return_value=db)
+    mocker.patch("argilla.tasks.users.migrate.SessionLocal", return_value=db)


### PR DESCRIPTION
# Description

I've updated the unit test setup to use a different database than the one used by the local deployment of the Argilla server. In addition, I've updated the pytest fixtures that provided a connection to the DB, and now before executing every test a new transaction is created that gets rollbacked when the execution of the test has finished, leaving no traces in the DB.

Also, I've aligned the SQLAlchemy models metadata with the metadata in the current alembic migrations scripts.

Closes #2987 

**Type of change**

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (change restructuring the codebase without changing functionality)
- [x] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

All the unit tests are passing using this new DB for the tests.

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)