### PR TITLE
chore: resolved wrong password notation for default user in docs

### DIFF
--- a/docs/_source/getting_started/installation/configurations/user_management.md
+++ b/docs/_source/getting_started/installation/configurations/user_management.md
@@ -45,7 +45,7 @@ rg.set_workspace("my_private_workspace")
 By default, if the Argilla instance has no users, the following default admin user will be configured:
 
 - username: `argilla`
-- password: `1234`
+- password: `12345678`
 - api_key: `argilla.apikey`
 
 For security reasons, we recommend changing at least the password and the API key. You can do this via the following CLI command:


### PR DESCRIPTION
# Description

resolved wrong password notation for default user in docs

Closes #3159 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Documentation update

**How Has This Been Tested**
N.A.

**Checklist**

N.A.