### PR TITLE
fix: `buildChanges` output had the value of `pythonChanges`

### DIFF
--- a/.github/workflows/check-repo-files.yml
+++ b/.github/workflows/check-repo-files.yml
@@ -8,7 +8,7 @@ on:
         value: ${{ jobs.check-repo-files.outputs.pythonChanges }}
       buildChanges:
         description: "True if some files affecting the build have changed"
-        value: ${{ jobs.check-repo-files.outputs.pythonChanges }}
+        value: ${{ jobs.check-repo-files.outputs.buildChanges }}
 
 jobs:
   check-repo-files:


### PR DESCRIPTION
# Description

The `check-repo-files.yml` workflow was setting the value of the `buildChanges` output equal to the value of `pythonChanges` causing the Docker image not to be built in some PRs in which only the frontend had been modified.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

I've created another branch in which I modified a frontend file. The build of the Docker image was triggered.

**Checklist**

- [x] I added relevant documentation
- [ ] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
