### PR TITLE
fix: `ArgillaDatasetCard` to handle all question `options`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ These are the section headers that we use:
 - Resolved wrong import structure `ArgillaTrainer` `TrainingTaskMapping` (Closes [#3345](https://github.com/argilla-io/argilla/issues/3345))
 - Pin pydantic dependency to version < 2 (Closes [3348](https://github.com/argilla-io/argilla/issues/3348))
 - Big number ids are properly rendered in UI (Closes [#3265](https://github.com/argilla-io/argilla/issues/3265))
+- Fixed `ArgillaDatasetCard` to include the values/labels for all the existing questions ([#3366](https://github.com/argilla-io/argilla/pull/3265))
 
 ### Deprecated
 

--- a/src/argilla/client/feedback/integrations/huggingface/card/argilla_template.md
+++ b/src/argilla/client/feedback/integrations/huggingface/card/argilla_template.md
@@ -75,7 +75,7 @@ The **questions** are the questions that will be asked to the annotators. They c
 
 | Question Name | Title | Type | Required | Description | Values/Labels |
 | ------------- | ----- | ---- | -------- | ----------- | ------------- |
-{% for question in argilla_questions %}| {{ question.name }} | {{ question.title }} | {{ question.__class__.__name__  }} | {{ question.required | default(true, true) }} | {{ question.description | default("N/A", true) }} | {% if question.settings.type == 'rating' %}{{ question.settings.options | map(attribute="value") | list }}{% else %} N/A {% endif %} |
+{% for question in argilla_questions %}| {{ question.name }} | {{ question.title }} | {{ question.__class__.__name__  }} | {{ question.required | default(true, true) }} | {{ question.description | default("N/A", true) }} | {% if question.settings.type in ["rating", "label_selection", "multi_label_selection", "ranking"] %}{{ question.settings.options | map(attribute="value") | list }}{% else %}N/A{% endif %} |
 {% endfor %}
 
 Finally, the **guidelines** are just a plain string that can be used to provide instructions to the annotators. Find those in the [annotation guidelines](#annotation-guidelines) section.
@@ -102,9 +102,9 @@ Among the dataset fields, we differentiate between the following:
     {% for field in argilla_fields %}
     * {% if field.required == false %}(optional) {% endif %}**{{ field.name }}** is of type `{{ field.__class__.__name__ }}`.{% endfor %}
 
-* **Questions:** These are the questions that will be asked to the annotators. They can be of different types, such as rating, text, single choice, or multiple choice.
+* **Questions:** These are the questions that will be asked to the annotators. They can be of different types, such as `RatingQuestion`, `TextQuestion`, `LabelQuestion`, `MultiLabelQuestion`, and `RankingQuestion`.
     {% for question in argilla_questions %}
-    * {% if question.required == false %}(optional) {% endif %}**{{ question.name }}** is of type `{{ question.__class__.__name__ }}`{% if question.settings.type == 'rating' %} with the following allowed values {{ question.settings.options | map(attribute="value") | list }}{% endif %}{% if question.description %}, and description "{{ question.description }}"{% endif %}.{% endfor %}
+    * {% if question.required == false %}(optional) {% endif %}**{{ question.name }}** is of type `{{ question.__class__.__name__ }}`{% if question.settings.type in ["rating", "label_selection", "multi_label_selection", "ranking"] %} with the following allowed values {{ question.settings.options | map(attribute="value") | list }}{% endif %}{% if question.description %}, and description "{{ question.description }}"{% endif %}.{% endfor %}
 
 Additionally, we also have one more field which is optional and is the following:
 


### PR DESCRIPTION
# Description

This PR addresses the issue mentioned below, to extend the current support from the `argilla_template.md` used by the `ArgillaDatasetCard` class to properly generate the card for all the questions to include their options (aka values/labels).

<img width="660" alt="image" src="https://github.com/argilla-io/argilla/assets/36760800/66ffbdbb-4efe-4621-928d-e3b127731e9b">

<img width="642" alt="image" src="https://github.com/argilla-io/argilla/assets/36760800/79bd4dc9-4c8d-495b-a564-ac6c186b357c">

Closes #3365

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

- [X] Generated `ArgillaDatasetCard` for a dataset including all the question types supported as of 1.13.0 (unreleased)

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [X] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
