### PR TITLE
Delete elasticsearch index when a dataset is removed from DB

### DIFF
--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -307,9 +307,10 @@ async def publish_dataset(
 
 
 @router.delete("/datasets/{dataset_id}", response_model=Dataset)
-def delete_dataset(
+async def delete_dataset(
     *,
     db: Session = Depends(get_db),
+    search_engine=Depends(get_search_engine),
     dataset_id: UUID,
     current_user: User = Security(auth.get_current_user),
 ):
@@ -317,6 +318,6 @@ def delete_dataset(
 
     dataset = _get_dataset(db, dataset_id)
 
-    datasets.delete_dataset(db, dataset)
+    await datasets.delete_dataset(db, search_engine, dataset=dataset)
 
     return dataset

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -101,8 +101,10 @@ async def publish_dataset(db: Session, search_engine: SearchEngine, dataset: Dat
     return dataset
 
 
-def delete_dataset(db: Session, dataset: Dataset):
+async def delete_dataset(db: Session, search_engine: SearchEngine, dataset: Dataset):
     db.delete(dataset)
+    await search_engine.delete_index(dataset)
+
     db.commit()
 
     return dataset

--- a/src/argilla/server/search_engine.py
+++ b/src/argilla/server/search_engine.py
@@ -63,6 +63,9 @@ class SearchDocument(BaseModel):
 class SearchEngine:
     config: Dict[str, Any]
 
+    es_number_of_shards: int
+    es_number_of_replicas: int
+
     def __post_init__(self):
         self.client = AsyncOpenSearch(**self.config)
 
@@ -93,8 +96,13 @@ class SearchEngine:
             "properties": fields,
         }
 
+        settings = {
+            "number_of_shards": self.es_number_of_shards,
+            "number_of_replicas": self.es_number_of_replicas,
+        }
+
         index_name = self._index_name_for_dataset(dataset)
-        await self.client.indices.create(index=index_name, body=dict(mappings=mappings))
+        await self.client.indices.create(index=index_name, body=dict(settings=settings, mappings=mappings))
 
     async def delete_index(self, dataset: Dataset):
         index_name = self._index_name_for_dataset(dataset)
@@ -155,7 +163,11 @@ async def get_search_engine():
         retry_on_timeout=True,
         max_retries=5,
     )
-    search_engine = SearchEngine(config)
+    search_engine = SearchEngine(
+        config,
+        es_number_of_shards=settings.es_records_index_shards,
+        es_number_of_replicas=settings.es_records_index_shards,
+    )
     try:
         yield search_engine
     finally:

--- a/src/argilla/server/search_engine.py
+++ b/src/argilla/server/search_engine.py
@@ -96,6 +96,10 @@ class SearchEngine:
         index_name = self._index_name_for_dataset(dataset)
         await self.client.indices.create(index=index_name, body=dict(mappings=mappings))
 
+    async def delete_index(self, dataset: Dataset):
+        index_name = self._index_name_for_dataset(dataset)
+        await self.client.indices.delete(index_name, ignore=[404], ignore_unavailable=True)
+
     def _field_mapping_for_question(self, question: Question):
         settings = question.parsed_settings
 

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -2396,7 +2396,7 @@ def test_publish_dataset_with_nonexistent_dataset_id(client: TestClient, db: Ses
     assert db.get(Dataset, dataset.id).status == "draft"
 
 
-def test_delete_dataset(client: TestClient, db: Session, admin: User, admin_auth_header: dict):
+def test_delete_dataset(client: TestClient, db: Session, opensearch: OpenSearch, admin: User, admin_auth_header: dict):
     dataset = DatasetFactory.create()
     TextFieldFactory.create(dataset=dataset)
     TextQuestionFactory.create(dataset=dataset)
@@ -2419,6 +2419,7 @@ def test_delete_dataset(client: TestClient, db: Session, admin: User, admin_auth
         dataset.workspace_id,
         other_dataset.workspace_id,
     ]
+    assert not opensearch.indices.exists(index=f"rg.{dataset.id}")
 
 
 def test_delete_published_dataset(client: TestClient, db: Session, admin: User, admin_auth_header: dict):

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -23,7 +23,7 @@ from argilla.server.services.datasets import DatasetsService
 
 @pytest_asyncio.fixture()
 async def search_engine(elasticsearch_config: dict):
-    engine = SearchEngine(config=elasticsearch_config)
+    engine = SearchEngine(config=elasticsearch_config, es_number_of_replicas=0, es_number_of_shards=1)
     yield engine
 
     await engine.client.close()

--- a/tests/server/test_search_engine.py
+++ b/tests/server/test_search_engine.py
@@ -44,6 +44,8 @@ class TestSuiteElasticSearchEngine:
                 "responses": {"dynamic": "true", "type": "object"},
             },
         }
+        assert index["settings"]["index"]["number_of_shards"] == str(search_engine.es_number_of_shards)
+        assert index["settings"]["index"]["number_of_replicas"] == str(search_engine.es_number_of_replicas)
 
     async def test_create_index_for_dataset_with_fields(
         self,


### PR DESCRIPTION
# Description

Remove the created es index when a dataset is deleted.
Also, control the number of shards and replicas used for each index.

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

Included check on current tests

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)