### PR TITLE
fix: `push_to_argilla` and `from_argilla` consistency issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ These are the section headers that we use:
 - Replaced `np.float` alias by `float` to avoid `AttributeError` when using `find_label_errors` function with `numpy>=1.24.0` ([#3214](https://github.com/argilla-io/argilla/pull/3214)).
 - Fixed `format_as("datasets")` when no responses or optional respones in `FeedbackRecord`, to set their value to what 🤗 Datasets expects instead of just `None` ([#3224](https://github.com/argilla-io/argilla/pull/3224)).
 - Fixed `push_to_huggingface()` when `generate_card=True` (default behaviour), as we were passing a sample record to the `ArgillaDatasetCard` class, and `UUID`s introduced in 1.10.0 ([#3192](https://github.com/argilla-io/argilla/pull/3192)), are not JSON-serializable ([#3231](https://github.com/argilla-io/argilla/pull/3231)).
+- Fixed `from_argilla` and `push_to_argilla` to ensure consistency on both field and question re-construction, and to ensure `UUID`s are properly serialized as `str`, respectively ([#3234](https://github.com/argilla-io/argilla/pull/3234)).
 
 ### Added
 

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -650,7 +650,6 @@ class FeedbackDataset:
                 )
             )
 
-        cls.argilla_id = existing_dataset.id
         fields = []
         for field in datasets_api_v1.get_fields(client=httpx_client, id=existing_dataset.id).parsed:
             base_field = field.dict(include={"name", "title", "required"})
@@ -695,6 +694,7 @@ class FeedbackDataset:
             questions=questions,
             guidelines=existing_dataset.guidelines or None,
         )
+        self.argilla_id = existing_dataset.id
         if with_records:
             self.fetch_records()
         return self

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -550,7 +550,7 @@ class FeedbackDataset:
 
             for field in self.fields:
                 try:
-                    datasets_api_v1.add_field(client=httpx_client, id=argilla_id, field=json.loads(field.json()))
+                    datasets_api_v1.add_field(client=httpx_client, id=argilla_id, field=field.dict())
                 except Exception as e:
                     delete_dataset(dataset_id=argilla_id)
                     raise Exception(
@@ -560,9 +560,7 @@ class FeedbackDataset:
 
             for question in self.questions:
                 try:
-                    datasets_api_v1.add_question(
-                        client=httpx_client, id=argilla_id, question=json.loads(question.json())
-                    )
+                    datasets_api_v1.add_question(client=httpx_client, id=argilla_id, question=question.dict())
                 except Exception as e:
                     delete_dataset(dataset_id=argilla_id)
                     raise Exception(
@@ -583,7 +581,7 @@ class FeedbackDataset:
                     datasets_api_v1.add_records(
                         client=httpx_client,
                         id=argilla_id,
-                        records=[json.loads(record.json()) for record in batch],
+                        records=[record.dict() for record in batch],
                     )
                 except Exception as e:
                     delete_dataset(dataset_id=argilla_id)

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
     import httpx
     from datasets import Dataset
 
+    from argilla.client.client import Argilla as ArgillaClient
     from argilla.client.sdk.v1.datasets.models import (
         FeedbackDatasetModel,
         FeedbackFieldModel,
@@ -483,7 +484,8 @@ class FeedbackDataset:
                 has been previously pushed to Argilla.
             workspace: the workspace where to push the dataset to. If not provided, the active workspace will be used.
         """
-        httpx_client: "httpx.Client" = rg.active_client().http_client.httpx
+        client: "ArgillaClient" = rg.active_client()
+        httpx_client: "httpx.Client" = client.http_client.httpx
 
         if name is None:
             if self.argilla_id is None:
@@ -515,7 +517,7 @@ class FeedbackDataset:
                 ) from e
         else:
             if workspace is None:
-                workspace = rg.Workspace.from_name(rg.active_client().get_workspace())
+                workspace = rg.Workspace.from_name(client.get_workspace())
 
             if isinstance(workspace, str):
                 workspace = rg.Workspace.from_name(workspace)

--- a/src/argilla/client/sdk/v1/datasets/api.py
+++ b/src/argilla/client/sdk/v1/datasets/api.py
@@ -256,6 +256,8 @@ def add_records(
                         active_user_id = client.get("api/me").json()["id"]
                     response["user_id"] = active_user_id
                     response_without_user_id = True
+            if isinstance(response["user_id"], UUID):
+                response["user_id"] = str(response["user_id"])
             cleaned_responses.append(response)
         record["responses"] = cleaned_responses
 

--- a/tests/client/feedback/test_dataset.py
+++ b/tests/client/feedback/test_dataset.py
@@ -387,6 +387,7 @@ def test_copy_dataset_in_argilla(
     assert same_dataset.argilla_id is not None
 
     same_dataset = FeedbackDataset.from_argilla("copy-dataset")
+    assert same_dataset.argilla_id != dataset.argilla_id
     assert same_dataset.fields == dataset.fields
     assert same_dataset.questions == dataset.questions
 

--- a/tests/client/feedback/test_dataset.py
+++ b/tests/client/feedback/test_dataset.py
@@ -384,8 +384,11 @@ def test_copy_dataset_in_argilla(
 
     same_dataset = FeedbackDataset.from_argilla("test-dataset")
     same_dataset.push_to_argilla("copy-dataset")
-
     assert same_dataset.argilla_id is not None
+
+    same_dataset = FeedbackDataset.from_argilla("copy-dataset")
+    assert same_dataset.fields == dataset.fields
+    assert same_dataset.questions == dataset.questions
 
 
 def test_push_to_huggingface_and_from_huggingface(

--- a/tests/client/feedback/test_dataset.py
+++ b/tests/client/feedback/test_dataset.py
@@ -137,7 +137,7 @@ def test_init_wrong_questions(
         )
 
 
-def test_records(
+def test_add_records(
     feedback_dataset_guidelines: str,
     feedback_dataset_fields: List["AllowedFieldTypes"],
     feedback_dataset_questions: List["AllowedQuestionTypes"],


### PR DESCRIPTION
# Description

This PR removes the unnecessary `json.loads(field.json())` and `json.loads(question.json())` as all the fields in those `pydantic.BaseModel`s are JSON-serializable, so we can just provide the `dict` to the endpoint.

Besides that, we're also using the `dict` for `FeedbackRecord`s, and then ensuring that the `user_id` in each response, which is an `UUID` and so on, not JSON-serializable, is properly serialized as a string in the `add_records` SDK function.

This also aligns both the `FeedbackRecord` logging in Argilla under the scenarios of pushing a new dataset and pushing records to an existing dataset.

Finally, also the `from_argilla` field and question re-construction is patched, as we were still using `construct` which was not respecting the `Config` set on those `pydantic.BaseModel`s as `construct` implies `Config.extra = 'allow'`. So on, now that's patched too, and the `FeedbackDataset` retrieved via `from_argilla` is exactly the same one as the one logged via `push_to_argilla` and/or `push_to_huggingface`; as well as the `argilla_id` assignment when retrieving a `FeedbackDataset.from_argilla` once the `argilla_id` has already been set as `cls.argilla_id = ...`.

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

- [X] Add unit tests for `push_to_argilla` to make sure the API doesn't throw any HTTP 422 when the payload contains UUIDs
- [X] Add unit tests for `from_argilla` to make sure the retrieve `FeedbackDataset` is consistent to what we should expect

**Checklist**

- [X] I have merged the original branch into my forked branch
- [X] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [X] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
