### PR TITLE
Documentation: fixing a hyperlink in tutorials.md

### DIFF
--- a/docs/_source/tutorials/tutorials.md
+++ b/docs/_source/tutorials/tutorials.md
@@ -1,6 +1,6 @@
 # What are Tutorials?
 
-These tutorials are a practical starting point and introduce you to various topics covered by Argilla. If you want a more theoretical approach, take a look at our deep dives! Are you unsure about our terminology, take a look [here](/getting_started/terminology).
+These tutorials are a practical starting point and introduce you to various topics covered by Argilla. If you want a more theoretical approach, take a look at our deep dives! Are you unsure about our terminology, take a look [here](/reference/terminology).
 
 ```{include} /_common/steps_all.md
 ```


### PR DESCRIPTION
fixing a hyperlink to the tutorials page that was no longer working.

# Description

Hyperlink at the end of the first paragraph here had a missing hyperlink:
https://docs.argilla.io/en/latest/tutorials/tutorials.html 

Closes #3090 

**Type of change**

- [ X] Documentation update

**How Has This Been Tested**

N/A

**Checklist**

N/A