### PR TITLE
Enable markdown configuration for text fields and questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ These are the section headers that we use:
 
 ## [Unreleased]
 
+## [1.9.0-dev](https://github.com/argilla-io/argilla/compare/v1.7.0...v1.8.0)
+
+## Added
+
+- Added boolean `use_markdown` property to `TextFieldSettings` model.
+- Added boolean `use_markdown` property to `TextQuestionSettings` model.
+
 ## [1.8.0-dev](https://github.com/argilla-io/argilla/compare/v1.7.0...v1.8.0)
 
 ## Added

--- a/src/argilla/server/models/questions.py
+++ b/src/argilla/server/models/questions.py
@@ -41,6 +41,7 @@ class BaseQuestionSettings(BaseModel):
 
 class TextQuestionSettings(BaseQuestionSettings):
     type: Literal[QuestionType.text]
+    use_markdown: bool = False
 
     def check_response(self, response: ResponseValue):
         if not isinstance(response.value, str):

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -96,6 +96,7 @@ class Metrics(BaseModel):
 
 class TextFieldSettings(BaseModel):
     type: Literal[FieldType.text]
+    use_markdown: bool = False
 
 
 class Field(BaseModel):
@@ -131,6 +132,7 @@ class FieldCreate(BaseModel):
 
 class TextQuestionSettings(BaseModel):
     type: Literal[QuestionType.text]
+    use_markdown: bool = False
 
 
 class RatingQuestionSettingsOption(BaseModel):

--- a/src/argilla/server/schemas/v1/fields.py
+++ b/src/argilla/server/schemas/v1/fields.py
@@ -27,6 +27,7 @@ from argilla.server.models import FieldType
 
 class TextFieldSettings(BaseModel):
     type: Literal[FieldType.text]
+    use_markdown: bool = False
 
 
 class Field(BaseModel):

--- a/src/argilla/server/schemas/v1/questions.py
+++ b/src/argilla/server/schemas/v1/questions.py
@@ -28,6 +28,7 @@ from argilla.server.models import QuestionType
 
 class TextQuestionSettings(BaseModel):
     type: Literal[QuestionType.text]
+    use_markdown: bool = False
 
 
 class RatingQuestionSettingsOption(BaseModel):

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -1570,7 +1570,7 @@ def test_create_dataset_question_with_nonexistent_dataset_id(client: TestClient,
             "options": [
                 {"value": "A wrong value"},
                 {"value": "B wrong value"},
-                {"value": "C Wrong value"},
+                {"value": "C wrong value"},
                 {"value": "D wrong value"},
             ],
         },

--- a/tests/server/api/v1/test_fields.py
+++ b/tests/server/api/v1/test_fields.py
@@ -37,7 +37,7 @@ def test_delete_field(client: TestClient, db: Session, admin_auth_header: dict):
         "name": "name",
         "title": "title",
         "required": False,
-        "settings": {"type": "text"},
+        "settings": {"type": "text", "use_markdown": False},
         "dataset_id": str(field.dataset.id),
         "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
         "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),

--- a/tests/server/api/v1/test_questions.py
+++ b/tests/server/api/v1/test_questions.py
@@ -38,7 +38,7 @@ def test_delete_question(client: TestClient, db: Session, admin_auth_header: dic
         "title": "title",
         "description": "description",
         "required": False,
-        "settings": {"type": "text"},
+        "settings": {"type": "text", "use_markdown": False},
         "dataset_id": str(question.dataset_id),
         "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
         "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),


### PR DESCRIPTION
# Description

This  PR adds a param `use_markdown`  to the `TextFieldSettings` and  `TextQuestionSettings` classes in API to enable markdown support. By default, the parameter is disabled, which is compatible with the previous behavior.


Also, some tests creating dataset fields and questions have been grouped using the `pytest.mark.parameterize` decorator, since the internal behavior was the same.

Refs #2998 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

New tests have been created 


**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)