### PR TITLE
refactor: simplify old bulk endpoints to avoid create datasets if does not exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ These are the section headers that we use:
 
 ## [Unreleased]
 
+### Changed
+
+- The `POST /api/datasets/:dataset-id/:task/bulk` endpoint don't create the dataset if does not exists (Closes [#3244](https://github.com/argilla-io/argilla/issues/3244))
+
 ## [1.12.0](https://github.com/argilla-io/argilla/compare/v1.11.0...v1.12.0)
 
 ### Added

--- a/src/argilla/server/apis/v0/handlers/text2text.py
+++ b/src/argilla/server/apis/v0/handlers/text2text.py
@@ -73,32 +73,17 @@ def configure_router():
     ) -> BulkResponse:
         task = task_type
         workspace = common_params.workspace
-        try:
-            dataset = await datasets.find_by_name(
-                current_user,
-                name=name,
-                task=task,
-                workspace=workspace,
-            )
-            await datasets.update(
-                user=current_user,
-                dataset=dataset,
-                tags=bulk.tags,
-                metadata=bulk.metadata,
-            )
-        except EntityNotFoundError:
-            dataset = CreateDatasetRequest(name=name, workspace=workspace, task=task, **bulk.dict())
-            dataset = await datasets.create_dataset(user=current_user, dataset=dataset)
+
+        dataset = await datasets.find_by_name(current_user, name=name, task=task, workspace=workspace)
+
+        await datasets.update(user=current_user, dataset=dataset, tags=bulk.tags, metadata=bulk.metadata)
 
         result = await service.add_records(
             dataset=dataset,
             records=[ServiceText2TextRecord.parse_obj(r) for r in bulk.records],
         )
-        return BulkResponse(
-            dataset=name,
-            processed=result.processed,
-            failed=result.failed,
-        )
+
+        return BulkResponse(dataset=name, processed=result.processed, failed=result.failed)
 
     @router.post(
         path=f"{base_endpoint}:search",

--- a/src/argilla/server/apis/v0/handlers/text_classification.py
+++ b/src/argilla/server/apis/v0/handlers/text_classification.py
@@ -92,36 +92,17 @@ def configure_router():
     ) -> BulkResponse:
         task = task_type
         workspace = common_params.workspace
-        try:
-            dataset = await datasets.find_by_name(
-                current_user,
-                name=name,
-                task=task,
-                workspace=workspace,
-            )
-            dataset = await datasets.update(
-                user=current_user,
-                dataset=dataset,
-                tags=bulk.tags,
-                metadata=bulk.metadata,
-            )
-        except EntityNotFoundError:
-            dataset = CreateDatasetRequest(name=name, workspace=workspace, task=task, **bulk.dict())
-            dataset = await datasets.create_dataset(user=current_user, dataset=dataset)
+
+        dataset = await datasets.find_by_name(current_user, name=name, task=task, workspace=workspace)
+
+        await datasets.update(user=current_user, dataset=dataset, tags=bulk.tags, metadata=bulk.metadata)
 
         # TODO(@frascuchon): Validator should be applied in the service layer
         records = [ServiceTextClassificationRecord.parse_obj(r) for r in bulk.records]
         await validator.validate_dataset_records(user=current_user, dataset=dataset, records=records)
 
-        result = await service.add_records(
-            dataset=dataset,
-            records=records,
-        )
-        return BulkResponse(
-            dataset=name,
-            processed=result.processed,
-            failed=result.failed,
-        )
+        result = await service.add_records(dataset=dataset, records=records)
+        return BulkResponse(dataset=name, processed=result.processed, failed=result.failed)
 
     @router.post(
         f"{base_endpoint}:search",

--- a/src/argilla/server/apis/v0/handlers/token_classification.py
+++ b/src/argilla/server/apis/v0/handlers/token_classification.py
@@ -82,40 +82,17 @@ def configure_router():
     ) -> BulkResponse:
         task = task_type
         workspace = common_params.workspace
