### PR TITLE
fix: `coroutine` not awaited

### DIFF
--- a/tests/client/test_init.py
+++ b/tests/client/test_init.py
@@ -58,8 +58,9 @@ def test_init(argilla_user: User):
     assert client.user.username == "argilla"
 
 
-def test_init_with_default_user_without_workspaces():
-    argilla_user = UserFactory.create(username="argilla")
+@pytest.mark.asyncio
+async def test_init_with_default_user_without_workspaces():
+    argilla_user = await UserFactory.create(username="argilla")
 
     api.init(api_key=argilla_user.api_key)
     client = active_client()
@@ -70,9 +71,10 @@ def test_init_with_default_user_without_workspaces():
         client.set_workspace("argilla")
 
 
-def test_init_with_default_user_and_different_workspace():
-    workspace = WorkspaceFactory.create()
-    argilla_user = UserFactory.create(username="argilla", workspaces=[workspace])
+@pytest.mark.asyncio
+async def test_init_with_default_user_and_different_workspace():
+    workspace = await WorkspaceFactory.create()
+    argilla_user = await UserFactory.create(username="argilla", workspaces=[workspace])
 
     api.init(api_key=argilla_user.api_key)
     client = active_client()


### PR DESCRIPTION
# Description

Some unit tests in `tests/client/test_init.py` were using the model factories but they were not being awaited.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)


**How Has This Been Tested**

Locally. Unit tests ran without errors.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
