### PR TITLE
style: rename `MixIn` to `Mixin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ These are the section headers that we use:
 ### Added
 
 - Added `GET /api/v1/users/{user_id}/workspaces` endpoint to list the workspaces to which a user belongs ([#3308](https://github.com/argilla-io/argilla/pull/3308) and [#3343](https://github.com/argilla-io/argilla/pull/3343)).
-- Added `HuggingFaceDatasetMixIn` for internal usage, to detach the `FeedbackDataset` integrations from the class itself, and use MixIns instead ([#3326](https://github.com/argilla-io/argilla/pull/3326)).
+- Added `HuggingFaceDatasetMixin` for internal usage, to detach the `FeedbackDataset` integrations from the class itself, and use Mixins instead ([#3326](https://github.com/argilla-io/argilla/pull/3326)).
 - Added `GET /api/v1/records/{record_id}/suggestions` API endpoint to get the list of suggestions for the responses associated to a record ([#3304](https://github.com/argilla-io/argilla/pull/3304)).
 - Added `POST /api/v1/records/{record_id}/suggestions` API endpoint to create a suggestion for a response associated to a record ([#3304](https://github.com/argilla-io/argilla/pull/3304)).
 - Added breaking simutaneously running tests within GitHub package worflows. ([#3354](https://github.com/argilla-io/argilla/pull/3354)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ postgresql = [
 ]
 listeners = ["schedule ~= 1.1.0", "prodict ~= 0.8.0"]
 integrations = [
-    "PyYAML >= 5.4.1,< 6.1.0", # Required by `argilla.client.feedback.config` just used in `HuggingFaceDatasetMixIn`
+    "PyYAML >= 5.4.1,< 6.1.0", # Required by `argilla.client.feedback.config` just used in `HuggingFaceDatasetMixin`
     "cleanlab ~= 2.0.0",
     # TODO: `push_to_hub` fails up to 2.3.2, check patches when they come out eventually
     "datasets > 1.17.0,!= 2.3.2",

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -27,7 +27,7 @@ from argilla.client.feedback.constants import (
     FETCHING_BATCH_SIZE,
     PUSHING_BATCH_SIZE,
 )
-from argilla.client.feedback.integrations.huggingface import HuggingFaceDatasetMixIn
+from argilla.client.feedback.integrations.huggingface import HuggingFaceDatasetMixin
 from argilla.client.feedback.schemas import (
     FeedbackRecord,
     FieldSchema,
@@ -70,7 +70,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class FeedbackDataset(HuggingFaceDatasetMixIn):
+class FeedbackDataset(HuggingFaceDatasetMixin):
     """Class to work with `FeedbackDataset`s either locally, or remotely (Argilla or HuggingFace Hub).
 
     Args:

--- a/src/argilla/client/feedback/integrations/huggingface/__init__.py
+++ b/src/argilla/client/feedback/integrations/huggingface/__init__.py
@@ -12,6 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from .dataset import HuggingFaceDatasetMixIn
+from .dataset import HuggingFaceDatasetMixin
 
-__all__ = ["HuggingFaceDatasetMixIn"]
+__all__ = ["HuggingFaceDatasetMixin"]

--- a/src/argilla/client/feedback/integrations/huggingface/dataset.py
+++ b/src/argilla/client/feedback/integrations/huggingface/dataset.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-class HuggingFaceDatasetMixIn:
+class HuggingFaceDatasetMixin:
     @staticmethod
     @requires_version("datasets")
     def _huggingface_format(dataset: "FeedbackDataset") -> "Dataset":
@@ -52,7 +52,7 @@ class HuggingFaceDatasetMixIn:
             >>> import argilla as rg
             >>> rg.init(...)
             >>> dataset = rg.FeedbackDataset.from_argilla(name="my-dataset")
-            >>> huggingface_dataset = rg.HuggingFaceDatasetMixIn.set_format(dataset)
+            >>> huggingface_dataset = rg.HuggingFaceDatasetMixin.set_format(dataset)
         """
         from datasets import Dataset, Features, Sequence, Value
 

--- a/src/argilla/training/autotrain_advanced.py
+++ b/src/argilla/training/autotrain_advanced.py
@@ -23,7 +23,7 @@ from argilla.training.base import ArgillaTrainerSkeleton
 from argilla.utils.dependency import require_version
 
 
-class AutoTrainMixIn:
+class AutoTrainMixin:
     def prepare_dataset(self, data_dict: Optional[dict] = {}) -> None:
         """
         This function prepares a dataset for autotrain using a dictionary of data and specific column
@@ -104,7 +104,7 @@ class AutoTrainMixIn:
         return job_params
 
 
-class ArgillaAutoTrainTrainer(ArgillaTrainerSkeleton, AutoTrainMixIn):
+class ArgillaAutoTrainTrainer(ArgillaTrainerSkeleton, AutoTrainMixin):
     _logger = logging.getLogger("ArgillaAutoTrainTrainer")
     _logger.setLevel(logging.INFO)
 


### PR DESCRIPTION
# Description

This PR aligns the defined `Mixin` classes to follow the same naming convention, since for some we were appending `MixIn` while for some others `Mixin`, even though both work equally, we've (@gabrielmbmb and myself) internally decided to use `Mixin` instead. So now all the occurrences of `MixIn` are renamed to `Mixin`.

**Type of change**

- [X] Refactor (change restructuring the codebase without changing functionality)