### PR TITLE
Documentation Update: docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       ARGILLA_ELASTICSEARCH: http://elasticsearch:9200
       # ARGILLA_ENABLE_TELEMETRY: 0 # Opt-out for telemetry https://docs.argilla.io/en/latest/reference/telemetry.html
 
-      # Set user configuration https://docs.argilla.io/en/latest/getting_started/installation/user_management.html
+      # Set user configuration https://docs.argilla.io/en/latest/getting_started/installation/configurations/user_management.html
       # ARGILLA_LOCAL_AUTH_USERS_DB_FILE: /config/.users.yaml
       # volumes:
       #- ${PWD}/.users.yaml:/config/.users.yaml


### PR DESCRIPTION
Fixed the URL for user management

# Description

The default docker-compose points to an invalid URL for user management. After digging through your docs I found the proper URL. 

Closes #<issue_number>

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)