### PR TITLE
:bug: FIX : passing null responseid break discard submit

### DIFF
--- a/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
+++ b/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
@@ -385,6 +385,7 @@ export default {
     formatResponsesApiForOrm(responsesFromApi) {
       const formattedRecordResponsesForOrm = [];
       if (responsesFromApi.values) {
+        // TODO - simplify if/else by one loop
         if (Object.keys(responsesFromApi.values).length === 0) {
           // IF responses.value  is an empty object, init formatted responses with questions data
           this.inputs.forEach(

--- a/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
+++ b/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
@@ -405,7 +405,7 @@ export default {
           // 1/ push formatted object corresponding to recordResponse which have been remove from api
           this.currentInputsWithNoResponses.forEach((input) => {
             formattedRecordResponsesForOrm.push({
-              id: input.response_id,
+              id: responsesFromApi.id,
               question_name: input.name,
               options: input.options,
               record_id: this.recordId,


### PR DESCRIPTION
# Description
Last refactoring to prepare `SingleLabel` and `MultiLabel` breaks the discard and submit.
The problem was that we the `responseId` put into the orm could be `null`, so it was not possible to update the corresponding response.

To reproduce : 
- Go to a dataset `pending` record_status, with questions `required` and `not required`
- answer the required question but not the optional
- `discard` the form
-  answer the optional and `submit`
=> an error is raising because a wrong `responseId` (an id from vuexOrm like `$uX`) is rising

**Type of change**

- Bug fix

**How Has This Been Tested**

- Only feedback task 
