### PR TITLE
style: curate auto-generated `DatasetCard` for `FeedbackDataset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ These are the section headers that we use:
 - Added `MultiLabelSelectionQuestionSettings` class allowing to create multi-label selection (multi-choice) questions in the API.
 - Database setup for unit tests. Now the unit tests use a different database than the one used by the local Argilla server (Closes [#2987]).
 - Updated `alembic` setup to be able to autogenerate revision/migration scripts using SQLAlchemy metadata from Argilla server models ([#3044])
+- Improved `DatasetCard` generation on `FeedbackDataset.push_to_huggingface` when `generate_card=True`, following the official HuggingFace Hub template, but suited to `FeedbackDataset`s from Argilla ([#3110])
 
 ## [1.8.0](https://github.com/argilla-io/argilla/compare/v1.7.0...v1.8.0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,14 @@ homepage = "https://www.argilla.io"
 documentation = "https://docs.argilla.io"
 repository = "https://github.com/argilla-io/argilla"
 
+[tool.setuptools.packages.find]
+where = ["src"]
+
 [tool.setuptools.dynamic]
 version = {attr = "argilla.__version__"}
+
+[tool.setuptools.package-data]
+"argilla.client.feedback.card" = ["argilla_template.md"]
 
 [tool.pytest.ini_options]
 log_format = "%(asctime)s %(name)s %(levelname)s %(message)s"

--- a/src/argilla/client/feedback/card/__init__.py
+++ b/src/argilla/client/feedback/card/__init__.py
@@ -1,0 +1,17 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from argilla.client.feedback.card._dataset_card import ArgillaDatasetCard
+
+__all__ = ["ArgillaDatasetCard"]

--- a/src/argilla/client/feedback/card/_dataset_card.py
+++ b/src/argilla/client/feedback/card/_dataset_card.py
@@ -1,0 +1,28 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from pathlib import Path
+
+from huggingface_hub import DatasetCard
+
+TEMPLATE_ARGILLA_DATASET_CARD_PATH = Path(__file__).parent / "argilla_template.md"
+
+
+class ArgillaDatasetCard(DatasetCard):
+    """`ArgillaDatasetCard` has been created similarly to `DatasetCard` from
+    `huggingface_hub` but with a different template. The template is located at
+    `argilla/client/feedback/card/argilla_template.md`.
+    """
+
+    default_template_path = TEMPLATE_ARGILLA_DATASET_CARD_PATH

--- a/src/argilla/client/feedback/card/_parser.py
+++ b/src/argilla/client/feedback/card/_parser.py
@@ -12,7 +12,23 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from argilla.client.feedback.card._dataset_card import ArgillaDatasetCard
-from argilla.client.feedback.card._parser import size_categories_parser
+AVAILABLE_SIZE_CATEGORIES = {
+    1_000: "n<1K",
+    10_000: "1K<n<10K",
+    100_000: "10K<n<100K",
+    1_000_000: "100K<n<1M",
+    10_000_000: "1M<n<10M",
+    100_000_000: "10M<n<100M",
+    1_000_000_000: "100M<n<1B",
+    10_000_000_000: "1B<n<10B",
+    100_000_000_000: "10B<n<100B",
+    1_000_000_000_000: "100B<n<1T",
+    10_000_000_000_000: "n>1T",
+}
 
-__all__ = ["ArgillaDatasetCard", "size_categories_parser"]
+
+def size_categories_parser(input_size: int) -> str:
+    for size, category in AVAILABLE_SIZE_CATEGORIES.items():
+        if input_size < size:
+            return category
+    return "other"

--- a/src/argilla/client/feedback/card/_parser.py
+++ b/src/argilla/client/feedback/card/_parser.py
@@ -23,7 +23,6 @@ AVAILABLE_SIZE_CATEGORIES = {
     10_000_000_000: "1B<n<10B",
     100_000_000_000: "10B<n<100B",
     1_000_000_000_000: "100B<n<1T",
-    10_000_000_000_000: "n>1T",
 }
 
 
@@ -31,4 +30,4 @@ def size_categories_parser(input_size: int) -> str:
     for size, category in AVAILABLE_SIZE_CATEGORIES.items():
         if input_size < size:
             return category
-    return "other"
+    return "n>1T"

--- a/src/argilla/client/feedback/card/argilla_template.md
+++ b/src/argilla/client/feedback/card/argilla_template.md
@@ -75,7 +75,7 @@ The **questions** are the questions that will be asked to the annotators. They c
 
 | Question Name | Title | Type | Required | Description | Values/Labels |
 | ------------- | ----- | ---- | -------- | ----------- | ------------- |
-{% for question in argilla_questions %}| {{ question.name }} | {{ question.title }} | {{ question.__class__.__name__  }} | {{ question.required | default(true, true) }} | {{ question.description | default("N/A", true) }} | {% if question.settings.type == 'rating' %}[{% for value in question.settings.options %} {{ value.value }} {% endfor %}]{% else %} N/A {% endif %} |
+{% for question in argilla_questions %}| {{ question.name }} | {{ question.title }} | {{ question.__class__.__name__  }} | {{ question.required | default(true, true) }} | {{ question.description | default("N/A", true) }} | {% if question.settings.type == 'rating' %}{{ question.settings.options | map(attribute="value") | list }}{% else %} N/A {% endif %} |
 {% endfor %}
 
 Finally, the **guidelines** are just a plain string that can be used to provide instructions to the annotators. Find those in the [annotation guidelines](#annotation-guidelines) section.
@@ -104,7 +104,7 @@ Among the dataset fields, we differentiate between the following:
 
 * **Questions:** These are the questions that will be asked to the annotators. They can be of different types, such as rating, text, single choice, or multiple choice.
     {% for question in argilla_questions %}
-    * {% if question.required == false %}(optional) {% endif %}**{{ question.name }}** is of type `{{ question.__class__.__name__ }}`{% if question.settings.type == 'rating' %} with the following allowed values [{% for value in question.settings.options %} {{ value.value }} {% endfor %}]{% endif %}{% if question.description %}, and description "{{ question.description }}"{% endif %}.{% endfor %}
+    * {% if question.required == false %}(optional) {% endif %}**{{ question.name }}** is of type `{{ question.__class__.__name__ }}`{% if question.settings.type == 'rating' %} with the following allowed values {{ question.settings.options | map(attribute="value") | list }}{% endif %}{% if question.description %}, and description "{{ question.description }}"{% endif %}.{% endfor %}
 
 Additionally, we also have one more field which is optional and is the following:
 

--- a/src/argilla/client/feedback/card/argilla_template.md
+++ b/src/argilla/client/feedback/card/argilla_template.md
@@ -1,0 +1,175 @@
+---
+# For reference on model card metadata, see the spec: https://github.com/huggingface/hub-docs/blob/main/datasetcard.md?plain=1
+# Doc / guide: https://huggingface.co/docs/hub/datasets-cards
+{{ card_data }}
+---
+
+# Dataset Card for {{ dataset_name }}
+
+This dataset has been created with [Argilla](https://docs.argilla.io).
+
+As shown in the [dataset description section](#dataset-description), this dataset can be loaded into Argilla, or used directly with the `datasets` library.
+
+## Dataset Description
+
+- **Homepage:** {{ homepage_url | default("https://argilla.io", true)}}
+- **Repository:** {{ repo_url | default("https://github.com/argilla-io/argilla", true)}}
+- **Paper:** {{ paper_url | default("", true)}}
+- **Leaderboard:** {{ leaderboard_url | default("", true)}}
+- **Point of Contact:** {{ point_of_contact | default("", true)}}
+
+### Dataset Summary
+
+This dataset contains:
+
+* A dataset configuration file conforming to the Argilla dataset format named `argilla.cfg`. This configuration file will be used to configure the dataset when using the `FeedbackDataset.from_huggingface` method in Argilla.
+
+* Dataset records in a format compatible with HuggingFace `datasets`. These records will be loaded automatically when using `FeedbackDataset.from_huggingface` and can be loaded independently using the `datasets` library via `load_dataset`.
+
+* The [annotation guidelines](#annotation-guidelines) that have been used for building and curating the dataset, if they've been defined in Argilla.
+
+### Load with Argilla
+
+To load with Argilla, you'll just need to install Argilla as `pip install argilla --upgrade` and then use the following code:
+
+```python
+import argilla as rg
+
+ds = rg.FeedbackDataset.from_huggingface("{{ repo_id }}")
+```
+
+### Load with `datasets`
+
+To load this dataset with `datasets`, you'll just need to install `datasets` as `pip install datasets --upgrade` and then use the following code:
+
+```python
+from datasets import load_dataset
+
+ds = load_dataset("{{ repo_id }}")
+```
+
+### Supported Tasks and Leaderboards
+
+This dataset can contain [multiple fields, questions and responses](https://docs.argilla.io/en/latest/guides/llms/conceptual_guides/data_model.html) so it can be used for different NLP tasks, depending on the configuration. The dataset structure is described in the [Dataset Structure section](#dataset-structure).
+
+There are no leaderboards associated with this dataset.
+
+### Languages
+
+{{ languages_section | default("[More Information Needed]", true)}}
+
+## Dataset Structure
+
+### Data in Argilla
+
+The dataset is created in Argilla with: **fields**, **questions**, and **guidelines**.
+
+The **fields** are the dataset records themselves, for the moment just text fields are suppported. These are the ones that will be used to provide responses to the questions.
+
+| Field Name | Title | Type | Required | Markdown |
+| ---------- | ----- | ---- | -------- | -------- |
+{% for field in argilla_fields %}| {{ field.name }} | {{ field.title }} | {{ field.__class__.__name__ }} | {{ field.required | default(true, true) }} | {{ field.settings.use_markdown | default(false, true) }} |
+{% endfor %}
+
+The **questions** are the questions that will be asked to the annotators. They can be of different types, such as rating, text, single choice, or multiple choice.
+
+| Question Name | Title | Type | Required | Description | Values/Labels |
+| ------------- | ----- | ---- | -------- | ----------- | ------------- |
+{% for question in argilla_questions %}| {{ question.name }} | {{ question.title }} | {{ question.__class__.__name__  }} | {{ question.required | default(true, true) }} | {{ question.description | default("N/A", true) }} | {% if question.settings.type == 'rating' %}[{% for value in question.settings.options %} {{ value.value }} {% endfor %}]{% else %} N/A {% endif %} |
+{% endfor %}
+
+Finally, the **guidelines** are just a plain string that can be used to provide instructions to the annotators. Find those in the [annotation guidelines](#annotation-guidelines) section.
+
+### Data Instances
+
+An example of a dataset instance looks as follows:
+
+```json
+{{ data_instance | tojson(indent=4) }}
+```
+
+### Data Fields
+
+Among the dataset fields, we differentiate between the following:
+
+* **Fields:** These are the dataset records themselves, for the moment just text fields are suppported. These are the ones that will be used to provide responses to the questions.
+    {% for field in argilla_fields %}
+    * {% if field.required == false %}(optional) {% endif %}**{{ field.name }}** is of type `{{ field.__class__.__name__ }}`.{% endfor %}
+
+* **Questions:** These are the questions that will be asked to the annotators. They can be of different types, such as rating, text, single choice, or multiple choice.
+    {% for question in argilla_questions %}
+    * {% if question.required == false %}(optional) {% endif %}**{{ question.name }}** is of type `{{ question.__class__.__name__ }}`{% if question.settings.type == 'rating' %} with the following allowed values [{% for value in question.settings.options %} {{ value.value }} {% endfor %}]{% endif %}{% if question.description %}, and description "{{ question.description }}"{% endif %}.{% endfor %}
+
+Additionally, we also have one more field which is optional and is the following:
+
+* **external_id:** This is an optional field that can be used to provide an external ID for the dataset record. This can be useful if you want to link the dataset record to an external resource, such as a database or a file.
+
+### Data Splits
+
+The dataset contains a single split, which is `train`.
+
+## Dataset Creation
+
+### Curation Rationale
+
+{{ curation_rationale_section | default("[More Information Needed]", true)}}
+
+### Source Data
+
+#### Initial Data Collection and Normalization
+
+{{ data_collection_section | default("[More Information Needed]", true)}}
+
+#### Who are the source language producers?
+
+{{ source_language_producers_section | default("[More Information Needed]", true)}}
+
+### Annotations
+
+#### Annotation guidelines
+
+{{ annotation_guidelines_section | default("[More Information Needed]", true)}}
+
+#### Annotation process
+
+{{ annotation_process_section | default("[More Information Needed]", true)}}
+
+#### Who are the annotators?
+
+{{ who_are_annotators_section | default("[More Information Needed]", true)}}
+
+### Personal and Sensitive Information
+
+{{ personal_and_sensitive_information_section | default("[More Information Needed]", true)}}
+
+## Considerations for Using the Data
+
+### Social Impact of Dataset
+
+{{ social_impact_section | default("[More Information Needed]", true)}}
+
+### Discussion of Biases
+
+{{ discussion_of_biases_section | default("[More Information Needed]", true)}}
+
+### Other Known Limitations
+
+{{ known_limitations_section | default("[More Information Needed]", true)}}
+
+## Additional Information
+
+### Dataset Curators
+
+{{ dataset_curators_section | default("[More Information Needed]", true)}}
+
+### Licensing Information
+
+{{ licensing_information_section | default("[More Information Needed]", true)}}
+
+### Citation Information
+
+{{ citation_information_section | default("[More Information Needed]", true)}}
+
+### Contributions
+
+{{ contributions_section | default("[More Information Needed]", true)}}

--- a/src/argilla/client/feedback/card/argilla_template.md
+++ b/src/argilla/client/feedback/card/argilla_template.md
@@ -8,7 +8,7 @@
 
 This dataset has been created with [Argilla](https://docs.argilla.io).
 
-As shown in the [dataset description section](#dataset-description), this dataset can be loaded into Argilla, or used directly with the `datasets` library.
+As shown in the sections below, this dataset can be loaded into Argilla as explained in [Load with Argilla](#load-with-argilla), or used directly with the `datasets` library in [Load with `datasets`](#load-with-datasets).
 
 ## Dataset Description
 

--- a/src/argilla/client/feedback/card/argilla_template.md
+++ b/src/argilla/client/feedback/card/argilla_template.md
@@ -10,14 +10,6 @@ This dataset has been created with [Argilla](https://docs.argilla.io).
 
 As shown in the [dataset description section](#dataset-description), this dataset can be loaded into Argilla, or used directly with the `datasets` library.
 
-## Table of Contents
-
-- [Dataset Description](#dataset-description)
-- [Dataset Structure](#dataset-structure)
-- [Dataset Creation](#dataset-creation)
-- [Considerations for Using the Data](#considerations-for-using-the-data)
-- [Additional Information](#additional-information)
-
 ## Dataset Description
 
 - **Homepage:** {{ homepage_url | default("https://argilla.io", true)}}

--- a/src/argilla/client/feedback/card/argilla_template.md
+++ b/src/argilla/client/feedback/card/argilla_template.md
@@ -4,11 +4,19 @@
 {{ card_data }}
 ---
 
-# Dataset Card for {{ dataset_name }}
+# Dataset Card for {{ repo_id.split("/")[-1] }}
 
 This dataset has been created with [Argilla](https://docs.argilla.io).
 
 As shown in the [dataset description section](#dataset-description), this dataset can be loaded into Argilla, or used directly with the `datasets` library.
+
+## Table of Contents
+
+- [Dataset Description](#dataset-description)
+- [Dataset Structure](#dataset-structure)
+- [Dataset Creation](#dataset-creation)
+- [Considerations for Using the Data](#considerations-for-using-the-data)
+- [Additional Information](#additional-information)
 
 ## Dataset Description
 
@@ -82,10 +90,16 @@ Finally, the **guidelines** are just a plain string that can be used to provide 
 
 ### Data Instances
 
-An example of a dataset instance looks as follows:
+An example of a dataset instance in Argilla looks as follows:
 
 ```json
