### PR TITLE
docs: add `User` and `Workspace` management layers

### DIFF
--- a/docs/_source/getting_started/installation/configurations/configurations.md
+++ b/docs/_source/getting_started/installation/configurations/configurations.md
@@ -24,12 +24,26 @@ Finetune your FastAPI deployment:
 :link: user_management.md
 
 Manage your Argilla users:
-- User management model
-- Default user
-- Add new users and workspaces
-- Listing Argilla users
+- User model
+- Prepare the DB
+- Get default user
+- Create a new user
+- Assign a user to a workspace
+- List all the existing users
 - Delete a user
-- Migrate users from the `users.yaml`
+- Migrate users from `users.yaml`
+- Migration users with Docker Compose
+```
+```{grid-item-card} Workspace Management
+:link: workspace_management.md
+
+Manage your Argilla workspaces:
+- Workspace model
+- Create a new workspace
+- List all the existing workspaces
+- Get a workspace by name
+- Get a workspace by id
+- Add, list, or delete users from a workspace
 ```
 
 ```{grid-item-card} Database Migrations
@@ -55,6 +69,7 @@ Multimodality at your fingertips:
 elasticsearch.md
 server_configuration.md
 user_management.md
+workspace_management.md
 database_migrations.md
 image_support.md
 ```

--- a/docs/_source/getting_started/installation/configurations/user_management.md
+++ b/docs/_source/getting_started/installation/configurations/user_management.md
@@ -119,11 +119,11 @@ Path: /path/to/alembic/versions/1769ee58fbb4_create_workspaces_users_table.py
 
 ## How to guide
 
-### Get default `User`
-
 :::{note}
 To connect to an old Argilla instance (`<1.3.0`) using newer clients, you should specify the default user API key `rubrix.apikey`. Otherwise, connections will fail with an Unauthorized server error.
 :::
+
+### Get default `User`
 
 #### CLI
 
@@ -241,6 +241,8 @@ The workspace `ws` is automatically created and assigned to the user.
 
 #### Python client
 
+To assign a user to a workspace, you can use the `add_user` method in the `Workspace` class. For more information about workspaces, see the [Workspace Management](./workspace_management.md) guide.
+
 ```python
 import argilla as rg
 
