### PR TITLE
FIX: Use underlying tokenizer for batch encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ These are the section headers that we use:
 
 ## [Unreleased]
 
+### Fixed
+
+- Resolve breaking issue with `ArgillaSpanMarkerTrainer` for Named Entity Recognition with `span_marker` v1.1.x onwards.
+
 ## [1.9.0](https://github.com/argilla-io/argilla/compare/v1.8.0...v1.9.0)
 
 ### Added

--- a/src/argilla/training/span_marker.py
+++ b/src/argilla/training/span_marker.py
@@ -164,7 +164,7 @@ class ArgillaSpanMarkerTrainer(ArgillaTrainerSkeleton):
                     (entity["label"], entity["char_start_index"], entity["char_end_index"], entity["score"])
                     for entity in entities
                 ]
-                encoding = self._span_marker_model.tokenizer(sentence, return_batch_encoding=True)["batch_encoding"]
+                encoding = self._span_marker_model.tokenizer.tokenizer(sentence)
                 word_ids = sorted(set(encoding.word_ids()) - {None})
                 tokens = []
                 for word_id in word_ids:


### PR DESCRIPTION
Hello!

# Description

Use underlying tokenizer for batch encoding rather than SpanMarkerTokenizer. That way, I can still freely update the SpanMarkerTokenizer. The underlying tokenizer `SpanMarkerTokenizer.tokenizer` should always tokenize equivalently as the `SpanMarkerTokenizer`. This change works for older and newer `span_marker` versions.

The reason this broke is because I changed the input to the `SpanMarkerTokenizer`.

Should fix the CI issues.

**Type of change**

- [x] Bug fix 

**How Has This Been Tested**

Running the test suite.

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

---

cc: @gabrielmbmb for notifying me that there were some issues

- Tom Aarsen