### PR TITLE
[Docs] Fix export feedback dataset link

### DIFF
--- a/docs/_source/guides/llms/practical_guides/practical_guides.md
+++ b/docs/_source/guides/llms/practical_guides/practical_guides.md
@@ -28,7 +28,7 @@ Check the Feedback Task UI and the available shortcuts.
 Collect annotations and solve disagreements.
 ```
 ```{grid-item-card} Export a Feedback Dataset
-:link: import_export_dataset.html
+:link: export_dataset.html
 
 Export your dataset and save it in the Hugging Face Hub or locally.
 


### PR DESCRIPTION
# Description

Fix the broken `Export a Feedback Dataset` link [here](https://docs.argilla.io/en/latest/guides/llms/practical_guides/practical_guides.html).

**Type of change**

- [x] Documentation update

Thanks @gabrielmbmb for reporting internally.

- Tom Aarsen