### PR TITLE
Return FeedbackDataset URL on push

### DIFF
--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -618,7 +618,7 @@ class FeedbackDataset:
                 )
             self.argilla_id = self.argilla_id or argilla_id
             url = f"{httpx_client.base_url}/dataset/{self.argilla_id}/annotation-mode"
-            rprint(f"Dataset Pushed to Argilla [link={url}]{url}")
+            rprint(f"`FeedbackDataset` pushed to Argilla [link={url}]{name or dataset.name}[/link]")
             return url
 
     @classmethod
@@ -876,7 +876,7 @@ class FeedbackDataset:
             )
             card.push_to_hub(repo_id, repo_type="dataset", token=kwargs.get("token"))
         url = f"https://huggingface.co/{repo_id}"
-        rprint(f"Dataset Pushed HuggingFace [link={url}]{url}")
+        rprint(f"`FeedbackDataset` pushed to HuggingFace [link={url}]{repo_id}[/link]")
         return url
 
     @classmethod


### PR DESCRIPTION
# Description

Return the URL of a FeedbackDataset that has been pushed either to Argilla or to the HuggingFace Hub, to let the user easily access the dataset and know where it has been pushed.

Argilla URL: <API_URL>/<DATASET_ID>/annotation-mode
HuggingFace Hub URL: https://huggingface.co/<REPO_ID>

Closes #3120 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Improvement (change adding some improvement to an existing functionality)

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)