### PR TITLE
fix(test): `Workspace` Python client and SDK unit tests

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -106,10 +106,6 @@ jobs:
           alembic upgrade head
           pytest --cov=argilla --cov-report=xml
 
-      - name: Setup tmate session
-        if: always()
-        uses: mxschmitt/action-tmate@v3
-
       - name: Upload Coverage to Codecov 📦
         uses: codecov/codecov-action@v1
         if: steps.filter.outputs.python_code == 'true' && matrix.version == '8.5'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -106,6 +106,9 @@ jobs:
           alembic upgrade head
           pytest --cov=argilla --cov-report=xml
 
+      - name: Setup tmate session
+        if: always()
+        uses: mxschmitt/action-tmate@v3
 
       - name: Upload Coverage to Codecov 📦
         uses: codecov/codecov-action@v1

--- a/src/argilla/client/sdk/workspaces/models.py
+++ b/src/argilla/client/sdk/workspaces/models.py
@@ -16,12 +16,9 @@ from datetime import datetime
 from typing import List, Optional
 from uuid import UUID
 
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
-
 from pydantic import BaseModel
+
+from argilla.server.models.models import UserRole
 
 
 class WorkspaceModel(BaseModel):
@@ -38,7 +35,7 @@ class WorkspaceUserModel(BaseModel):
     last_name: Optional[str]
     full_name: Optional[str]
     username: str
-    role: Literal["admin", "annotator"]
+    role: UserRole
     workspaces: Optional[List[str]]
     api_key: str
     inserted_at: datetime

--- a/src/argilla/client/workspaces.py
+++ b/src/argilla/client/workspaces.py
@@ -98,11 +98,9 @@ class Workspace:
             " advance in Argilla."
         )
         if id is not None:
-            error_msg += " As the `id` argument is not None, you should use" f" `Workspace.from_id('{id}')` instead."
+            error_msg += f" As the `id` argument is not None, you should use `Workspace.from_id('{id}')` instead."
         if name is not None:
-            error_msg += (
-                " As the `name` argument is not None, you should use" f" `Workspace.from_name('{name}')` instead."
-            )
+            error_msg += f" As the `name` argument is not None, you should use `Workspace.from_name('{name}')` instead."
         raise Exception(error_msg)
 
     @property
@@ -142,11 +140,9 @@ class Workspace:
                 user_id=user_id,
             )
         except AlreadyExistsApiError as e:
-            raise ValueError(f"User with id=`{user_id}` already exists in workspace with" f" id=`{self.id}`.") from e
+            raise ValueError(f"User with id=`{user_id}` already exists in workspace with id=`{self.id}`.") from e
         except BaseClientError as e:
