### PR TITLE
fix: default user to be `owner` instead of `admin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ These are the section headers that we use:
 
 - The role system now support three different roles `owner`, `admin` and `annotator` ([#3104](https://github.com/argilla-io/argilla/pull/3104))
 - `admin` role is scoped to workspace-level operations ([#3115](https://github.com/argilla-io/argilla/pull/3115))
-- Default argilla user has the `admin` role instead of `owner` one ([#3188](https://github.com/argilla-io/argilla/pull/3188))
+- Default argilla user has the `owner` role instead of `admin` one ([#3248](https://github.com/argilla-io/argilla/pull/3248)), reverting ([#3188](https://github.com/argilla-io/argilla/pull/3188)).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ These are the section headers that we use:
 
 - The role system now support three different roles `owner`, `admin` and `annotator` ([#3104](https://github.com/argilla-io/argilla/pull/3104))
 - `admin` role is scoped to workspace-level operations ([#3115](https://github.com/argilla-io/argilla/pull/3115))
-- The `owner` user is created among the default pool of users in the quickstart ([#3248](https://github.com/argilla-io/argilla/pull/3248)), reverting ([#3188](https://github.com/argilla-io/argilla/pull/3188)).
+- The `owner` user is created among the default pool of users in the quickstart, and the default user in the server has now `owner` role ([#3248](https://github.com/argilla-io/argilla/pull/3248)), reverting ([#3188](https://github.com/argilla-io/argilla/pull/3188)).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ These are the section headers that we use:
 
 - The role system now support three different roles `owner`, `admin` and `annotator` ([#3104](https://github.com/argilla-io/argilla/pull/3104))
 - `admin` role is scoped to workspace-level operations ([#3115](https://github.com/argilla-io/argilla/pull/3115))
-- Default argilla user has the `owner` role instead of `admin` one ([#3248](https://github.com/argilla-io/argilla/pull/3248)), reverting ([#3188](https://github.com/argilla-io/argilla/pull/3188)).
+- The `owner` user is created among the default pool of users in the quickstart ([#3248](https://github.com/argilla-io/argilla/pull/3248)), reverting ([#3188](https://github.com/argilla-io/argilla/pull/3188)).
 
 ### Deprecated
 

--- a/docs/_source/getting_started/installation/configurations/user_management.md
+++ b/docs/_source/getting_started/installation/configurations/user_management.md
@@ -6,6 +6,10 @@ This guide explains how to setup and manage the users in Argilla via the Python 
 The `User` class for user management has been included as of the Argilla 1.11.0 release, and is not available in previous versions. But you will be able to use it with older Argilla instances, from 1.6.0 onwards, the only difference will be that the main role is now `owner` instead of `admin`.
 :::
 
+:::{warning}
+As of Argilla 1.11.0 the default pool of users contains an owner user which uses the same credentials as the admin user from previous Argilla versions i.e. `admin` as username and `1234` as the password. So on, both `argilla/argilla-quickstart:latest` and `argilla/argilla-server:latest` Docker images will create now an "owner" user instead of an "admin" as before, but will use the same credentials. Note that the quickstart image uses the `api_key=admin.apikey` while the server uses `api_key=argilla.apikey`, unless explicitly modified.
+:::
+
 ## User Model
 
 A user in Argilla is an authorized person who can access the UI and use the Python client and CLI in a running Argilla instance.

--- a/docs/_source/getting_started/installation/configurations/user_management.md
+++ b/docs/_source/getting_started/installation/configurations/user_management.md
@@ -7,7 +7,9 @@ The `User` class for user management has been included as of the Argilla 1.11.0 
 :::
 
 :::{warning}
-As of Argilla 1.11.0 the default pool of users contains an owner user which uses the same credentials as the admin user from previous Argilla versions i.e. `admin` as username and `1234` as the password. So on, both `argilla/argilla-quickstart:latest` and `argilla/argilla-server:latest` Docker images will create now an "owner" user instead of an "admin" as before, but will use the same credentials. Note that the quickstart image uses the `api_key=admin.apikey` while the server uses `api_key=argilla.apikey`, unless explicitly modified.
+As of Argilla 1.11.0 the default pool of users contains an owner user which uses the same credentials as the admin user from previous Argilla versions i.e. `admin` as username and, in the quickstart `12345678` as the password, and `1234` in the server.
+
+So on, both `argilla/argilla-quickstart:latest` and `argilla/argilla-server:latest` Docker images will create now an "owner" user instead of an "admin" as before, but will use the same credentials. Note that the quickstart image uses the `api_key=admin.apikey` while the server uses `api_key=argilla.apikey`, unless explicitly modified.
 :::
 
 ## User Model

--- a/docs/_source/getting_started/installation/configurations/user_management.md
+++ b/docs/_source/getting_started/installation/configurations/user_management.md
@@ -7,9 +7,7 @@ The `User` class for user management has been included as of the Argilla 1.11.0 
 :::
 
 :::{warning}
-As of Argilla 1.11.0 the default pool of users contains an owner user which uses the same credentials as the admin user from previous Argilla versions i.e. `admin` as username and, in the quickstart `12345678` as the password, and `1234` in the server.
-
-So on, both `argilla/argilla-quickstart:latest` and `argilla/argilla-server:latest` Docker images will create now an "owner" user instead of an "admin" as before, but will use the same credentials. Note that the quickstart image uses the `api_key=admin.apikey` while the server uses `api_key=argilla.apikey`, unless explicitly modified.
+As of Argilla 1.11.0 the default pool of users in the quickstart contains also an owner user which uses the credentials: username `owner`, password `12345678`, and API key `owner.apikey`; while for the server image the default user is now an `owner` instead of an `admin` with the same credentials: username `argilla`, password `1234` and API key `argilla.apikey`.
 :::
 
 ## User Model

--- a/docs/_source/getting_started/installation/deployments/docker-quickstart.md
+++ b/docs/_source/getting_started/installation/deployments/docker-quickstart.md
@@ -19,7 +19,7 @@ Apple Silicon M1/M2 users might have issues with this deployment. To resolve thi
 
 This will run the latest quickstart docker image with 3 users `owner`, `admin` and `argilla`. The password for these users is `12345678`. You can also configure these [environment variables](#environment-variables) as per your needs.
 
-### Environment Variables
+## Environment Variables
 
 - `OWNER_USERNAME`: The owner username to log in Argilla. The default owner username is `owner`. By setting up
   a custom username you can use your own username to login into the app.

--- a/docs/_source/getting_started/installation/deployments/docker-quickstart.md
+++ b/docs/_source/getting_started/installation/deployments/docker-quickstart.md
@@ -17,20 +17,28 @@ Apple Silicon M1/M2 users might have issues with this deployment. To resolve thi
 
 </div>
 
-This will run the latest quickstart docker image with 2 users `owner` and `argilla`. The password for these users is `12345678`. You can also configure these [environment variables](#environment-variables) as per your needs.
+This will run the latest quickstart docker image with 3 users `owner`, `admin` and `argilla`. The password for these users is `12345678`. You can also configure these [environment variables](#environment-variables) as per your needs.
 
-## Environment Variables
+### Environment Variables
 
-- `ADMIN_USERNAME`: The owner username to log in Argilla. The default onwer username is `admin`. By setting up
-  a custom username you can use your own username to log in to the app.
+- `OWNER_USERNAME`: The owner username to log in Argilla. The default owner username is `owner`. By setting up
+  a custom username you can use your own username to login into the app.
+- `OWNER_PASSWORD`: This sets a custom password for login into the app with the `owner` username. The default
+  password is `12345678`. By setting up a custom password you can use your own password to login into the app.
+- `OWNER_API_KEY`: Argilla provides a Python library to interact with the app (read, write, and update data, log model
+  predictions, etc.). If you don't set this variable, the library and your app will use the default API key
+  i.e. `owner.apikey`. If you want to secure your app for reading and writing data, we recommend you to set up this
+  variable. The API key you choose can be any string of your choice and you can check an online generator if you like.
+- `ADMIN_USERNAME`: The admin username to log in Argilla. The default admin username is `admin`. By setting up
+  a custom username you can use your own username to login into the app.
+- `ADMIN_PASSWORD`: This sets a custom password for login into the app with the `argilla` username. The default
+  password is `12345678`. By setting up a custom password you can use your own password to login into the app.
 - `ADMIN_API_KEY`: Argilla provides a Python library to interact with the app (read, write, and update data, log model
   predictions, etc.). If you don't set this variable, the library and your app will use the default API key
   i.e. `admin.apikey`. If you want to secure your app for reading and writing data, we recommend you to set up this
   variable. The API key you choose can be any string of your choice and you can check an online generator if you like.
-- `ADMIN_PASSWORD`: This sets a custom password to log in to the app with the `admin` username. The default
-  password is `12345678`. By setting up a custom password you can use your own password to login into the app.
-- `ANNOTATOR_USERNAME`: The annotator username to login in Argilla. The default annotator username is `argilla`. By setting up
-  a custom username you can use your own username to login into the app.
+- `ANNOTATOR_USERNAME`: The annotator username to login in Argilla. The default annotator username is `argilla`. By setting
+  up a custom username you can use your own username to login into the app.
 - `ANNOTATOR_PASSWORD`: This sets a custom password for login into the app with the `argilla` username. The default password
   is `12345678`. By setting up a custom password you can use your own password to login into the app.
 - `LOAD_DATASETS`: This variables will allow you to load sample datasets. The default value will be `full`. The

--- a/docs/_source/getting_started/installation/deployments/huggingface-spaces.md
+++ b/docs/_source/getting_started/installation/deployments/huggingface-spaces.md
@@ -133,28 +133,36 @@ The Space template provides a way to set up different **optional settings** focu
 
 To set up these secrets, you can go to the Settings tab on your created Space. Make sure to save these values somewhere for later use.
 
-The template space has two users: `admin` and `argilla`. The username `admin` corresponds to the root user, who can upload datasets and access any workspace within your Argilla Space. The username `argilla` is a normal user with access to the `argilla` workspace.
+The template space has three users: `owner`, `admin` and `argilla`. The username `owner` corresponds to the root user, who can create users, workspaces, and upload datasets within your Argilla Space. The username `admin` can upload datasets in their workspace/s. And, the username `argilla` is an annotator user with access to the `argilla` workspace and to the datasets uploaded there.
 
 The usernames, passwords, and API keys to upload, read, update, and delete datasets can be configured using the following secrets:
 
+- `OWNER_USERNAME`: The owner username to log in Argilla. The default owner username is `owner`. By setting up
+  a custom username you can use your own username to login into the app.
+- `OWNER_PASSWORD`: This sets a custom password for login into the app with the `owner` username. The default
+  password is `12345678`. By setting up a custom password you can use your own password to login into the app.
+- `OWNER_API_KEY`: Argilla provides a Python library to interact with the app (read, write, and update data, log model
+  predictions, etc.). If you don't set this variable, the library and your app will use the default API key
+  i.e. `owner.apikey`. If you want to secure your app for reading and writing data, we recommend you to set up this
+  variable. The API key you choose can be any string of your choice and you can check an online generator if you like.
 - `ADMIN_USERNAME`: The admin username to log in Argilla. The default admin username is `admin`. By setting up
-  a custom username you can use your own username to log in to the app.
+  a custom username you can use your own username to login into the app.
+- `ADMIN_PASSWORD`: This sets a custom password for login into the app with the `argilla` username. The default
+  password is `12345678`. By setting up a custom password you can use your own password to login into the app.
 - `ADMIN_API_KEY`: Argilla provides a Python library to interact with the app (read, write, and update data, log model
   predictions, etc.). If you don't set this variable, the library and your app will use the default API key
   i.e. `admin.apikey`. If you want to secure your app for reading and writing data, we recommend you to set up this
-  variable. The API key can be any string of your choice. You can check an online generator if you like.
-- `ADMIN_PASSWORD`: This sets a custom password to log in to the app with the `argilla` username. The default
-  password is `12345678`. By setting up a custom password you can use your own password to log in to the app.
-- `ANNOTATOR_USERNAME`: The annotator username to log in to Argilla. The default annotator username is `argilla`. By setting up
-  a custom username you can use your own username to log in to the app.
+  variable. The API key you choose can be any string of your choice and you can check an online generator if you like.
+- `ANNOTATOR_USERNAME`: The annotator username to login in Argilla. The default annotator username is `argilla`. By setting
+  up a custom username you can use your own username to login into the app.
 - `ANNOTATOR_PASSWORD`: This sets a custom password to log in to the app with the `argilla` username. The default password
   is `12345678`. By setting up a custom password you can use your own password to log in to the app.
 
 The combination of these secret variables gives you the following setup options:
 
-1. *I want to avoid that anyone without the API keys adds, deletes, or updates datasets using the Python client*: You need to setup `ADMIN_PASSWORD` and `ADMIN_API_KEY`.
-2. *Additionally, I want to avoid that the `argilla` username deletes datasets from the UI*: You need to setup `ANNOTATOR_PASSWORD` and use the `argilla` generated API key with the Python Client (check your Space logs). This option might be interesting if you want to control dataset management but want anyone to browse your datasets using the `argilla` user.
-3. *Additionally, I want to avoid that anyone without password browses my datasets with the `argilla` user*: You need to setup `ANNOTATOR_PASSWORD`. In this case, you can use the `argilla` generated API key and/or `ADMIN_API_KEY` values with the Python Client depending on your needs for dataset deletion rights.
+1. *I want to avoid that anyone without the API keys adds, deletes, or updates datasets using the Python client*: You need to set up `ADMIN_PASSWORD` and `ADMIN_API_KEY`.
+2. *Additionally, I want to avoid that the `argilla` username deletes datasets from the UI*: You need to set up `ANNOTATOR_PASSWORD` and use the `argilla` generated API key with the Python Client (check your Space logs). This option might be interesting if you want to control dataset management but want anyone to browse your datasets using the `argilla` user.
+3. *Additionally, I want to avoid that anyone without password browses my datasets with the `argilla` user*: You need to set up `ANNOTATOR_PASSWORD`. In this case, you can use the `argilla` generated API key and/or `ADMIN_API_KEY` values with the Python Client depending on your needs for dataset deletion rights.
 
 Additionally, the `LOAD_DATASETS` will let you configure the sample datasets that will be pre-loaded. The default value is `single` and the supported values for this variable are:
     1. `single`: Load single datasets for TextClassification task.

--- a/quickstart.Dockerfile
+++ b/quickstart.Dockerfile
@@ -1,5 +1,9 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch:8.5.3
 
+ENV OWNER_USERNAME=owner
+ENV OWNER_PASSWORD=12345678
+ENV OWNER_API_KEY=owner.apikey
+
 ENV ADMIN_USERNAME=admin
 ENV ADMIN_PASSWORD=12345678
 ENV ADMIN_API_KEY=admin.apikey

--- a/quickstart.README.md
+++ b/quickstart.README.md
@@ -108,21 +108,28 @@ To get started you just need to run the docker image with following command:
   docker run -d --name quickstart -p 6900:6900 argilla/argilla-quickstart:latest
 ```
 
