### PR TITLE
feat: warn user when trying to load `FeedbackDataset` using `rg.load` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ These are the section headers that we use:
 
 - All docker related files have been moved into the `docker` folder
 - `release.Dockerfile` have been renamed to `Dockerfile`
+- Update `rg.load` function to raise a `ValueError` with a explanatory message for the cases in which the user tries to use the function to load a `FeedbackDataset` ([#3289](https://github.com/argilla-io/argilla/pull/3289)).
 
 ## [1.11.0](https://github.com/argilla-io/argilla/compare/v1.10.0...v1.11.0)
 

--- a/src/argilla/client/api.py
+++ b/src/argilla/client/api.py
@@ -337,8 +337,7 @@ def load(
                 f"The dataset '{name}' exists but it is a `FeedbackDataset`. Use `rg.FeedbackDataset.from_argilla`"
                 " instead to load it."
             )
-        else:
-            raise e
+        raise e
 
 
 def copy(

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -60,7 +60,12 @@ from argilla.client.sdk.users.models import UserModel
 from argilla.server.models import User, UserRole
 from httpx import ConnectError
 
-from tests.factories import UserFactory, WorkspaceFactory
+from tests.factories import (
+    DatasetFactory,
+    UserFactory,
+    WorkspaceFactory,
+    WorkspaceUserFactory,
+)
 from tests.server.test_api import create_some_data_for_text_classification
 
 
@@ -237,6 +242,17 @@ def test_load_limits(argilla_user: User, supported_vector_search: bool):
 
     ds = api.load(name=dataset, limit=limit_data_to)
     assert len(ds) == limit_data_to
+
+
+def test_load_with_feedback_dataset(mocked_client, argilla_user: User):
+    workspace = argilla_user.workspaces[0]
+    dataset = DatasetFactory.create(name="dataset-a", workspace=workspace)
+
+    with pytest.raises(
+        ValueError,
+        match=f"The dataset '{dataset.name}' exists but it is a `FeedbackDataset`. Use `rg.FeedbackDataset.from_argilla` instead to load it.",
+    ):
+        rg.load(name=dataset.name, workspace=workspace.name)
 
 
 def test_log_records_with_too_long_text(api: Argilla):


### PR DESCRIPTION
# Description

A few users have already reported an "error" (one on GitHub and a few others on Slack) when trying to load a `FeedbackDataset` using `rg.load`. `rg.load` cannot be used to load `FeedbackDataset`s and `rg.FeedbackDataset.from_argilla` has to be used instead.

This PR updated the `rg.load` function to try to check if there's a `FeedbackDataset` with the provided `name` and `workspace` if `NotFoundApiError` is raised when trying to get the V0 dataset. If the `FeedbackDataset` is found, then it will raise an error telling the user how to load the `FeedbackDataset`. Otherwise, the original exception will be re-raised.

Closes #3175

**Type of change**

- [x] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

Some manual tests and I've added a new unit test covering this case.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
