### PR TITLE
fix: explicit import svg icons in the Feedback Task form

### DIFF
--- a/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
+++ b/frontend/components/commons/forms/questions-form/QuestionsForm.component.vue
@@ -101,6 +101,7 @@
 </template>
 
 <script>
+import "assets/icons/external";
 import { isEqual, cloneDeep } from "lodash";
 import { Notification } from "@/models/Notifications";
 import { COMPONENT_TYPE } from "@/components/feedback-task/feedbackTask.properties";

--- a/frontend/components/commons/forms/questions-form/fields/shared-components/question-header/QuestionHeader.component.vue
+++ b/frontend/components/commons/forms/questions-form/fields/shared-components/question-header/QuestionHeader.component.vue
@@ -18,6 +18,7 @@
 </template>
 
 <script>
+import "assets/icons/info";
 export default {
   name: "QuestionHeader",
   props: {


### PR DESCRIPTION
# Description

This PR makes an explicit import of the "export" and "info" icons in the Feedback Task form, in order to be always visible in all environments.

Closes #3154

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)