### PR TITLE
Fixing the base docker image to fix the docker build

### DIFF
--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.9.16-slim
 
 # Environment Variables
 ENV ARGILLA_HOME_PATH=/var/lib/argilla


### PR DESCRIPTION
# Description

One hour ago the python:3.9-slim docker image has been updated and the build fails since an apt package is not found.

This PR fixes the base image to 3.9.16-slim