### PR TITLE
🐛 FIX : Replaced Enum for string value in URLs for client API calls

### DIFF
--- a/src/argilla/client/apis/datasets.py
+++ b/src/argilla/client/apis/datasets.py
@@ -316,13 +316,13 @@ class Datasets(AbstractApi):
         try:
             with api_compatibility(self, min_version="1.4"):
                 self.http_client.patch(
-                    f"{self._API_PREFIX}/{dataset.name}/{dataset.task}/settings",
+                    f"{self._API_PREFIX}/{dataset.name}/{dataset.task.value}/settings",
                     json=settings_.dict(),
                 )
         except ApiCompatibilityError:
             with api_compatibility(self, min_version="0.15"):
                 self.http_client.put(
-                    f"{self._API_PREFIX}/{dataset.task}/{dataset.name}/settings",
+                    f"{self._API_PREFIX}/{dataset.task.value}/{dataset.name}/settings",
                     json=settings_.dict(),
                 )
 
@@ -339,7 +339,7 @@ class Datasets(AbstractApi):
         dataset = self.find_by_name(name)
         try:
             with api_compatibility(self, min_version="1.0"):
-                response = self.http_client.get(f"{self._API_PREFIX}/{dataset.name}/{dataset.task}/settings")
+                response = self.http_client.get(f"{self._API_PREFIX}/{dataset.name}/{dataset.task.value}/settings")
                 return __TASK_TO_SETTINGS__.get(dataset.task).from_dict(response)
         except NotFoundApiError:
             return None


### PR DESCRIPTION
# Description

This PR fixes saving settings programmatically, with replacing ENUM for string value of task name in URLs which calls client.

Closes #3149 

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)