@@ -257,7 +259,6 @@ user = rg.User.create(
 workspace = rg.Workspace.create(name="ws")
 workspace.add_user(user.id)
 ```
-
 
 ### List `User`s
 

--- a/docs/_source/getting_started/installation/configurations/user_management.md
+++ b/docs/_source/getting_started/installation/configurations/user_management.md
@@ -35,89 +35,9 @@ An Argilla user composed of the following attributes:
 
 The `User` class in the Python client gives developers with `owner` role the ability to create and manage users in Argilla. Check the [User - Python Reference](../reference/python/python_users.rst) to see the attributes, arguments, and methods of the `User` class.
 
-## How to guide
-
-### Get/Create default `User`
-
-:::{note}
-To connect to an old Argilla instance (`<1.3.0`) using newer clients, you should specify the default user API key `rubrix.apikey`. Otherwise, connections will fail with an Unauthorized server error.
-:::
-
-#### CLI
-
-By default, if the Argilla instance has no users, the following default owner user will be configured:
-
-- username: `argilla`
-- password: `12345678`
-- api_key: `argilla.apikey`
-
-For security reasons, we recommend changing at least the password and the API key. You can do this via the following CLI command:
-
-```bash
-python -m argilla users create_default --password new-password --api-key new-api-key
-```
-
-```bash
-User with default credentials succesfully created:
-• username: 'argilla'
-• password: 'newpassword'
-• api_key:  'new-api-key'
-```
-
-#### Python client
-
-You can get the current active user in Argilla using the `me` classmethod in the `User` class. Note that the `me` method will return the active user as specified via the credentials provided via `rg.init`.
-
-```python
-import argilla as rg
-
-rg.init(api_url="<API_URL>", api_key="<API_KEY>")
-
-user = rg.User.me()
-```
-
-### List `User`s
-
-#### Python client
-
-You can list all the existing users in Argilla calling the `list` classmethod of the `User` class.
-
-:::{note}
-Just the "owner" can list all the users in Argilla.
-:::
-
-```python
-import argilla as rg
-
-rg.init(api_url="<API_URL>", api_key="<OWNER_API_KEY>")
-
-users = rg.User.list()
-```
-
-### Delete a `User`
-
-#### Python client
-
-You can delete an existing user from Argilla calling the `delete` method on the `User` class.
-
-:::{note}
-Just the "owner" can delete users in Argilla.
-:::
-
-```python
-import argilla as rg
-
-rg.init(api_url="<API_URL>", api_key="<OWNER_API_KEY>")
-
-user = rg.User.from_name("existing-user")
-user.delete()
-```
-
-## Add new users and workspaces
-
 The above user management model is configured using the Argilla tasks, which server maintainers can define before launching an Argilla instance.
 
-### Prepare the database
+## Prepare the database
 
 First of all, you need to make sure that database tables and models are up-to-date. This task must be launched when a new version of Argilla is installed.
 
@@ -138,7 +58,7 @@ INFO  [alembic.runtime.migration] Running upgrade 82a5a88a3fa5 -> 1769ee58fbb4, 
 It is important to launch this task prior to any other database action.
 :::
 
-#### Migrate to an specific version
+### Migrate DB to an specific version
 
 If you want to apply migrations corresponding to a specific version or revision, for example, to apply a version rollback, you can pass the `--revision` option to the database migrate command:
 ```bash
@@ -197,7 +117,54 @@ Path: /path/to/alembic/versions/1769ee58fbb4_create_workspaces_users_table.py
     Create Date: 2023-02-14 10:36:56.313539
 ```
 
-### Creating users
+## How to guide
+
+### Get default `User`
+
+:::{note}
+To connect to an old Argilla instance (`<1.3.0`) using newer clients, you should specify the default user API key `rubrix.apikey`. Otherwise, connections will fail with an Unauthorized server error.
+:::
+
+#### CLI
+
+By default, if the Argilla instance has no users, the following default owner user will be configured:
+
+- username: `argilla`
+- password: `12345678`
+- api_key: `argilla.apikey`
+
+For security reasons, we recommend changing at least the password and the API key. You can do this via the following CLI command:
+
+```bash
+python -m argilla users create_default --password new-password --api-key new-api-key
+```
+
+Which should produce the following output:
+
+```bash
+User with default credentials succesfully created:
+• username: 'argilla'
+• password: 'newpassword'
+• api_key:  'new-api-key'
+```
+
+#### Python client
+
+You can get the current active user in Argilla using the `me` classmethod in the `User` class. Note that the `me` method will return the active user as specified via the credentials provided via `rg.init`.
+
+```python
+import argilla as rg
+
+rg.init(api_url="<API_URL>", api_key="<API_KEY>")
+
+user = rg.User.me()
+```
+
+### Create a `User`
+
+#### CLI
+
+You can create a new user in Argilla using the `create` command in the `users` group.
 
 ```bash
 python -m argilla users create
@@ -228,50 +195,33 @@ Options:
   --help                    Show this message and exit.
 ```
 
-#### Creating an owner user
-
-**CLI:**
+So for example, to create a new user with `admin` role, you can run the following command:
 
 ```bash
-python -m argilla users create --role owner --first-name Hulio --last-name Ramos --username hurra --password abcde123
+python -m argilla users create --username new-user --first-name New --last-name User --password new-password --role admin
 ```
 
-```
-User succesfully created:
-• first_name: 'Hulio'
-• last_name: 'Ramos'
-• username: 'hurra'
-• role: 'owner'
-• api_key: 'eZDbiNZSZuTyLnVxtxUQ5K4M4WHmPBvIvnc3wofqT7ZPmS33FERjgNd9IECsAdC4qEaks4yVxjomkbDXcjfUoiuotA2-mrdcSZCVUDGGbQE'
-• workspaces: []
-```
+#### Python client
 
-**Python:**
+You can also create a new user in Argilla using the `create` classmethod in the `User` class.
 
 ```python
-auth_headers = {"X-Argilla-API-Key": "argilla.apikey"}
-http = httpx.Client(base_url="http://localhost:6900", headers=auth_headers)
+import argilla as rg
 
-response = http.post("/api/users", json={"role": "admin", "first_name": "Hulio", "last_name": "Ramos", "username": "hurra", "password": "abcde123"})
-response.json()
-```
-```json
-{
-   "id":"8e62808e-df44-4135-87bd-d022f1d9fcf0",
-   "username":"hurra",
-   "role":"owner",
-   "full_name":"Hulio Ramos",
-   "workspaces":[],
-   "api_key":"67Ae7sRYpvu98MqMMkrPNtYx-pyjrRCiyieiwXsE7qP2npG8Eo_8cGpx4EZKJ_APt1FQ7qtX5jcnrUBLq7iW6N5KRhd32pBfHLFHHbnqIK4",
-   "inserted_at":"2023-03-16T11:11:59.871532",
-   "updated_at":"2023-03-16T11:11:59.871532"
-}
+rg.init(api_url="<API_URL>", api_key="<OWNER_API_KEY>")
+
+user = rg.User.create(
+    username="new-user",
+    first_name="New",
+    last_name="User",
+    password="new-password",
+    role="admin",
+)
 ```
 
+### Assign a `User` to a `Workspace`
 
-#### Creating an annotator user assigned to a workspace
-
-**CLI:**
+#### CLI
 
 ```bash
 python -m argilla users create --role annotator --first-name Nick --last-name Name --username nick --password 11223344 --workspace ws
@@ -291,9 +241,62 @@ The workspace `ws` is automatically created and assigned to the user.
 
 #### Python client
 
-TODO
+```python
+import argilla as rg
 
-## Migrate users from the `users.yaml` file
+rg.init(api_url="<API_URL>", api_key="<OWNER_API_KEY>")
+
+user = rg.User.create(
+    username="nick",
+    first_name="Nick",
+    last_name="Name",
+    password="11223344",
+    role="annotator",
+)
+
+workspace = rg.Workspace.create(name="ws")
+workspace.add_user(user.id)
+```
+
+
+### List `User`s
+
+#### Python client
+
+You can list all the existing users in Argilla calling the `list` classmethod of the `User` class.
+
+:::{note}
+Just the "owner" can list all the users in Argilla.
+:::
+
+```python
+import argilla as rg
+
+rg.init(api_url="<API_URL>", api_key="<OWNER_API_KEY>")
+
+users = rg.User.list()
+```
+
+### Delete a `User`
+
+#### Python client
+
+You can delete an existing user from Argilla calling the `delete` method on the `User` class.
+
+:::{note}
+Just the "owner" can delete users in Argilla.
+:::
+
+```python
+import argilla as rg
+
+rg.init(api_url="<API_URL>", api_key="<OWNER_API_KEY>")
+
+user = rg.User.from_name("existing-user")
+user.delete()
+```
+
+### Migrate users from the `users.yaml` file
 
 The migration tasks can create users and workspaces automatically from a yaml file with the following format:
 
@@ -339,99 +342,24 @@ Migrating User with username 'daisy'
 Users migration process successfully finished
 ```
 
-```python
-http.get("/api/users").json()
-```
-
-```json
-[
-   {
-      "id":"8e4da958-1dba-44d9-82f3-ea2ec3beecdf",
-      "username":"john",
-      "role":"owner",
-      "full_name":"John Doe None",
-      "workspaces":[
-         "john"
-      ],
-      "api_key":"a14427ea-9197-11ec-b909-0242ac120002",
-      "inserted_at":"2023-03-16T11:31:12.979241",
-      "updated_at":"2023-03-16T11:31:12.979241"
-   },
-   {
-      "id":"0ed76afb-e9a5-409c-9716-ac7ae919afe8",
-      "username":"tanya",
-      "role":"annotator",
-      "full_name":"Tanya Franklin None",
-      "workspaces":[
-         "tanya",
-         "argilla",
-         "team"
-      ],
-      "api_key":"78a10b53-8db7-4ab5-9e9e-fbd4b7e76551",
-      "inserted_at":"2023-03-16T11:31:12.986146",
-      "updated_at":"2023-03-16T11:31:12.986146"
-   },
-   {
-      "id":"944e4f76-6cf9-4242-8568-41b2d683cd9f",
-      "username":"daisy",
-      "role":"annotator",
-      "full_name":"Daisy Gonzalez None",
-      "workspaces":[
-         "daisy",
-         "argilla",
-         "team",
-         "latam"
-      ],
-      "api_key":"a8168929-8668-494c-b7a5-98cd35740d9b",
-      "inserted_at":"2023-03-16T11:31:12.990718",
-      "updated_at":"2023-03-16T11:31:12.990718"
-   }
-]
-```
+Ensure everything went as expected via the `User` class from the Python client:
 
 ```python
-http.get("/api/workspaces").json()
+import argilla as rg
+
+rg.init(api_url="<API_URL>", api_key="<OWNER_API_KEY>")
+
+users = rg.User.list()
+for user in users:
+   print(f"username={user.username} role={user.role} workspaces={user.workspaces}")
 ```
 
-```json
-[
-   {
-      "id":"96169426-c27b-48b7-a386-8f58193f8d64",
-      "name":"john",
-      "inserted_at":"2023-03-16T11:31:12.981784",
-      "updated_at":"2023-03-16T11:31:12.981784"
-   },
-   {
-      "id":"adc51bfb-3940-4f3a-ad2a-46bad05ffe90",
-      "name":"tanya",
-      "inserted_at":"2023-03-16T11:31:12.986924",
-      "updated_at":"2023-03-16T11:31:12.986924"
-   },
-   {
-      "id":"5d2e5fc1-179e-4b6a-8bc0-3eba4e85bba3",
-      "name":"argilla",
-      "inserted_at":"2023-03-16T11:31:12.986941",
-      "updated_at":"2023-03-16T11:31:12.986941"
-   },
-   {
-      "id":"abb6f7ca-9585-4499-a23b-4433be8c5a60",
-      "name":"team",
-      "inserted_at":"2023-03-16T11:31:12.986953",
-      "updated_at":"2023-03-16T11:31:12.986953"
-   },
-   {
-      "id":"3a2acec8-fc61-4704-993b-a8606dacaaf3",
-      "name":"daisy",
-      "inserted_at":"2023-03-16T11:31:12.991027",
-      "updated_at":"2023-03-16T11:31:12.991027"
-   },
-   {
-      "id":"bd314fdf-5f20-487a-989a-b628f2e2bbd6",
-      "name":"latam",
-      "inserted_at":"2023-03-16T11:31:12.991047",
-      "updated_at":"2023-03-16T11:31:12.991047"
-   }
-]
+Which should print:
+
+```
+username=john role=owner workspaces=['john']
+username=tanya role=annotator workspaces=['tanya', 'argilla', 'team']
+username=daisy role=annotator workspaces=['daisy', 'argilla', 'team', 'latam']
 ```
 
 ### Migrate users with Docker Compose

--- a/docs/_source/getting_started/installation/configurations/user_management.md
+++ b/docs/_source/getting_started/installation/configurations/user_management.md
@@ -1,4 +1,4 @@
-docs/_source/getting_started/installation/configurations/user_management.md# User Management
+# User Management
 
 This guide explains how to setup and manage the users in Argilla via the Python client and the CLI.
 

--- a/docs/_source/getting_started/installation/configurations/user_management.md
+++ b/docs/_source/getting_started/installation/configurations/user_management.md
@@ -1,4 +1,4 @@
-# User Management
+docs/_source/getting_started/installation/configurations/user_management.md# User Management
 
 This guide explains how to setup and manage the users in Argilla via the Python client and the CLI.
 
@@ -13,8 +13,8 @@ A user in Argilla is an authorized person who can access the UI and use the Pyth
 We differentiate between three types of users depending on their role:
 
 - **Owner**: The owner is the user who created the Argilla instance. It has full access to all workspaces and can create new users and workspaces.
-- **Admin**: An admin user can access all workspaces, but cannot create new users or workspaces.
-- **Annotator**: An annotator user can only access the workspaces it has been assigned to.
+- **Admin**: An admin user can only access the workspaces it has been assigned to. Admin users can manage datasets on assigned workspaces.
+- **Annotator**: As admin users, an annotator user can only access the workspaces it has been assigned to.
 
 An Argilla user composed of the following attributes:
 
@@ -218,6 +218,24 @@ user = rg.User.create(
     role="admin",
 )
 ```
+
+### Update a `User`
+
+#### CLI
+
+You can change the assigned role for an existing user.
+
+```bash
+python -m argilla users update argilla --role owner
+```
+```bash
+User 'argilla' successfully updated:
+• role: 'admin' -> 'owner'
+```
+
+:::{note}
+You should use this command to review and migrate user roles from version <=1.10.0
+:::
 
 ### Get a `User` by username
 

--- a/docs/_source/getting_started/installation/configurations/user_management.md
+++ b/docs/_source/getting_started/installation/configurations/user_management.md
@@ -219,6 +219,34 @@ user = rg.User.create(
 )
 ```
 
+### Get a `User` by username
+
+#### Python client
+
+You can get a user by username using the `from_name` classmethod in the `User` class.
+
+```python
+import argilla as rg
+
+rg.init(api_url="<API_URL>", api_key="<OWNER_API_KEY>")
+
+user = rg.User.from_name("new-user")
+```
+
+### Get a `User` by id
+
+#### Python client
+
+You can get a user by id using the `from_id` classmethod in the `User` class.
+
+```python
+import argilla as rg
+
+rg.init(api_url="<API_URL>", api_key="<OWNER_API_KEY>")
+
+user = rg.User.from_id("new-user")
+```
+
 ### Assign a `User` to a `Workspace`
 
 #### CLI

--- a/docs/_source/getting_started/installation/configurations/user_management.md
+++ b/docs/_source/getting_started/installation/configurations/user_management.md
@@ -234,7 +234,7 @@ User 'argilla' successfully updated:
 ```
 
 :::{note}
-You should use this command to review and migrate user roles from version <=1.10.0
+You should use this command to review and migrate user roles from version `<=1.10.0`
 :::
 
 ### Get a `User` by username

--- a/docs/_source/getting_started/installation/configurations/workspace_management.md
+++ b/docs/_source/getting_started/installation/configurations/workspace_management.md
@@ -6,7 +6,7 @@ This guide explains how setup and manage the workspaces in Argilla via the Pytho
 The `Workspace` class for workspace management has been included as of the Argilla 1.11.0 release, and is not available in previous versions. But you will be able to use it with older Argilla instances, from 1.6.0 onwards, the only difference will be that the main role is now `owner` instead of `admin`.
 :::
 
-## Model
+## Workspace Model
 
 A workspace is a "space" inside your Argilla instance where authorized users can collaborate. It is accessible through the UI and the Python client.
 
@@ -23,7 +23,7 @@ An Argilla workspace is composed of the following attributes:
 | `inserted_at` | `datetime` | The date and time when the workspace was created. |
 | `updated_at` | `datetime` | The date and time when the workspace was last updated. |
 
-## Python client
+### Python client
 
 The `Workspace` class in the Python client gives developers with `owner` role the ability to create and manage workspaces in Argilla, and the users that belong to them. Check the [Workspace - Python Reference](../reference/python/python_workspaces.rst) to see the attributes, arguments, and methods of the `Workspace` class.
 
@@ -37,7 +37,12 @@ The `Workspace` class in Argilla is composed of the following attributes:
 | `inserted_at` | `datetime` | The date and time when the workspace was created. |
 | `updated_at` | `datetime` | The date and time when the workspace was last updated. |
 
+
+## How to guide
+
 ### Create a new `Workspace`
+
+#### Python client
 
 Creating a workspace in Argilla is now as easy as calling the `create` method from the `Workspace` class. It will return a `Workspace` instance.
 
@@ -50,6 +55,8 @@ workspace = rg.Workspace.create("new-workspace")
 ```
 
 ### List all the existing `Workspaces`
+
+#### Python client
 
 You can also list all the existing workspaces in Argilla using the `list` method. It will return a list of `Workspace` instances.
 
@@ -65,6 +72,8 @@ for workspace in workspaces:
 
 ### Get a `Workspace` by name
 
+#### Python client
+
 You can get a workspace by its name using the `from_name` method. It must exist in advance in Argilla, otherwise an exception will be raised.
 
 ```python
@@ -76,6 +85,8 @@ workspace = rg.Workspace.from_name("new-workspace")
 ```
 
 ### Get a `Workspace` by id
+
+#### Python client
 
 Additionally, if you know the `id` of the workspace, you can get it directly using the `from_id` method. It must exist in advance in Argilla, otherwise an exception will be raised.
 
@@ -92,6 +103,8 @@ workspace = rg.Workspace.from_id("00000000-0000-0000-0000-000000000000")
 ```
 
 ### Add, list, or delete users from a `Workspace`
+
+#### Python client
 
 Once you instantiate a `Workspace` instance from a workspace in Argilla, you can add, list, or delete users from it. But note that just the `owner` has sufficient permissions to perform those operations.
 

--- a/docs/_source/getting_started/installation/configurations/workspace_management.md
+++ b/docs/_source/getting_started/installation/configurations/workspace_management.md
@@ -14,11 +14,30 @@ If you're an owner, you can assign users to workspaces, either when you create a
 
 An `owner` has full access to the workspace, and can assign other users to it; while the `admin` role can only access the workspace, but cannot assign other users to it; and the `annotator` role can only access their assigned datasets in the workspace they belong to and annotate it via the UI.
 
-### Python client
+An Argilla workspace is composed of the following attributes:
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | `UUID` | The unique identifier of the workspace. |
+| `name` | `str` | The name of the workspace. |
+| `inserted_at` | `datetime` | The date and time when the workspace was created. |
+| `updated_at` | `datetime` | The date and time when the workspace was last updated. |
+
+## Python client
 
 The `Workspace` class in the Python client gives developers with `owner` role the ability to create and manage workspaces in Argilla, and the users that belong to them. Check the [Workspace - Python Reference](../reference/python/python_workspaces.rst) to see the attributes, arguments, and methods of the `Workspace` class.
 
-#### Create a new `Workspace`
+The `Workspace` class in Argilla is composed of the following attributes:
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `id` | `UUID` | The unique identifier of the workspace. |
+| `name` | `str` | The name of the workspace. |
+| `users` | `List[User]` | The list of users that belong to the workspace. |
+| `inserted_at` | `datetime` | The date and time when the workspace was created. |
+| `updated_at` | `datetime` | The date and time when the workspace was last updated. |
+
+### Create a new `Workspace`
 
 Creating a workspace in Argilla is now as easy as calling the `create` method from the `Workspace` class. It will return a `Workspace` instance.
 
@@ -30,7 +49,7 @@ rg.init(api_url="<API_URL>", api_key="<OWNER_API_KEY>")
 workspace = rg.Workspace.create("new-workspace")
 ```
 
-#### List all the existing `Workspaces`
+### List all the existing `Workspaces`
 
 You can also list all the existing workspaces in Argilla using the `list` method. It will return a list of `Workspace` instances.
 
@@ -44,7 +63,7 @@ for workspace in workspaces:
    ...
 ```
 
-#### Get a `Workspace` by name
+### Get a `Workspace` by name
 
 You can get a workspace by its name using the `from_name` method. It must exist in advance in Argilla, otherwise an exception will be raised.
 
@@ -56,7 +75,7 @@ rg.init(api_url="<API_URL>", api_key="<OWNER_API_KEY>")
 workspace = rg.Workspace.from_name("new-workspace")
 ```
 
-#### Get a `Workspace` by id
+### Get a `Workspace` by id
 
 Additionally, if you know the `id` of the workspace, you can get it directly using the `from_id` method. It must exist in advance in Argilla, otherwise an exception will be raised.
 
@@ -72,7 +91,7 @@ rg.init(api_url="<API_URL>", api_key="<OWNER_API_KEY>")
 workspace = rg.Workspace.from_id("00000000-0000-0000-0000-000000000000")
 ```
 
-#### Add, list, or delete users from a `Workspace`
+### Add, list, or delete users from a `Workspace`
 
 Once you instantiate a `Workspace` instance from a workspace in Argilla, you can add, list, or delete users from it. But note that just the `owner` has sufficient permissions to perform those operations.
 

--- a/docs/_source/getting_started/installation/configurations/workspace_management.md
+++ b/docs/_source/getting_started/installation/configurations/workspace_management.md
@@ -1,0 +1,95 @@
+# Workspace Management
+
+This guide explains how setup and manage the workspaces in Argilla via the Python client.
+
+:::{note}
+The `Workspace` class for workspace management has been included as of the Argilla 1.11.0 release, and is not available in previous versions. But you will be able to use it with older Argilla instances, from 1.6.0 onwards, the only difference will be that the main role is now `owner` instead of `admin`.
+:::
+
+## Model
+
+A workspace is a "space" inside your Argilla instance where authorized users can collaborate. It is accessible through the UI and the Python client.
+
+If you're an owner, you can assign users to workspaces, either when you create a new user, or using the method `add_user` from the `Workspace` class.
+
+An `owner` has full access to the workspace, and can assign other users to it; while the `admin` role can only access the workspace, but cannot assign other users to it; and the `annotator` role can only access their assigned datasets in the workspace they belong to and annotate it via the UI.
+
+### Python client
+
+The `Workspace` class in the Python client gives developers with `owner` role the ability to create and manage workspaces in Argilla, and the users that belong to them. Check the [Workspace - Python Reference](../reference/python/python_workspaces.rst) to see the attributes, arguments, and methods of the `Workspace` class.
+
+#### Create a new `Workspace`
+
+Creating a workspace in Argilla is now as easy as calling the `create` method from the `Workspace` class. It will return a `Workspace` instance.
+
+```python
+import argilla as rg
+
+rg.init(api_url="<API_URL>", api_key="<OWNER_API_KEY>")
+
+workspace = rg.Workspace.create("new-workspace")
+```
+
+#### List all the existing `Workspaces`
+
+You can also list all the existing workspaces in Argilla using the `list` method. It will return a list of `Workspace` instances.
+
+```python
+import argilla as rg
+
+rg.init(api_url="<API_URL>", api_key="<OWNER_API_KEY>")
+
+workspaces = rg.Workspace.list()
+for workspace in workspaces:
+   ...
+```
+
+#### Get a `Workspace` by name
+
+You can get a workspace by its name using the `from_name` method. It must exist in advance in Argilla, otherwise an exception will be raised.
+
+```python
+import argilla as rg
+
+rg.init(api_url="<API_URL>", api_key="<OWNER_API_KEY>")
+
+workspace = rg.Workspace.from_name("new-workspace")
+```
+
+#### Get a `Workspace` by id
+
+Additionally, if you know the `id` of the workspace, you can get it directly using the `from_id` method. It must exist in advance in Argilla, otherwise an exception will be raised.
+
+:::{note}
+The `id` of a workspace is a UUID, and it is generated automatically when you create a new workspace.
+:::
+
+```python
+import argilla as rg
+
+rg.init(api_url="<API_URL>", api_key="<OWNER_API_KEY>")
+
+workspace = rg.Workspace.from_id("00000000-0000-0000-0000-000000000000")
+```
+
+#### Add, list, or delete users from a `Workspace`
+
+Once you instantiate a `Workspace` instance from a workspace in Argilla, you can add, list, or delete users from it. But note that just the `owner` has sufficient permissions to perform those operations.
+
+:::{note}
+As of the 1.11.0 version of the Python client, to add and delete users from a `Workspace` one must use the `UUID` which is the unique identifier in Argilla for each user. To do so, one can simply use the `id` attribute of the `User` class. More information about it can be found in the [User - Python Reference](../reference/python/python_users.rst) or in the [User Management](user_management.md) guide.
+:::
+
+```python
+import argilla as rg
+
+rg.init(api_url="<API_URL>", api_key="<OWNER_API_KEY>")
+
+workspace = rg.Workspace.from_name("new-workspace")
+
+users = workspace.users
+for user in users:
+   ...
+workspace.add_user("<USER_ID>")
+workspace.delete_user("<USER_ID>")
+```

--- a/docs/_source/guides/llms/practical_guides/set_up_annotation_team.md
+++ b/docs/_source/guides/llms/practical_guides/set_up_annotation_team.md
@@ -6,13 +6,14 @@ You will need to decide the level of overlap before creating or pushing a datase
 ```
 
 ## Full overlap
-The Feedback Task supports having multiple annotations for your records by default. This means that all users with access to the dataset can give responses to all the records in the dataset. To have this full overlap just push the dataset (as detailed in [Create a Feedback Dataset](create_dataset.md#push-to-argilla)) in a workspace where all team members have access. Learn more about managing user access to workspaces [here](../../../getting_started/installation/configurations/user_management.md#creating-an-annotator-user-assigned-to-a-workspace).
+
+The Feedback Task supports having multiple annotations for your records by default. This means that all users with access to the dataset can give responses to all the records in the dataset. To have this full overlap just push the dataset (as detailed in [Create a Feedback Dataset](create_dataset.md#push-to-argilla)) in a workspace where all team members have access. Learn more about managing user access to workspaces [here](../../../getting_started/installation/configurations/user_management.md#assign-a-user-to-a-workspace).
 
 ## Zero overlap
 If you only want one annotation per record, we recommend that you split your records into chunks and assign each of them to a single annotator. Then, you can create several datasets, one in each annotator's personal workspace with the records assigned to them.
 
 ```{note}
-This assumes that each annotator has a personal workspace attached to their user. If this is not the case, learn how create a workspace and assign it to a user [here](../../../getting_started/installation/configurations/user_management.md#creating-an-annotator-user-assigned-to-a-workspace).
+This assumes that each annotator has a personal workspace attached to their user. If this is not the case, learn how create a workspace and assign it to a user [here](../../../getting_started/installation/configurations/user_management.md#assign-a-user-to-a-workspace).
 ```
 
 Here's how you can do this:

--- a/docs/_source/reference/python/index.rst
+++ b/docs/_source/reference/python/index.rst
@@ -11,7 +11,8 @@ The Python reference guide for Argilla. This section contains:
 * :ref:`python_monitoring`: An overview of all methods for Argilla to monitor models and log prediction
 * :ref:`python_listeners`: This module contains all you need to define and configure dataset Argilla listeners
 * :ref:`python_training`: The training integration module
-
+* :ref:`python_users`: The Python client module to manage users in Argilla
+* :ref:`python_workspaces`: The Python client module to manage workspaces in Argilla
 
 .. toctree::
    :maxdepth: 2
@@ -24,4 +25,5 @@ The Python reference guide for Argilla. This section contains:
    python_training
    python_monitoring
    python_listeners
-
+   python_users
+   python_workspaces

--- a/docs/_source/reference/python/python_client.rst
+++ b/docs/_source/reference/python/python_client.rst
@@ -3,7 +3,7 @@
 Client
 ======
 
-Here we describe the Python client of Argilla that we divide into three basic modules:
+Here we describe the Python client of Argilla that we divide into four basic modules:
 
 - :ref:`python ref methods`: These methods make up the interface to interact with Argilla's REST API.
 - :ref:`python ref records`: You need to wrap your data in these *Records* for Argilla to understand it.

--- a/docs/_source/reference/python/python_users.rst
+++ b/docs/_source/reference/python/python_users.rst
@@ -1,0 +1,9 @@
+.. _python_users:
+
+Users
+=====
+
+Here we describe how to manage users in Argilla via the Python client.
+
+.. automodule:: argilla.client.users
+   :members: User

--- a/docs/_source/reference/python/python_workspaces.rst
+++ b/docs/_source/reference/python/python_workspaces.rst
@@ -1,0 +1,9 @@
+.. _python_workspaces:
+
+Workspaces
+==========
+
+Here we describe how to manage workspaces in Argilla via the Python client.
+
+.. automodule:: argilla.client.workspaces
+   :members: Workspace


### PR DESCRIPTION
# Description

This PR updates the existing documentation for "User Management" to avoid showcasing the user-management via the Argilla API, to show how to use the `User` class in the Python client instead; as well as adding a new "Workspace Management" section, and both `User` and `Workspace` classed to be included in the Python reference.

## What's missing?

- [ ] Update `user_management.md`
- [ ] Make sure that there are no references to the `/api/users` explicitly in any documentation entry

**Type of change**

- [X] Documentation update
