### PR TITLE
feat: return `total` number of search hits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ These are the section headers that we use:
 
 ## [Unreleased]
 
+## [1.10.0](https://github.com/argilla-io/argilla/compare/v1.9.0...v1.10.0)
+
+### Changed
+
+- Updated `SearchEngine` and `POST /api/v1/me/datasets/{dataset_id}/records/search` to return the `total` number of records matching the search query ([#3166](https://github.com/argilla-io/argilla/pull/3166))
+
 ## [1.9.0](https://github.com/argilla-io/argilla/compare/v1.8.0...v1.9.0)
 
 ### Added

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -352,7 +352,9 @@ async def search_dataset_records(
             record=record.__dict__, query_score=record_id_score_map[record.id]["query_score"]
         )
 
-    return SearchRecordsResult(items=[record["search_record"] for record in record_id_score_map.values()])
+    return SearchRecordsResult(
+        items=[record["search_record"] for record in record_id_score_map.values()], total=search_responses.total
+    )
 
 
 @router.put("/datasets/{dataset_id}/publish", response_model=Dataset)

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -355,3 +355,4 @@ class SearchRecord(BaseModel):
 
 class SearchRecordsResult(BaseModel):
     items: List[SearchRecord]
+    total: int = 0

--- a/src/argilla/server/search_engine.py
+++ b/src/argilla/server/search_engine.py
@@ -202,6 +202,7 @@ class SearchEngine:
             size=limit,
             _source=False,
             sort="_score:desc,id:asc",
+            track_total_hits=True,
         )
 
         items = [

--- a/src/argilla/server/search_engine.py
+++ b/src/argilla/server/search_engine.py
@@ -90,6 +90,7 @@ class SearchResponseItem:
 @dataclasses.dataclass
 class SearchResponses:
     items: List[SearchResponseItem]
+    total: int = 0
 
 
 @dataclasses.dataclass
@@ -206,8 +207,9 @@ class SearchEngine:
         items = [
             SearchResponseItem(record_id=UUID(hit["_id"]), score=hit["_score"]) for hit in response["hits"]["hits"]
         ]
+        total = response["hits"]["total"]["value"]
 
-        return SearchResponses(items=items)
+        return SearchResponses(items=items, total=total)
 
     @staticmethod
     def _text_query_builder(dataset: Dataset, text: TextQuery) -> dict:

--- a/tests/server/api/v1/test_datasets.py
+++ b/tests/server/api/v1/test_datasets.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import TYPE_CHECKING, List, Optional, Tuple, Type
+from typing import List, Optional, Tuple, Type
 from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
@@ -72,9 +72,6 @@ from tests.factories import (
     TextQuestionFactory,
     WorkspaceFactory,
 )
-
-if TYPE_CHECKING:
-    from pytest_mock import MockerFixture
 
 
 def test_list_current_user_datasets(client: TestClient, admin_auth_header: dict):
@@ -2460,7 +2457,8 @@ def test_search_dataset_records(
         items=[
             SearchResponseItem(record_id=records[0].id, score=14.2),
             SearchResponseItem(record_id=records[1].id, score=12.2),
-        ]
+        ],
+        total=2,
     )
 
     query_json = {"query": {"text": {"q": "Hello", "field": "input"}}}
@@ -2509,7 +2507,8 @@ def test_search_dataset_records(
                 },
                 "query_score": 12.2,
             },
-        ]
+        ],
+        "total": 2,
     }
 
 
@@ -2522,7 +2521,8 @@ def test_search_dataset_records_including_responses(
         items=[
             SearchResponseItem(record_id=records[0].id, score=14.2),
             SearchResponseItem(record_id=records[1].id, score=12.2),
-        ]
+        ],
+        total=2,
     )
 
     query_json = {"query": {"text": {"q": "Hello", "field": "input"}}}
@@ -2600,7 +2600,8 @@ def test_search_dataset_records_including_responses(
                 },
                 "query_score": 12.2,
             },
-        ]
+        ],
+        "total": 2,
     }
 
 
@@ -2608,7 +2609,7 @@ def test_search_dataset_records_with_response_status_filter(
     client: TestClient, mock_search_engine: SearchEngine, admin: User, admin_auth_header: dict
 ):
     dataset, _, _ = create_dataset_for_search(user=admin)
-    mock_search_engine.search.return_value = SearchResponses(items=[])
+    mock_search_engine.search.return_value = SearchResponses(items=[], total=0)
 
     query_json = {"query": {"text": {"q": "Hello", "field": "input"}}}
     response = client.post(
@@ -2636,7 +2637,8 @@ def test_search_dataset_records_with_offset_and_limit(
         items=[
             SearchResponseItem(record_id=records[0].id, score=14.2),
             SearchResponseItem(record_id=records[1].id, score=12.2),
-        ]
+        ],
+        total=2,
     )
 
     query_json = {"query": {"text": {"q": "Hello", "field": "input"}}}
@@ -2655,7 +2657,9 @@ def test_search_dataset_records_with_offset_and_limit(
         limit=5,
     )
     assert response.status_code == 200
-    assert len(response.json()["items"]) == 2
+    response_json = response.json()
+    assert len(response_json["items"]) == 2
+    assert response_json["total"] == 2
 
 
 def test_search_dataset_records_as_annotator(client: TestClient, admin: User, mock_search_engine: SearchEngine):
@@ -2666,7 +2670,8 @@ def test_search_dataset_records_as_annotator(client: TestClient, admin: User, mo
         items=[
             SearchResponseItem(record_id=records[0].id, score=14.2),
             SearchResponseItem(record_id=records[1].id, score=12.2),
-        ]
+        ],
+        total=2,
     )
 
     query_json = {"query": {"text": {"q": "unit test", "field": "input"}}}


### PR DESCRIPTION
# Description

I've added the `total` attribute to the `SearchResponses` and `SearchRecordResult` (schema) classes, so the `POST /api/v1/me/datasets/{dataset_id}/records/search` will return a number of the total records that the ElasticSearch query returned.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

Manually doing several requests to a local server with a dataset containing IMDB reviews. Also, I've updated the unit tests regarding the `SearchEngine` and `search` endpoint.

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)