### PR TITLE
refactor: `FeedbackDataset.records` are now `FeedbackRecord` instead of Python `dict`

### DIFF
--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -218,13 +218,13 @@ class FeedbackDataset:
         ...     ]
         ... )
         >>> dataset.records
-        [FeedbackRecord(fields={"text": "This is the first record", "label": "positive"}, responses=[{"user_id": None, "values": {"question-1": {"value": "This is the first answer"}, "question-2": {"value": 5}}}])]
+        [FeedbackRecord(fields={"text": "This is the first record", "label": "positive"}, responses=[ResponseSchema(user_id=None, values={"question-1": ValueSchema(value="This is the first answer"), "question-2": ValueSchema(value=5)})])]
         >>> dataset.push_to_argilla(name="my-dataset", workspace="my-workspace")
         >>> dataset.argilla_id
         "..."
         >>> dataset = rg.FeedbackDataset.from_argilla(argilla_id="...")
         >>> dataset.records
-        [FeedbackRecord(fields={"text": "This is the first record", "label": "positive"}, responses=[{"user_id": None, "values": {"question-1": {"value": "This is the first answer"}, "question-2": {"value": 5}}}])]
+        [FeedbackRecord(fields={"text": "This is the first record", "label": "positive"}, responses=[ResponseSchema(user_id=None, values={"question-1": ValueSchema(value="This is the first answer"), "question-2": ValueSchema(value=5)})])]
     """
 
     argilla_id: Optional[str] = None
@@ -474,7 +474,7 @@ class FeedbackDataset:
             ...     ]
             ... )
             >>> dataset.records
-            [FeedbackRecord(fields={"text": "This is the first record", "label": "positive"}, responses=[{"user_id": None, "values": {"question-1": {"value": "This is the first answer"}, "question-2": {"value": 5}}}])]
+            [FeedbackRecord(fields={"text": "This is the first record", "label": "positive"}, responses=[ResponseSchema(user_id=None, values={"question-1": ValueSchema(value="This is the first answer"), "question-2": ValueSchema(value=5)})])]
         """
         if isinstance(records, list):
             records = [FeedbackRecord(**record) if isinstance(record, dict) else record for record in records]

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -437,6 +437,7 @@ class FeedbackDataset:
                 with the fields of the record.
 
         Raises:
+            ValueError: if the given records are an empty list.
             ValueError: if the given records are neither: `FeedbackRecord`, list of `FeedbackRecord`,
                 list of dictionaries as a record or dictionary as a record.
             ValueError: if the given records do not match the expected schema.
@@ -479,6 +480,8 @@ class FeedbackDataset:
             [FeedbackRecord(fields={"text": "This is the first record", "label": "positive"}, responses=[ResponseSchema(user_id=None, values={"question-1": ValueSchema(value="This is the first answer"), "question-2": ValueSchema(value=5)})])]
         """
         if isinstance(records, list):
+            if len(records) == 0:
+                raise ValueError("Expected `records` to be a non-empty list of `dict` or `rg.FeedbackRecord`.")
             new_records = []
             for record in records:
                 if isinstance(record, dict):

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -437,6 +437,8 @@ class FeedbackDataset:
                 with the fields of the record.
 
         Raises:
+            ValueError: if the given records are neither: `FeedbackRecord`, list of `FeedbackRecord`,
+                list of dictionaries as a record or dictionary as a record.
             ValueError: if the given records do not match the expected schema.
 
         Examples:
@@ -477,11 +479,23 @@ class FeedbackDataset:
             [FeedbackRecord(fields={"text": "This is the first record", "label": "positive"}, responses=[ResponseSchema(user_id=None, values={"question-1": ValueSchema(value="This is the first answer"), "question-2": ValueSchema(value=5)})])]
         """
         if isinstance(records, list):
-            records = [FeedbackRecord(**record) if isinstance(record, dict) else record for record in records]
-        if isinstance(records, dict):
+            for record in records:
+                if isinstance(record, dict):
+                    self.add_records(record)
+                elif isinstance(record, FeedbackRecord):
+                    self.add_records(record)
+                else:
+                    raise ValueError(
+                        f"Expected `records` to be a list of `dict` or `rg.FeedbackRecord`, got type {type(record)} instead."
+                    )
+        elif isinstance(records, dict):
             records = [FeedbackRecord(**records)]