-This will run the latest quickstart docker image with 2 users `admin` and `argilla`. The password for these users is
-`12345678`. You can also configure these [environment variables](#environment-variables) as per you needs.
+This will run the latest quickstart docker image with 3 users `owner`, `admin`, and `argilla`. The password for these users is `12345678`. You can also configure these [environment variables](#environment-variables) as per you needs.
 
 ### Environment Variables
 
+- `OWNER_USERNAME`: The owner username to log in Argilla. The default owner username is `owner`. By setting up
+  a custom username you can use your own username to login into the app.
+- `OWNER_PASSWORD`: This sets a custom password for login into the app with the `owner` username. The default
+  password is `12345678`. By setting up a custom password you can use your own password to login into the app.
+- `OWNER_API_KEY`: Argilla provides a Python library to interact with the app (read, write, and update data, log model
+  predictions, etc.). If you don't set this variable, the library and your app will use the default API key
+  i.e. `owner.apikey`. If you want to secure your app for reading and writing data, we recommend you to set up this
+  variable. The API key you choose can be any string of your choice and you can check an online generator if you like.
 - `ADMIN_USERNAME`: The admin username to log in Argilla. The default admin username is `admin`. By setting up
   a custom username you can use your own username to login into the app.
+- `ADMIN_PASSWORD`: This sets a custom password for login into the app with the `argilla` username. The default
+  password is `12345678`. By setting up a custom password you can use your own password to login into the app.
 - `ADMIN_API_KEY`: Argilla provides a Python library to interact with the app (read, write, and update data, log model
   predictions, etc.). If you don't set this variable, the library and your app will use the default API key
   i.e. `admin.apikey`. If you want to secure your app for reading and writing data, we recommend you to set up this
   variable. The API key you choose can be any string of your choice and you can check an online generator if you like.
-- `ADMIN_PASSWORD`: This sets a custom password for login into the app with the `argilla` username. The default
-  password is `12345678`. By setting up a custom password you can use your own password to login into the app.
-- `ANNOTATOR_USERNAME`: The annotator username to login in Argilla. The default annotator username is `argilla`. By setting up
-  a custom username you can use your own username to login into the app.
+- `ANNOTATOR_USERNAME`: The annotator username to login in Argilla. The default annotator username is `argilla`. By setting
+  up a custom username you can use your own username to login into the app.
 - `ANNOTATOR_PASSWORD`: This sets a custom password for login into the app with the `argilla` username. The default password
   is `12345678`. By setting up a custom password you can use your own password to login into the app.
 - `ARGILLA_WORKSPACE`: The name of a workspace that will be created and used by default for admin and annotator users. The default value will be the one defined by `ADMIN_USERNAME` environment variable.

--- a/scripts/start_quickstart_argilla.sh
+++ b/scripts/start_quickstart_argilla.sh
@@ -13,11 +13,20 @@ python3.9 -m argilla database migrate
 
 echo "Creating owner user"
 python3.9 -m argilla users create \
+  --first-name "Owner" \
+  --username "$OWNER_USERNAME" \
+  --password "$OWNER_PASSWORD" \
+  --api-key "$OWNER_API_KEY" \
+  --role owner \
+  --workspace "$ARGILLA_WORKSPACE"
+
+echo "Creating admin user"
+python3.9 -m argilla users create \
   --first-name "Admin" \
   --username "$ADMIN_USERNAME" \
   --password "$ADMIN_PASSWORD" \
   --api-key "$ADMIN_API_KEY" \
-  --role owner \
+  --role admin \
   --workspace "$ARGILLA_WORKSPACE"
 
 echo "Creating annotator user"
@@ -29,7 +38,7 @@ python3.9 -m argilla users create \
   --workspace "$ARGILLA_WORKSPACE"
 
 # Load data
-python3.9 /load_data.py "$ADMIN_API_KEY" "$LOAD_DATASETS" &
+python3.9 /load_data.py "$OWNER_API_KEY" "$LOAD_DATASETS" &
 
 # Start Argilla
 echo "Starting Argilla"

--- a/scripts/start_quickstart_argilla.sh
+++ b/scripts/start_quickstart_argilla.sh
@@ -11,13 +11,13 @@ sleep 30
 echo "Running database migrations"
 python3.9 -m argilla database migrate
 
-echo "Creating admin user"
+echo "Creating owner user"
 python3.9 -m argilla users create \
   --first-name "Admin" \
   --username "$ADMIN_USERNAME" \
   --password "$ADMIN_PASSWORD" \
   --api-key "$ADMIN_API_KEY" \
-  --role admin \
+  --role owner \
   --workspace "$ARGILLA_WORKSPACE"
 
 echo "Creating annotator user"

--- a/src/argilla/tasks/users/create_default.py
+++ b/src/argilla/tasks/users/create_default.py
@@ -37,7 +37,7 @@ def create_default(
             User(
                 first_name="",
                 username=DEFAULT_USERNAME,
-                role=UserRole.admin,
+                role=UserRole.owner.value,
                 api_key=api_key,
                 password_hash=accounts.hash_password(password),
                 workspaces=[Workspace(name=DEFAULT_USERNAME)],
@@ -49,6 +49,7 @@ def create_default(
             typer.echo("User with default credentials successfully created:")
             typer.echo(f"• username: {DEFAULT_USERNAME!r}")
             typer.echo(f"• password: {password!r}")
+            typer.echo(f"• role:     {UserRole.owner.value!r}")
             typer.echo(f"• api_key:  {api_key!r}")
 
 

--- a/src/argilla/tasks/users/create_default.py
+++ b/src/argilla/tasks/users/create_default.py
@@ -37,7 +37,7 @@ def create_default(
             User(
                 first_name="",
                 username=DEFAULT_USERNAME,
-                role=UserRole.owner.value,
+                role=UserRole.owner,
                 api_key=api_key,
                 password_hash=accounts.hash_password(password),
                 workspaces=[Workspace(name=DEFAULT_USERNAME)],


### PR DESCRIPTION
# Description

This PR creates the default user with `owner` role instead of `admin` in `release.Dockerfile`, so that the default user has all the required permissions matching the ones that the `admin` user had before, to avoid disruption. Also this PR creates an `owner` user besides the current `admin` and `annotator` users being created as part of the `quickstart.Dockerfile`.

Reverts the PR at https://github.com/argilla-io/argilla/pull/3188

**Type of change**

- [X] Refactor (change restructuring the codebase without changing functionality)

**How Has This Been Tested**

- [X] `docker build` both `quickstart.Dockerfile` and `release.Dockerfile`

**Checklist**

- [X] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [X] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [X] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)