### PR TITLE
feat: Allow admin and owner roles to display "Train" button

### DIFF
--- a/frontend/components/commons/header/appHeader.vue
+++ b/frontend/components/commons/header/appHeader.vue
@@ -31,7 +31,7 @@
         <BaseButton
           class="header__button small"
           @on-click="onClickTrain"
-          v-if="isOwnerRole"
+          v-if="isAdminOrOwnerRole"
         >
           <svgicon name="code" width="20" height="20" />Train
         </BaseButton>
@@ -121,8 +121,9 @@ export default {
     viewSettings() {
       return DatasetViewSettings.query().whereId(this.datasetName).first();
     },
-    isOwnerRole() {
-      return this.$auth.user.role === "owner";
+    isAdminOrOwnerRole() {
+      const role = this.$auth.user.role;
+      return role === "admin" || role === "owner";
     },
     globalHeaderHeight() {
       if (this.sticky && this.dataset) {

--- a/frontend/components/commons/header/header-feedback-task/HeaderFeedbackTask.component.vue
+++ b/frontend/components/commons/header/header-feedback-task/HeaderFeedbackTask.component.vue
@@ -8,6 +8,7 @@
     />
     <template v-if="datasetId">
       <BaseButton
+        ref="trainButtonRef"
         class="header__button small"
         @on-click="onClickTrain"
         v-if="isAdminOrOwnerRole && showTrainButton"
@@ -23,7 +24,7 @@
         />
       </NuxtLink>
     </template>
-    <user />
+    <User />
   </BaseTopbarBrand>
 </template>
 

--- a/frontend/components/commons/header/header-feedback-task/HeaderFeedbackTask.component.vue
+++ b/frontend/components/commons/header/header-feedback-task/HeaderFeedbackTask.component.vue
@@ -10,7 +10,7 @@
       <BaseButton
         class="header__button small"
         @on-click="onClickTrain"
-        v-if="isAdminRole && showTrainButton"
+        v-if="isAdminOrOwnerRole && showTrainButton"
       >
         <svgicon name="code" width="20" height="20" />Train
       </BaseButton>
@@ -50,8 +50,9 @@ export default {
     };
   },
   computed: {
-    isAdminRole() {
-      return this.$auth.user.role === "admin";
+    isAdminOrOwnerRole() {
+      const role = this.$auth.user.role;
+      return role === "admin" || role === "owner";
     },
   },
   methods: {

--- a/frontend/components/commons/header/header-feedback-task/headerFeedbackTask.spec.js
+++ b/frontend/components/commons/header/header-feedback-task/headerFeedbackTask.spec.js
@@ -1,0 +1,88 @@
+import { shallowMount } from "@vue/test-utils";
+import HeaderFeedbackTask from "./HeaderFeedbackTask.component";
+
+let wrapper = null;
+const options = {
+  stubs: [
+    "BaseTopbarBrand",
+    "BaseBreadcrumbs",
+    "BaseButton",
+    "DatasetSettingsIconFeedbackTaskComponent",
+    "User",
+    "NuxtLink",
+  ],
+  mocks: {
+    $auth: {
+      user: {
+        role: "admin",
+      },
+    },
+  },
+  propsData: {
+    breadcrumbs: [
+      { link: { name: "datasets" }, name: "Home" },
+      { link: { path: "/datasets?workspace=recognai" }, name: "recognai" },
+      {
+        link: {
+          name: null,
+          params: {
+            workspace: "recognai",
+            dataset: "imdb-single-label-all-records",
+          },
+        },
+        name: "imdb-single-label-all-records",
+      },
+    ],
+    datasetId: "65931567-0b51-4e74-9aff-834c32a3d898",
+    showTrainButton: true,
+  },
+};
+
+beforeEach(() => {
+  wrapper = shallowMount(HeaderFeedbackTask, options);
+});
+
+afterEach(() => {
+  wrapper.destroy();
+});
+
+describe("HeaderFeedbackTask", () => {
+  it("render the component", () => {
+    expect(wrapper.is(HeaderFeedbackTask)).toBe(true);
+  });
+  it("render Train button if user role is admin", () => {
+    expect(wrapper.findComponent({ ref: "trainButtonRef" }).exists()).toBe(
+      true
+    );
+  });
+  it("render Train button if user role is owner", () => {
+    const wrapper = shallowMount(HeaderFeedbackTask, {
+      ...options,
+      mocks: {
+        $auth: {
+          user: {
+            role: "owner",
+          },
+        },
+      },
+    });
+    expect(wrapper.findComponent({ ref: "trainButtonRef" }).exists()).toBe(
+      true
+    );
+  });
+  it("Don't render Train button if user role is not admin or owner", () => {
+    const wrapper = shallowMount(HeaderFeedbackTask, {
+      ...options,
+      mocks: {
+        $auth: {
+          user: {
+            role: "annotator",
+          },
+        },
+      },
+    });
+    expect(wrapper.findComponent({ ref: "trainButtonRef" }).exists()).toBe(
+      false
+    );
+  });
+});


### PR DESCRIPTION
# Description

This PR updates user role requirement in frontend, allowing admin and owner roles to display "Train" button in the different tasks application header

See #3094

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [x] Test HeaderFeedbackTask user roles for showing Train button

**Checklist**

- [x] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)