### PR TITLE
feat: add `LabelQuestion` and `MultiLabelQuestion` in Python client

### DIFF
--- a/src/argilla/__init__.py
+++ b/src/argilla/__init__.py
@@ -69,7 +69,9 @@ if _TYPE_CHECKING:
     from argilla.client.feedback.dataset import FeedbackDataset
     from argilla.client.feedback.schemas import (
         FeedbackRecord,
+        MultiLabelQuestion,
         RatingQuestion,
+        SingleLabelQuestion,
         TextField,
         TextQuestion,
     )
@@ -127,6 +129,8 @@ _import_structure = {
         "RatingQuestion",
         "TextField",
         "TextQuestion",
+        "SingleLabelQuestion",
+        "MultiLabelQuestion",
     ],
     "client.workspaces": ["Workspace"],
     "monitoring.model_monitor": ["monitor"],

--- a/src/argilla/__init__.py
+++ b/src/argilla/__init__.py
@@ -69,9 +69,9 @@ if _TYPE_CHECKING:
     from argilla.client.feedback.dataset import FeedbackDataset
     from argilla.client.feedback.schemas import (
         FeedbackRecord,
+        LabelQuestion,
         MultiLabelQuestion,
         RatingQuestion,
-        SingleLabelQuestion,
         TextField,
         TextQuestion,
     )
@@ -129,7 +129,7 @@ _import_structure = {
         "RatingQuestion",
         "TextField",
         "TextQuestion",
-        "SingleLabelQuestion",
+        "LabelQuestion",
         "MultiLabelQuestion",
     ],
     "client.workspaces": ["Workspace"],

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -40,9 +40,9 @@ from argilla.client.feedback.schemas import (
     FeedbackDatasetConfig,
     FeedbackRecord,
     FieldSchema,
+    LabelQuestion,
     MultiLabelQuestion,
     RatingQuestion,
-    SingleLabelQuestion,
     TextField,
     TextQuestion,
 )
@@ -86,7 +86,7 @@ class FeedbackDataset:
         TypeError: if `fields` is not a list of `FieldSchema`.
         ValueError: if `fields` does not contain at least one required field.
         TypeError: if `questions` is not a list of `TextQuestion`, `RatingQuestion`,
-            `SingleLabelQuestion`, and/or `MultiLabelQuestion`.
+            `LabelQuestion`, and/or `MultiLabelQuestion`.
         ValueError: if `questions` does not contain at least one required question.
 
     Examples:
@@ -109,7 +109,7 @@ class FeedbackDataset:
         ...             required=True,
         ...             values=[1, 2, 3, 4, 5],
         ...         ),
