### PR TITLE
feat: reviewing user tasks cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,18 @@ These are the section headers that we use:
 
 ## [Unreleased]
 
+### Added
+
+- New `users update` command to update the role for an existing user ([#3188])
+
 ### Changed
 
 - The role system now support three different roles `owner`, `admin` and `annotator` ([#3094])
 - `admin` role is scoped to workspace-level operations ([#3094])
+- Default argilla user has the `admin` role instead of `owner` one.
 
 [#3094]: https://github.com/argilla-io/argilla/issues/3094
+[#3188]: https://github.com/argilla-io/argilla/pull/3188
 
 ## [1.10.0](https://github.com/argilla-io/argilla/compare/v1.9.0...v1.10.0)
 

--- a/src/argilla/tasks/users/__main__.py
+++ b/src/argilla/tasks/users/__main__.py
@@ -17,13 +17,13 @@ import typer
 from .create import create
 from .create_default import create_default
 from .migrate import migrate
-
-# from .create import create
+from .update import update
 
 app = typer.Typer(help="Holds CLI commands for user and workspace management.", no_args_is_help=True)
 
 app.command(name="create_default", help="Creates default users and workspaces in the Argilla database.")(create_default)
 app.command(name="create", help="Creates a user and add it to the Argilla database.", no_args_is_help=True)(create)
+app.command(name="update", help="Updates the user's role into the Argilla database.", no_args_is_help=True)(update)
 app.command(name="migrate")(migrate)
 
 

--- a/src/argilla/tasks/users/create.py
+++ b/src/argilla/tasks/users/create.py
@@ -69,7 +69,6 @@ def create(
         help="Username as a lowercase string without spaces allowing letters, numbers, dashes and underscores.",
     ),
     role: UserRole = typer.Option(
-        callback=role_callback,
         prompt=True,
         default=UserRole.annotator.value,
         show_default=True,

--- a/src/argilla/tasks/users/create_default.py
+++ b/src/argilla/tasks/users/create_default.py
@@ -37,7 +37,7 @@ def create_default(
             User(
                 first_name="",
                 username=DEFAULT_USERNAME,
-                role=UserRole.owner,
+                role=UserRole.admin,
                 api_key=api_key,
                 password_hash=accounts.hash_password(password),
                 workspaces=[Workspace(name=DEFAULT_USERNAME)],

--- a/src/argilla/tasks/users/update.py
+++ b/src/argilla/tasks/users/update.py
@@ -1,0 +1,52 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import typer
+
+from argilla.server.contexts import accounts
+from argilla.server.database import SessionLocal
+from argilla.server.models import UserRole
+
+
+def update(
+    username: str = typer.Argument(
+        default=None,
+        help="Username as a lowercase string without spaces allowing letters, numbers, dashes and underscores.",
+    ),
+    role: UserRole = typer.Option(
+        prompt=True,
+        default=None,
+        show_default=False,
+        help="New role for the user.",
+    ),
+):
+    with SessionLocal() as session:
+        user = accounts.get_user_by_username(session, username)
+
+        if not user:
+            typer.echo(f"User with username {username!r} does not exists in database. Skipping...")
+            return
+
+        if user.role == role:
+            typer.echo(f"User {username!r} already has role {role.value!r}. Skipping...")
+            return
+
+        old_role = user.role
+        user.role = role
+
+        session.add(user)
+        session.commit()
+
+        typer.echo(f"User {username!r} successfully updated:")
+        typer.echo(f"• role: {old_role.value!r} -> {user.role.value!r}")

--- a/tests/tasks/users/conftest.py
+++ b/tests/tasks/users/conftest.py
@@ -25,5 +25,6 @@ if TYPE_CHECKING:
 def mock_session_local(mocker: "MockerFixture", db: "Session") -> None:
     mocker.patch.object(db, "close", side_effect=lambda: None)
     mocker.patch("argilla.tasks.users.create.SessionLocal", return_value=db)
+    mocker.patch("argilla.tasks.users.update.SessionLocal", return_value=db)
     mocker.patch("argilla.tasks.users.create_default.SessionLocal", return_value=db)
     mocker.patch("argilla.tasks.users.migrate.SessionLocal", return_value=db)

--- a/tests/tasks/users/test_create_default.py
+++ b/tests/tasks/users/test_create_default.py
@@ -28,7 +28,7 @@ def test_create_default(db: Session, cli_runner: CliRunner, cli: Typer):
 
     default_user = db.query(User).filter_by(username=DEFAULT_USERNAME).first()
     assert default_user
-    assert default_user.role == UserRole.owner
+    assert default_user.role == UserRole.admin
     assert default_user.api_key == DEFAULT_API_KEY
     assert accounts.verify_password(DEFAULT_PASSWORD, default_user.password_hash)
     assert [ws.name for ws in default_user.workspaces] == [DEFAULT_USERNAME]
@@ -43,7 +43,7 @@ def test_create_default_with_specific_api_key_and_password(db: Session, cli_runn
 
     default_user = db.query(User).filter_by(username=DEFAULT_USERNAME).first()
     assert default_user
-    assert default_user.role == UserRole.owner
+    assert default_user.role == UserRole.admin
     assert default_user.api_key == "my-api-key"
     assert accounts.verify_password("my-password", default_user.password_hash)
     assert [ws.name for ws in default_user.workspaces] == [DEFAULT_USERNAME]

--- a/tests/tasks/users/test_update.py
+++ b/tests/tasks/users/test_update.py
@@ -1,0 +1,60 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+from argilla.server.models import User, UserRole
+from click.testing import CliRunner
+from sqlalchemy.orm import Session
+from typer import Typer
+
+from tests.factories import UserFactory
+
+
+@pytest.mark.parametrize("new_role_string", ["owner", "admin"])
+def test_update(db: Session, cli_runner: CliRunner, cli: Typer, new_role_string: str):
+    UserFactory.create(username="username", role=UserRole.annotator)
+
+    result = cli_runner.invoke(cli, f"users update username --role {new_role_string}")
+
+    assert result.exit_code == 0
+
+    user = db.query(User).filter_by(username="username").first()
+    assert user.role.value == UserRole(new_role_string).value
+
+
+def test_update_with_invalid_role(db: Session, cli_runner: CliRunner, cli: Typer):
+    bad_role_str = "bad-role"
+    result = cli_runner.invoke(cli, f"users update username --role {bad_role_str}")
+
+    assert result.exit_code == 2
+    assert f"{bad_role_str!r} is not" in result.output
+
+
+def test_update_with_missing_username(db: Session, cli_runner: CliRunner, cli: Typer):
+    missing_username = "missing-username"
+    result = cli_runner.invoke(cli, f"users update {missing_username} --role owner")
+
+    assert result.exit_code == 0
+    assert result.output == f"User with username {missing_username!r} does not exists in database. Skipping...\n"
+
+
+@pytest.mark.parametrize("role_string", ["owner", "admin", "annotator"])
+def test_update_with_same_user_role(db: Session, cli_runner: CliRunner, cli: Typer, role_string):
+    username = "username"
+    UserFactory.create(username=username, role=UserRole(role_string))
+
+    result = cli_runner.invoke(cli, f"users update {username} --role {role_string}")
+
+    assert result.exit_code == 0
+    assert result.output == f"User {username!r} already has role {role_string!r}. Skipping...\n"


### PR DESCRIPTION
# Description

This PRs mainly adds a new users task command to update an existing user (for now, only the user role can be used, but other fields like last name or even the password can be updated through this command)

Also, some refactors have been applied:

-  Remove the role_callback function, since `typer` tries to cast the role into a valid `UserRole` value.
- The default user is defined with the `admin` role, instead of `owner`. This still works for environments with one single user and workspace.


**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (change restructuring the codebase without changing functionality)
- [x] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

New tests have been added

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)