-        if isinstance(records, FeedbackRecord):
+        elif isinstance(records, FeedbackRecord):
             records = [records]
+        else:
+            raise ValueError(
+                f"Expected `records` to be a `dict` or `rg.FeedbackRecord`, got type {type(records)} instead."
+            )
 
         if self.__fields_schema is None:
             self.__fields_schema = generate_pydantic_schema(self.fields)

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -970,7 +970,7 @@ class FeedbackDataset:
                     fields={field.name: hfds[index][field.name] for field in cls.fields},
                     responses=list(responses.values()) or None,
                     external_id=hfds[index]["external_id"],
-                ).dict()
+                )
             )
         del hfds
         return cls

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -31,6 +31,7 @@ from pydantic import (
     StrictStr,
     ValidationError,
     create_model,
+    parse_obj_as,
     validator,
 )
 from tqdm import tqdm
@@ -402,7 +403,7 @@ class FeedbackDataset:
             first_batch = datasets_api_v1.get_records(
                 client=httpx_client, id=self.argilla_id, offset=0, limit=FETCHING_BATCH_SIZE
             ).parsed
-            self.__records = [FeedbackRecord(**item.dict()) for item in first_batch.items]
+            self.__records = parse_obj_as(List[FeedbackRecord], first_batch.items)
             current_batch = 1
             # TODO(alvarobartt): use `total` from Argilla Metrics API
             with tqdm(
@@ -416,7 +417,7 @@ class FeedbackDataset:
                         offset=FETCHING_BATCH_SIZE * current_batch,
                         limit=FETCHING_BATCH_SIZE,
                     ).parsed
-                    records = [FeedbackRecord(**item.dict()) for item in batch.items]
+                    records = parse_obj_as(List[FeedbackRecord], batch.items)
                     self.__records += records
                     current_batch += 1
                     pbar.update(1)

