### PR TITLE
:bug: FIX : Ensure current user is disconnected when going to login page

### DIFF
--- a/frontend/components/commons/header/header-feedback-task/headerFeedbackTask.spec.js
+++ b/frontend/components/commons/header/header-feedback-task/headerFeedbackTask.spec.js
@@ -8,7 +8,7 @@ const options = {
     "BaseBreadcrumbs",
     "BaseButton",
     "DatasetSettingsIconFeedbackTaskComponent",
-    "User",
+    "UserAvatarTooltip",
     "NuxtLink",
   ],
   mocks: {

--- a/frontend/pages/login.spec.js
+++ b/frontend/pages/login.spec.js
@@ -9,7 +9,6 @@ const mountLoginPage = ({ auth } = {}) => {
   return shallowMount(Login, {
     stubs,
     mocks: {
-      $auth: { logout: () => {} },
       $config: {},
       $route: {
         query: {

--- a/frontend/pages/login.spec.js
+++ b/frontend/pages/login.spec.js
@@ -9,6 +9,7 @@ const mountLoginPage = ({ auth } = {}) => {
   return shallowMount(Login, {
     stubs,
     mocks: {
+      $auth: { logout: () => {} },
       $config: {},
       $route: {
         query: {

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -78,6 +78,9 @@ export default {
     };
   },
   async created() {
+    // ensure the auth info are cleanned
+    await this.$auth.logout();
+
     const rawAuthToken = this.$route.query.auth;
 
     if (!rawAuthToken) return;
@@ -100,6 +103,7 @@ export default {
   },
   async mounted() {
     try {
+      // TODO - Next call is failling in local: it would be nice to make this call on server only
       const response = await fetch("deployment.json");
       const { deployment } = await response.json();
 
@@ -126,9 +130,9 @@ export default {
     },
     async loginUser(authData) {
       await this.$store.dispatch("entities/deleteAll");
-      await this.$auth.loginWith("authProvider", {
+        await this.$auth.loginWith("authProvider", {
         data: this.encodedLoginData(authData),
-      });
+        });
 
       this.nextRedirect();
     },

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -78,9 +78,6 @@ export default {
     };
   },
   async created() {
-    // ensure the auth info are cleanned
-    await this.$auth.logout();
-
     const rawAuthToken = this.$route.query.auth;
 
     if (!rawAuthToken) return;
@@ -103,8 +100,8 @@ export default {
   },
   async mounted() {
     try {
-      // TODO - Next call is failling in local: it would be nice to make this call on server only
       const response = await fetch("deployment.json");
+
       const { deployment } = await response.json();
 
       this.deployment = deployment;
@@ -129,6 +126,7 @@ export default {
       });
     },
     async loginUser(authData) {
+      await this.$auth.logout();
       await this.$store.dispatch("entities/deleteAll");
       await this.$auth.loginWith("authProvider", {
         data: this.encodedLoginData(authData),

--- a/frontend/pages/login.vue
+++ b/frontend/pages/login.vue
@@ -130,9 +130,9 @@ export default {
     },
     async loginUser(authData) {
       await this.$store.dispatch("entities/deleteAll");
-        await this.$auth.loginWith("authProvider", {
+      await this.$auth.loginWith("authProvider", {
         data: this.encodedLoginData(authData),
-        });
+      });
 
       this.nextRedirect();
     },


### PR DESCRIPTION
# Description

On the `login page`, after putting the credential, user have to click twice on the button enter to be connected.
Since the auth table is not well initiate (it could have the previous info if user touch the url directly to go to login page ), this break the auth : 
- first click failed to connect but the auth table is initiate
- second click succeed to connect because the initial value in auth are well.


**Type of change**

-  Bug fix

**How Has This Been Tested**

- [x] loggedin after first try from loggin page
- [x] loggedin after be connected and then change manually (or copy paste) the url to go to `*/login`

