### PR TITLE
Review elasticsearch mappings for question responses info

### DIFF
--- a/tests/server/test_search_engine.py
+++ b/tests/server/test_search_engine.py
@@ -146,9 +146,8 @@ class TestSuiteElasticSearchEngine:
         label_questions = LabelSelectionQuestionFactory.create_batch(size=text_ann_size)
         multilabel_questions = MultiLabelSelectionQuestionFactory.create_batch(size=rating_ann_size)
 
-        dataset = DatasetFactory.create(
-            questions=(text_questions + rating_questions) + (label_questions + multilabel_questions)
-        )
+        all_questions = text_questions + rating_questions + label_questions + multilabel_questions
+        dataset = DatasetFactory.create(questions=all_questions)
 
         await search_engine.create_index(dataset)
 

--- a/tests/server/test_search_engine.py
+++ b/tests/server/test_search_engine.py
@@ -24,6 +24,8 @@ from sqlalchemy.orm import Session
 
 from tests.factories import (
     DatasetFactory,
+    LabelSelectionQuestionFactory,
+    MultiLabelSelectionQuestionFactory,
     RatingQuestionFactory,
     RecordFactory,
     TextFieldFactory,
@@ -89,7 +91,9 @@ class TestSuiteElasticSearchEngine:
         index = opensearch.indices.get(index=index_name)[index_name]
         assert index["mappings"] == {
             "dynamic": "strict",
-            "dynamic_templates": [],
+            "dynamic_templates": [
+                {"status_responses": {"mapping": {"type": "keyword"}, "path_match": "responses.*.status"}}
+            ],
             "properties": {
                 "id": {"type": "keyword"},
                 "responses": {"dynamic": "true", "type": "object"},
@@ -115,7 +119,9 @@ class TestSuiteElasticSearchEngine:
         index = opensearch.indices.get(index=index_name)[index_name]
         assert index["mappings"] == {
             "dynamic": "strict",
-            "dynamic_templates": [],
+            "dynamic_templates": [
+                {"status_responses": {"mapping": {"type": "keyword"}, "path_match": "responses.*.status"}}
+            ],
             "properties": {
                 "id": {"type": "keyword"},
                 "fields": {"properties": {field.name: {"type": "text"} for field in dataset.fields}},
@@ -137,8 +143,12 @@ class TestSuiteElasticSearchEngine:
     ):
         text_questions = TextQuestionFactory.create_batch(size=text_ann_size)
         rating_questions = RatingQuestionFactory.create_batch(size=rating_ann_size)
+        label_questions = LabelSelectionQuestionFactory.create_batch(size=text_ann_size)
+        multilabel_questions = MultiLabelSelectionQuestionFactory.create_batch(size=rating_ann_size)
 
-        dataset = DatasetFactory.create(questions=text_questions + rating_questions)
+        dataset = DatasetFactory.create(
+            questions=(text_questions + rating_questions) + (label_questions + multilabel_questions)
+        )
 
         await search_engine.create_index(dataset)
 
@@ -153,6 +163,7 @@ class TestSuiteElasticSearchEngine:
                 "responses": {"dynamic": "true", "type": "object"},
             },
             "dynamic_templates": [
+                {"status_responses": {"mapping": {"type": "keyword"}, "path_match": "responses.*.status"}},
                 *[
                     config
                     for question in text_questions
@@ -172,6 +183,18 @@ class TestSuiteElasticSearchEngine:
                         {
                             f"{question.name}_responses": {
                                 "mapping": {"type": "integer"},
+                                "path_match": f"responses.*.values.{question.name}",
+                            }
+                        },
+                    ]
+                ],
+                *[
+                    config
+                    for question in label_questions + multilabel_questions
+                    for config in [
+                        {
+                            f"{question.name}_responses": {
+                                "mapping": {"type": "keyword"},
                                 "path_match": f"responses.*.values.{question.name}",
                             }
                         },


### PR DESCRIPTION
# Description

This PR defines the mapping config for label and multilabel selection response values as `keyword`, which is more accurate to terminological filtering related to these responses.

Also, the response status mapping is defined as a `keyword`, for similar reasons.


**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

Existing tests have been adapted

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)