### PR TITLE
Bugfixes/align availables workspaces and set workspace operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ These are the section headers that we use:
 
 ## [Unreleased]
 
+### Fixed
+
+- Check available workspaces on Argilla on `rg.set_workspace` (Closes [#3262](https://github.com/argilla-io/argilla/issues/3262))
+
 ## [1.11.0](https://github.com/argilla-io/argilla/compare/v1.10.0...v1.11.0)
 
 ### Fixed

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -28,6 +28,7 @@ from rich.progress import Progress
 
 from argilla._constants import (
     DEFAULT_API_KEY,
+    DEFAULT_USERNAME,
     ES_INDEX_REGEX_PATTERN,
     WORKSPACE_HEADER_NAME,
 )
@@ -136,7 +137,24 @@ class Argilla:
         )
 
         self._user = users_api.whoami(client=self.http_client)  # .parsed
-        self.set_workspace(workspace or self._user.username)
+
+        if not workspace and self._user.username == DEFAULT_USERNAME:
+            warnings.warn(
+                "Default user was detected and no workspace configuration was provided, so "
+                f"the default {DEFAULT_USERNAME!r} workspace will be used. "
+                "If you want to setup another workspace, use the `rg.set_workspace` function "
+                "or provide a different one on `rg.init`",
+                category=UserWarning,
+            )
+            workspace = DEFAULT_USERNAME
+        if workspace:
+            self.set_workspace(workspace or self._user.username)
+        else:
+            warnings.warn(
+                "No workspace configuration was detected. To work with Argilla datasets, "
+                "specify a valid workspace name on `rg.init` or set it up through the `rg.set_workspace` function. ",
+                category=UserWarning,
+            )
 
         self._check_argilla_versions()
 
@@ -214,10 +232,12 @@ class Argilla:
             )
 
         if workspace != self.get_workspace():
-            if workspace == self.user.username or (self.user.workspaces and workspace in self.user.workspaces):
-                self.http_client.update_headers({WORKSPACE_HEADER_NAME: workspace})
-            else:
-                raise Exception(f"Wrong provided workspace {workspace}")
+            # TODO(frascuchon): user should list ONLY their accessible workspaces
+            for ws in self.list_workspaces():
+                if ws.name == workspace:
+                    self.http_client.update_headers({WORKSPACE_HEADER_NAME: ws.name})
+                    return
+            raise ValueError(f"Wrong provided workspace {workspace!r}")
 
     def get_workspace(self) -> str:
         """Returns the name of the active workspace.

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -140,10 +140,10 @@ class Argilla:
 
         if not workspace and self._user.username == DEFAULT_USERNAME:
             warnings.warn(
-                "Default user was detected and no workspace configuration was provided, so "
-                f"the default {DEFAULT_USERNAME!r} workspace will be used. "
-                "If you want to setup another workspace, use the `rg.set_workspace` function "
-                "or provide a different one on `rg.init`",
+                "Default user was detected and no workspace configuration was provided,"
+                f" so the default {DEFAULT_USERNAME!r} workspace will be used. If you"
+                " want to setup another workspace, use the `rg.set_workspace` function"
+                " or provide a different one on `rg.init`",
                 category=UserWarning,
             )
             workspace = DEFAULT_USERNAME
@@ -151,8 +151,9 @@ class Argilla:
             self.set_workspace(workspace or self._user.username)
         else:
             warnings.warn(
-                "No workspace configuration was detected. To work with Argilla datasets, "
-                "specify a valid workspace name on `rg.init` or set it up through the `rg.set_workspace` function. ",
+                "No workspace configuration was detected. To work with Argilla "
+                " datasets, specify a valid workspace name on `rg.init` or set it"
+                " up through the `rg.set_workspace` function.",
                 category=UserWarning,
             )
 

--- a/src/argilla/client/sdk/users/api.py
+++ b/src/argilla/client/sdk/users/api.py
@@ -29,7 +29,7 @@ from argilla.client.sdk.users.models import UserCreateModel, UserModel, UserRole
 
 # TODO(alvarobartt,frascuchon): use ONLY `httpx.Client` instead of `AuthenticatedClient` and
 # fix mock in `tests/conftest.py` to use `httpx.Client` instead of `AuthenticatedClient`
-def whoami(client: AuthenticatedClient) -> Union[UserModel, Response[UserModel]]:
+def whoami(client: AuthenticatedClient) -> UserModel:
     """Sends a GET request to `/api/me` endpoint to get the current user information.
 
     Args:

