### PR TITLE
[DOCS] Change version of argilla in pip install command

### DIFF
--- a/docs/_source/tutorials/notebooks/labelling-textclassification-setfit-zeroshot.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-setfit-zeroshot.ipynb
@@ -36,6 +36,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "VC3Vr_cHXywF"
@@ -69,6 +70,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "nmo0eqPTXywI"
@@ -88,10 +90,11 @@
    },
    "outputs": [],
    "source": [
-    "%pip install argilla==1.3.0 datasets==2.8.0 sentence-transformers==2.2.2 setfit==0.6.0 plotly==4.1.0 -qqq"
+    "%pip install argilla==1.8.0 datasets==2.8.0 sentence-transformers==2.2.2 setfit==0.6.0 plotly==4.1.0 -qqq"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "rhjQqFAnXywJ"
@@ -113,6 +116,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "7TRNourOwigS"
@@ -139,6 +143,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "PLMuw3w_XywO"
@@ -207,6 +212,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "aja6kiW4XywS"
@@ -451,6 +457,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "-ZQMFaRLXywT"
@@ -1615,6 +1622,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "oeV9Kig-tlrr"


### PR DESCRIPTION
# Description

In command %pip install, I changed argilla version from 1.3 to 1.8. While running the tutorial, I got an error saying that a workspace had to be provided. I fixed it by updating to the last version.

**Type of change**

- [X] Documentation update

**How Has This Been Tested**

- [X] Run the entire notebook. No errors raised. 
- [ ] I don't know why the graphs in the last cell are empty. Probably because I didn't do any labeling for the test?
![imagen](https://github.com/argilla-io/argilla/assets/69391549/fc8a13e9-5c24-4abf-b857-7a2a592c1253)


**Checklist**

- [X] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)