--- a/src/argilla/client/feedback.py
+++ b/src/argilla/client/feedback.py
@@ -479,15 +479,17 @@ class FeedbackDataset:
             [FeedbackRecord(fields={"text": "This is the first record", "label": "positive"}, responses=[ResponseSchema(user_id=None, values={"question-1": ValueSchema(value="This is the first answer"), "question-2": ValueSchema(value=5)})])]
         """
         if isinstance(records, list):
+            new_records = []
             for record in records:
                 if isinstance(record, dict):
-                    self.add_records(record)
+                    new_records.append(FeedbackRecord(**record))
                 elif isinstance(record, FeedbackRecord):
-                    self.add_records(record)
+                    new_records.append(record)
                 else:
                     raise ValueError(
                         f"Expected `records` to be a list of `dict` or `rg.FeedbackRecord`, got type {type(record)} instead."
                     )
+            records = new_records
         elif isinstance(records, dict):
             records = [FeedbackRecord(**records)]
         elif isinstance(records, FeedbackRecord):

--- a/src/argilla/client/sdk/v1/datasets/api.py
+++ b/src/argilla/client/sdk/v1/datasets/api.py
@@ -207,7 +207,7 @@ def get_records(
     )
 
     if response.status_code == 200:
-        parsed_response = FeedbackRecordsModel.construct(**response.json())
+        parsed_response = FeedbackRecordsModel(**response.json())
         return Response(
             status_code=response.status_code,
             content=response.content,
@@ -286,7 +286,7 @@ def get_fields(
     response = client.get(url=url)
 
     if response.status_code == 200:
-        parsed_response = [FeedbackFieldModel.construct(**item) for item in response.json()["items"]]
+        parsed_response = [FeedbackFieldModel(**item) for item in response.json()["items"]]
         return Response(
             status_code=response.status_code,
             content=response.content,
@@ -343,7 +343,7 @@ def get_questions(
     response = client.get(url=url)
 
     if response.status_code == 200:
-        parsed_response = [FeedbackQuestionModel.construct(**item) for item in response.json()["items"]]
+        parsed_response = [FeedbackQuestionModel(**item) for item in response.json()["items"]]
         return Response(
             status_code=response.status_code,
             content=response.content,

--- a/tests/client/sdk/v1/datasets/test_api.py
+++ b/tests/client/sdk/v1/datasets/test_api.py
@@ -323,4 +323,4 @@ def test_get_records(mocked_client, sdk_client, monkeypatch) -> None:
     assert response.status_code == 200
     assert isinstance(response.parsed, FeedbackRecordsModel)
     assert len(response.parsed.items) > 0
-    assert FeedbackItemModel(**response.parsed.items[0])
+    assert FeedbackItemModel(**response.parsed.items[0].dict())

--- a/tests/client/test_feedback.py
+++ b/tests/client/test_feedback.py
@@ -184,6 +184,15 @@ def test_records(
         "status": "submitted",
     }
 
+    with pytest.raises(ValueError, match="Expected `records` to be a non-empty list"):
+        dataset.add_records([])
+
+    with pytest.raises(ValueError, match="Expected `records` to be a list of `dict` or `rg.FeedbackRecord`"):
+        dataset.add_records([None])
+
+    with pytest.raises(ValueError, match="Expected `records` to be a `dict` or `rg.FeedbackRecord`"):
+        dataset.add_records(None)
+
     with pytest.raises(ValueError, match="`rg.FeedbackRecord.fields` does not match the expected schema"):
         dataset.add_records(
             [

--- a/tests/client/test_feedback.py
+++ b/tests/client/test_feedback.py
@@ -145,11 +145,11 @@ def test_records(
     )
 
     assert len(dataset.records) == 1
-    assert dataset.records[0]["fields"] == {
+    assert dataset.records[0].fields == {
         "text": "A",
         "label": "B",
     }
-    assert dataset.records[0]["responses"] == []
+    assert dataset.records[0].responses == []
 
     dataset.add_records(
         [
@@ -171,20 +171,18 @@ def test_records(
     )
 
     assert len(dataset.records) == 2
-    assert dataset.records[1]["fields"] == {
+    assert dataset.records[1].fields == {
         "text": "C",
         "label": "D",
     }
-    assert dataset.records[1]["responses"] == [
-        {
-            "user_id": None,
-            "values": {
-                "question-1": {"value": "answer"},
-                "question-2": {"value": 0},
-            },
-            "status": "submitted",
+    assert dataset.records[1].responses[0].dict() == {
+        "user_id": None,
+        "values": {
+            "question-1": {"value": "answer"},
+            "question-2": {"value": 0},
         },
-    ]
+        "status": "submitted",
+    }
 
     with pytest.raises(ValueError, match="`rg.FeedbackRecord.fields` does not match the expected schema"):
         dataset.add_records(
@@ -198,18 +196,12 @@ def test_records(
         )
 
     for record in dataset.records:
-        assert all(
-            key in ["id", "fields", "external_id", "responses", "inserted_at", "updated_at"]
-            for key in list(record.keys())
-        )
+        assert isinstance(record, FeedbackRecord)
 
     for batch in dataset.iter(batch_size=1):
         assert len(batch) == 1
         for record in batch:
-            assert all(
-                key in ["id", "fields", "external_id", "responses", "inserted_at", "updated_at"]
-                for key in list(record.keys())
-            )
+            assert isinstance(record, FeedbackRecord)
 
     assert len(dataset[:2]) == 2
     assert len(dataset[1:2]) == 1
@@ -309,9 +301,7 @@ def test_push_to_argilla_and_from_argilla(
         question.name for question in dataset.questions
     ]
     assert len(dataset_from_argilla.records) == len(dataset.records)
-    assert (
-        len(dataset_from_argilla.records[-1]["responses"]) == 1
-    )  # Since the second one was discarded as `user_id=None`
+    assert len(dataset_from_argilla.records[-1].responses) == 1  # Since the second one was discarded as `user_id=None`
 
 
 @pytest.mark.usefixtures(


### PR DESCRIPTION
# Description

As of a recent discussion with @frascuchon we should return the `FeedbackRecord` `pydantic.BaseModel` itself, instead of the Python dict conversion of it. So this PR basically removes all the `.dict()` conversion towards the Python client, while it's kept in the API. Besides that we also use `pydantic.BaseModel` validation instead of using `.construct` when there are nested `pydantic.BaseModels`.

Docs have been updated accordingly at #3036 

**Type of change**

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (change restructuring the codebase without changing functionality)
- [X] Documentation update

**How Has This Been Tested**

- [X] Updated unit tests accordingly

**Checklist**

- [X] I have merged the original branch into my forked branch
- [X] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [X] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works