--- a/src/argilla/client/sdk/users/api.py
+++ b/src/argilla/client/sdk/users/api.py
@@ -27,9 +27,9 @@ from argilla.client.sdk.commons.models import (
 from argilla.client.sdk.users.models import UserCreateModel, UserModel, UserRole
 
 
-def whoami(
-    client: Union[AuthenticatedClient, httpx.Client],
-) -> Union[UserModel, Response[UserModel]]:
+# TODO(alvarobartt,frascuchon): use ONLY `httpx.Client` instead of `AuthenticatedClient` and
+# fix mock in `tests/conftest.py` to use `httpx.Client` instead of `AuthenticatedClient`
+def whoami(client: AuthenticatedClient) -> Union[UserModel, Response[UserModel]]:
     """Sends a GET request to `/api/me` endpoint to get the current user information.
 
     Args:
@@ -41,20 +41,7 @@ def whoami(
     url = "/api/me"
 
     response = client.get(url)
-    # TODO(alvarobartt,frascuchon): use ONLY `httpx.Client` instead of `AuthenticatedClient` and
-    # fix mock in `tests/conftest.py` to use `httpx.Client` instead of `AuthenticatedClient`
-    if isinstance(response, httpx.Response):
-        if response.status_code == 200:
-            return Response(
-                status_code=response.status_code,
-                content=response.content,
-                headers=response.headers,
-                parsed=UserModel(**response.json()),
-            )
-        else:
-            handle_response_error(response)
-    else:
-        return UserModel(**response)
+    return UserModel(**response)
 
 
 def list_users(

--- a/src/argilla/client/users.py
+++ b/src/argilla/client/users.py
@@ -124,7 +124,7 @@ class User:
     @property
     def workspaces(self) -> List[str]:
         try:
-            user = users_api.whoami(self.__client)
+            user = users_api.whoami(self.__client).parsed
             return user.workspaces
         except Exception as e:
             raise RuntimeError("Error while retrieving the current user workspaces from Argilla.") from e
@@ -285,7 +285,7 @@ class User:
         client = cls.__active_client()
         try:
             user = users_api.whoami(client).parsed
-            return cls.__new_instance(client.httpx, user)
+            return cls.__new_instance(client, user)
         except Exception as e:
             raise RuntimeError("Error while retrieving the current user from Argilla.") from e
 

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -47,6 +47,8 @@ from argilla.client.sdk.commons.errors import (
 from argilla.client.sdk.datasets.models import TaskType
 from argilla.client.sdk.users import api as users_api
 from argilla.client.sdk.users.models import UserModel
+from argilla.client.sdk.workspaces import api as workspaces_api
+from argilla.client.sdk.workspaces.models import WorkspaceModel
 from argilla.server.models import User, UserRole
 from httpx import ConnectError
 
@@ -77,8 +79,24 @@ def mock_init_ok(monkeypatch):
             updated_at=datetime.datetime.now(),
         )
 
+    def mock_list_workspaces(*args, **kwargs):
+        return Response(
+            content=b"",
+            parsed=[
+                WorkspaceModel(
+                    id=uuid4(),
+                    name="mock_workspace",
+                    inserted_at=datetime.datetime.utcnow(),
+                    updated_at=datetime.datetime.utcnow(),
+                )
+            ],
+            status_code=200,
+            headers={},
+        )
+
     monkeypatch.setattr(Status, "get_info", mock_get_info)
     monkeypatch.setattr(users_api, "whoami", mock_whoami)
+    monkeypatch.setattr(workspaces_api, "list_workspaces", mock_list_workspaces)
 
 
 @pytest.fixture
@@ -160,7 +178,7 @@ def test_init_environment_url(mock_init_ok, monkeypatch):
     It checks the url in the environment variable gets passed to client.
     """
     workspace_name = "mock_workspace"
-    url = "mock_url"
+    url = "http://mock_url"
     api_key = "mock_api_key"
 
     monkeypatch.setenv("ARGILLA_API_URL", url)
@@ -733,7 +751,7 @@ def test_client_workspace(api: Argilla, argilla_user: User):
     with pytest.raises(Exception, match="Must provide a workspace"):
         api.set_workspace(None)
 
-    with pytest.raises(Exception, match="Wrong provided workspace not-found"):
+    with pytest.raises(Exception, match="Wrong provided workspace 'not-found'"):
         api.set_workspace("not-found")
 
     api.set_workspace(argilla_user.username)
@@ -792,4 +810,5 @@ def test_not_aligned_argilla_versions(monkeypatch):
 def test_aligned_argilla_versions(mock_init_ok):
     with pytest.warns(None) as record:
         Argilla()
-    assert len(record) == 0
+        for warning in record:
+            assert "You're connecting to Argilla Server" not in str(warning.message)

--- a/tests/client/test_users.py
+++ b/tests/client/test_users.py
@@ -63,6 +63,7 @@ def test_user_from_id(owner: "ServerUser"):
         User.from_id(id="00000000-0000-0000-0000-000000000000")
 
 
+@pytest.mark.skip(reason="This behaviour is not yet implemented. Onwer users won't have workspaces through this")
 def test_user_workspaces(owner: "ServerUser"):
     workspaces = WorkspaceFactory.create_batch(3)
 

--- a/tests/client/test_users.py
+++ b/tests/client/test_users.py
@@ -22,7 +22,7 @@ from argilla.client.users import User
 if TYPE_CHECKING:
     from argilla.server.models import User as ServerUser
 
-from tests.factories import UserFactory
+from tests.factories import UserFactory, WorkspaceFactory
 
 
 def test_user_cls_init() -> None:
@@ -61,6 +61,30 @@ def test_user_from_id(owner: "ServerUser"):
 
     with pytest.raises(ValueError, match="User with id="):
         User.from_id(id="00000000-0000-0000-0000-000000000000")
+
+
+def test_user_workspaces(owner: "ServerUser"):
+    workspaces = WorkspaceFactory.create_batch(3)
+
+    import argilla as rg
+
+    rg.init(api_key=owner.api_key)
+
+    user = rg.User.from_name(owner.username)
+
+    assert len(workspaces) == len(user.workspaces)
+    assert [ws.name for ws in workspaces] == user.workspaces
+
+
+def test_user_me(owner: "ServerUser"):
+    import argilla as rg
+
+    rg.init(api_key=owner.api_key)
+
+    user = rg.User.me()
+
+    assert user.id == owner.id
+    assert user.username == owner.username
 
 
 def test_user_create(owner: "ServerUser") -> None:

--- a/tests/client/test_workspaces.py
+++ b/tests/client/test_workspaces.py
@@ -122,3 +122,39 @@ def test_workspace_delete_user(owner: "ServerUser") -> None:
 
     with pytest.raises(ValueError, match="Either the user with id="):
         workspace.delete_user(owner.id)
+
+
+def test_set_new_workspace(owner: "ServerUser"):
+    import argilla as rg
+
+    rg.init(api_key=owner.api_key)
+    ws = rg.Workspace.create("new-workspace")
+
+    rg.set_workspace(ws.name)
+    assert rg.get_workspace() == ws.name
+
+
+def test_init_with_workspace(owner: "ServerUser"):
+    workspace = WorkspaceFactory.create(name="test_workspace")
+
+    import argilla as rg
+
+    rg.init(api_key=owner.api_key, workspace=workspace.name)
+
+    assert rg.get_workspace() == workspace.name
+
+
+def test_set_workspace_with_missing_workspace(owner: "ServerUser"):
+    import argilla as rg
+
+    rg.init(api_key=owner.api_key)
+
+    with pytest.raises(ValueError):
+        rg.set_workspace("missing-workspace")
+
+
+def test_init_with_missing_workspace(owner: "ServerUser"):
+    import argilla as rg
+
+    with pytest.raises(ValueError):
+        rg.init(api_key=owner.api_key, workspace="missing-workspace")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,9 +183,9 @@ def using_test_client_from_argilla_python_client(monkeypatch, test_telemetry: "M
 
     def whoami_mocked(*args, **kwargs):
         client_arg = args[-1] if args else kwargs["client"]
-        if isinstance(client_arg, AuthenticatedClient):
-            monkeypatch.setattr(client_arg, "__httpx__", client)
-            client.headers.update(client_arg.get_headers())
+
+        monkeypatch.setattr(client_arg, "__httpx__", client)
+        client.headers.update(client_arg.get_headers())
 
         return real_whoami(client_arg)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,9 +183,9 @@ def using_test_client_from_argilla_python_client(monkeypatch, test_telemetry: "M
 
     def whoami_mocked(*args, **kwargs):
         client_arg = args[-1] if args else kwargs["client"]
-
-        monkeypatch.setattr(client_arg, "__httpx__", client)
-        client.headers.update(client_arg.get_headers())
+        if isinstance(client_arg, AuthenticatedClient):
+            monkeypatch.setattr(client_arg, "__httpx__", client)
+            client.headers.update(client_arg.get_headers())
 
         return real_whoami(client_arg)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,6 +185,8 @@ def using_test_client_from_argilla_python_client(monkeypatch, test_telemetry: "M
         client_arg = args[-1] if args else kwargs["client"]
 
         monkeypatch.setattr(client_arg, "__httpx__", client)
+        client.headers.update(client_arg.get_headers())
+
         return real_whoami(client_arg)
 
     monkeypatch.setattr(users_api, "whoami", whoami_mocked)

--- a/tests/functional_tests/test_log_for_text_classification.py
+++ b/tests/functional_tests/test_log_for_text_classification.py
@@ -28,6 +28,7 @@ from argilla.server.settings import settings
 from sqlalchemy.orm import Session
 
 from tests.client.conftest import SUPPORTED_VECTOR_SEARCH
+from tests.factories import WorkspaceFactory
 from tests.helpers import SecuredClient
 
 
@@ -160,32 +161,29 @@ def test_log_data_with_vectors_and_update_ko(mocked_client: SecuredClient):
         )
 
 
-def test_log_data_in_several_workspaces(mocked_client: SecuredClient, owner, db: Session):
-    workspace_name = "my-fun-workspace"
+def test_log_data_in_several_workspaces(owner: User, db: Session):
     dataset_name = "test_log_data_in_several_workspaces"
     text = "This is a text"
 
-    for ws_name in [workspace_name, owner.username]:
-        workspace = accounts.create_workspace(db, WorkspaceCreate(name=ws_name))
-        accounts.create_workspace_user(db, WorkspaceUserCreate(workspace_id=workspace.id, user_id=owner.id))
+    workspace = WorkspaceFactory.create()
+    other_workspace = WorkspaceFactory.create()
 
-    api = Argilla(api_key=owner.api_key)
+    api = Argilla(api_key=owner.api_key, workspace=workspace.name)
 
-    current_workspace = api.get_workspace()
-    for ws in [current_workspace, workspace_name]:
-        api.set_workspace(ws)
+    for ws in [workspace, other_workspace]:
+        api.set_workspace(ws.name)
         api.delete(dataset_name)
 
-    api.set_workspace(current_workspace)
+    api.set_workspace(workspace.name)
     api.log(rg.TextClassificationRecord(id=0, inputs=text), name=dataset_name)
 
-    api.set_workspace(workspace_name)
+    api.set_workspace(other_workspace.name)
     api.log(rg.TextClassificationRecord(id=1, inputs=text), name=dataset_name)
 
     ds = api.load(dataset_name)
     assert len(ds) == 1
 
-    api.set_workspace(current_workspace)
+    api.set_workspace(workspace.name)
 
     ds = api.load(dataset_name)
     assert len(ds) == 1


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR adapts the client workflow to check available workspaces before the `rg.set_workspace` function.  Since the `set_workspace` is based on `list_workspaces` method, a code refactor has been applied to return only available workspaces for the connected user.

@alvarobartt we need to align the `User.workspaces`, `list_workspace`, and `Workspace.create`

Closes #3262 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)


**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
