### PR TITLE
[DOCS] Fix broken links and develop branch name in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ These are the section headers that we use:
 ### Fixed
 
 - Disallow `fields` and `questions` in `FeedbackDataset` with the same name ([#3126]).
+- Fixed broken links in the documentation and updated the development branch name from `development` to `develop` ([#3145]).
 
 [#3126]: https://github.com/argilla-io/argilla/pull/3126
 

--- a/docs/_source/community/contributing.md
+++ b/docs/_source/community/contributing.md
@@ -57,7 +57,7 @@ Scan through our [existing issues](https://github.com/argilla-io/argilla/issues?
 
 ### Make Changes
 
-- Create [a fork](https://github.com/argilla-io/argilla/fork) of our `development` branch.
+- Create [a fork](https://github.com/argilla-io/argilla/fork) of our `develop` branch.
   - Note, for updates solely to the documentation, you are allowed to work in the `main` branch.
 - To start working on code changes, we suggest, you take a look at our tutorial on setting up the [development environment](./developer_docs.md).
 - Work on your awesome contribution and adhere to our formatting guidelines.

--- a/docs/_source/community/developer_docs.md
+++ b/docs/_source/community/developer_docs.md
@@ -8,7 +8,7 @@ Here we provide some guides for the development of *Argilla*.
 
 Argilla supports ElasticSearch and OpenSearch as his main search engine. One of the two is required to correctly run Argilla in your development environment.
 
-For more information please visit our [Setup and Installation](../getting_started/installation/installation.md) section.
+For more information please visit our [Setup and Installation](../getting_started/installation/deployments/deployments.md) section.
 
 ### SQLite
 

--- a/docs/_source/getting_started/installation/deployments/docker.md
+++ b/docs/_source/getting_started/installation/deployments/docker.md
@@ -67,7 +67,7 @@ But you can customize this by setting the `ELASTICSEARCH` environment variable.
 docker run --network argilla-net -p 6900:6900 -e "ELASTICSEARCH=http://elasticsearch-for-argilla:9200" --name argilla argilla/argilla-server
 ```
 :::{note}
-By default, telemetry is enabled. This helps us to improve our product. For more info about the metrics and disabling them check [telemetry](../../reference/telemetry.md).
+By default, telemetry is enabled. This helps us to improve our product. For more info about the metrics and disabling them check [telemetry](../../../reference/telemetry.md).
 
 :::
 


### PR DESCRIPTION
# Description

Fixed two broken links the docs and corrected the name of the development branch, from `development` to `develop`.

Closes #3145 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Documentation update

**How Has This Been Tested**

- [x] Tested by developing the docs using `make html` and verified the links

**Checklist**

- [x] I have merged the original branch into my forked branch
- [x] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)