### PR TITLE
chore: drop Python 3.7 support due to its close EOL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,8 @@ These are the section headers that we use:
 
 - The role system now support three different roles `owner`, `admin` and `annotator` ([#3104](https://github.com/argilla-io/argilla/pull/3104))
 - `admin` role is scoped to workspace-level operations ([#3115](https://github.com/argilla-io/argilla/pull/3115))
-- Default argilla user has the `admin` role instead of `owner` one ([#3188](https://github.com/argilla-io/argilla/pull/33188))
+- Default argilla user has the `admin` role instead of `owner` one ([#3188](https://github.com/argilla-io/argilla/pull/3188))
+
 
 ## [1.10.0](https://github.com/argilla-io/argilla/compare/v1.9.0...v1.10.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ These are the section headers that we use:
 - `admin` role is scoped to workspace-level operations ([#3115](https://github.com/argilla-io/argilla/pull/3115))
 - Default argilla user has the `admin` role instead of `owner` one ([#3188](https://github.com/argilla-io/argilla/pull/3188))
 
+### Deprecated
+
+- As of Python 3.7 end-of-life (EOL) on 2023-06-27, Argilla will no longer support Python 3.7 ([#3188](https://github.com/argilla-io/argilla/pull/33188)). More information at https://peps.python.org/pep-0537/
 
 ## [1.10.0](https://github.com/argilla-io/argilla/compare/v1.9.0...v1.10.0)
 
@@ -130,7 +133,7 @@ These are the section headers that we use:
 
 ### Deprecated
 
-- Using argilla with python 3.7 runtime is deprecated and support will be removed from version 1.9.0 ([#2902](https://github.com/argilla-io/argilla/issues/2902))
+- Using Argilla with Python 3.7 runtime is deprecated and support will be removed from version 1.11.0 ([#2902](https://github.com/argilla-io/argilla/issues/2902))
 - `tokens_length` metrics function has been deprecated and will be removed in 1.10.0 ([#3045])
 - `token_length` metrics function has been deprecated and will be removed in 1.10.0 ([#3045])
 - `mention_length` metrics function has been deprecated and will be removed in 1.10.0 ([#3045])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "argilla"
 description = "Open-source tool for exploring, labeling, and monitoring data for NLP projects."
 readme = "README.md"
-requires-python = ">=3.7"  # TODO: upgrade minimum Python version to 3.8, and pin maximum to < 3.12
+requires-python = ">=3.8,<3.12"
 license = { text = "Apache-2.0" }
 keywords = [
     "data-science",

--- a/src/argilla/__init__.py
+++ b/src/argilla/__init__.py
@@ -35,15 +35,6 @@ try:
 except ModuleNotFoundError:
     pass
 
-# TODO: Remove this warning once https://github.com/argilla-io/argilla/issues/2902 is tackled
-if _sys.version_info < (3, 8):
-    warnings.warn(
-        message="Python 3.7 is coming to its end-of-life and will be no longer supported in the upcoming release of Argilla. "
-        "To ensure compatibility and uninterrupted service, we kindly request that you migrate to Argilla with"
-        " Python 3.8 or higher.",
-        category=DeprecationWarning,
-    )
-
 __version__ = _version.version
 
 if _TYPE_CHECKING:

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -14,13 +14,8 @@
 import json
 import logging
 import tempfile
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Literal, Optional, Union
 from uuid import UUID
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import (
     ValidationError,

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -13,13 +13,8 @@
 #  limitations under the License.
 
 import warnings
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import (
     BaseModel,

--- a/src/argilla/client/sdk/v1/datasets/models.py
+++ b/src/argilla/client/sdk/v1/datasets/models.py
@@ -14,13 +14,8 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import BaseModel, Field, StrictInt, StrictStr
 

--- a/src/argilla/client/sdk/workspaces/models.py
+++ b/src/argilla/client/sdk/workspaces/models.py
@@ -13,13 +13,8 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Literal, Optional
 from uuid import UUID
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from pydantic import BaseModel
 

--- a/src/argilla/server/models/questions.py
+++ b/src/argilla/server/models/questions.py
@@ -13,14 +13,14 @@
 #  limitations under the License.
 
 from enum import Enum
-from typing import Any, Generic, List, Optional, TypeVar, Union
+from typing import Any, Generic, List, Literal, Optional, TypeVar, Union
 
 from pydantic import BaseModel, Field
 
 try:
-    from typing import Annotated, Literal
+    from typing import Annotated
 except ImportError:
-    from typing_extensions import Annotated, Literal
+    from typing_extensions import Annotated
 
 
 class QuestionType(str, Enum):

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -14,7 +14,7 @@
 
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel, PositiveInt, conlist, constr, root_validator, validator
@@ -24,9 +24,9 @@ from pydantic.utils import GetterDict
 from argilla.server.search_engine import Query
 
 try:
-    from typing import Annotated, Literal
+    from typing import Annotated
 except ImportError:
-    from typing_extensions import Annotated, Literal
+    from typing_extensions import Annotated
 
 from argilla.server.models import (
     DatasetStatus,

--- a/src/argilla/server/schemas/v1/fields.py
+++ b/src/argilla/server/schemas/v1/fields.py
@@ -13,14 +13,10 @@
 #  limitations under the License.
 
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from argilla.server.models import FieldType
 

--- a/src/argilla/server/schemas/v1/questions.py
+++ b/src/argilla/server/schemas/v1/questions.py
@@ -13,15 +13,10 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel, Field, conlist
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
 
 from argilla.server.models import QuestionType
 

--- a/src/argilla/server/schemas/v1/responses.py
+++ b/src/argilla/server/schemas/v1/responses.py
@@ -13,11 +13,15 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Literal, Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel, Field
-from typing_extensions import Annotated, Literal
+
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
 
 from argilla.server.models import ResponseStatus
 


### PR DESCRIPTION
# Description

This PR drops support for Python 3.7 by pinning the minimum required Python version to be 3.8 or higher (below 3.12). Besides that, all the occurrences of `from typing_extensions import Literal` have been removed, as `Literal` was included as part of `typing` in Python 3.8.

This PR has continued what was started at #2942 by @frascuchon.

Closes #2902

**Type of change**

- [X] Deprecation (something's been deprecated or support to it has been dropped)

**Checklist**

- [X] I have merged the original branch into my forked branch
- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)