### PR TITLE
:bug: reinitiate flag onDestroy hook

### DIFF
--- a/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
+++ b/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
@@ -218,6 +218,7 @@ export default {
     document.addEventListener("keydown", this.onPressKeyboardShortCut);
   },
   destroyed() {
+    this.$root.$emit("are-responses-untouched", true); // NOTE - ensure that on destroy, all parents and siblings have the flag well reinitiate
     document.removeEventListener("keydown", this.onPressKeyboardShortCut);
   },
   methods: {

--- a/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
+++ b/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
@@ -204,7 +204,7 @@ export default {
   },
   watch: {
     isFormUntouched(isFormUntouched) {
-      this.emitIsQuestionsFormUntouchedByBusEvent(isFormUntouched);
+      this.emitIsQuestionsFormUntouched(isFormUntouched);
     },
   },
   async created() {
@@ -218,7 +218,7 @@ export default {
     document.addEventListener("keydown", this.onPressKeyboardShortCut);
   },
   destroyed() {
-    this.$root.$emit("are-responses-untouched", true); // NOTE - ensure that on destroy, all parents and siblings have the flag well reinitiate
+    this.emitIsQuestionsFormUntouched(true); // NOTE - ensure that on destroy, all parents and siblings have the flag well reinitiate
     document.removeEventListener("keydown", this.onPressKeyboardShortCut);
   },
   methods: {
@@ -527,7 +527,7 @@ export default {
         type: typeOfToast,
       });
     },
-    emitIsQuestionsFormUntouchedByBusEvent(isFormUntouched) {
+    emitIsQuestionsFormUntouched(isFormUntouched) {
       this.$emit("on-question-form-touched", !isFormUntouched);
       // TODO: Once notifications are centralized in one single point, we can remove this.
       this.$root.$emit("are-responses-untouched", isFormUntouched);

--- a/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
+++ b/frontend/components/page-contents/feedback-task-content/RecordFeedbackTaskAndQuestionnaire.content.vue
@@ -251,7 +251,6 @@ export default {
       await this.$fetch();
 
       this.reRenderQuestionForm++;
-      this.questionFormTouched = false;
     },
     emitResetStatusFilter() {
       this.$root.$emit("reset-status-filter");


### PR DESCRIPTION
# Description
We need to ensure that all components which are listenning to the flag `are-responses-untouched` are reinitiate when questionnaire is destroyed.

To reproduce issue : 
1/ go to a dataset with no record in one queue 
2/ apply filter status to go to a queue with record
3/ update response without submit/clear/discard the record
4/ change filter status to the previous one where there is no record
5/ the toast appear => click on `continue` button
6/ try to refresh or change route => The toast should not appear and you should be able to do normally the action

**Type of change**

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

- Only feedback task