-            raise RuntimeError(
-                f"Error while adding user with id=`{user_id}` to workspace with" f" id=`{self.id}`."
-            ) from e
+            raise RuntimeError(f"Error while adding user with id=`{user_id}` to workspace with id=`{self.id}`.") from e
 
     def delete_user(self, user_id: str) -> None:
         """Deletes an existing user from the workspace in Argilla. Note that the user
@@ -177,7 +173,7 @@ class Workspace:
             ) from e
         except BaseClientError as e:
             raise RuntimeError(
-                f"Error while deleting user with id=`{user_id}` from workspace with" f" id=`{self.id}`."
+                f"Error while deleting user with id=`{user_id}` from workspace with id=`{self.id}`."
             ) from e
 
     @staticmethod
@@ -221,7 +217,7 @@ class Workspace:
             ws = workspaces_api.create_workspace(client, name).parsed
             return cls.__new_instance(client, ws)
         except AlreadyExistsApiError as e:
-            raise ValueError(f"Workspace with name=`{name}` already exists, so please use a" " different name.") from e
+            raise ValueError(f"Workspace with name=`{name}` already exists, so please use a different name.") from e
         except (ValidationApiError, BaseClientError) as e:
             raise RuntimeError(f"Error while creating workspace with name=`{name}`.") from e
 

--- a/src/argilla/client/workspaces.py
+++ b/src/argilla/client/workspaces.py
@@ -24,8 +24,9 @@ from argilla.client.sdk.commons.errors import (
     ValidationApiError,
 )
 from argilla.client.sdk.v1.workspaces import api as workspaces_api_v1
+from argilla.client.sdk.v1.workspaces.models import WorkspaceModel as WorkspaceModelV1
 from argilla.client.sdk.workspaces import api as workspaces_api
-from argilla.client.sdk.workspaces.models import WorkspaceModel
+from argilla.client.sdk.workspaces.models import WorkspaceModel as WorkspaceModelV0
 
 if TYPE_CHECKING:
     import httpx
@@ -189,12 +190,12 @@ class Workspace:
 
     @classmethod
     def __new_instance(
-        cls, client: Optional["httpx.Client"] = None, ws: Optional[WorkspaceModel] = None
+        cls, client: Optional["httpx.Client"] = None, ws: Optional[Union[WorkspaceModelV0, WorkspaceModelV1]] = None
     ) -> "Workspace":
         """Returns a new `Workspace` instance."""
         instance = cls.__new__(cls)
         instance.__client = client or cls.__active_client()
-        if isinstance(ws, WorkspaceModel):
+        if isinstance(ws, (WorkspaceModelV0, WorkspaceModelV1)):
             instance.__dict__.update(ws.dict())
         return instance
 

--- a/tests/client/sdk/workspaces/test_api.py
+++ b/tests/client/sdk/workspaces/test_api.py
@@ -12,12 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from uuid import UUID
-
-import pytest
-from argilla._constants import DEFAULT_API_KEY
-from argilla.client.client import Argilla
-from argilla.client.sdk.client import AuthenticatedClient
+from argilla.client.api import ArgillaSingleton
 from argilla.client.sdk.workspaces.api import (
     create_workspace,
     create_workspace_user,
@@ -26,116 +21,59 @@ from argilla.client.sdk.workspaces.api import (
     list_workspaces,
 )
 from argilla.client.sdk.workspaces.models import WorkspaceModel, WorkspaceUserModel
-from pytest import MonkeyPatch
+from argilla.server.models import User
 
-from tests.helpers import SecuredClient
-
-
-@pytest.fixture
-def sdk_client() -> AuthenticatedClient:
-    return AuthenticatedClient(base_url="http://localhost:6900", token=DEFAULT_API_KEY).httpx
+from tests.factories import WorkspaceFactory, WorkspaceUserFactory
 
 
-def test_list_workspaces(
-    mocked_client: SecuredClient, sdk_client: AuthenticatedClient, monkeypatch: MonkeyPatch
-) -> None:
-    monkeypatch.setattr(sdk_client, "get", mocked_client.get)
+def test_list_workspaces(owner: User) -> None:
+    WorkspaceFactory.create(name="test_workspace")
+    httpx_client = ArgillaSingleton.init(api_key=owner.api_key).http_client.httpx
 
-    workspace_name = "test_workspace"
-    mocked_client.post(f"/api/workspaces", json={"name": workspace_name})
-
-    response = list_workspaces(client=sdk_client)
+    response = list_workspaces(client=httpx_client)
     assert response.status_code == 200
     assert isinstance(response.parsed, list)
     assert len(response.parsed) > 0
     assert isinstance(response.parsed[0], WorkspaceModel)
 
 
-def test_create_workspace(
-    mocked_client: SecuredClient, sdk_client: AuthenticatedClient, monkeypatch: MonkeyPatch
-) -> None:
-    monkeypatch.setattr(sdk_client, "post", mocked_client.post)
+def test_create_workspace(owner: User) -> None:
+    httpx_client = ArgillaSingleton.init(api_key=owner.api_key).http_client.httpx
 
-    workspace_name = "test_workspace"
-    response = create_workspace(client=sdk_client, name=workspace_name)
+    response = create_workspace(client=httpx_client, name="test_workspace")
     assert response.status_code == 200
     assert isinstance(response.parsed, WorkspaceModel)
-    assert response.parsed.name == workspace_name
+    assert response.parsed.name == "test_workspace"
 
 
-def test_list_workspace_users(
-    mocked_client: SecuredClient, sdk_client: AuthenticatedClient, monkeypatch: MonkeyPatch
-) -> None:
-    monkeypatch.setattr(sdk_client, "get", mocked_client.get)
+def test_list_workspace_users(owner: User) -> None:
+    workspace = WorkspaceFactory.create(name="test_workspace")
+    WorkspaceUserFactory.create(workspace_id=workspace.id, user_id=owner.id)
+    httpx_client = ArgillaSingleton.init(api_key=owner.api_key).http_client.httpx
 
-    workspace_name = "test_workspace"
-    workspace = mocked_client.post(f"/api/workspaces", json={"name": workspace_name}).json()
-    user_name = "test_user"
-    user = mocked_client.post(
-        "/api/users",
-        json={
-            "first_name": "string",
-            "last_name": "string",
-            "username": user_name,
-            "role": "admin",
-            "password": "stringst",
-        },
-    ).json()
-    mocked_client.post(f"/api/workspaces/{workspace['id']}/users/{user['id']}")
-
-    response = list_workspace_users(client=sdk_client, id=workspace["id"])
+    response = list_workspace_users(client=httpx_client, id=workspace.id)
     assert response.status_code == 200
     assert isinstance(response.parsed, list)
     assert len(response.parsed) > 0
     assert isinstance(response.parsed[0], WorkspaceUserModel)
 
 
-def test_create_workspace_user(
-    mocked_client: SecuredClient, sdk_client: AuthenticatedClient, monkeypatch: MonkeyPatch
-) -> None:
-    monkeypatch.setattr(sdk_client, "post", mocked_client.post)
+def test_create_workspace_user(owner: User) -> None:
+    workspace = WorkspaceFactory.create(name="test_workspace")
+    httpx_client = ArgillaSingleton.init(api_key=owner.api_key).http_client.httpx
 
-    workspace_name = "test_workspace"
-    workspace = mocked_client.post(f"/api/workspaces", json={"name": workspace_name}).json()
-    user_name = "test_user"
-    user = mocked_client.post(
-        "/api/users",
-        json={
-            "first_name": "string",
-            "last_name": "string",
-            "username": user_name,
-            "role": "admin",
-            "password": "stringst",
-        },
-    ).json()
-
-    response = create_workspace_user(client=sdk_client, id=workspace["id"], user_id=user["id"])
+    response = create_workspace_user(client=httpx_client, id=workspace.id, user_id=owner.id)
     assert response.status_code == 200
     assert isinstance(response.parsed, WorkspaceUserModel)
-    assert response.parsed.id == UUID(user["id"])
-    assert response.parsed.workspaces[0] == workspace["name"]
+    assert response.parsed.id == owner.id
+    assert response.parsed.workspaces[0] == workspace.name
 
 
-def test_delete_workspace_user(
-    mocked_client: SecuredClient, sdk_client: AuthenticatedClient, monkeypatch: MonkeyPatch
-) -> None:
-    monkeypatch.setattr(sdk_client, "delete", mocked_client.delete)
+def test_delete_workspace_user(owner: User) -> None:
+    workspace = WorkspaceFactory.create(name="test_workspace")
+    WorkspaceUserFactory.create(workspace_id=workspace.id, user_id=owner.id)
+    httpx_client = ArgillaSingleton.init(api_key=owner.api_key).http_client.httpx
 
-    workspace_name = "test_workspace"
-    workspace = mocked_client.post(f"/api/workspaces", json={"name": workspace_name}).json()
-    user_name = "test_user"
-    user = mocked_client.post(
-        "/api/users",
-        json={
-            "first_name": "string",
-            "last_name": "string",
-            "username": user_name,
-            "role": "admin",
-            "password": "stringst",
-        },
-    ).json()
-    mocked_client.post(f"/api/workspaces/{workspace['id']}/users/{user['id']}").json()
-
-    response = delete_workspace_user(client=sdk_client, id=workspace["id"], user_id=user["id"])
+    response = delete_workspace_user(client=httpx_client, id=workspace.id, user_id=owner.id)
     assert response.status_code == 200
     assert response.parsed.workspaces == []


### PR DESCRIPTION
# Description

As of the recent addition of the `owner` user at https://github.com/argilla-io/argilla/pull/3104, once we merged https://github.com/argilla-io/argilla/pull/3180, the unit tests were not passing in `develop` due to the addition of the new role.

So on, we've refactored the `Workspace` unit tests for both the Python client and the SDK to use the `owner` user defined in `conftest.py` as the user to use to authenticate against the Argilla API and the one to add/delete from the workspace/s if applicable.

Kudos to @gabrielmbmb for initially proposing this approach!

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (change restructuring the codebase without changing functionality)

**How Has This Been Tested**

- [X] Refactored unit tests to use `owner`
- [X] Remove the API calls with the factories: `WorkspaceFactory` and `WorkspaceUserFactory`

**Checklist**

- [X] I have merged the original branch into my forked branch
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works