### PR TITLE
Use different question settings for requests and responses

### DIFF
--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -25,7 +25,13 @@ try:
 except ImportError:
     from typing_extensions import Annotated, Literal
 
-from argilla.server.models import DatasetStatus, FieldType, QuestionType, ResponseStatus
+from argilla.server.models import (
+    DatasetStatus,
+    FieldType,
+    QuestionSettings,
+    QuestionType,
+    ResponseStatus,
+)
 
 DATASET_CREATE_GUIDELINES_MIN_LENGTH = 1
 DATASET_CREATE_GUIDELINES_MAX_LENGTH = 10000
@@ -140,7 +146,7 @@ class FieldCreate(BaseModel):
     settings: TextFieldSettings
 
 
-class TextQuestionSettings(BaseModel):
+class TextQuestionSettingsCreate(BaseModel):
     type: Literal[QuestionType.text]
     use_markdown: bool = False
 
@@ -165,7 +171,7 @@ class RatingQuestionSettingsOption(BaseModel):
     value: int
 
 
-class RatingQuestionSettings(UniqueValuesCheckerMixin):
+class RatingQuestionSettingsCreate(UniqueValuesCheckerMixin):
     type: Literal[QuestionType.rating]
     options: conlist(
         item_type=RatingQuestionSettingsOption,
@@ -191,7 +197,7 @@ class LabelSelectionQuestionSettingsOption(BaseModel):
     ] = None
 
 
-class LabelSelectionQuestionSettings(UniqueValuesCheckerMixin):
+class LabelSelectionQuestionSettingsCreate(UniqueValuesCheckerMixin):
     type: Literal[QuestionType.label_selection]
     options: conlist(
         item_type=LabelSelectionQuestionSettingsOption,
@@ -201,16 +207,16 @@ class LabelSelectionQuestionSettings(UniqueValuesCheckerMixin):
     visible_options: Optional[PositiveInt] = None
 
 
-class MultiLabelSelectionQuestionSettings(LabelSelectionQuestionSettings):
+class MultiLabelSelectionQuestionSettingsCreate(LabelSelectionQuestionSettingsCreate):
     type: Literal[QuestionType.multi_label_selection]
 
 
-QuestionSettings = Annotated[
+QuestionSettingsCreate = Annotated[
     Union[
-        TextQuestionSettings,
-        RatingQuestionSettings,
-        LabelSelectionQuestionSettings,
-        MultiLabelSelectionQuestionSettings,
+        TextQuestionSettingsCreate,
+        RatingQuestionSettingsCreate,
+        LabelSelectionQuestionSettingsCreate,
+        MultiLabelSelectionQuestionSettingsCreate,
     ],
     PydanticField(discriminator="type"),
 ]
@@ -251,7 +257,7 @@ class QuestionCreate(BaseModel):
         )
     ]
     required: Optional[bool]
-    settings: QuestionSettings
+    settings: QuestionSettingsCreate
 
 
 class ResponseValue(BaseModel):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -124,6 +124,7 @@ class QuestionFactory(BaseFactory):
     title = "Question Title"
     description = "Question Description"
     dataset = factory.SubFactory(DatasetFactory)
+    settings = {}
 
 
 class TextQuestionFactory(QuestionFactory):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -111,6 +111,15 @@ class QuestionFactory(BaseFactory):
     class Meta:
         model = Question
 
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        default_settings = cls.settings.copy()
+        settings = kwargs.get("settings", {})
+        if settings:
+            default_settings.update(settings)
+            kwargs["settings"] = default_settings
+        return super()._create(model_class, *args, **kwargs)
+
     name = factory.Sequence(lambda n: f"question-{n}")
     title = "Question Title"
     description = "Question Description"

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Type
+from typing import Type
 from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
@@ -65,9 +65,6 @@ from tests.factories import (
     TextQuestionFactory,
     WorkspaceFactory,
 )
-
-if TYPE_CHECKING:
-    from tests.factories import QuestionFactory
 
 
 def test_list_current_user_datasets(client: TestClient, admin_auth_header: dict):
@@ -299,7 +296,7 @@ def test_list_dataset_questions(client: TestClient, admin_auth_header: dict):
     ],
 )
 def test_list_dataset_questions_with_duplicate_values(
-    client: TestClient, admin_auth_header: dict, QuestionFactory: Type["QuestionFactory"], settings: dict
+    client: TestClient, admin_auth_header: dict, QuestionFactory: Type[QuestionFactory], settings: dict
 ):
     dataset = DatasetFactory.create()
     question = QuestionFactory.create(dataset=dataset, settings=settings)

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 from datetime import datetime
+from typing import TYPE_CHECKING, Type
 from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
@@ -64,6 +65,9 @@ from tests.factories import (
     TextQuestionFactory,
     WorkspaceFactory,
 )
+
+if TYPE_CHECKING:
+    from tests.factories import QuestionFactory
 
 
 def test_list_current_user_datasets(client: TestClient, admin_auth_header: dict):
@@ -295,7 +299,7 @@ def test_list_dataset_questions(client: TestClient, admin_auth_header: dict):
     ],
 )
 def test_list_dataset_questions_with_duplicate_values(
-    client: TestClient, admin_auth_header: dict, QuestionFactory, settings
+    client: TestClient, admin_auth_header: dict, QuestionFactory: Type["QuestionFactory"], settings: dict
 ):
     dataset = DatasetFactory.create()
     question = QuestionFactory.create(dataset=dataset, settings=settings)


### PR DESCRIPTION
# Description

This PR adapts changes introduced in #3055 to avoid applying validation on response models. So, the `QuestionCreate` input schema will use `QuestionSettingsCreate` pydantic models, which include the data validation. On the other hand, the `Question` response schema will use `QuestionSettings` which has no data validation.

**Type of change**

- [x] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

New tests have been included

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)