### PR TITLE
chore: add missing `greenlet` dependency in `server` extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ server = [
     # Database dependencies
     "alembic ~= 1.9.0",
     "SQLAlchemy ~= 2.0.0",
+    "greenlet >= 2.0.0",
     # Async SQLite
     "aiosqlite >=0.19.0",
     # Advanced query search dsl


### PR DESCRIPTION
# Description

This PR adds the `greenlet` dependency to the `server` extras in `pyproject.toml`, as it was included as part of https://github.com/argilla-io/argilla/pull/3162.

**Type of change**

- [X] Dependency (add, update, delete, upgrade, or downgrade)

**How Has This Been Tested**

- [X] Install `argilla[server]` and re-run unit tests

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