-        ...         rg.SingleLabelQuestion(
+        ...         rg.LabelQuestion(
         ...             name="question-3",
         ...             description="This is the third question",
         ...             required=True,
@@ -163,7 +163,7 @@ class FeedbackDataset:
             TypeError: if `fields` is not a list of `FieldSchema`.
             ValueError: if `fields` does not contain at least one required field.
             TypeError: if `questions` is not a list of `TextQuestion`, `RatingQuestion`,
-                `SingleLabelQuestion`, and/or `MultiLabelQuestion`.
+                `LabelQuestion`, and/or `MultiLabelQuestion`.
             ValueError: if `questions` does not contain at least one required question.
             TypeError: if `guidelines` is not None and not a string.
             ValueError: if `guidelines` is an empty string.
@@ -188,7 +188,7 @@ class FeedbackDataset:
             ...             required=True,
             ...             values=[1, 2, 3, 4, 5],
             ...         ),
-            ...         rg.SingleLabelQuestion(
+            ...         rg.LabelQuestion(
             ...             name="question-3",
             ...             description="This is the third question",
             ...             required=True,
@@ -221,10 +221,10 @@ class FeedbackDataset:
             raise TypeError(f"Expected `questions` to be a list, got {type(questions)} instead.")
         any_required = False
         for question in questions:
-            if not isinstance(question, (TextQuestion, RatingQuestion, SingleLabelQuestion, MultiLabelQuestion)):
+            if not isinstance(question, (TextQuestion, RatingQuestion, LabelQuestion, MultiLabelQuestion)):
                 raise TypeError(
                     "Expected `questions` to be a list of `TextQuestion`, `RatingQuestion`,"
-                    " `SingleLabelQuestion`, and/or `MultiLabelQuestion` got a"
+                    " `LabelQuestion`, and/or `MultiLabelQuestion` got a"
                     f" question in the list with type {type(question)} instead."
                 )
             if not any_required and question.required:
@@ -392,7 +392,7 @@ class FeedbackDataset:
             ...             required=True,
             ...             values=[1, 2, 3, 4, 5],
             ...         ),
-            ...         rg.SingleLabelQuestion(
+            ...         rg.LabelQuestion(
             ...             name="question-3",
             ...             description="This is the third question",
             ...             required=True,
@@ -681,14 +681,14 @@ class FeedbackDataset:
             elif question.settings["type"] == "text":
                 question = TextQuestion.construct(**question.dict())
             elif question.settings["type"] == "label_selection":
-                question = SingleLabelQuestion.construct(**question.dict())
+                question = LabelQuestion.construct(**question.dict())
             elif question.settings["type"] == "multi_label_selection":
                 question = MultiLabelQuestion.construct(**question.dict())
             else:
                 raise ValueError(
                     f"Question '{question.name}' is not a supported question in the current Python package"
                     " version, supported question types are: `RatingQuestion`, `TextQuestion`,"
-                    "`SingleLabelQuestion`, and/or `MultiLabelQuestion`."
+                    " `LabelQuestion`, and/or `MultiLabelQuestion`."
                 )
             questions.append(question)
         self = cls(

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -560,7 +560,19 @@ class FeedbackDataset:
 
             for question in self.questions:
                 try:
-                    datasets_api_v1.add_question(client=httpx_client, id=argilla_id, question=question.dict())
+                    datasets_api_v1.add_question(
+                        client=httpx_client,
+                        id=argilla_id,
+                        question=question.dict(
+                            include={
+                                "name": True,
+                                "title": True,
+                                "description": True,
+                                "required": True,
+                                "settings": True,
+                            }
+                        ),
+                    )
                 except Exception as e:
                     delete_and_raise_exception(
                         dataset_id=argilla_id,

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -735,11 +735,23 @@ class FeedbackDataset:
                 if field.name not in dataset:
                     dataset[field.name] = []
             for question in self.questions:
+                if question.settings["type"] in ["text", "label_selection"]:
+                    value = Value(dtype="string")
+                elif question.settings["type"] == "rating":
+                    value = Value(dtype="int32")
+                elif question.settings["type"] == "multi_label_selection":
+                    value = Sequence(Value(dtype="string"))
+                else:
+                    raise ValueError(
+                        f"Question {question.name} has an unsupported type: {question.settings['type']}, for the"
+                        " moment only the following types are supported: 'text', 'rating', 'label_selection', and"
+                        " 'multi_label_selection'"
+                    )
                 # TODO(alvarobartt): if we constraint ranges from 0 to N, then we can use `ClassLabel` for ratings
                 features[question.name] = Sequence(
                     {
                         "user_id": Value(dtype="string"),
-                        "value": Value(dtype="string" if question.settings["type"] == "text" else "int32"),
+                        "value": value,
                         "status": Value(dtype="string"),
                     },
                     id="question",

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -563,15 +563,7 @@ class FeedbackDataset:
                     datasets_api_v1.add_question(
                         client=httpx_client,
                         id=argilla_id,
-                        question=question.dict(
-                            include={
-                                "name": True,
-                                "title": True,
-                                "description": True,
-                                "required": True,
-                                "settings": True,
-                            }
-                        ),
+                        question=question.dict(include={"name", "title", "description", "required", "settings"}),
                     )
                 except Exception as e:
                     delete_and_raise_exception(

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -35,10 +35,14 @@ from argilla.client.feedback.constants import (
 )
 from argilla.client.feedback.schemas import (
     FIELD_TYPE_TO_PYTHON_TYPE,
+    AllowedFieldTypes,
+    AllowedQuestionTypes,
     FeedbackDatasetConfig,
     FeedbackRecord,
     FieldSchema,
+    MultiLabelQuestion,
     RatingQuestion,
+    SingleLabelQuestion,
     TextField,
     TextQuestion,
 )
@@ -81,7 +85,8 @@ class FeedbackDataset:
         TypeError: if `guidelines` is not a string.
         TypeError: if `fields` is not a list of `FieldSchema`.
         ValueError: if `fields` does not contain at least one required field.
-        TypeError: if `questions` is not a list of `TextQuestion` and/or `RatingQuestion`.
+        TypeError: if `questions` is not a list of `TextQuestion`, `RatingQuestion`,
+            `SingleLabelQuestion`, and/or `MultiLabelQuestion`.
         ValueError: if `questions` does not contain at least one required question.
 
     Examples:
@@ -104,17 +109,21 @@ class FeedbackDataset:
         ...             required=True,
         ...             values=[1, 2, 3, 4, 5],
         ...         ),
+        ...         rg.SingleLabelQuestion(
+        ...             name="question-3",
+        ...             description="This is the third question",
+        ...             required=True,
+        ...             labels=["positive", "negative"],
+        ...         ),
+        ...         rg.MultiLabelQuestion(
+        ...             name="question-4",
+        ...             description="This is the fourth question",
+        ...             required=True,
+        ...             labels=["category-1", "category-2", "category-3"],
+        ...         ),
         ...     ],
         ...     guidelines="These are the annotation guidelines.",
         ... )
-        >>> dataset.guidelines
-        "These are the annotation guidelines."
-        >>> dataset.fields
-        [TextField(name="text", title="Text", required=True, settings={"type": "text"}), TextField(name="label", title="Label", required=True, settings={"type": "text"})]
-        >>> dataset.questions
-        [TextQuestion(name="question-1", title="Question 1", description="This is the first question", required=True, settings={"type": "text"}), RatingQuestion(name="question-2", title="Question 2", description="This is the second question", required=True, settings={"type": "rating"}, values=[1, 2, 3, 4, 5])]
-        >>> dataset.records
-        []
         >>> dataset.add_records(
         ...     [
         ...         rg.FeedbackRecord(
@@ -125,13 +134,13 @@ class FeedbackDataset:
         ...     ]
         ... )
         >>> dataset.records
-        [FeedbackRecord(fields={"text": "This is the first record", "label": "positive"}, responses=[ResponseSchema(user_id=None, values={"question-1": ValueSchema(value="This is the first answer"), "question-2": ValueSchema(value=5)})])]
+        [FeedbackRecord(fields={"text": "This is the first record", "label": "positive"}, responses=[ResponseSchema(user_id=None, values={"question-1": ValueSchema(value="This is the first answer"), "question-2": ValueSchema(value=5), "question-3": ValueSchema(value="positive"), "question-4": ValueSchema(value=["category-1"])})], external_id="entry-1")]
         >>> dataset.push_to_argilla(name="my-dataset", workspace="my-workspace")
         >>> dataset.argilla_id
         "..."
         >>> dataset = rg.FeedbackDataset.from_argilla(argilla_id="...")
         >>> dataset.records
-        [FeedbackRecord(fields={"text": "This is the first record", "label": "positive"}, responses=[ResponseSchema(user_id=None, values={"question-1": ValueSchema(value="This is the first answer"), "question-2": ValueSchema(value=5)})])]
+        [FeedbackRecord(fields={"text": "This is the first record", "label": "positive"}, responses=[ResponseSchema(user_id=None, values={"question-1": ValueSchema(value="This is the first answer"), "question-2": ValueSchema(value=5), "question-3": ValueSchema(value="positive"), "question-4": ValueSchema(value=["category-1"])})], external_id="entry-1")]
     """
 
     argilla_id: Optional[str] = None
@@ -139,8 +148,8 @@ class FeedbackDataset:
     def __init__(
         self,
         *,
-        fields: List[FieldSchema],
-        questions: List[Union[TextQuestion, RatingQuestion]],
+        fields: List[AllowedFieldTypes],
+        questions: List[AllowedQuestionTypes],
         guidelines: Optional[str] = None,
     ) -> None:
         """Initializes a `FeedbackDataset` instance locally.
@@ -153,7 +162,8 @@ class FeedbackDataset:
         Raises:
             TypeError: if `fields` is not a list of `FieldSchema`.
             ValueError: if `fields` does not contain at least one required field.
-            TypeError: if `questions` is not a list of `TextQuestion` and/or `RatingQuestion`.
+            TypeError: if `questions` is not a list of `TextQuestion`, `RatingQuestion`,
+                `SingleLabelQuestion`, and/or `MultiLabelQuestion`.
             ValueError: if `questions` does not contain at least one required question.
             TypeError: if `guidelines` is not None and not a string.
             ValueError: if `guidelines` is an empty string.
@@ -178,6 +188,18 @@ class FeedbackDataset:
             ...             required=True,
             ...             values=[1, 2, 3, 4, 5],
             ...         ),
+            ...         rg.SingleLabelQuestion(
+            ...             name="question-3",
+            ...             description="This is the third question",
+            ...             required=True,
+            ...             labels=["positive", "negative"],
+            ...         ),
+            ...         rg.MultiLabelQuestion(
+            ...             name="question-4",
+            ...             description="This is the fourth question",
+            ...             required=True,
+            ...             labels=["category-1", "category-2", "category-3"],
+            ...         ),
             ...     ],
             ...     guidelines="These are the annotation guidelines.",
             ... )
@@ -199,9 +221,10 @@ class FeedbackDataset:
             raise TypeError(f"Expected `questions` to be a list, got {type(questions)} instead.")
         any_required = False
         for question in questions:
-            if not isinstance(question, (TextQuestion, RatingQuestion)):
+            if not isinstance(question, (TextQuestion, RatingQuestion, SingleLabelQuestion, MultiLabelQuestion)):
                 raise TypeError(
-                    "Expected `questions` to be a list of `TextQuestion` and/or `RatingQuestion`, got a"
+                    "Expected `questions` to be a list of `TextQuestion`, `RatingQuestion`,"
+                    " `SingleLabelQuestion`, and/or `MultiLabelQuestion` got a"
                     f" question in the list with type {type(question)} instead."
                 )
             if not any_required and question.required:
@@ -369,22 +392,32 @@ class FeedbackDataset:
             ...             required=True,
             ...             values=[1, 2, 3, 4, 5],
             ...         ),
+            ...         rg.SingleLabelQuestion(
+            ...             name="question-3",
+            ...             description="This is the third question",
+            ...             required=True,
+            ...             labels=["positive", "negative"],
+            ...         ),
+            ...         rg.MultiLabelQuestion(
+            ...             name="question-4",
+            ...             description="This is the fourth question",
+            ...             required=True,
+            ...             labels=["category-1", "category-2", "category-3"],
+            ...         ),
             ...     ],
             ...     guidelines="These are the annotation guidelines.",
             ... )
