### PR TITLE
:sparkles: FEAT: show required question instead of optional one

### DIFF
--- a/frontend/components/commons/forms/questions-form/fields/shared-components/question-header/QuestionHeader.component.vue
+++ b/frontend/components/commons/forms/questions-form/fields/shared-components/question-header/QuestionHeader.component.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="title-area --body1">
-    <span v-text="title" v-optional-field="!isRequired" />
+    <span v-text="title" v-required-field="isRequired" />
 
     <BaseIconWithBadge
       class="icon-info"


### PR DESCRIPTION
# Description

Instead of showing `(Optional)` after optional question, there is `*` at the end of a `required` question

**How Has This Been Tested**

- Only feedback task (all question types are concerned by this modification)
