### PR TITLE
fix: `rg.init` with argilla user using quickstart images raise an unexpected error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ These are the section headers that we use:
 
 ## [Unreleased]
 
+### Fixed
+
+- Using `rg.init` with default `argilla` user skips setting the default workspace if not available. (Closes [#3340](https://github.com/argilla-io/argilla/issues/3340))
+
 ## [1.12.0](https://github.com/argilla-io/argilla/compare/v1.11.0...v1.12.0)
 
 ### Added

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -138,7 +138,7 @@ class Argilla:
 
         self._user = users_api.whoami(client=self.http_client)  # .parsed
 
-        if not workspace and self._user.username == DEFAULT_USERNAME:
+        if not workspace and self._user.username == DEFAULT_USERNAME and DEFAULT_USERNAME in self._user.workspaces:
             warnings.warn(
                 "Default user was detected and no workspace configuration was provided,"
                 f" so the default {DEFAULT_USERNAME!r} workspace will be used. If you"

--- a/tests/client/test_init.py
+++ b/tests/client/test_init.py
@@ -11,49 +11,73 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import pytest
 from argilla.client import api
-from argilla.client.api import active_api
+from argilla.client.api import active_api, active_client
 from argilla.client.models import TextClassificationRecord
+from argilla.server.models import User
+
+from tests.factories import UserFactory, WorkspaceFactory
 
 
-def test_resource_leaking_with_several_init(mocked_client):
+def test_resource_leaking_with_several_init(argilla_user: User):
     dataset = "test_resource_leaking_with_several_init"
+    api.init(api_key=argilla_user.api_key)
     api.delete(dataset)
 
     # TODO: review performance in Windows. See https://github.com/recognai/argilla/pull/1702
     for i in range(0, 20):
-        api.init()
+        api.init(api_key=argilla_user.api_key)
 
     for i in range(0, 10):
-        api.init()
-        api.log(
-            TextClassificationRecord(text="The text"),
-            name=dataset,
-            verbose=False,
-        )
+        api.init(api_key=argilla_user.api_key)
+        api.log(TextClassificationRecord(text="The text"), name=dataset, verbose=False)
 
     assert len(api.load(dataset)) == 10
 
 
-def test_init_with_extra_headers(mocked_client):
+def test_init_with_extra_headers(argilla_user: User):
     expected_headers = {
         "X-Custom-Header": "Mocking rules!",
         "Other-header": "Header value",
     }
-    api.init(extra_headers=expected_headers)
-    active_api = api.active_api()
+    api.init(api_key=argilla_user.api_key, extra_headers=expected_headers)
+    client = active_client()
 
     for key, value in expected_headers.items():
-        assert active_api.http_client.headers[key] == value, f"{key}:{value} not in client headers"
+        assert client.http_client.headers[key] == value, f"{key}:{value} not in client headers"
 
 
-def test_init(mocked_client):
-    the_api = active_api()
-    user = the_api.http_client.get("/api/me")
-    assert user["username"] == "argilla"
+def test_init(argilla_user: User):
+    api.init(api_key=argilla_user.api_key)
+    client = active_client()
+    assert client.user.username == "argilla"
 
     api.init(api_key="argilla.apikey")
-    the_api = active_api()
-    user = the_api.http_client.get("/api/me")
-    assert user["username"] == "argilla"
+    client = active_api()
+    assert client.user.username == "argilla"
+
+
+def test_init_with_default_user_without_workspaces():
+    argilla_user = UserFactory.create(username="argilla")
+
+    api.init(api_key=argilla_user.api_key)
+    client = active_client()
+
+    assert client.get_workspace() is None
+
+    with pytest.raises(expected_exception=ValueError):
+        client.set_workspace("argilla")
+
+
+def test_init_with_default_user_and_different_workspace():
+    workspace = WorkspaceFactory.create()
+    argilla_user = UserFactory.create(username="argilla", workspaces=[workspace])
+
+    api.init(api_key=argilla_user.api_key)
+    client = active_client()
+
+    assert client.get_workspace() is None
+
+    client.set_workspace(workspace.name)
+    assert client.get_workspace() == workspace.name


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR checks the existence of the default workspace on `rg.init` when the default user is used. This allows using the quickstart docker image without weird errors.

Closes #3340 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

Tested using a quickstart server connection 

**Checklist**

- [x] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
