### PR TITLE
chore: split `integrations` and `tests` dependencies

### DIFF
--- a/docs/_source/_common/tabs/argilla_install_python.md
+++ b/docs/_source/_common/tabs/argilla_install_python.md
@@ -13,6 +13,7 @@ pip install argilla
 pip install argilla[listeners] # use argilla.listeners background processes
 pip install argilla[server] # running FastAPI locally
 pip install argilla[postgresql] # use PostgreSQL instead of SQLite as database
+pip install argilla[integrations] # use integrations with other libraries/frameworks
 pip install argilla[tests] # running tests locally
 ```
 :::

--- a/docs/_source/community/developer_docs.md
+++ b/docs/_source/community/developer_docs.md
@@ -59,11 +59,10 @@ Or installing just the `server` extra:
 pip install -e ".[server]"
 ```
 
-Or installing all the extras, that are also required to run the tests via `pytest` to make sure that the implemented features or the
-bug fixes work as expected, and that the unit/integration tests are passing.
+Or installing all the extras, that are also required to run the tests via `pytest` to make sure that the implemented features or the bug fixes work as expected, and that the unit/integration tests are passing.
 
 ```sh
-pip install -e ".[server,listeners,postgresql,tests]"
+pip install -e ".[server,listeners,postgresql,integrations,tests]"
 ```
 
 #### Via `conda`

--- a/docs/_source/getting_started/installation/deployments/python.md
+++ b/docs/_source/getting_started/installation/deployments/python.md
@@ -14,6 +14,7 @@ Our Python package requires some extras that might be downloaded to facilitate m
 - `pip install "argilla[listeners]"`: the [argilla.listeners-module](/guides/schedule_jobs_with_listeners) allows for the usage of background processes to monitor dataset changes and schedule jobs.
 - `pip install "argilla[server]"`: the [Argilla FastAPI server](/getting_started/installation/configurations/server_configuration) can be deployed locally to test development changes or custom configs.
 - `pip install "argilla[postgresql]"`: the default data management is done with built-in `sqlite` but can be replaced with a [PostgreSQL database](/getting_started/installation/configurations/server_configuration).
+- `pip install "argilla[integrations]"`: [integrations](/tutorials/libraries) with other libraries/frameworks are available to use.
 - `pip install "argilla[tests]"` When [running tests](/community/developer_docs) as a developer, you might need third-party integration packages to test end-to-end workflows.
 
 ## Install from `develop`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,8 @@ integrations = [
     "setfit",
     "span_marker",
     "openai",
+    "peft",
+    "autotrain-advanced == 0.5.2",
 ]
 tests = [
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,12 +80,7 @@ postgresql = [
     "psycopg2-binary ~= 2.9.5; sys_platform == 'darwin'",
 ]
 listeners = ["schedule ~= 1.1.0", "prodict ~= 0.8.0"]
-tests = [
-    "pytest",
-    "pytest-cov",
-    "pytest-mock",
-    "pytest-asyncio",
-    "factory_boy ~= 3.2.1",
+integrations = [
     "cleanlab ~= 2.0.0",
     # TODO: `push_to_hub` fails up to 2.3.2, check patches when they come out eventually
     "datasets > 1.17.0,!= 2.3.2",
@@ -105,7 +100,13 @@ tests = [
     "setfit",
     "span_marker",
     "openai",
-    "rich == 13.0.1",
+]
+tests = [
+    "pytest",
+    "pytest-cov",
+    "pytest-mock",
+    "pytest-asyncio",
+    "factory_boy ~= 3.2.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
# Description

This PR splits the `tests` dependencies, recently included as `argilla` extras, from the integration extras in a new extra named `integrations`. This would help a better dependency management and installation.

## What's missing?

Only missing thing is the addition of the `spaCy` extra: `en_core_web_md`, as we cannot include installable URLs in the `pyproject.toml` when publishing to PyPI cc @gabrielmbmb 

**Type of change**

- [X] Refactor (change restructuring the codebase without changing functionality)
- [X] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [X] Installed `integrations` and `tests` extras in a matrix from Python 3.8 to 3.11, and working fine

**Checklist**

- [X] I have merged the original branch into my forked branch
- [X] I added relevant documentation
- [X] I made corresponding changes to the documentation
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/) -> Should we?