-        try:
-            dataset = await datasets.find_by_name(
-                current_user,
-                name=name,
-                task=task,
-                workspace=workspace,
-            )
-            await datasets.update(
-                user=current_user,
-                dataset=dataset,
-                tags=bulk.tags,
-                metadata=bulk.metadata,
-            )
-        except EntityNotFoundError:
-            dataset = CreateDatasetRequest(name=name, workspace=workspace, task=task, **bulk.dict())
-            dataset = await datasets.create_dataset(user=current_user, dataset=dataset)
+
+        dataset = await datasets.find_by_name(current_user, name=name, task=task, workspace=workspace)
+
+        await datasets.update(user=current_user, dataset=dataset, tags=bulk.tags, metadata=bulk.metadata)
 
         records = [ServiceTokenClassificationRecord.parse_obj(r) for r in bulk.records]
         # TODO(@frascuchon): validator can be applied in service layer
-        await validator.validate_dataset_records(
-            user=current_user,
-            dataset=dataset,
-            records=records,
-        )
+        await validator.validate_dataset_records(user=current_user, dataset=dataset, records=records)
 
-        result = await service.add_records(
-            dataset=dataset,
-            records=records,
-        )
-        return BulkResponse(
-            dataset=name,
-            processed=result.processed,
-            failed=result.failed,
-        )
+        result = await service.add_records(dataset=dataset, records=records)
+        return BulkResponse(dataset=name, processed=result.processed, failed=result.failed)
 
     @router.post(
         path=f"{base_endpoint}:search",

--- a/tests/client/sdk/datasets/test_api.py
+++ b/tests/client/sdk/datasets/test_api.py
@@ -21,7 +21,7 @@ from argilla.client.sdk.commons.errors import (
     ValidationApiError,
 )
 from argilla.client.sdk.datasets.api import _build_response, get_dataset
-from argilla.client.sdk.datasets.models import Dataset
+from argilla.client.sdk.datasets.models import Dataset, TaskType
 from argilla.client.sdk.text_classification.models import TextClassificationBulkData
 from argilla.server.models import UserRole
 
@@ -40,6 +40,13 @@ async def test_get_dataset(role: UserRole):
     api = Argilla(api_key=user.api_key, workspace=workspace.name)
 
     api.delete(dataset_name)
+    assert (
+        api.http_client.httpx.post(
+            "/api/datasets",
+            json={"name": dataset_name, "workspace": workspace.name, "task": TaskType.text_classification.value},
+        ).status_code
+        == 200
+    )
     api.http_client.httpx.post(
         f"/api/datasets/{dataset_name}/TextClassification:bulk", json=bulk_data.dict(by_alias=True)
     )

--- a/tests/labeling/text_classification/test_rule.py
+++ b/tests/labeling/text_classification/test_rule.py
@@ -36,9 +36,15 @@ from tests.helpers import SecuredClient
 
 
 @pytest.fixture
-def log_dataset_without_annotations(mocked_client) -> str:
+def log_dataset_without_annotations(mocked_client: SecuredClient) -> str:
     dataset_name = "test_dataset_for_rule"
     mocked_client.delete(f"/api/datasets/{dataset_name}")
+    assert (
+        mocked_client.post(
+            "/api/datasets", json={"name": dataset_name, "task": TaskType.text_classification.value}
+        ).status_code
+        == 200
+    )
     records = [
         CreationTextClassificationRecord.parse_obj(
             {
@@ -62,6 +68,12 @@ def log_dataset_without_annotations(mocked_client) -> str:
 def log_dataset(mocked_client) -> str:
     dataset_name = "test_dataset_for_rule"
     mocked_client.delete(f"/api/datasets/{dataset_name}")
+    assert (
+        mocked_client.post(
+            "/api/datasets", json={"name": dataset_name, "task": TaskType.text_classification.value}
+        ).status_code
+        == 200
+    )
     records = [
         CreationTextClassificationRecord.parse_obj(
             {

--- a/tests/labeling/text_classification/test_weak_labels.py
+++ b/tests/labeling/text_classification/test_weak_labels.py
@@ -33,13 +33,22 @@ from argilla.labeling.text_classification.weak_labels import (
     NoRulesFoundError,
     WeakLabelsBase,
 )
+from argilla.server.commons.models import TaskType
 from pandas.testing import assert_frame_equal
+
+from tests.helpers import SecuredClient
 
 
 @pytest.fixture
-def log_dataset(mocked_client) -> str:
+def log_dataset(mocked_client: SecuredClient) -> str:
     dataset_name = "test_dataset_for_applier"
     mocked_client.delete(f"/api/datasets/{dataset_name}")
+    assert (
+        mocked_client.post(
+            "/api/datasets", json={"name": dataset_name, "task": TaskType.text_classification.value}
+        ).status_code
+        == 200
+    )
     records = [
         CreationTextClassificationRecord.parse_obj(
             {
@@ -92,9 +101,15 @@ def rules(monkeypatch) -> List[Callable]:
 
 
 @pytest.fixture
-def log_multilabel_dataset(mocked_client) -> str:
+def log_multilabel_dataset(mocked_client: SecuredClient) -> str:
     dataset_name = "test_dataset_for_multilabel_applier"
     mocked_client.delete(f"/api/datasets/{dataset_name}")
+    assert (
+        mocked_client.post(
+            "/api/datasets", json={"name": dataset_name, "task": TaskType.text_classification.value}
+        ).status_code
+        == 200
+    )
     records = [
         CreationTextClassificationRecord.parse_obj(
             {

--- a/tests/server/functional_tests/datasets/test_get_record.py
+++ b/tests/server/functional_tests/datasets/test_get_record.py
@@ -26,14 +26,14 @@ from argilla.server.apis.v0.models.token_classification import (
 )
 from argilla.server.commons.models import TaskType
 
+from tests.helpers import SecuredClient
 
-def create_dataset(
-    mocked_client,
-    task: TaskType,
-):
+
+def create_dataset(mocked_client, task: TaskType):
     dataset = "test-dataset"
     record_text = "This is my text"
-    assert mocked_client.delete(f"/api/datasets/{dataset}").status_code == 200
+    assert mocked_client.delete(f"/api/datasets/{dataset}").status_code in [200, 404]
+    assert mocked_client.post("/api/datasets", json={"name": dataset, "task": task.value}).status_code == 200
     tags = {
         "env": "test",
         "type": task,
@@ -102,10 +102,7 @@ def create_dataset(
     ],
 )
 def test_get_record_by_id(mocked_client, task, expected_record_class):
-    dataset = create_dataset(
-        mocked_client,
-        task=task,
-    )
+    dataset = create_dataset(mocked_client, task=task)
 
     record_id = 0
     response = mocked_client.get(f"/api/datasets/{dataset}/records/{record_id}")
@@ -123,11 +120,8 @@ def test_get_record_by_id(mocked_client, task, expected_record_class):
         TaskType.text2text,
     ],
 )
-def test_get_record_by_id_not_found(mocked_client, task):
-    dataset = create_dataset(
-        mocked_client,
-        task=task,
-    )
+def test_get_record_by_id_not_found(mocked_client: SecuredClient, task: TaskType):
+    dataset = create_dataset(mocked_client, task=task)
 
     record_id = "not-found"
     response = mocked_client.get(f"/api/datasets/{dataset}/records/{record_id}")

--- a/tests/server/test_api.py
+++ b/tests/server/test_api.py
@@ -90,7 +90,11 @@ def create_some_data_for_text_classification(
             record.vectors = record_vectors
 
     client.post(
-        f"/api/datasets/{name}/{TaskType.text_classification}:bulk",
+        "/api/datasets", json={"name": name, "task": TaskType.text_classification.value, "workspace": "argilla"}
+    )
+
+    client.post(
+        f"/api/datasets/{name}/{TaskType.text_classification.value}:bulk",
         json=TextClassificationBulkRequest(
             tags={"env": "test", "class": "text classification"},
             metadata={"config": {"the": "config"}},

--- a/tests/server/text2text/test_api.py
+++ b/tests/server/text2text/test_api.py
@@ -20,13 +20,24 @@ from argilla.server.apis.v0.models.text2text import (
     Text2TextRecordInputs,
     Text2TextSearchResults,
 )
+from argilla.server.commons.models import TaskType
+from argilla.server.models import User
 
 from tests.client.conftest import SUPPORTED_VECTOR_SEARCH
+from tests.helpers import SecuredClient
 
 
-def test_search_records(mocked_client):
+def test_search_records(mocked_client: SecuredClient, argilla_user: User):
     dataset = "test_search_records"
     delete_dataset(dataset, mocked_client)
+
+    assert (
+        mocked_client.post(
+            "/api/datasets",
+            json={"name": dataset, "task": TaskType.text2text.value, "workspace": argilla_user.username},
+        ).status_code
+        == 200
+    )
 
     records = [
         Text2TextRecordInputs.parse_obj(data)
@@ -114,10 +125,17 @@ def search_data(
     condition=not SUPPORTED_VECTOR_SEARCH,
     reason="Vector search not supported",
 )
-def test_search_with_vectors(mocked_client):
+def test_search_with_vectors(mocked_client: SecuredClient, argilla_user: User):
     dataset = "test_search_with_vectors"
 
     delete_dataset(dataset, mocked_client)
+    assert (
+        mocked_client.post(
+            "/api/datasets",
+            json={"name": dataset, "task": TaskType.text2text.value, "workspace": argilla_user.username},
+        ).status_code
+        == 200
+    )
 
     records_for_text2text_with_vectors = [
         Text2TextRecordInputs.parse_obj(data)
@@ -172,9 +190,16 @@ def test_search_with_vectors(mocked_client):
     )
 
 
-def test_api_with_new_predictions_data_model(mocked_client):
+def test_api_with_new_predictions_data_model(mocked_client: SecuredClient, argilla_user: User):
     dataset = "test_api_with_new_predictions_data_model"
     delete_dataset(dataset, mocked_client)
+    assert (
+        mocked_client.post(
+            "/api/datasets",
+            json={"name": dataset, "task": TaskType.text2text.value, "workspace": argilla_user.username},
+        ).status_code
+        == 200
+    )
 
     records = [
         Text2TextRecordInputs.parse_obj(

--- a/tests/server/text_classification/test_api.py
+++ b/tests/server/text_classification/test_api.py
@@ -25,17 +25,24 @@ from argilla.server.apis.v0.models.text_classification import (
     TextClassificationSearchRequest,
     TextClassificationSearchResults,
 )
-from argilla.server.commons.models import PredictionStatus
+from argilla.server.commons.models import PredictionStatus, TaskType
 from argilla.server.models import User
 from argilla.server.schemas.datasets import Dataset
-from starlette.testclient import TestClient
 
 from tests.client.conftest import SUPPORTED_VECTOR_SEARCH
+from tests.helpers import SecuredClient
 
 
-def test_create_records_for_text_classification_with_multi_label(mocked_client):
+def test_create_records_for_text_classification_with_multi_label(mocked_client: SecuredClient, argilla_user: User):
     dataset = "test_create_records_for_text_classification_with_multi_label"
     assert mocked_client.delete(f"/api/datasets/{dataset}").status_code == 200
+    assert (
+        mocked_client.post(
+            f"/api/datasets",
+            json={"name": dataset, "task": TaskType.text_classification, "workspace": argilla_user.username},
+        ).status_code
+        == 200
+    )
 
     records = [
         TextClassificationRecord.parse_obj(data)
@@ -135,9 +142,16 @@ def test_create_records_for_text_classification_with_multi_label(mocked_client):
     assert results.aggregations.predicted_by == {"testA": 1}
 
 
-def test_create_records_for_text_classification(mocked_client, test_telemetry):
+def test_create_records_for_text_classification(mocked_client: SecuredClient, argilla_user: User, test_telemetry):
     dataset = "test_create_records_for_text_classification"
     assert mocked_client.delete(f"/api/datasets/{dataset}").status_code == 200
+    assert (
+        mocked_client.post(
+            f"/api/datasets",
+            json={"name": dataset, "task": TaskType.text_classification, "workspace": argilla_user.username},
+        ).status_code
+        == 200
+    )
     tags = {"env": "test", "class": "text classification"}
     metadata = {"config": {"the": "config"}}
     classification_bulk = TextClassificationBulkRequest(
@@ -202,9 +216,18 @@ def test_create_records_for_text_classification(mocked_client, test_telemetry):
     condition=not SUPPORTED_VECTOR_SEARCH,
     reason="Vector search not supported",
 )
-def test_create_records_for_text_classification_vector_search(mocked_client, test_telemetry):
+def test_create_records_for_text_classification_vector_search(
+    mocked_client: SecuredClient, argilla_user: User, test_telemetry
+):
     dataset = "test_create_records_for_text_classification_vector_search"
     assert mocked_client.delete(f"/api/datasets/{dataset}").status_code == 200
+    assert (
+        mocked_client.post(
+            f"/api/datasets",
+            json={"name": dataset, "task": TaskType.text_classification, "workspace": argilla_user.username},
+        ).status_code
+        == 200
+    )
     tags = {"env": "test", "class": "text classification"}
     metadata = {"config": {"the": "config"}}
     classification_bulk = TextClassificationBulkRequest(
@@ -308,9 +331,16 @@ def test_create_records_for_text_classification_vector_search(mocked_client, tes
     ]  ## similarity ordered records
 
 
-def test_partial_record_update(mocked_client):
+def test_partial_record_update(mocked_client: SecuredClient, argilla_user: User):
     name = "test_partial_record_update"
     assert mocked_client.delete(f"/api/datasets/{name}").status_code == 200
+    assert (
+        mocked_client.post(
+            f"/api/datasets",
+            json={"name": name, "task": TaskType.text_classification, "workspace": argilla_user.username},
+        ).status_code
+        == 200
+    )
 
     record = TextClassificationRecord(
         **{
@@ -388,9 +418,16 @@ def test_partial_record_update(mocked_client):
     )
 
 
-def test_sort_by_last_updated(mocked_client):
+def test_sort_by_last_updated(mocked_client: SecuredClient, argilla_user: User):
     dataset = "test_sort_by_last_updated"
     assert mocked_client.delete(f"/api/datasets/{dataset}").status_code == 200
+    assert (
+        mocked_client.post(
+            f"/api/datasets",
+            json={"name": dataset, "task": TaskType.text_classification, "workspace": argilla_user.username},
+        ).status_code
+        == 200
+    )
     for i in range(0, 10):
         mocked_client.post(
             f"/api/datasets/{dataset}/TextClassification:bulk",
@@ -415,9 +452,16 @@ def test_sort_by_last_updated(mocked_client):
     assert [r["id"] for r in response.json()["records"]] == list(range(0, 10))
 
 
-def test_sort_by_id_as_default(mocked_client):
+def test_sort_by_id_as_default(mocked_client: SecuredClient, argilla_user: User):
     dataset = "test_sort_by_id_as_default"
     assert mocked_client.delete(f"/api/datasets/{dataset}").status_code == 200
+    assert (
+        mocked_client.post(
+            f"/api/datasets",
+            json={"name": dataset, "task": TaskType.text_classification, "workspace": argilla_user.username},
+        ).status_code
+        == 200
+    )
     response = mocked_client.post(
         f"/api/datasets/{dataset}/TextClassification:bulk",
         json=TextClassificationBulkRequest(
@@ -454,11 +498,18 @@ def test_sort_by_id_as_default(mocked_client):
     ]
 
 
-def test_some_sort_by(mocked_client):
+def test_some_sort_by(mocked_client: SecuredClient, argilla_user: User):
     dataset = "test_some_sort_by"
 
     expected_records_length = 50
     assert mocked_client.delete(f"/api/datasets/{dataset}").status_code == 200
+    assert (
+        mocked_client.post(
+            f"/api/datasets",
+            json={"name": dataset, "task": TaskType.text_classification, "workspace": argilla_user.username},
+        ).status_code
+        == 200
+    )
     mocked_client.post(
         f"/api/datasets/{dataset}/TextClassification:bulk",
         json=TextClassificationBulkRequest(
@@ -531,9 +582,16 @@ def test_some_sort_by(mocked_client):
     ]
 
 
-def test_disable_aggregations_when_scroll(mocked_client):
+def test_disable_aggregations_when_scroll(mocked_client: SecuredClient, argilla_user: User):
     dataset = "test_disable_aggregations_when_scroll"
     assert mocked_client.delete(f"/api/datasets/{dataset}").status_code == 200
+    assert (
+        mocked_client.post(
+            f"/api/datasets",
+            json={"name": dataset, "task": TaskType.text_classification, "workspace": argilla_user.username},
+        ).status_code
+        == 200
+    )
 
     response = mocked_client.post(
         f"/api/datasets/{dataset}/TextClassification:bulk",
@@ -571,9 +629,16 @@ def test_disable_aggregations_when_scroll(mocked_client):
     assert results.aggregations is None
 
 
-def test_include_event_timestamp(mocked_client):
+def test_include_event_timestamp(mocked_client: SecuredClient, argilla_user: User):
     dataset = "test_include_event_timestamp"
     assert mocked_client.delete(f"/api/datasets/{dataset}").status_code == 200
+    assert (
+        mocked_client.post(
+            f"/api/datasets",
+            json={"name": dataset, "task": TaskType.text_classification, "workspace": argilla_user.username},
+        ).status_code
+        == 200
+    )
 
     response = mocked_client.post(
         f"/api/datasets/{dataset}/TextClassification:bulk",
@@ -612,9 +677,16 @@ def test_include_event_timestamp(mocked_client):
     assert all(map(lambda record: record.event_timestamp is not None, results.records))
 
 
-def test_words_cloud(mocked_client):
+def test_words_cloud(mocked_client: SecuredClient, argilla_user: User):
     dataset = "test_language_detection"
     assert mocked_client.delete(f"/api/datasets/{dataset}").status_code == 200
+    assert (
+        mocked_client.post(
+            f"/api/datasets",
+            json={"name": dataset, "task": TaskType.text_classification, "workspace": argilla_user.username},
+        ).status_code
+        == 200
+    )
 
     response = mocked_client.post(
         f"/api/datasets/{dataset}/TextClassification:bulk",
@@ -652,9 +724,16 @@ def test_words_cloud(mocked_client):
     assert results.aggregations.words is not None
 
 
-def test_metadata_with_point_in_field_name(mocked_client):
+def test_metadata_with_point_in_field_name(mocked_client: SecuredClient, argilla_user: User):
     dataset = "test_metadata_with_point_in_field_name"
     assert mocked_client.delete(f"/api/datasets/{dataset}").status_code == 200
+    assert (
+        mocked_client.post(
+            f"/api/datasets",
+            json={"name": dataset, "task": TaskType.text_classification, "workspace": argilla_user.username},
+        ).status_code
+        == 200
+    )
 
     response = mocked_client.post(
         f"/api/datasets/{dataset}/TextClassification:bulk",
@@ -689,9 +768,16 @@ def test_metadata_with_point_in_field_name(mocked_client):
     assert results.aggregations.metadata.get("field.two", {})["2"] == 2
 
 
-def test_wrong_text_query(mocked_client):
+def test_wrong_text_query(mocked_client: SecuredClient, argilla_user: User):
     dataset = "test_wrong_text_query"
     assert mocked_client.delete(f"/api/datasets/{dataset}").status_code == 200
+    assert (
+        mocked_client.post(
+            f"/api/datasets",
+            json={"name": dataset, "task": TaskType.text_classification, "workspace": argilla_user.username},
+        ).status_code
+        == 200
+    )
 
     mocked_client.post(
         f"/api/datasets/{dataset}/TextClassification:bulk",
@@ -721,9 +807,16 @@ def test_wrong_text_query(mocked_client):
     }
 
 
-def test_search_using_text(mocked_client):
+def test_search_using_text(mocked_client: SecuredClient, argilla_user: User):
     dataset = "test_search_using_text"
     assert mocked_client.delete(f"/api/datasets/{dataset}").status_code == 200
+    assert (
+        mocked_client.post(
+            f"/api/datasets",
+            json={"name": dataset, "task": TaskType.text_classification, "workspace": argilla_user.username},
+        ).status_code
+        == 200
+    )
 
     mocked_client.post(
         f"/api/datasets/{dataset}/TextClassification:bulk",

--- a/tests/server/text_classification/test_api_rules.py
+++ b/tests/server/text_classification/test_api_rules.py
@@ -20,6 +20,7 @@ from argilla.server.apis.v0.models.text_classification import (
     TextClassificationBulkRequest,
     TextClassificationRecord,
 )
+from argilla.server.commons.models import TaskType
 
 
 def log_some_records(
@@ -31,6 +32,11 @@ def log_some_records(
 ):
     if delete:
         assert client.delete(f"/api/datasets/{dataset}").status_code == 200
+
+    client.post(
+        "/api/datasets",
+        json={"name": dataset, "task": TaskType.text_classification.value, "workspace": "argilla"},
+    )
 
     record = {
         "id": 0,

--- a/tests/server/text_classification/test_api_settings.py
+++ b/tests/server/text_classification/test_api_settings.py
@@ -19,6 +19,7 @@ from argilla.server.commons.models import TaskType
 from starlette.testclient import TestClient
 
 from tests.factories import AnnotatorFactory, WorkspaceFactory
+from tests.helpers import SecuredClient
 
 
 def create_dataset(client, name: str):
@@ -90,10 +91,11 @@ def test_validate_settings_when_logging_data(mocked_client):
     }
 
 
-def test_validate_settings_after_logging(mocked_client):
+def test_validate_settings_after_logging(mocked_client: SecuredClient):
     name = "test_validate_settings_after_logging"
 
     delete(name)
+    create_dataset(mocked_client, name)
     response = log_some_data(mocked_client, name)
     assert response.status_code == 200
 

--- a/tests/server/token_classification/test_api_settings.py
+++ b/tests/server/token_classification/test_api_settings.py
@@ -16,6 +16,8 @@ import argilla as rg
 from argilla.client.api import delete
 from argilla.server.commons.models import TaskType
 
+from tests.helpers import SecuredClient
+
 
 def create_dataset(client, name: str):
     response = client.post("/api/datasets", json={"name": name, "task": TaskType.token_classification})
@@ -109,9 +111,10 @@ def log_some_data(mocked_client, name):
     return response
 
 
-def test_validate_settings_after_logging(mocked_client):
+def test_validate_settings_after_logging(mocked_client: SecuredClient):
     name = "test_validate_settings_after_logging"
     delete(name)
+    create_dataset(mocked_client, name)
     response = log_some_data(mocked_client, name)
     assert response.status_code == 200
 


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR changes the `POST /api/datasets/:dataset-id/:task/bulk` endpoints behavior to not create the dataset if does not exist. The dataset must be created first using the `POST /api/datasets` endpoint.

Since version 1.11, the Python client is already adapted, but the `rg.log` may fail for older clients.

Closes #3244

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Refactor (change restructuring the codebase without changing functionality)


**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
