### PR TITLE
test: force init argilla client credentials

### DIFF
--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -18,7 +18,8 @@ from argilla.client.client import Argilla
 from argilla.client.sdk.commons.errors import ForbiddenApiError
 from argilla.datasets import TextClassificationSettings, TokenClassificationSettings
 from argilla.server.contexts import accounts
-from argilla.server.security.model import User, WorkspaceUserCreate
+from argilla.server.models import User
+from argilla.server.security.model import WorkspaceUserCreate
 from sqlalchemy.orm import Session
 
 

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -18,7 +18,7 @@ from argilla.client.client import Argilla
 from argilla.client.sdk.commons.errors import ForbiddenApiError
 from argilla.datasets import TextClassificationSettings, TokenClassificationSettings
 from argilla.server.contexts import accounts
-from argilla.server.security.model import WorkspaceUserCreate
+from argilla.server.security.model import User, WorkspaceUserCreate
 from sqlalchemy.orm import Session
 
 
@@ -35,8 +35,10 @@ from sqlalchemy.orm import Session
         ),
     ],
 )
-def test_settings_workflow(mocked_client, settings_, wrong_settings):
+def test_settings_workflow(argilla_user: User, settings_, wrong_settings):
     dataset = "test-dataset"
+
+    rg.init(api_key=argilla_user.api_key, workspace=argilla_user.username)
     workspace = rg.get_workspace()
 
     rg.delete(dataset)


### PR DESCRIPTION
# Description

This PR fix the weird failing test by forcing an Argilla init with default user credentials before the test operations.

Closes #3228

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Test fix

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

The test works now.

