### PR TITLE
Fix function-args retrieval and file-deletion after train

### DIFF
--- a/docs/_source/community/developer_docs.md
+++ b/docs/_source/community/developer_docs.md
@@ -38,7 +38,7 @@ git remote add upstream https://github.com/argilla-io/argilla.git
 
 ### Install dependencies
 
-To be able to use Argilla via either the Python client or the Python Command Line Interface (CLI), you'll need to 
+To be able to use Argilla via either the Python client or the Python Command Line Interface (CLI), you'll need to
 install `argilla` and its extra dependencies, if applicable. To do so, you can either install it via `pip` or setup
 a Conda environment with all the required dependencies.
 
@@ -75,7 +75,7 @@ conda env create -f environment_dev.yml
 conda activate argilla
 ```
 
-In the new Conda environment, *Argilla* will already be installed in [editable mode](https://pip.pypa.io/en/stable/cli/pip_install/#install-editable) 
+In the new Conda environment, *Argilla* will already be installed in [editable mode](https://pip.pypa.io/en/stable/cli/pip_install/#install-editable)
 with all the server dependencies. But if you're willing to install any other dependency you can do so via `pip` to install your own, or just
 see the available extras besides the `server` extras, which are: `listeners`, `postgresql`, and `tests`; all those installable as `pip install -e ".[<EXTRA_NAME>]"`.
 

--- a/src/argilla/training/setfit.py
+++ b/src/argilla/training/setfit.py
@@ -72,18 +72,14 @@ class ArgillaSetFitTrainer(ArgillaTransformersTrainer):
 
     def update_config(
         self,
-        **setfit_kwargs,
+        **kwargs,
     ):
         """
         Updates the `setfit_model_kwargs` and `setfit_trainer_kwargs` dictionaries with the keyword
         arguments passed to the `update_config` function.
         """
-        from setfit import SetFitTrainer
-
-        self.setfit_model_kwargs.update(setfit_kwargs)
-
-        self.setfit_trainer_kwargs.update(setfit_kwargs)
-        self.setfit_trainer_kwargs = filter_allowed_args(SetFitTrainer.__init__, **self.setfit_trainer_kwargs)
+        self.setfit_model_kwargs.update((k, v) for k, v in kwargs.items() if k in self.setfit_model_kwargs)
+        self.setfit_trainer_kwargs.update((k, v) for k, v in kwargs.items() if k in self.setfit_trainer_kwargs)
 
     def __repr__(self):
         formatted_string = []

--- a/src/argilla/training/setfit.py
+++ b/src/argilla/training/setfit.py
@@ -47,7 +47,17 @@ class ArgillaSetFitTrainer(ArgillaTransformersTrainer):
     def init_training_args(self):
         from setfit import SetFitModel, SetFitTrainer
 
-        self.setfit_model_kwargs = get_default_args(SetFitModel.from_pretrained)
+        # SetFit only: we get both the HuggingFace Hub args and the SetFit-specific args
+        # We get the default args for `_from_pretrained` first to override the shared args
+        # with the HuggingFace Hub specific args
+        self.setfit_model_kwargs = get_default_args(SetFitModel._from_pretrained)
+        self.setfit_model_kwargs.update(get_default_args(SetFitModel.from_pretrained))
+
+        # Due to an inconsistency between `pretrained_model_name_or_path` with both `model_id` and `revision`
+        # we pop both `model_id` and `revision`
+        self.setfit_model_kwargs.pop("model_id", None)
+        self.setfit_model_kwargs.pop("revision", None)
+
         self.setfit_model_kwargs["pretrained_model_name_or_path"] = self._model
         self.setfit_model_kwargs["multi_target_strategy"] = self.multi_target_strategy
         self.setfit_model_kwargs["device"] = self.device

--- a/src/argilla/training/setfit.py
+++ b/src/argilla/training/setfit.py
@@ -44,7 +44,7 @@ class ArgillaSetFitTrainer(ArgillaTransformersTrainer):
             self._column_mapping = {"text": "text", "label": "label"}
         self.init_training_args()
 
-    def init_training_args(self):
+    def init_training_args(self) -> None:
         from setfit import SetFitModel, SetFitTrainer
 
         # SetFit only: we get both the HuggingFace Hub args and the SetFit-specific args
@@ -73,7 +73,7 @@ class ArgillaSetFitTrainer(ArgillaTransformersTrainer):
     def update_config(
         self,
         **kwargs,
-    ):
+    ) -> None: 
         """
         Updates the `setfit_model_kwargs` and `setfit_trainer_kwargs` dictionaries with the keyword
         arguments passed to the `update_config` function.

--- a/src/argilla/training/setfit.py
+++ b/src/argilla/training/setfit.py
@@ -73,7 +73,7 @@ class ArgillaSetFitTrainer(ArgillaTransformersTrainer):
     def update_config(
         self,
         **kwargs,
-    ) -> None: 
+    ) -> None:
         """
         Updates the `setfit_model_kwargs` and `setfit_trainer_kwargs` dictionaries with the keyword
         arguments passed to the `update_config` function.

--- a/src/argilla/training/utils.py
+++ b/src/argilla/training/utils.py
@@ -18,7 +18,7 @@ from typing import Dict
 args_to_remove = ["self", "cls", "model_args", "args", "kwargs", "model_kwargs"]
 
 
-def get_default_args(fn):
+def get_default_args(fn) -> dict:
     """
     It takes a function and returns a dictionary of the default arguments
 

--- a/tests/training/helpers.py
+++ b/tests/training/helpers.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from argilla.training import ArgillaTrainer
 
 
-def train_with_cleanup(trainer: ArgillaTrainer, output_dir: str, train: bool = True):
+def train_with_cleanup(trainer: ArgillaTrainer, output_dir: str, train: bool = True) -> None:
     try:
         if train:
             trainer.train(output_dir)
@@ -30,7 +30,7 @@ def train_with_cleanup(trainer: ArgillaTrainer, output_dir: str, train: bool = T
             shutil.rmtree(output_dir)
 
 
-def cleanup_spacy_config(trainer: ArgillaTrainer):
+def cleanup_spacy_config(trainer: ArgillaTrainer) -> None:
     for split in ["train", "dev"]:
         path = trainer._trainer.config["paths"][split]
         if path is not None and Path(path).exists():

--- a/tests/training/helpers.py
+++ b/tests/training/helpers.py
@@ -25,9 +25,9 @@ def train_with_cleanup(trainer: ArgillaTrainer, output_dir: str, train: bool = T
             trainer.train(output_dir)
         else:
             trainer.save(output_dir)
-        assert Path(output_dir).exists()
     finally:
-        shutil.rmtree(output_dir)
+        if Path(output_dir).exists():
+            shutil.rmtree(output_dir)
 
 
 def cleanup_spacy_config(trainer: ArgillaTrainer):


### PR DESCRIPTION
# Description

Some `setfit` unit tests were not passing as it can be seen at https://github.com/argilla-io/argilla/actions/runs/5113755403/jobs/9193313124, with the exception `FileNotFound` which was due to the function defined in `tests/training/helpers.py` named `train_with_cleanup` was not properly cleaning the file, since it was trying to `shutil.rmtree` over a file that could or could not exist. I assume that issue was not appearing on other runs since probably the file was cached at some point.

Then after solving that issue, another issue appeared `TypeError: got multiple values for argument 'model_id'`, and `TypeError: got multiple values for argument 'revision'`, which was also leading the `setfit` tests to fail.

That was due to the function defined at `argilla/training/utils.py` named `get_default_args` was not working as expected, since it was having issues with the inheritance of the classmethod `from_pretrained`, and adding some args that were not from the original function such as `model_id` and `revision` which are args from the `_from_pretrained` method, so on, since `from_pretrained` keeps the `kwargs` and then propagates those to `_from_pretrained` (called as part of the return statement), it was receiving the `model_id` and `revision` args set during `from_pretrained`, as well as the ones propagated via `kwargs` since those are not valid args in `from_pretrained`. So on, I've fixed this by using `inspect.getfullargspec` instead, and that seems to work without any issue when inheriting from multiple classes or even inheriting from a MixIn.

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

- [X] Re-run the `setfit` unit tests on Python 3.8, 3.9, and 3.10 and all those are passing properly now

**Checklist**

- [X] I have merged the original branch into my forked branch
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [X] My changes generate no new warnings