### PR TITLE
chore: upgrade `flair` to latest version (0.12.2)

### DIFF
--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -37,7 +37,7 @@ dependencies:
       - cleanlab~=2.0.0 # With this version, tests are failing
       - datasets>1.17.0,!= 2.3.2 # TODO: push_to_hub fails up to 2.3.2, check patches when they come out eventually
       - huggingface_hub
-      - flair==0.12
+      - flair>=0.12.2
       - faiss-cpu
       - flyingsquid
       - pgmpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ tests = [
     # TODO: some backward comp. problems introduced in 0.5.0. 0.13 does not match with setfit
     "huggingface_hub >= 0.5.0,< 0.13",
     # Version 0.12 fixes a known installation issue related to `sentencepiece` and `tokenizers`, more at https://github.com/flairNLP/flair/issues/3129
-    "flair == 0.12",
+    "flair >= 0.12.2",  # Version 0.12.2 relaxes the `huggingface_hub` dependency
     "faiss-cpu",
     "flyingsquid",
     "pgmpy",


### PR DESCRIPTION
# Description

As of #3012, we decided to upgrade `flair` to 0.12.0 to avoid some known installation issues with both dependencies: `tokenizers` and `sentencepiece`. It was solved, but we recently included the `ArgillaAutoTrainTrainer` at #2940 (kudos to @davidberenstein1957), and it seems that `autotrain-advanced` dependency expects a greater `huggingface_hub` version, while `flair` 0.12.0 had it pinned to `==0.10.0` which was pretty restrictive and, so on, running into conflicts with `autotrain-advanced`.

So on, it seems that `flair` 0.12.2 already defines `huggingface_hub` dependency as `>=0.10.0` which is more relaxed, and doesn't run into any conflict with the rest of the dependencies.

See the previous `huggingface_hub` dependency pinned to ==0.10.0 at https://github.com/flairNLP/flair/blob/d13f8ea36e60c5ab1d7468893498db96d91fd4be/requirements.txt#L22, and now being pinned to >=0.10.0 at https://github.com/flairNLP/flair/blob/621e7dd58be8e3c5985176d9a7f54eb5c0cd8c88/requirements.txt#L22, as of 0.12.2, since in 0.12.1 it's still pinned to ==0.10.0.

**Type of change**

- [X] Upgrade/Add dependency

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [X] Installed via `pip` in Python 3.8, 3.9, 3.10, and 3.11; and with `conda` in Python 3.8

**Checklist**

- [X] I have merged the original branch into my forked branch
- [X] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)