-            >>> dataset.records
-            []
             >>> dataset.add_records(
             ...     [
             ...         rg.FeedbackRecord(
             ...             fields={"text": "This is the first record", "label": "positive"},
-            ...             responses=[{"values": {"question-1": {"value": "This is the first answer"}, "question-2": {"value": 5}}}],
+            ...             responses=[{"values": {"question-1": {"value": "This is the first answer"}, "question-2": {"value": 5}, "question-3": {"value": "positive"}, "question-4": {"value": ["category-1"]}}}],
             ...             external_id="entry-1",
             ...         ),
             ...     ]
             ... )
             >>> dataset.records
-            [FeedbackRecord(fields={"text": "This is the first record", "label": "positive"}, responses=[ResponseSchema(user_id=None, values={"question-1": ValueSchema(value="This is the first answer"), "question-2": ValueSchema(value=5)})])]
+            [FeedbackRecord(fields={"text": "This is the first record", "label": "positive"}, responses=[ResponseSchema(user_id=None, values={"question-1": ValueSchema(value="This is the first answer"), "question-2": ValueSchema(value=5), "question-3": ValueSchema(value="positive"), "question-4": ValueSchema(value=["category-1"])})], external_id="entry-1")]
         """
         if isinstance(records, list):
             if len(records) == 0:
@@ -643,10 +676,15 @@ class FeedbackDataset:
                 question = RatingQuestion.construct(**question.dict())
             elif question.settings["type"] == "text":
                 question = TextQuestion.construct(**question.dict())
+            elif question.settings["type"] == "label_selection":
+                question = SingleLabelQuestion.construct(**question.dict())
+            elif question.settings["type"] == "multi_label_selection":
+                question = MultiLabelQuestion.construct(**question.dict())
             else:
                 raise ValueError(
                     f"Question '{question.name}' is not a supported question in the current Python package"
-                    " version, supported question types are: `RatingQuestion` and `TextQuestion`."
+                    " version, supported question types are: `RatingQuestion`, `TextQuestion`,"
+                    "`SingleLabelQuestion`, and/or `MultiLabelQuestion`."
                 )
             questions.append(question)
         self = cls(

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -150,7 +150,7 @@ class _LabelQuestion(QuestionSchema):
 
     @root_validator
     def update_settings(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        values["settings"]["options"] = [{"value": label} for label in values.get("labels", [])]
+        values["settings"]["options"] = [{"value": label, "text": label} for label in values.get("labels", [])]
         values["settings"]["visible_options"] = values.get("visible_labels", None)
         return values
 

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -155,7 +155,7 @@ class _LabelQuestion(QuestionSchema):
         return values
 
 
-class SingleLabelQuestion(_LabelQuestion):
+class LabelQuestion(_LabelQuestion):
     settings: Dict[str, Any] = Field({"type": "label_selection"})
 
 
@@ -164,7 +164,7 @@ class MultiLabelQuestion(_LabelQuestion):
 
 
 AllowedFieldTypes = TextField
-AllowedQuestionTypes = Union[TextQuestion, RatingQuestion, SingleLabelQuestion, MultiLabelQuestion]
+AllowedQuestionTypes = Union[TextQuestion, RatingQuestion, LabelQuestion, MultiLabelQuestion]
 
 
 class FeedbackDatasetConfig(BaseModel):

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -25,9 +25,9 @@ from pydantic import (
     BaseModel,
     Extra,
     Field,
-    PositiveInt,
     StrictInt,
     StrictStr,
+    conint,
     root_validator,
     validator,
 )
@@ -147,7 +147,7 @@ class _LabelQuestion(QuestionSchema):
     settings: Dict[str, Any] = Field(default_factory=dict, allow_mutation=False)
     labels: List[str] = Field(unique_items=True)
     label_mapping: Dict[str, str] = Field(default_factory=dict)
-    visible_labels: Optional[PositiveInt] = 20
+    visible_labels: Optional[conint(ge=3)] = 20
 
     @root_validator
     def update_settings(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -28,6 +28,7 @@ from pydantic import (
     StrictInt,
     StrictStr,
     conint,
+    conlist,
     root_validator,
     validator,
 )
@@ -145,7 +146,7 @@ class RatingQuestion(QuestionSchema):
 
 class _LabelQuestion(QuestionSchema):
     settings: Dict[str, Any] = Field(default_factory=dict, allow_mutation=False)
-    labels: Union[List[str], Dict[str, str]] = Field(unique_items=True, min_items=2)
+    labels: Union[conlist(str, unique_items=True, min_items=2), Dict[str, str]]
     visible_labels: Optional[conint(ge=3)] = 20
 
     @validator("labels", always=True)

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -135,7 +135,7 @@ class TextQuestion(QuestionSchema):
 
 class RatingQuestion(QuestionSchema):
     settings: Dict[str, Any] = Field({"type": "rating"}, allow_mutation=False)
-    values: List[int] = Field(unique_items=True)
+    values: List[int] = Field(unique_items=True, min_items=2)
 
     @root_validator
     def update_settings(cls, values: Dict[str, Any]) -> Dict[str, Any]:
@@ -145,7 +145,7 @@ class RatingQuestion(QuestionSchema):
 
 class _LabelQuestion(QuestionSchema):
     settings: Dict[str, Any] = Field(default_factory=dict, allow_mutation=False)
-    labels: List[str] = Field(unique_items=True)
+    labels: List[str] = Field(unique_items=True, min_items=2)
     label_mapping: Dict[str, str] = Field(default_factory=dict)
     visible_labels: Optional[conint(ge=3)] = 20
 

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -75,7 +75,7 @@ class FeedbackRecord(BaseModel):
 class FieldSchema(BaseModel):
     name: str
     title: Optional[str] = None
-    required: Optional[bool] = True
+    required: bool = True
     settings: Dict[str, Any]
 
     @validator("title", always=True)
@@ -103,7 +103,7 @@ class QuestionSchema(BaseModel):
     name: str
     title: Optional[str] = None
     description: Optional[str] = None
-    required: Optional[bool] = True
+    required: bool = True
     settings: Dict[str, Any]
 
     @validator("title", always=True)

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -151,14 +151,10 @@ class _LabelQuestion(QuestionSchema):
 
     @validator("labels", always=True)
     def labels_dict_must_be_valid(cls, v: Union[List[str], Dict[str, str]]) -> Union[List[str], Dict[str, str]]:
-        if isinstance(v, list):
-            return v
         if isinstance(v, dict):
-            if len(v.keys()) < 2:
-                raise ValueError("ensure this dict has at least 2 items")
-            if len(set(v.values())) != len(v.values()):
-                raise ValueError("ensure this dict has unique values")
-            return v
+            assert len(v.keys()) > 1, "ensure this dict has at least 2 items"
+            assert len(set(v.values())) == len(v.values()), "ensure this dict has unique values"
+        return v
 
     @root_validator(skip_on_failure=True)
     def update_settings(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -146,11 +146,18 @@ class RatingQuestion(QuestionSchema):
 class _LabelQuestion(QuestionSchema):
     settings: Dict[str, Any] = Field({})
     labels: List[str] = Field(unique_items=True)
+    label_mapping: Dict[str, str] = Field(default_factory=dict)
     visible_labels: Optional[PositiveInt] = 20
 
     @root_validator
     def update_settings(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        values["settings"]["options"] = [{"value": label, "text": label} for label in values.get("labels", [])]
+        values["settings"]["options"] = [
+            {
+                "value": label,
+                "text": label if not values["label_mapping"] else values["label_mapping"].get(label, label),
+            }
+            for label in values.get("labels", [])
+        ]
         values["settings"]["visible_options"] = values.get("visible_labels", 20)
         return values
 

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -158,7 +158,6 @@ class _LabelQuestion(QuestionSchema):
             if len(set(v.values())) != len(v.values()):
                 raise ValueError("ensure this dict has unique values")
             return v
-        raise TypeError("ensure this value is a list or a dict")
 
     @root_validator(skip_on_failure=True)
     def update_settings(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -143,8 +143,28 @@ class RatingQuestion(QuestionSchema):
         return values
 
 
+class _LabelQuestion(QuestionSchema):
+    settings: Dict[str, Any] = Field({})
+    labels: List[str] = Field(unique_items=True)
+    visible_labels: Optional[PositiveInt] = None
+
+    @root_validator
+    def update_settings(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        values["settings"]["options"] = [{"value": label} for label in values.get("labels", [])]
+        values["settings"]["visible_options"] = values.get("visible_labels", None)
+        return values
+
+
+class SingleLabelQuestion(_LabelQuestion):
+    settings: Dict[str, Any] = Field({"type": "label_selection"})
+
+
+class MultiLabelQuestion(_LabelQuestion):
+    settings: Dict[str, Any] = Field({"type": "multi_label_selection"})
+
+
 AllowedFieldTypes = TextField
-AllowedQuestionTypes = Union[TextQuestion, RatingQuestion]
+AllowedQuestionTypes = Union[TextQuestion, RatingQuestion, SingleLabelQuestion, MultiLabelQuestion]
 
 
 class FeedbackDatasetConfig(BaseModel):

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -146,12 +146,12 @@ class RatingQuestion(QuestionSchema):
 class _LabelQuestion(QuestionSchema):
     settings: Dict[str, Any] = Field({})
     labels: List[str] = Field(unique_items=True)
-    visible_labels: Optional[PositiveInt] = None
+    visible_labels: Optional[PositiveInt] = 20
 
     @root_validator
     def update_settings(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         values["settings"]["options"] = [{"value": label, "text": label} for label in values.get("labels", [])]
-        values["settings"]["visible_options"] = values.get("visible_labels", None)
+        values["settings"]["visible_options"] = values.get("visible_labels", 20)
         return values
 
 

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -83,7 +83,7 @@ class FieldSchema(BaseModel):
     @validator("title", always=True)
     def title_must_have_value(cls, v: Optional[str], values: Dict[str, Any]) -> str:
         if not v:
-            return values["name"].capitalize()
+            return values.get("name").capitalize()
         return v
 
     class Config:
@@ -114,7 +114,7 @@ class QuestionSchema(BaseModel):
     @validator("title", always=True)
     def title_must_have_value(cls, v: Optional[str], values: Dict[str, Any]) -> str:
         if not v:
-            return values["name"].capitalize()
+            return values.get("name").capitalize()
         return v
 
     class Config:
@@ -139,7 +139,7 @@ class RatingQuestion(QuestionSchema):
 
     @root_validator
     def update_settings(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        values["settings"]["options"] = [{"value": value} for value in values.get("values", [])]
+        values["settings"]["options"] = [{"value": value} for value in values.get("values")]
         return values
 
 
@@ -150,13 +150,15 @@ class _LabelQuestion(QuestionSchema):
 
     @root_validator
     def update_settings(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        if isinstance(values["labels"], dict):
-            values["settings"]["options"] = [{"value": key, "text": value} for key, value in values["labels"].items()]
-        elif isinstance(values["labels"], list):
-            values["settings"]["options"] = [{"value": label, "text": label} for label in values["labels"]]
+        if isinstance(values.get("labels"), dict):
+            values["settings"]["options"] = [
+                {"value": key, "text": value} for key, value in values.get("labels").items()
+            ]
+        elif isinstance(values.get("labels"), list):
+            values["settings"]["options"] = [{"value": label, "text": label} for label in values.get("labels")]
         else:
             raise ValueError(
-                f"Invalid `labels` value: {values['labels']}. It must be a list or a dictionary of `str` values."
+                f"Invalid `labels` value: {values.get('labels')} of type: {type(values.get('labels'))}. It must be a list or a dictionary of `str` values."
             )
         values["settings"]["visible_options"] = values.get("visible_labels", 20)
         return values

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -95,7 +95,7 @@ class TextField(FieldSchema):
     settings: Dict[str, Any] = Field({"type": "text"}, allow_mutation=False)
     use_markdown: bool = False
 
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def update_settings(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         values["settings"]["use_markdown"] = values.get("use_markdown", False)
         return values
@@ -127,7 +127,7 @@ class TextQuestion(QuestionSchema):
     settings: Dict[str, Any] = Field({"type": "text", "use_markdown": False}, allow_mutation=False)
     use_markdown: bool = False
 
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def update_settings(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         values["settings"]["use_markdown"] = values.get("use_markdown", False)
         return values
@@ -137,7 +137,7 @@ class RatingQuestion(QuestionSchema):
     settings: Dict[str, Any] = Field({"type": "rating"}, allow_mutation=False)
     values: List[int] = Field(unique_items=True, min_items=2)
 
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def update_settings(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         values["settings"]["options"] = [{"value": value} for value in values.get("values")]
         return values
@@ -148,7 +148,7 @@ class _LabelQuestion(QuestionSchema):
     labels: Union[List[str], Dict[str, str]] = Field(unique_items=True, min_items=2)
     visible_labels: Optional[conint(ge=3)] = 20
 
-    @root_validator
+    @root_validator(skip_on_failure=True)
     def update_settings(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         if isinstance(values.get("labels"), dict):
             values["settings"]["options"] = [

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -37,7 +37,7 @@ PUSHING_BATCH_SIZE = 32
 
 
 class ValueSchema(BaseModel):
-    value: Union[StrictStr, StrictInt]
+    value: Union[StrictStr, StrictInt, List[str]]
 
 
 class ResponseSchema(BaseModel):

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -78,7 +78,7 @@ class FieldSchema(BaseModel):
     name: str
     title: Optional[str] = None
     required: bool = True
-    settings: Dict[str, Any]
+    settings: Dict[str, Any] = Field(default_factory=dict, allow_mutation=False)
 
     @validator("title", always=True)
     def title_must_have_value(cls, v: Optional[str], values: Dict[str, Any]) -> str:
@@ -92,7 +92,7 @@ class FieldSchema(BaseModel):
 
 
 class TextField(FieldSchema):
-    settings: Dict[str, Any] = Field({"type": "text"})
+    settings: Dict[str, Any] = Field({"type": "text"}, allow_mutation=False)
     use_markdown: bool = False
 
     @root_validator
@@ -109,7 +109,7 @@ class QuestionSchema(BaseModel):
     title: Optional[str] = None
     description: Optional[str] = None
     required: bool = True
-    settings: Dict[str, Any]
+    settings: Dict[str, Any] = Field(default_factory=dict, allow_mutation=False)
 
     @validator("title", always=True)
     def title_must_have_value(cls, v: Optional[str], values: Dict[str, Any]) -> str:
@@ -124,7 +124,7 @@ class QuestionSchema(BaseModel):
 
 # TODO(alvarobartt): add `TextResponse` and `RatingResponse` classes
 class TextQuestion(QuestionSchema):
-    settings: Dict[str, Any] = Field({"type": "text", "use_markdown": False})
+    settings: Dict[str, Any] = Field({"type": "text", "use_markdown": False}, allow_mutation=False)
     use_markdown: bool = False
 
     @root_validator
@@ -134,7 +134,7 @@ class TextQuestion(QuestionSchema):
 
 
 class RatingQuestion(QuestionSchema):
-    settings: Dict[str, Any] = Field({"type": "rating"})
+    settings: Dict[str, Any] = Field({"type": "rating"}, allow_mutation=False)
     values: List[int] = Field(unique_items=True)
 
     @root_validator
@@ -144,7 +144,7 @@ class RatingQuestion(QuestionSchema):
 
 
 class _LabelQuestion(QuestionSchema):
-    settings: Dict[str, Any] = Field({})
+    settings: Dict[str, Any] = Field(default_factory=dict, allow_mutation=False)
     labels: List[str] = Field(unique_items=True)
     label_mapping: Dict[str, str] = Field(default_factory=dict)
     visible_labels: Optional[PositiveInt] = 20

--- a/src/argilla/client/sdk/v1/datasets/models.py
+++ b/src/argilla/client/sdk/v1/datasets/models.py
@@ -36,7 +36,7 @@ class FeedbackDatasetModel(BaseModel):
 
 
 class FeedbackValueModel(BaseModel):
-    value: Union[StrictStr, StrictInt]
+    value: Union[StrictStr, StrictInt, List[str]]
 
 
 class FeedbackResponseModel(BaseModel):

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
 
 from argilla.client.feedback.schemas import (
     FeedbackRecord,
+    LabelQuestion,
+    MultiLabelQuestion,
     RatingQuestion,
     TextField,
     TextQuestion,
@@ -400,6 +402,8 @@ def feedback_dataset_questions() -> List["AllowedQuestionTypes"]:
     return [
         TextQuestion(name="question-1", required=True),
         RatingQuestion(name="question-2", values=[0, 1], required=True),
+        LabelQuestion(name="question-3", labels=["a", "b", "c"], required=True),
+        MultiLabelQuestion(name="question-4", labels=["a", "b", "c"], required=True),
     ]
 
 
@@ -408,8 +412,32 @@ def feedback_dataset_records() -> List[FeedbackRecord]:
     return [
         FeedbackRecord(
             fields={"text": "This is a positive example", "label": "positive"},
+            responses=[
+                {
+                    "values": {
+                        "question-1": {"value": "This is a response to question 1"},
+                        "question-2": {"value": 1},
+                        "question-3": {"value": "a"},
+                        "question-4": {"value": ["a", "b"]},
+                    },
+                    "status": "submitted",
+                }
+            ],
+            external_id="1",
         ),
         FeedbackRecord(
             fields={"text": "This is a negative example", "label": "negative"},
+            responses=[
+                {
+                    "values": {
+                        "question-1": {"value": "This is a response to question 1"},
+                        "question-2": {"value": 1},
+                        "question-3": {"value": "a"},
+                        "question-4": {"value": ["a", "b"]},
+                    },
+                    "status": "submitted",
+                }
+            ],
+            external_id="2",
         ),
     ]

--- a/tests/client/feedback/test_dataset.py
+++ b/tests/client/feedback/test_dataset.py
@@ -112,14 +112,6 @@ def test_init_wrong_questions(feedback_dataset_guidelines: str, feedback_dataset
                 RatingQuestion(name="test", values=[0, 1], required=False),
             ],
         )
-    with pytest.raises(ValidationError, match="1 validation error for RatingQuestion"):
-        FeedbackDataset(
-            guidelines=feedback_dataset_guidelines,
-            fields=feedback_dataset_fields,
-            questions=[
-                RatingQuestion(name="test", values=[0, 0], required=True),
-            ],
-        )
 
 
 @pytest.mark.usefixtures("feedback_dataset_guidelines", "feedback_dataset_fields", "feedback_dataset_questions")
@@ -165,6 +157,8 @@ def test_records(
                     "values": {
                         "question-1": {"value": "answer"},
                         "question-2": {"value": 0},
+                        "question-3": {"value": "a"},
+                        "question-4": {"value": ["a", "b"]},
                     },
                     "status": "submitted",
                 },
@@ -183,6 +177,8 @@ def test_records(
         "values": {
             "question-1": {"value": "answer"},
             "question-2": {"value": 0},
+            "question-3": {"value": "a"},
+            "question-4": {"value": ["a", "b"]},
         },
         "status": "submitted",
     }
@@ -285,6 +281,8 @@ def test_push_to_argilla_and_from_argilla(
                         "values": {
                             "question-1": {"value": "answer"},
                             "question-2": {"value": 0},
+                            "question-3": {"value": "a"},
+                            "question-4": {"value": ["a", "b"]},
                         },
                         "status": "submitted",
                     },
@@ -292,6 +290,8 @@ def test_push_to_argilla_and_from_argilla(
                         "values": {
                             "question-1": {"value": "answer"},
                             "question-2": {"value": 0},
+                            "question-3": {"value": "a"},
+                            "question-4": {"value": ["a", "b"]},
                         },
                         "status": "submitted",
                     },

--- a/tests/client/feedback/test_dataset.py
+++ b/tests/client/feedback/test_dataset.py
@@ -94,7 +94,10 @@ def test_init_wrong_questions(feedback_dataset_guidelines: str, feedback_dataset
             fields=feedback_dataset_fields,
             questions=None,
         )
-    with pytest.raises(TypeError, match="Expected `questions` to be a list of `TextQuestion` and/or `RatingQuestion`"):
+    with pytest.raises(
+        TypeError,
+        match="Expected `questions` to be a list of `TextQuestion`, `RatingQuestion`, `SingleLabelQuestion`, and/or `MultiLabelQuestion`",
+    ):
         FeedbackDataset(
             guidelines=feedback_dataset_guidelines,
             fields=feedback_dataset_fields,

--- a/tests/client/feedback/test_dataset.py
+++ b/tests/client/feedback/test_dataset.py
@@ -96,7 +96,7 @@ def test_init_wrong_questions(feedback_dataset_guidelines: str, feedback_dataset
         )
     with pytest.raises(
         TypeError,
-        match="Expected `questions` to be a list of `TextQuestion`, `RatingQuestion`, `SingleLabelQuestion`, and/or `MultiLabelQuestion`",
+        match="Expected `questions` to be a list of `TextQuestion`, `RatingQuestion`, `LabelQuestion`, and/or `MultiLabelQuestion`",
     ):
         FeedbackDataset(
             guidelines=feedback_dataset_guidelines,

--- a/tests/client/feedback/test_schemas.py
+++ b/tests/client/feedback/test_schemas.py
@@ -1,0 +1,169 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Any, Dict, Union
+
+import pytest
+from argilla.client.feedback.schemas import LabelQuestion, MultiLabelQuestion
+from pydantic import ValidationError
+
+
+@pytest.mark.parametrize(
+    "schema_kwargs, expected_exception, expected_exception_message",
+    [
+        (
+            {"name": "a", "description": "a", "required": True, "labels": ["a"]},
+            ValidationError,
+            "ensure this value has at least 2 items",
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": ["a", "b"], "visible_labels": 2},
+            ValidationError,
+            "ensure this value is greater than or equal to 3",
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": ["a", "a"]},
+            ValidationError,
+            "the list has duplicated items",
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": "a"},
+            ValidationError,
+            "(value is not a valid list)|(value is not a valid dict)",
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": {"a": "a"}},
+            ValidationError,
+            "ensure this dict has at least 2 items",
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": {"a": "a", "b": "a"}},
+            ValidationError,
+            "ensure this dict has unique values",
+        ),
+    ],
+)
+def test_label_question_errors(
+    schema_kwargs: Dict[str, Any], expected_exception: Exception, expected_exception_message: Union[str, None]
+) -> None:
+    with pytest.raises(expected_exception, match=expected_exception_message):
+        LabelQuestion(**schema_kwargs)
+
+
+@pytest.mark.parametrize(
+    "schema_kwargs, expected_settings",
+    [
+        (
+            {"name": "a", "description": "a", "required": True, "labels": ["a", "b"]},
+            {
+                "type": "label_selection",
+                "options": [{"value": "a", "text": "a"}, {"value": "b", "text": "b"}],
+                "visible_options": 20,
+            },
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": {"a": "A", "b": "B"}},
+            {
+                "type": "label_selection",
+                "options": [{"value": "a", "text": "A"}, {"value": "b", "text": "B"}],
+                "visible_options": 20,
+            },
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": ["a", "b"], "visible_labels": 5},
+            {
+                "type": "label_selection",
+                "options": [{"value": "a", "text": "a"}, {"value": "b", "text": "b"}],
+                "visible_options": 5,
+            },
+        ),
+    ],
+)
+def test_label_question(schema_kwargs: Dict[str, Any], expected_settings: Dict[str, Any]) -> None:
+    assert LabelQuestion(**schema_kwargs).dict(include={"settings"})["settings"] == expected_settings
+
+
+@pytest.mark.parametrize(
+    "schema_kwargs, expected_exception, expected_exception_message",
+    [
+        (
+            {"name": "a", "description": "a", "required": True, "labels": ["a"]},
+            ValidationError,
+            "ensure this value has at least 2 items",
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": ["a", "b"], "visible_labels": 2},
+            ValidationError,
+            "ensure this value is greater than or equal to 3",
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": ["a", "a"]},
+            ValidationError,
+            "the list has duplicated items",
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": "a"},
+            ValidationError,
+            "(value is not a valid list)|(value is not a valid dict)",
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": {"a": "a"}},
+            ValidationError,
+            "ensure this dict has at least 2 items",
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": {"a": "a", "b": "a"}},
+            ValidationError,
+            "ensure this dict has unique values",
+        ),
+    ],
+)
+def test_multi_label_question_errors(
+    schema_kwargs: Dict[str, Any], expected_exception: Exception, expected_exception_message: Union[str, None]
+) -> None:
+    with pytest.raises(expected_exception, match=expected_exception_message):
+        MultiLabelQuestion(**schema_kwargs)
+
+
+@pytest.mark.parametrize(
+    "schema_kwargs, expected_settings",
+    [
+        (
+            {"name": "a", "description": "a", "required": True, "labels": ["a", "b"]},
+            {
+                "type": "multi_label_selection",
+                "options": [{"value": "a", "text": "a"}, {"value": "b", "text": "b"}],
+                "visible_options": 20,
+            },
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": {"a": "A", "b": "B"}},
+            {
+                "type": "multi_label_selection",
+                "options": [{"value": "a", "text": "A"}, {"value": "b", "text": "B"}],
+                "visible_options": 20,
+            },
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": ["a", "b"], "visible_labels": 5},
+            {
+                "type": "multi_label_selection",
+                "options": [{"value": "a", "text": "a"}, {"value": "b", "text": "b"}],
+                "visible_options": 5,
+            },
+        ),
+    ],
+)
+def test_multi_label_question(schema_kwargs: Dict[str, Any], expected_settings: Dict[str, Any]) -> None:
+    assert MultiLabelQuestion(**schema_kwargs).dict(include={"settings"})["settings"] == expected_settings


### PR DESCRIPTION
# Description

This PR adds support to the recently included `LabelSelectionQuestion` and `MultiLabelSelectionQuestion` new types of questions as of #3005 and #3010, respectively, in the Python client side.

Closes #3099 

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [x] Add integration tests for the recently included questions

**Checklist**

- [X] I have merged the original branch into my forked branch
- [X] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)