### PR TITLE
fix: resolved missing training references and big page navigation icons

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.9"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/_source/_templates/page.html
+++ b/docs/_source/_templates/page.html
@@ -154,16 +154,12 @@
               </div>
               <div class="title">{{ next.title }}</div>
             </div>
-            <svg>
-              <use href="#svg-arrow-right"></use>
-            </svg>
+            <svg class="furo-related-icon"><use href="#svg-arrow-right"></use></svg>
           </a>
           {%- endif %}
           {% if prev -%}
           <a class="prev-page" href="{{ prev.link }}">
-            <svg>
-              <use href="#svg-arrow-right"></use>
-            </svg>
+            <svg class="furo-related-icon"><use href="#svg-arrow-right"></use></svg>
             <div class="page-info">
               <div class="context">
                 <span>{{ _("Previous") }}</span>

--- a/docs/_source/reference/python/python_training.rst
+++ b/docs/_source/reference/python/python_training.rst
@@ -7,6 +7,9 @@ Here we describe the available trainers in Argilla:
 
 - Base Trainer: Internal mechanism to handle Trainers
 - SetFit Trainer: Internal mechanism for handling training logic of SetFit models
+- OpenAI Trainer: Internal mechanism for handling training logic of OpenAI models
+- PEFT (LoRA) Trainer: Internal mechanism for handling training logic of PEFT (LoRA) models
+- AutoTrain Trainer: Internal mechanism for handling training logic of AutoTrain models
 - spaCy Trainer: Internal mechanism for handling training logic of spaCy models
 - Transformers Trainer: Internal mechanism for handling training logic of Transformers models
 - SpanMarker Trainer: Internal mechanism for handling training logic of SpanMarker models
@@ -21,6 +24,24 @@ SetFit Trainer
 --------------
 
 .. automodule:: argilla.training.setfit
+   :members:
+
+OpenAI Trainer
+--------------
+
+.. automodule:: argilla.training.openai
+   :members:
+
+PEFT (LoRA) Trainer
+-------------------
+
+.. automodule:: argilla.training.peft
+   :members:
+
+AutoTrain Trainer
+-----------------
+
+.. automodule:: argilla.training.autotrain_advanced
    :members:
 
 spaCy Trainer


### PR DESCRIPTION
fix: resolved large page navigation icons

# Description

- added Trainer API references
- updated template formatting
- updated build Python version to allow for PeftTrainer import


**Type of change**

- [X] Documentation update

**How Has This Been Tested**

N.A.

**Checklist**

N.A.