-{{ data_instance | tojson(indent=4) }}
+{{ argilla_record | tojson(indent=4) }}
+```
+
+While the same record in HuggingFace `datasets` looks as follows:
+
+```json
+{{ huggingface_record | tojson(indent=4) }}
 ```
 
 ### Data Fields
@@ -128,7 +142,7 @@ The dataset contains a single split, which is `train`.
 
 #### Annotation guidelines
 
-{{ annotation_guidelines_section | default("[More Information Needed]", true)}}
+{{ argilla_guidelines | default("[More Information Needed]", true)}}
 
 #### Annotation process
 

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -743,7 +743,7 @@ class FeedbackDataset:
             **kwargs: the kwargs to pass to `datasets.Dataset.push_to_hub`.
         """
         import huggingface_hub
-        from huggingface_hub import DatasetCard, HfApi
+        from huggingface_hub import DatasetCard, DatasetCardData, HfApi
         from packaging.version import parse as parse_version
 
         if parse_version(huggingface_hub.__version__) < parse_version("0.14.0"):
@@ -777,6 +777,11 @@ class FeedbackDataset:
             )
 
         if generate_card:
+            yaml_metadata = DatasetCardData(
+                size_categories=["1K<n<10K"],
+                tags=["rlfh", "argilla", "human-feedback"],
+            ).to_yaml()
+
             explained_guidelines = f"## Annotation guidelines\n\n{self.guidelines if self.guidelines else 'There are no annotation guidelines defined for this `FeedbackDataset`.'}"
 
             explained_fields = ["## Fields\n"]
@@ -812,7 +817,12 @@ class FeedbackDataset:
             )
 
             card = DatasetCard(
-                f"{explained_guidelines}\n\n" f"{explained_fields}\n\n" f"{explained_questions}\n\n" f"{loading_guide}"
+                f"---\n{yaml_metadata}\n---\n\n"
+                f"# Dataset card for `{repo_id.split('/')[-1]}`\n\n"
+                f"{explained_guidelines}\n\n"
+                f"{explained_fields}\n\n"
+                f"{explained_questions}\n\n"
+                f"{loading_guide}"
             )
             card.push_to_hub(repo_id, repo_type="dataset", token=kwargs.get("token"))
 

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -777,22 +777,23 @@ class FeedbackDataset:
             )
 
         if generate_card:
-            explained_guidelines = f"## Guidelines\n\n{self.guidelines if self.guidelines else 'There are no guidelines defined for this `FeedbackDataset`.'}\n\n"
+            explained_guidelines = f"## Annotation guidelines\n\n{self.guidelines if self.guidelines else 'There are no annotation guidelines defined for this `FeedbackDataset`.'}"
 
-            explained_fields = ["## Fields\n\n"]
+            explained_fields = ["## Fields\n"]
             for field in self.fields:
                 explained_fields.append(
-                    f"* `{'(optional)' if not field.required else ''} {field.name}` is of type `{type(field).__name__}`\n"
+                    f"\n* `{'(optional)' if not field.required else ''} {field.name}` is of type `{type(field).__name__}`."
                 )
+            explained_fields = "".join(explained_fields)
 
-            explained_questions = ["## Questions\n\n"]
+            explained_questions = ["## Questions\n"]
             for question in self.questions:
                 explained_question = f"* `{'(optional)' if not question.required else ''} {question.name}` is of type `{type(question).__name__}`"
                 if question.settings["type"] == "rating":
                     explained_question += f" with the following allowed values: {[option['value'] for option in question.settings['options']]}"
                 if question.description:
                     explained_question += f" with the following description: '{question.description}'"
-                explained_questions.append(f"{explained_question}.\n")
+                explained_questions.append(f"\n{explained_question}.")
             explained_questions = "".join(explained_questions)
 
             loading_guide = (
@@ -811,10 +812,7 @@ class FeedbackDataset:
             )
 
             card = DatasetCard(
-                f"{explained_guidelines}\n\n"
-                f"{explained_fields}\n\n"
-                f"{explained_questions}\n\n"
-                f"{loading_guide}\n\n"
+                f"{explained_guidelines}\n\n" f"{explained_fields}\n\n" f"{explained_questions}\n\n" f"{loading_guide}"
             )
             card.push_to_hub(repo_id, repo_type="dataset", token=kwargs.get("token"))
 

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -744,7 +744,7 @@ class FeedbackDataset:
             **kwargs: the kwargs to pass to `datasets.Dataset.push_to_hub`.
         """
         import huggingface_hub
-        from huggingface_hub import DatasetCard, DatasetCardData, HfApi
+        from huggingface_hub import DatasetCardData, HfApi
         from packaging.version import parse as parse_version
 
         if parse_version(huggingface_hub.__version__) < parse_version("0.14.0"):

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -34,7 +34,6 @@ from argilla.client.feedback.constants import (
     PUSHING_BATCH_SIZE,
 )
 from argilla.client.feedback.schemas import (
-    FIELD_TYPE_TO_PYTHON_TYPE,
     FeedbackDatasetConfig,
     FeedbackRecord,
     FieldSchema,

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -777,18 +777,22 @@ class FeedbackDataset:
             )
 
         if generate_card:
+            explained_guidelines = f"## Guidelines\n\n{self.guidelines if self.guidelines else 'There are no guidelines defined for this `FeedbackDataset`.'}\n\n"
             explained_fields = "## Fields\n\n" + "".join(
                 [
-                    f"* `{field.name}` is of type {FIELD_TYPE_TO_PYTHON_TYPE[field.settings['type']]}\n"
+                    f"* `{field.name}` is of type `{FIELD_TYPE_TO_PYTHON_TYPE[field.settings['type']].__name__}`\n"
                     for field in self.fields
                 ]
             )
-            explained_questions = "## Questions\n\n" + "".join(
-                [
-                    f"* `{question.name}` {': ' + question.description if question.description else None}\n"
-                    for question in self.questions
-                ]
-            )
+            explained_questions = ["## Questions\n\n"]
+            for question in self.questions:
+                explained_question = f"* `{question.name}` is of type `{type(question).__name__}`"
+                if question.settings["type"] == "rating":
+                    explained_question += f" with the following allowed values: {[option['value'] for option in question.settings['options']]}"
+                if question.description:
+                    explained_question += f" with the following description: '{question.description}'"
+                explained_questions.append(f"{explained_question}.\n")
+            explained_questions = "".join(explained_questions)
             loading_guide = (
                 "## Load with Argilla\n\nTo load this dataset with Argilla, you'll just need to "
                 "install Argilla as `pip install argilla --upgrade` and then use the following code:\n\n"
@@ -804,7 +808,7 @@ class FeedbackDataset:
                 "```"
             )
             card = DatasetCard(
-                f"## Guidelines\n\n{self.guidelines}\n\n"
+                f"{explained_guidelines}\n\n"
                 f"{explained_fields}\n\n"
                 f"{explained_questions}\n\n"
                 f"{loading_guide}\n\n"

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -778,21 +778,23 @@ class FeedbackDataset:
 
         if generate_card:
             explained_guidelines = f"## Guidelines\n\n{self.guidelines if self.guidelines else 'There are no guidelines defined for this `FeedbackDataset`.'}\n\n"
-            explained_fields = "## Fields\n\n" + "".join(
-                [
-                    f"* `{field.name}` is of type `{FIELD_TYPE_TO_PYTHON_TYPE[field.settings['type']].__name__}`\n"
-                    for field in self.fields
-                ]
-            )
+
+            explained_fields = ["## Fields\n\n"]
+            for field in self.fields:
+                explained_fields.append(
+                    f"* `{'(optional)' if not field.required else ''} {field.name}` is of type `{type(field).__name__}`\n"
+                )
+
             explained_questions = ["## Questions\n\n"]
             for question in self.questions:
-                explained_question = f"* `{question.name}` is of type `{type(question).__name__}`"
+                explained_question = f"* `{'(optional)' if not question.required else ''} {question.name}` is of type `{type(question).__name__}`"
                 if question.settings["type"] == "rating":
                     explained_question += f" with the following allowed values: {[option['value'] for option in question.settings['options']]}"
                 if question.description:
                     explained_question += f" with the following description: '{question.description}'"
                 explained_questions.append(f"{explained_question}.\n")
             explained_questions = "".join(explained_questions)
+
             loading_guide = (
                 "## Load with Argilla\n\nTo load this dataset with Argilla, you'll just need to "
                 "install Argilla as `pip install argilla --upgrade` and then use the following code:\n\n"
@@ -807,6 +809,7 @@ class FeedbackDataset:
                 f"ds = load_dataset({repo_id!r})\n"
                 "```"
             )
+
             card = DatasetCard(
                 f"{explained_guidelines}\n\n"
                 f"{explained_fields}\n\n"

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -28,7 +28,7 @@ from pydantic import (
 from tqdm import tqdm
 
 import argilla as rg
-from argilla.client.feedback.card import ArgillaDatasetCard
+from argilla.client.feedback.card import ArgillaDatasetCard, size_categories_parser
 from argilla.client.feedback.constants import (
     FETCHING_BATCH_SIZE,
     FIELD_TYPE_TO_PYTHON_TYPE,
@@ -780,7 +780,7 @@ class FeedbackDataset:
         if generate_card:
             card = ArgillaDatasetCard.from_template(
                 card_data=DatasetCardData(
-                    size_categories=["1K<n<10K"],
+                    size_categories=size_categories_parser(len(self.records)),
                     tags=["rlfh", "argilla", "human-feedback"],
                 ),
                 repo_id=repo_id,

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -784,10 +784,11 @@ class FeedbackDataset:
                     tags=["rlfh", "argilla", "human-feedback"],
                 ),
                 repo_id=repo_id,
-                dataset_name=repo_id.split("/")[-1],
                 argilla_fields=self.fields,
                 argilla_questions=self.questions,
-                data_instance=self.records[0].dict(),
+                argilla_guidelines=self.guidelines,
+                argilla_record=self.records[0].dict(),
+                huggingface_record=hfds[0],
             )
             card.push_to_hub(repo_id, repo_type="dataset", token=kwargs.get("token"))
 

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -28,6 +28,7 @@ from pydantic import (
 from tqdm import tqdm
 
 import argilla as rg
+from argilla.client.feedback.card import ArgillaDatasetCard
 from argilla.client.feedback.constants import (
     FETCHING_BATCH_SIZE,
     FIELD_TYPE_TO_PYTHON_TYPE,
@@ -777,52 +778,16 @@ class FeedbackDataset:
             )
 
         if generate_card:
-            yaml_metadata = DatasetCardData(
-                size_categories=["1K<n<10K"],
-                tags=["rlfh", "argilla", "human-feedback"],
-            ).to_yaml()
-
-            explained_guidelines = f"## Annotation guidelines\n\n{self.guidelines if self.guidelines else 'There are no annotation guidelines defined for this `FeedbackDataset`.'}"
-
-            explained_fields = ["## Fields\n"]
-            for field in self.fields:
-                explained_fields.append(
-                    f"\n* `{'(optional)' if not field.required else ''} {field.name}` is of type `{type(field).__name__}`."
-                )
-            explained_fields = "".join(explained_fields)
-
-            explained_questions = ["## Questions\n"]
-            for question in self.questions:
-                explained_question = f"* `{'(optional)' if not question.required else ''} {question.name}` is of type `{type(question).__name__}`"
-                if question.settings["type"] == "rating":
-                    explained_question += f" with the following allowed values: {[option['value'] for option in question.settings['options']]}"
-                if question.description:
-                    explained_question += f" with the following description: '{question.description}'"
-                explained_questions.append(f"\n{explained_question}.")
-            explained_questions = "".join(explained_questions)
-
-            loading_guide = (
-                "## Load with Argilla\n\nTo load this dataset with Argilla, you'll just need to "
-                "install Argilla as `pip install argilla --upgrade` and then use the following code:\n\n"
-                "```python\n"
-                "import argilla as rg\n\n"
-                f"ds = rg.FeedbackDataset.from_huggingface({repo_id!r})\n"
-                "```\n\n"
-                "## Load with Datasets\n\nTo load this dataset with Datasets, you'll just need to "
-                "install Datasets as `pip install datasets --upgrade` and then use the following code:\n\n"
-                "```python\n"
-                "from datasets import load_dataset\n\n"
-                f"ds = load_dataset({repo_id!r})\n"
-                "```"
-            )
-
-            card = DatasetCard(
-                f"---\n{yaml_metadata}\n---\n\n"
-                f"# Dataset card for `{repo_id.split('/')[-1]}`\n\n"
-                f"{explained_guidelines}\n\n"
-                f"{explained_fields}\n\n"
-                f"{explained_questions}\n\n"
-                f"{loading_guide}"
+            card = ArgillaDatasetCard.from_template(
+                card_data=DatasetCardData(
+                    size_categories=["1K<n<10K"],
+                    tags=["rlfh", "argilla", "human-feedback"],
+                ),
+                repo_id=repo_id,
+                dataset_name=repo_id.split("/")[-1],
+                argilla_fields=self.fields,
+                argilla_questions=self.questions,
+                data_instance=self.records[0].dict(),
             )
             card.push_to_hub(repo_id, repo_type="dataset", token=kwargs.get("token"))
 

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -96,9 +96,6 @@ class TextField(FieldSchema):
         return False
 
 
-FIELD_TYPE_TO_PYTHON_TYPE = {"text": str}
-
-
 class QuestionSchema(BaseModel):
     name: str
     title: Optional[str] = None

--- a/src/argilla/client/feedback/utils.py
+++ b/src/argilla/client/feedback/utils.py
@@ -24,7 +24,6 @@ from argilla.client.feedback.constants import (
     FIELD_TYPE_TO_PYTHON_TYPE,
 )
 from argilla.client.feedback.schemas import (
-    FIELD_TYPE_TO_PYTHON_TYPE,
     FieldSchema,
 )
 from argilla.client.sdk.v1.datasets import api as datasets_api_v1

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -15,7 +15,6 @@
 import datetime
 from typing import TYPE_CHECKING, List
 
-import argilla
 import argilla as rg
 import pytest
 from argilla.client.sdk.datasets.models import TaskType
@@ -76,10 +75,10 @@ def gutenberg_spacy_ner(mocked_client):
         revision="fff5f572e4cc3127f196f46ba3f9914c6fd0d763",
     )
 
-    dataset_rb = argilla.read_datasets(dataset_ds, task="TokenClassification")
+    dataset_rb = rg.read_datasets(dataset_ds, task="TokenClassification")
 
-    argilla.delete(dataset)
-    argilla.log(name=dataset, records=dataset_rb)
+    rg.delete(dataset)
+    rg.log(name=dataset, records=dataset_rb)
 
     return dataset
 

--- a/tests/client/conftest.py
+++ b/tests/client/conftest.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, List
 import argilla as rg
 import pytest
 from argilla.client.sdk.datasets.models import TaskType
+from datasets import Dataset
 
 if TYPE_CHECKING:
     from argilla.client.feedback.schemas import AllowedFieldTypes, AllowedQuestionTypes
@@ -440,3 +441,18 @@ def feedback_dataset_records() -> List[FeedbackRecord]:
             external_id="2",
         ),
     ]
+
+
+@pytest.fixture
+def feedback_dataset_huggingface() -> Dataset:
+    return Dataset.from_dict(
+        {
+            "text": ["This is a positive example"],
+            "label": ["positive"],
+            "question-1": [{"user_id": [None], "value": ["This is a response to question 1"], "status": ["submitted"]}],
+            "question-2": [{"user_id": [None], "value": [1], "status": ["submitted"]}],
+            "question-3": [{"user_id": [None], "value": ["a"], "status": ["submitted"]}],
+            "question-4": [{"user_id": [None], "value": [["a", "b"]], "status": ["submitted"]}],
+            "external_id": ["1"],
+        }
+    )

--- a/tests/client/feedback/test_card.py
+++ b/tests/client/feedback/test_card.py
@@ -1,0 +1,70 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import TYPE_CHECKING, List
+
+import pytest
+from argilla.client.feedback.card import ArgillaDatasetCard, size_categories_parser
+from huggingface_hub import DatasetCardData
+
+if TYPE_CHECKING:
+    from argilla.client.feedback.schemas import (
+        AllowedFieldTypes,
+        AllowedQuestionTypes,
+        FeedbackRecord,
+    )
+    from datasets import Dataset
+
+
+@pytest.mark.parametrize(
+    "size,expected",
+    [
+        (1, "n<1K"),
+        (999, "n<1K"),
+        (1_000, "1K<n<10K"),
+        (10_000_000_000_001, "n>1T"),
+    ],
+)
+def test_size_categories_parser(size: int, expected: str) -> None:
+    assert size_categories_parser(size) == expected
+
+
+@pytest.mark.usefixtures(
+    "feedback_dataset_fields",
+    "feedback_dataset_questions",
+    "feedback_dataset_guidelines",
+    "feedback_dataset_records",
+    "feedback_dataset_huggingface",
+)
+def test_argilla_dataset_card_from_template(
+    feedback_dataset_fields: List["AllowedFieldTypes"],
+    feedback_dataset_questions: List["AllowedQuestionTypes"],
+    feedback_dataset_guidelines: str,
+    feedback_dataset_records: List["FeedbackRecord"],
+    feedback_dataset_huggingface: "Dataset",
+) -> None:
+    card = ArgillaDatasetCard.from_template(
+        card_data=DatasetCardData(language="en", size_categories="n<1K", tags=["rlfh", "argilla", "human-feedback"]),
+        template_path=ArgillaDatasetCard.default_template_path,
+        repo_id="argilla/dataset-card",
+        argilla_fields=feedback_dataset_fields,
+        argilla_questions=feedback_dataset_questions,
+        argilla_guidelines=feedback_dataset_guidelines,
+        argilla_record=feedback_dataset_records[0].dict(),
+        huggingface_record=feedback_dataset_huggingface[0],
+    )
+
+    assert isinstance(card, ArgillaDatasetCard)
+    assert card.default_template_path == ArgillaDatasetCard.default_template_path
+    assert card.content.__contains__("# Dataset Card for dataset-card")


### PR DESCRIPTION
# Description

Curate the auto-generated `DatasetCard` when calling `FeedbackDataset.push_to_huggingface(..., generate_card=True)` since there were some things that were not looking fine in terms of style and readability.

So now we're using the `DatasetCard` template provided by the HuggingFace Hub team, but with some minor tweaks to create `ArgillaDatasetCard`. We're using the template defined at https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/templates/datasetcard_template.md.

Closes #3018 and #3066

**Type of change**

- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

- [X] Uploaded various datasets to the HuggingFace Hub via `FeedbackDataset.push_to_huggingface` with questions without description, questions with description, rating questions with different values, and different combination of those.

**Checklist**

- [X] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)