### PR TITLE
fix: unhandled `ImportError` on `huggingface_hub`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@ These are the section headers that we use:
 ### Changed
 
 - Updated `SearchEngine` and `POST /api/v1/me/datasets/{dataset_id}/records/search` to return the `total` number of records matching the search query ([#3166](https://github.com/argilla-io/argilla/pull/3166))
+
 ### Fixed
 
 - Resolve breaking issue with `ArgillaSpanMarkerTrainer` for Named Entity Recognition with `span_marker` v1.1.x onwards.
+- Move `ArgillaDatasetCard` import under `@requires_version` decorator, so that the `ImportError` on `huggingface_hub` is handled properly ([#3174](https://github.com/argilla-io/argilla/pull/3174))
 
 ## [1.9.0](https://github.com/argilla-io/argilla/compare/v1.8.0...v1.9.0)
 

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -28,7 +28,6 @@ from pydantic import (
 from tqdm import tqdm
 
 import argilla as rg
-from argilla.client.feedback.card import ArgillaDatasetCard, size_categories_parser
 from argilla.client.feedback.constants import (
     FETCHING_BATCH_SIZE,
     FIELD_TYPE_TO_PYTHON_TYPE,
@@ -840,6 +839,11 @@ class FeedbackDataset:
             )
 
         if generate_card:
+            from argilla.client.feedback.card import (
+                ArgillaDatasetCard,
+                size_categories_parser,
+            )
+
             card = ArgillaDatasetCard.from_template(
                 card_data=DatasetCardData(
                     size_categories=size_categories_parser(len(self.records)),


### PR DESCRIPTION
# Description

As reported by @dvsrepo, when installing `argilla` without any extra dependency, an unhandled `ImportError` is raised. That's due to the import of `ArgillaDatasetCard` being on top of the file instead of under the `@requires_version` decorator, so that the `ImportError` will still be raised, but at least it will be handled.

Also the `ImportError` was being triggered just when importing the `FeedbackDataset` class as it was on top of the file, which was obviously wrong, as it should just raise when calling `push_to_huggingface`.

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [X] Re-run unit tests locally on Python 3.11
- [X] Make sure that `from argilla.client.feedback.dataset import FeedbackDataset` doesn't raise an `ImportError` when `huggingface_hub` is not installed

**Checklist**

- [X] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)