### PR TITLE
:bug: fix logout when questionnaire have been touched

### DIFF
--- a/frontend/pages/dataset/_id/annotation-mode/index.vue
+++ b/frontend/pages/dataset/_id/annotation-mode/index.vue
@@ -59,7 +59,7 @@ export default {
   beforeRouteLeave(to, from, next) {
     const isNotificationForThisRoute =
       !this.areResponsesUntouched &&
-      ["datasets", "dataseat-id-settings", "user-settings"].includes(to.name);
+      ["datasets", "dataset-id-settings", "user-settings"].includes(to.name);
 
     if (isNotificationForThisRoute) {
       this.showNotification({

--- a/frontend/pages/dataset/_id/annotation-mode/index.vue
+++ b/frontend/pages/dataset/_id/annotation-mode/index.vue
@@ -56,26 +56,17 @@ export default {
       areResponsesUntouched: true, // NOTE - this flag is used to show or to not show a toast when questionnaire is touched (to prevent loosing current modification)
     };
   },
-  async beforeRouteLeave(to, from, next) {
-    if (!this.areResponsesUntouched) {
-      let message = "";
-      switch (to.name) {
-        case "datasets":
-        case "dataset-id-settings":
-        case "user-settings":
-          message = "Your changes will be lost if you leave the current page";
-          break;
-        default:
-          await next();
-      }
-      message.length &&
-        this.showNotification({
-          eventToFireOnClick: async () => {
-            await next();
-          },
-          message,
-          buttonMessage: this.buttonMessage,
-        });
+  beforeRouteLeave(to, from, next) {
+    const isNotificationForThisRoute =
+      !this.areResponsesUntouched &&
+      ["datasets", "dataseat-id-settings", "user-settings"].includes(to.name);
+
+    if (isNotificationForThisRoute) {
+      this.showNotification({
+        eventToFireOnClick: next,
+        message: this.toastMessageOnLeavingRoute,
+        buttonMessage: this.buttonMessage,
+      });
     } else {
       next();
     }
@@ -127,7 +118,11 @@ export default {
   },
   created() {
     this.checkIfUrlHaveRecordStatusOrInitiateQueryParams();
-    this.toastMessage = "Your changes will be lost if you refresh the page";
+
+    this.toastMessageOnRefresh =
+      "Your changes will be lost if you refresh the page";
+    this.toastMessageOnLeavingRoute =
+      "Your changes will be lost if you leave the current page";
     this.buttonMessage = LABEL_PROPERTIES.CONTINUE;
     this.typeOfToast = "warning";
   },
@@ -201,7 +196,7 @@ export default {
           eventToFireOnClick: async () => {
             await this.deleteRecordsAndRefreshDataset();
           },
-          message: this.toastMessage,
+          message: this.toastMessageOnRefresh,
           buttonMessage: this.buttonMessage,
           typeOfToast: "warning",
         });

--- a/frontend/pages/dataset/_id/annotation-mode/index.vue
+++ b/frontend/pages/dataset/_id/annotation-mode/index.vue
@@ -56,7 +56,7 @@ export default {
       areResponsesUntouched: true, // NOTE - this flag is used to show or to not show a toast when questionnaire is touched (to prevent loosing current modification)
     };
   },
-  beforeRouteLeave(to, from, next) {
+  async beforeRouteLeave(to, from, next) {
     if (!this.areResponsesUntouched) {
       let message = "";
       switch (to.name) {
@@ -66,7 +66,7 @@ export default {
           message = "Your changes will be lost if you leave the current page";
           break;
         default:
-        // do nothing
+          await next();
       }
       message.length &&
         this.showNotification({


### PR DESCRIPTION
# Description
After the questionnaire have been touched, when the user try to logout , the user icon disappear and nothing seems to happend. 
This behaviour was happenning because the `next` function  was not fired by default on the `beforeRouteLeave` from the annotated-mode page.

**Type of change**
- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
- only feedback task => edit the formular questionnnaire without submit/discard/clear and then try to logout
