### PR TITLE
feat: create `/data` directory in quickstart Docker image

### DIFF
--- a/quickstart.Dockerfile
+++ b/quickstart.Dockerfile
@@ -1,24 +1,13 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch:8.5.3
 
-ENV ADMIN_USERNAME=admin
-ENV ADMIN_PASSWORD=12345678
-ENV ADMIN_API_KEY=admin.apikey
-
-ENV ANNOTATOR_USERNAME=argilla
-ENV ANNOTATOR_PASSWORD=12345678
-
-ENV ARGILLA_WORKSPACE=$ADMIN_USERNAME
-ENV LOAD_DATASETS=full
-ENV UVICORN_PORT=6900
-
-ENV xpack.security.enabled=false
-ENV cluster.routing.allocation.disk.threshold_enabled=false
-ENV discovery.type=single-node
-ENV ES_JAVA_OPTS=-'Xms512m -Xmx512m'
-
 ENV DEBIAN_FRONTEND=noninteractive
 
 USER root
+
+# Create a directory where Elasticsearch and Argilla will store their data
+# We will use this directory as a volume to persist data between container restarts (mainly in HF spaces)
+RUN mkdir /data
+RUN chown -R elasticsearch:elasticsearch /data
 
 COPY scripts/start_quickstart_argilla.sh /
 COPY scripts/load_data.py /
@@ -40,5 +29,24 @@ RUN apt update && \
     > /usr/local/lib/python3.9/dist-packages/argilla/server/static/deployment.json
 
 USER elasticsearch
+
+RUN echo "path.data: /data/elasticsearch" >> /usr/share/elasticsearch/config/elasticsearch.yml
+
+ENV ADMIN_USERNAME=admin
+ENV ADMIN_PASSWORD=12345678
+ENV ADMIN_API_KEY=admin.apikey
+
+ENV ANNOTATOR_USERNAME=argilla
+ENV ANNOTATOR_PASSWORD=12345678
+
+ENV ARGILLA_HOME_PATH=/data/argilla
+ENV ARGILLA_WORKSPACE=$ADMIN_USERNAME
+ENV LOAD_DATASETS=full
+ENV UVICORN_PORT=6900
+
+ENV xpack.security.enabled=false
+ENV cluster.routing.allocation.disk.threshold_enabled=false
+ENV discovery.type=single-node
+ENV ES_JAVA_OPTS=-'Xms512m -Xmx512m'
 
 CMD ["/start_quickstart_argilla.sh"]


### PR DESCRIPTION
# Description

I've updated the quickstart image to create the `/data` directory which will be used to store Argilla Server data and Elasticsearch data.

This change is mainly needed so the quickstart is compatible with the new HF Spaces feature, persistent storage. HF Spaces persistent storage mounts a volume in the `/data` directory of the container, so `ARGILLA_HOME_PATH` should be set to `/data/argilla` (or other directory but within `/data`). Additionally, we need to also change the `path.data` config parameter of Elasticsearch to `/data/elasticsearch`, so elastic data is also persisted.

If the HF persistent storage is not used (volume is not mounted), then the `/data` directory won't exist and the Linux user used in the quickstart Docker image (`elasticsearch`) won't have the rights needed to create it. To avoid this from happening, we also create the `/data` directory in the Dockerimage and we give permissions to the `elasticsearch` user to manage this directory.

I've also moved the `ENV` in the top of the Dockerfile to the bottom. This is to take advantage of the Dockerimage layering system, so if we change one of these `ENV`s the cached layers are not invalidated and we don't have to reinstall everything again.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (change restructuring the codebase without changing functionality)

**How Has This Been Tested**

Running the new `quickstart` image locally.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
