### PR TITLE
refactor: mocking search engine for api tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,7 @@ def db(connection: "Connection") -> Generator["Session", None, None]:
 
 
 @pytest.fixture(scope="function")
-def search_engine():
+def search_engine() -> Generator["MockSearchEngine", None, None]:
     # TODO: MockSearchEngine will implement the SearchEngine once is defined as an interface
     class MockSearchEngine:
         async def create_index(self, dataset):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ from argilla.server.commons import telemetry
 from argilla.server.commons.telemetry import TelemetryClient
 from argilla.server.database import Base, get_db
 from argilla.server.models import User, UserRole, Workspace
+from argilla.server.search_engine import SearchEngine, get_search_engine
 from argilla.server.server import app, argilla_app
 from argilla.server.settings import settings
 from fastapi.testclient import TestClient
@@ -73,13 +74,39 @@ def db(connection: "Connection") -> Generator["Session", None, None]:
 
 
 @pytest.fixture(scope="function")
-def client(request) -> Generator[TestClient, None, None]:
+def search_engine():
+    # TODO: MockSearchEngine will implement the SearchEngine once is defined as an interface
+    class MockSearchEngine:
+        async def create_index(self, dataset):
+            pass
+
+        async def delete_index(self, dataset):
+            pass
+
+        async def add_records(self, dataset, records):
+            pass
+
+        async def update_record_responses(self, record, responses):
+            pass
+
+        async def search(self, dataset, query, user_response_status_filter, limit):
+            pass
+
+    yield MockSearchEngine()
+
+
+@pytest.fixture(scope="function")
+def client(request, search_engine: SearchEngine) -> Generator[TestClient, None, None]:
     session = TestSession()
 
     def override_get_db():
         yield session
 
+    async def override_get_search_engine():
+        yield search_engine
+
     argilla_app.dependency_overrides[get_db] = override_get_db
+    argilla_app.dependency_overrides[get_search_engine] = override_get_search_engine
 
     raise_server_exceptions = request.param if hasattr(request, "param") else False
     with TestClient(app, raise_server_exceptions=raise_server_exceptions) as client:

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -2478,10 +2478,12 @@ def test_delete_dataset(
         other_dataset.workspace_id,
     ]
 
-    assert spy_delete_index.assert_called_once_with(dataset=dataset)
+    spy_delete_index.assert_called_once_with(dataset=dataset)
 
 
-def test_delete_published_dataset(client: TestClient, db: Session, admin: User, admin_auth_header: dict):
+def test_delete_published_dataset(
+    mocker, client: TestClient, db: Session, search_engine: SearchEngine, admin: User, admin_auth_header: dict
+):
     dataset = DatasetFactory.create()
     TextFieldFactory.create(dataset=dataset)
     TextQuestionFactory.create(dataset=dataset)
@@ -2508,13 +2510,16 @@ def test_delete_published_dataset(client: TestClient, db: Session, admin: User, 
     ]
 
 
-def test_delete_dataset_without_authentication(client: TestClient, db: Session):
+def test_delete_dataset_without_authentication(mocker, client: TestClient, db: Session, search_engine: SearchEngine):
     dataset = DatasetFactory.create()
+    spy_delete_index = mocker.spy(search_engine, "delete_index")
 
     response = client.delete(f"/api/v1/datasets/{dataset.id}")
 
     assert response.status_code == 401
     assert db.query(Dataset).count() == 1
+
+    assert not spy_delete_index.called
 
 
 def test_delete_dataset_as_annotator(client: TestClient, db: Session):

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from typing import AsyncGenerator
+
 import pytest
 import pytest_asyncio
 from argilla.server.daos.backend import GenericElasticEngineBackend
@@ -22,7 +24,7 @@ from argilla.server.services.datasets import DatasetsService
 
 
 @pytest_asyncio.fixture()
-async def elastic_search_engine(elasticsearch_config: dict):
+async def elastic_search_engine(elasticsearch_config: dict) -> AsyncGenerator[SearchEngine, None]:
     engine = SearchEngine(config=elasticsearch_config, es_number_of_replicas=0, es_number_of_shards=1)
     yield engine
 

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -22,7 +22,7 @@ from argilla.server.services.datasets import DatasetsService
 
 
 @pytest_asyncio.fixture()
-async def search_engine(elasticsearch_config: dict):
+async def elastic_search_engine(elasticsearch_config: dict):
     engine = SearchEngine(config=elasticsearch_config, es_number_of_replicas=0, es_number_of_shards=1)
     yield engine
 

--- a/tests/server/test_search_engine.py
+++ b/tests/server/test_search_engine.py
@@ -34,7 +34,7 @@ from tests.factories import (
 
 
 @pytest_asyncio.fixture()
-async def test_banking_sentiment_dataset(elastic_search_engine):
+async def test_banking_sentiment_dataset(elastic_search_engine: SearchEngine):
     text_question = TextQuestionFactory()
     rating_question = RatingQuestionFactory()
 


### PR DESCRIPTION
# Description

This PR uses a mock search_engine for all API tests and keeps the elastic search implementation tests in the proper test suite. 

TODO: Some tests are missed for the elastic search engine, but they will be included in a separate PR with other enhancements.


**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Refactor (change restructuring the codebase without changing functionality)

**How Has This Been Tested**

Tests have been updated. 

**Checklist**

- [x] I have merged the original branch into my forked branch
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
