### PR TITLE
remove support for non-prefixed env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ These are the section headers that we use:
 - Renamed `FeedbackDatasetConfig` to `DatasetConfig` and export/import from YAML as default instead of JSON (just used internally on `push_to_huggingface` and `from_huggingface` methods of `FeedbackDataset`) ([#3326](https://github.com/argilla-io/argilla/pull/3326)).
 - The protected metadata fields support other than textual info - existing datasets must be reindex. See [docs](https://docs.argilla.io/en/latest/getting_started/installation/configurations/database_migrations.html#elasticsearch) for more detail (Closes [#3332](https://github.com/argilla-io/argilla/issues/3332)).
 
+### Removed
+
+- Removed support to non-prefixed environment variables. All valid env vars start with `ARGILLA_` (See [#3392](https://github.com/argilla-io/argilla/pull/3392)).
+
 ### Fixed
 
 - Fixed `GET /api/v1/me/datasets/{dataset_id}/records` endpoint returning always the responses for the records even if `responses` was not provided via the `include` query parameter ([#3304](https://github.com/argilla-io/argilla/pull/3304)).

--- a/docs/_source/getting_started/installation/configurations/server_configuration.md
+++ b/docs/_source/getting_started/installation/configurations/server_configuration.md
@@ -38,9 +38,9 @@ You can set following environment variables to further configure your server and
 
 - `ARGILLA_BASE_URL`: If you want to launch the Argilla server in a specific base path other than /, you should set up this environment variable. This can be useful when running Argilla behind a proxy that adds a prefix path to route the service (Default: "/").
 
-- `CORS_ORIGINS`: List of host patterns for CORS origin access.
+- `ARGILLA_CORS_ORIGINS`: List of host patterns for CORS origin access.
 
-- `DOCS_ENABLED`: If False, disables openapi docs endpoint at */api/docs*.
+- `ARGILLA_DOCS_ENABLED`: If False, disables openapi docs endpoint at */api/docs*.
 
 - `ARGILLA_ENABLE_TELEMETRY`: If False, disables telemetry for usage metrics.
 

--- a/src/argilla/server/settings.py
+++ b/src/argilla/server/settings.py
@@ -186,34 +186,7 @@ class Settings(BaseSettings):
         return self.elasticsearch
 
     class Config:
-        # TODO: include a common prefix for all argilla env vars.
         env_prefix = "ARGILLA_"
-        fields = {
-            # TODO(@frascuchon): Remove in 0.20.0
-            "elasticsearch": {
-                "env": ["ELASTICSEARCH", f"{env_prefix}ELASTICSEARCH"],
-            },
-            "elasticsearch_ssl_verify": {
-                "env": [
-                    "ELASTICSEARCH_SSL_VERIFY",
-                    f"{env_prefix}ELASTICSEARCH_SSL_VERIFY",
-                ]
-            },
-            "cors_origins": {"env": ["CORS_ORIGINS", f"{env_prefix}CORS_ORIGINS"]},
-            "docs_enabled": {"env": ["DOCS_ENABLED", f"{env_prefix}DOCS_ENABLED"]},
-            "es_records_index_shards": {
-                "env": [
-                    "ES_RECORDS_INDEX_SHARDS",
-                    f"{env_prefix}ES_RECORDS_INDEX_SHARDS",
-                ]
-            },
-            "es_records_index_replicas": {
-                "env": [
-                    "ES_RECORDS_INDEX_REPLICAS",
-                    f"{env_prefix}ES_RECORDS_INDEX_SHARDS",
-                ]
-            },
-        }
 
 
 settings = Settings()

--- a/tests/server/commons/test_settings.py
+++ b/tests/server/commons/test_settings.py
@@ -12,22 +12,20 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import os
-
 import pytest
 from argilla.server.settings import Settings
 from pydantic import ValidationError
 
 
 @pytest.mark.parametrize("bad_namespace", ["Badns", "bad-ns", "12-bad-ns", "@bad"])
-def test_wrong_settings_namespace(bad_namespace):
-    os.environ["ARGILLA_NAMESPACE"] = bad_namespace
+def test_wrong_settings_namespace(monkeypatch, bad_namespace):
+    monkeypatch.setenv("ARGILLA_NAMESPACE", bad_namespace)
     with pytest.raises(ValidationError):
         Settings()
 
 
-def test_settings_namespace():
-    os.environ["ARGILLA_NAMESPACE"] = "namespace"
+def test_settings_namespace(monkeypatch):
+    monkeypatch.setenv("ARGILLA_NAMESPACE", "namespace")
     settings = Settings()
 
     assert settings.namespace == "namespace"
@@ -35,14 +33,17 @@ def test_settings_namespace():
     assert settings.dataset_records_index_name == "namespace.ar.dataset.{}"
 
 
-def test_settings_index_replicas_with_shards_defined():
-    os.environ["ARGILLA_ES_RECORDS_INDEX_SHARDS"] = "100"
-    os.environ["ARGILLA_ES_RECORDS_INDEX_REPLICAS"] = "2"
+def test_settings_index_replicas_with_shards_defined(monkeypatch):
+    monkeypatch.setenv("ARGILLA_ES_RECORDS_INDEX_SHARDS", "100")
+    monkeypatch.setenv("ARGILLA_ES_RECORDS_INDEX_REPLICAS", "2")
+
     settings = Settings()
     assert settings.es_records_index_replicas == 2
 
 
-def test_settings_default_index_replicas_with_shards_defined():
-    os.environ["ARGILLA_ES_RECORDS_INDEX_SHARDS"] = "100"
+def test_settings_default_index_replicas_with_shards_defined(monkeypatch):
+    monkeypatch.setenv("ARGILLA_ES_RECORDS_INDEX_SHARDS", "100")
     settings = Settings()
+
+    assert settings.es_records_index_shards == 100
     assert settings.es_records_index_replicas == 0

--- a/tests/server/commons/test_settings.py
+++ b/tests/server/commons/test_settings.py
@@ -33,3 +33,16 @@ def test_settings_namespace():
     assert settings.namespace == "namespace"
     assert settings.dataset_index_name == "namespace.ar.datasets"
     assert settings.dataset_records_index_name == "namespace.ar.dataset.{}"
+
+
+def test_settings_index_replicas_with_shards_defined():
+    os.environ["ARGILLA_ES_RECORDS_INDEX_SHARDS"] = "100"
+    os.environ["ARGILLA_ES_RECORDS_INDEX_REPLICAS"] = "2"
+    settings = Settings()
+    assert settings.es_records_index_replicas == 2
+
+
+def test_settings_default_index_replicas_with_shards_defined():
+    os.environ["ARGILLA_ES_RECORDS_INDEX_SHARDS"] = "100"
+    settings = Settings()
+    assert settings.es_records_index_replicas == 0


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR removes support for non-prefixed environment variables. All used env vars should start with `ARGILLA_`. This change also fixes a problem with the elastic replica set configuration if the primary shard configuration is modified.


**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (change adding some improvement to an existing functionality)


**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
