### PR TITLE
feat: update response info in search index

### DIFF
--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -358,7 +358,7 @@ async def create_response(
     db.add(response)
     db.flush([response])
     # TODO: Rollback
-    await search_engine.update_record_responses(record, responses=[response])
+    await search_engine.update_record_response(response)
 
     db.commit()
     db.refresh(response)
@@ -376,7 +376,7 @@ async def update_response(
 
     db.flush([response])
     # TODO: Rollback
-    await search_engine.update_record_responses(response.record, responses=[response])
+    await search_engine.update_record_response(response)
 
     db.commit()
     db.refresh(response)

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -343,7 +343,9 @@ def count_records_with_missing_responses_by_dataset_id_and_user_id(db: Session, 
     )
 
 
-def create_response(db: Session, record: Record, user: User, response_create: ResponseCreate):
+async def create_response(
+    db: Session, search_engine: SearchEngine, record: Record, user: User, response_create: ResponseCreate
+):
     validate_response_values(record.dataset, values=response_create.values, status=response_create.status)
 
     response = Response(
@@ -354,26 +356,39 @@ def create_response(db: Session, record: Record, user: User, response_create: Re
     )
 
     db.add(response)
+    db.flush([response])
+    # TODO: Rollback
+    await search_engine.update_record_responses(record, responses=[response])
+
     db.commit()
     db.refresh(response)
 
     return response
 
 
-def update_response(db: Session, response: Response, response_update: ResponseUpdate):
+async def update_response(
+    db: Session, search_engine: SearchEngine, response: Response, response_update: ResponseUpdate
+):
     validate_response_values(response.record.dataset, values=response_update.values, status=response_update.status)
 
     response.values = jsonable_encoder(response_update.values)
     response.status = response_update.status
 
+    db.flush([response])
+    # TODO: Rollback
+    await search_engine.update_record_responses(response.record, responses=[response])
+
     db.commit()
     db.refresh(response)
 
     return response
 
 
-def delete_response(db: Session, response: Response):
+async def delete_response(db: Session, search_engine: SearchEngine, response: Response):
     db.delete(response)
+    # TODO: Rollback
+    await search_engine.delete_record_response(response)
+
     db.commit()
 
     return response

--- a/src/argilla/server/search_engine.py
+++ b/src/argilla/server/search_engine.py
@@ -166,7 +166,7 @@ class SearchEngine:
         await self.client.update(
             index=index_name,
             id=record.id,
-            body={"script": f'ctx._source.remove("responses.{response.user.username}")'},
+            body={"script": f'ctx._source["responses"].remove("{response.user.username}")'},
         )
 
     async def search(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,39 +74,19 @@ def db(connection: "Connection") -> Generator["Session", None, None]:
 
 
 @pytest.fixture(scope="function")
-def search_engine() -> Generator["MockSearchEngine", None, None]:
-    # TODO: MockSearchEngine will implement the SearchEngine once is defined as an interface
-    class MockSearchEngine:
-        async def create_index(self, dataset):
-            pass
-
-        async def delete_index(self, dataset):
-            pass
-
-        async def add_records(self, dataset, records):
-            pass
-
-        async def update_record_responses(self, record, responses):
-            pass
-
-        async def delete_record_response(self, response):
-            pass
-
-        async def search(self, dataset, query, user_response_status_filter, limit):
-            pass
-
-    yield MockSearchEngine()
+def mock_search_engine(mocker) -> Generator["SearchEngine", None, None]:
+    return mocker.AsyncMock(SearchEngine)
 
 
 @pytest.fixture(scope="function")
-def client(request, search_engine: SearchEngine) -> Generator[TestClient, None, None]:
+def client(request, mock_search_engine) -> Generator[TestClient, None, None]:
     session = TestSession()
 
     def override_get_db():
         yield session
 
     async def override_get_search_engine():
-        yield search_engine
+        yield mock_search_engine
 
     argilla_app.dependency_overrides[get_db] = override_get_db
     argilla_app.dependency_overrides[get_search_engine] = override_get_search_engine

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,9 @@ def search_engine() -> Generator["MockSearchEngine", None, None]:
         async def update_record_responses(self, record, responses):
             pass
 
+        async def delete_record_response(self, response):
+            pass
+
         async def search(self, dataset, query, user_response_status_filter, limit):
             pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def mock_search_engine(mocker) -> Generator["SearchEngine", None, None]:
 
 
 @pytest.fixture(scope="function")
-def client(request, mock_search_engine) -> Generator[TestClient, None, None]:
+def client(request, mock_search_engine: SearchEngine) -> Generator[TestClient, None, None]:
     session = TestSession()
 
     def override_get_db():

--- a/tests/server/api/v1/test_records.py
+++ b/tests/server/api/v1/test_records.py
@@ -115,10 +115,9 @@ def create_multi_label_selection_questions(dataset: "Dataset") -> None:
     ],
 )
 def test_create_record_response_with_required_questions(
-    mocker,
     client: TestClient,
     db: Session,
-    search_engine: SearchEngine,
+    mock_search_engine: SearchEngine,
     admin: User,
     admin_auth_header: dict,
     create_questions_func: Callable[["Dataset"], None],
@@ -128,8 +127,6 @@ def test_create_record_response_with_required_questions(
     dataset = DatasetFactory.create()
     create_questions_func(dataset)
     record = RecordFactory.create(dataset=dataset)
-
-    spy_update_record_responses = mocker.spy(search_engine, "update_record_responses")
 
     response_json = {**responses, "status": response_status}
     response = client.post(f"/api/v1/records/{record.id}/responses", headers=admin_auth_header, json=response_json)
@@ -147,8 +144,8 @@ def test_create_record_response_with_required_questions(
         "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
     }
 
-    spy_update_record_responses.assert_called_once_with(
-        record=record, responses=db.query(Response).where(Record.id == record.id).all()
+    mock_search_engine.update_record_response.assert_called_once_with(
+        db.query(Response).where(Record.id == record.id).first()
     )
 
 
@@ -214,10 +211,9 @@ def test_create_submitted_record_response_with_missing_required_questions(client
     ],
 )
 def test_create_record_response_with_missing_required_questions(
-    mocker,
     client: TestClient,
     db: Session,
-    search_engine: SearchEngine,
+    mock_search_engine: SearchEngine,
     admin: User,
     admin_auth_header: dict,
     create_questions_func: Callable[["Dataset"], None],
@@ -227,8 +223,6 @@ def test_create_record_response_with_missing_required_questions(
     dataset = DatasetFactory.create()
     create_questions_func(dataset)
     record = RecordFactory.create(dataset=dataset)
-
-    spy_update_record_responses = mocker.spy(search_engine, "update_record_responses")
 
     response_json = {**responses, "status": response_status}
     response = client.post(f"/api/v1/records/{record.id}/responses", headers=admin_auth_header, json=response_json)
@@ -246,8 +240,8 @@ def test_create_record_response_with_missing_required_questions(
         "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
     }
 
-    spy_update_record_responses.assert_called_once_with(
-        record=record, responses=db.query(Response).where(Record.id == record.id).all()
+    mock_search_engine.update_record_response.assert_called_once_with(
+        db.query(Response).where(Record.id == record.id).first()
     )
 
 

--- a/tests/server/test_search_engine.py
+++ b/tests/server/test_search_engine.py
@@ -82,6 +82,13 @@ async def test_banking_sentiment_dataset(elastic_search_engine: SearchEngine):
 
 @pytest.mark.asyncio
 class TestSuiteElasticSearchEngine:
+    async def test_get_index_or_raise(self, elastic_search_engine: SearchEngine):
+        dataset = DatasetFactory.create()
+        with pytest.raises(
+            ValueError, match=f"Cannot access to index for dataset {dataset.id}: the specified index does not exist"
+        ):
+            await elastic_search_engine._get_index_or_raise(dataset)
+
     async def test_create_index_for_dataset(self, elastic_search_engine: SearchEngine, opensearch: OpenSearch):
         dataset = DatasetFactory.create()
         await elastic_search_engine.create_index(dataset)

--- a/tests/server/test_search_engine.py
+++ b/tests/server/test_search_engine.py
@@ -288,7 +288,7 @@ class TestSuiteElasticSearchEngine:
         question = test_banking_sentiment_dataset.questions[0]
 
         response = ResponseFactory.create(record=record, values={question.name: {"value": "test"}})
-        await elastic_search_engine.update_record_responses(record, responses=[response])
+        await elastic_search_engine.update_record_response(response)
 
         index_name = f"rg.{test_banking_sentiment_dataset.id}"
         opensearch.indices.refresh(index=index_name)

--- a/tests/server/test_search_engine.py
+++ b/tests/server/test_search_engine.py
@@ -28,6 +28,7 @@ from tests.factories import (
     MultiLabelSelectionQuestionFactory,
     RatingQuestionFactory,
     RecordFactory,
+    ResponseFactory,
     TextFieldFactory,
     TextQuestionFactory,
 )
@@ -81,7 +82,7 @@ async def test_banking_sentiment_dataset(elastic_search_engine: SearchEngine):
 
 @pytest.mark.asyncio
 class TestSuiteElasticSearchEngine:
-    async def test_create_index_for_dataset(self, elastic_search_engine, opensearch: OpenSearch):
+    async def test_create_index_for_dataset(self, elastic_search_engine: SearchEngine, opensearch: OpenSearch):
         dataset = DatasetFactory.create()
         await elastic_search_engine.create_index(dataset)
 
@@ -104,7 +105,7 @@ class TestSuiteElasticSearchEngine:
 
     async def test_create_index_for_dataset_with_fields(
         self,
-        elastic_search_engine,
+        elastic_search_engine: SearchEngine,
         opensearch: OpenSearch,
         db: Session,
     ):
@@ -135,7 +136,7 @@ class TestSuiteElasticSearchEngine:
     )
     async def test_create_index_for_dataset_with_questions(
         self,
-        elastic_search_engine,
+        elastic_search_engine: SearchEngine,
         opensearch: OpenSearch,
         db: Session,
         text_ann_size: int,
@@ -202,7 +203,9 @@ class TestSuiteElasticSearchEngine:
             ],
         }
 
-    async def test_create_index_with_existing_index(self, elastic_search_engine, opensearch: OpenSearch, db: Session):
+    async def test_create_index_with_existing_index(
+        self, elastic_search_engine: SearchEngine, opensearch: OpenSearch, db: Session
+    ):
         dataset = DatasetFactory.create()
         await elastic_search_engine.create_index(dataset)
 
@@ -238,7 +241,6 @@ class TestSuiteElasticSearchEngine:
         self,
         elastic_search_engine,
         opensearch: OpenSearch,
-        db: Session,
         test_banking_sentiment_dataset: Dataset,
         query: str,
         expected_items: int,
@@ -246,6 +248,7 @@ class TestSuiteElasticSearchEngine:
         opensearch.indices.refresh(index=f"rg.{test_banking_sentiment_dataset.id}")
 
         result = await elastic_search_engine.search(test_banking_sentiment_dataset, query=query)
+
         assert len(result.items) == expected_items
 
         scores = [item.score > 0 for item in result.items]
@@ -255,3 +258,59 @@ class TestSuiteElasticSearchEngine:
         sorted_scores.sort(reverse=True)
 
         assert scores == sorted_scores
+
+    async def test_add_records(self, elastic_search_engine: SearchEngine, opensearch: OpenSearch):
+        text_fields = TextFieldFactory.create_batch(5)
+        dataset = DatasetFactory.create(fields=text_fields)
+
+        records = RecordFactory.create_batch(
+            size=10,
+            dataset=dataset,
+            fields={field.name: f"This is the value for {field.name}" for field in text_fields},
+        )
+        await elastic_search_engine.create_index(dataset)
+        await elastic_search_engine.add_records(dataset, records)
+
+        index_name = f"rg.{dataset.id}"
+        opensearch.indices.refresh(index=index_name)
+
+        es_docs = [hit["_source"] for hit in opensearch.search(index=index_name)["hits"]["hits"]]
+        assert es_docs == [{"id": str(record.id), "fields": record.fields, "responses": {}} for record in records]
+
+    async def test_update_record_response(
+        self,
+        elastic_search_engine: SearchEngine,
+        opensearch: OpenSearch,
+        db: Session,
+        test_banking_sentiment_dataset: Dataset,
+    ):
+        record = test_banking_sentiment_dataset.records[0]
+        question = test_banking_sentiment_dataset.questions[0]
+
+        response = ResponseFactory.create(record=record, values={question.name: {"value": "test"}})
+        await elastic_search_engine.update_record_responses(record, responses=[response])
+
+        index_name = f"rg.{test_banking_sentiment_dataset.id}"
+        opensearch.indices.refresh(index=index_name)
+
+        results = opensearch.get(index=index_name, id=record.id)
+
+        assert results["_source"]["responses"] == {
+            response.user.username: {
+                "values": {question.name: "test"},
+                "status": response.status.value,
+            }
+        }
+
+        index = opensearch.indices.get(index=index_name)[index_name]
+        assert index["mappings"]["properties"]["responses"] == {
+            "dynamic": "true",
+            "properties": {
+                response.user.username: {
+                    "properties": {
+                        "status": {"type": "keyword"},
+                        "values": {"properties": {question.name: {"index": False, "type": "text"}}},
+                    }
+                }
+            },
+        }


### PR DESCRIPTION
# Description

This PR adds the missing link between record responses actions and sync in the search engine. Also, the default search_engine fixture has been rewritten to use `AsyncMock`. This allows to injecting and using mock instances in tests without extra spy/mock configurations.


**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

Tests have been reviewed.

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)