### PR TITLE
fix: wrong `FeedbackDatasetConfig` parsing in `from_huggingface`

### DIFF
--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -147,3 +147,6 @@ class FeedbackDatasetConfig(BaseModel):
     fields: List[AllowedFieldTypes]
     questions: List[AllowedQuestionTypes]
     guidelines: Optional[str] = None
+
+    class Config:
+        smart_union = True

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -124,6 +124,10 @@ class TextQuestion(QuestionSchema):
             values["settings"]["use_markdown"] = v
         return False
 
+    class Config:
+        validate_assignment = True
+        extra = Extra.forbid
+
 
 class RatingQuestion(QuestionSchema):
     settings: Dict[str, Any] = Field({"type": "rating"})
@@ -137,6 +141,7 @@ class RatingQuestion(QuestionSchema):
 
     class Config:
         validate_assignment = True
+        extra = Extra.forbid
 
 
 AllowedFieldTypes = TextField

--- a/tests/client/feedback/test_dataset.py
+++ b/tests/client/feedback/test_dataset.py
@@ -360,3 +360,6 @@ def test_push_to_huggingface_and_from_huggingface(
     assert isinstance(dataset_from_huggingface, FeedbackDataset)
     assert dataset_from_huggingface.guidelines == dataset.guidelines
     assert len(dataset_from_huggingface.fields) == len(dataset.fields)
+    assert all(original_field in dataset_from_huggingface.fields for original_field in dataset.fields)
+    assert len(dataset_from_huggingface.questions) == len(dataset.questions)
+    assert all(original_question in dataset_from_huggingface.questions for original_question in dataset.questions)


### PR DESCRIPTION
# Description

When loading back a dataset previously pushed to the HuggingFace Hub via `push_to_huggingface`, the config was not being properly parsed when reading it from the HuggingFace Hub repository, as there was an `Union` in the `pydantic.BaseModel` that was ignored. So when the first value was parsed e.g. `TextQuestion`, then that model was kept and the remaining values were parsed using the same model, even though the type-hint was e.g. `Union[TextQuestion, RatingQuestion, ...]`.

Using `Config.smart_union = True` solves it, as the `Union` is properly identified and the parsing is "smart".

Besides that, I also had to restrict the `pydantic.BaseModel`s to be unique, since both could parse any question, so adding `Config.extra = forbid` solves it.

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

- [x] Add unit tests to make sure that the types of the loaded `fields` and `questions` from the `FeedbackDatasetConfig` match the ones originally dumped

**Checklist**

- [X] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)