### PR TITLE
🐛 fix: avoid line break in the number of records of the search bar

### DIFF
--- a/frontend/components/feedback-task/SearchBar.base.vue
+++ b/frontend/components/feedback-task/SearchBar.base.vue
@@ -188,8 +188,8 @@ export default {
   }
   &__additional-info {
     @include font-size(13px);
-    color: rgba(0, 0, 0, 0.37);
-    text-wrap: nowrap;
+    color: $black-37;
+    white-space: nowrap;
   }
 }
 </style>


### PR DESCRIPTION
# Description

This PR fixes nowrap style to avoid line break in the number of records of the search bar

**Type of change**

Bug fix
