### PR TITLE
fix : wrong init flag value for showing toast

### DIFF
--- a/frontend/pages/dataset/_id/annotation-mode/index.vue
+++ b/frontend/pages/dataset/_id/annotation-mode/index.vue
@@ -53,7 +53,7 @@ export default {
   },
   data: () => {
     return {
-      areResponsesUntouched: false,
+      areResponsesUntouched: true, // NOTE - this flag is used to show or to not show a toast when questionnaire is touched (to prevent loosing current modification)
     };
   },
   beforeRouteLeave(to, from, next) {


### PR DESCRIPTION
# Description

The initial value of the flag to show or to not show the toast to prevent user loosing his current modifications was wrongly initiate. 

**Type of change**

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

Only feedback task
