### PR TITLE
fix: `User` and `Workspace` to maintain `Argilla` as `__client` instead of `ArgillaSingleton.get()`

### DIFF
--- a/src/argilla/client/utils.py
+++ b/src/argilla/client/utils.py
@@ -20,7 +20,7 @@ try:
 except ImportError:
     from typing_extensions import ParamSpec
 
-from argilla.client.api import ArgillaSingleton
+from argilla.client.api import active_client
 from argilla.client.sdk.users.models import UserRole
 
 _P = ParamSpec("_P")
@@ -43,7 +43,8 @@ def allowed_for_roles(roles: List[UserRole]) -> Callable[[Callable[_P, _R]], Cal
     def decorator(func: Callable[_P, _R]) -> Callable[_P, _R]:
         @functools.wraps(func)
         def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
-            role = ArgillaSingleton.get().user.role
+            client = args[0].__client if hasattr(args[0], "__client") else active_client()
+            role = client.user.role
             if role not in roles:
                 raise PermissionError(
                     f"User with role={role} is not allowed to call `{func.__name__}`."


### PR DESCRIPTION
# Description

As of the recent suggestions/recommendations from @frascuchon, using the `ArgillaSingleton` to get information from the active session is discouraged, because we may switch between sessions and the information of a session may be relative to a `User` and/or `Workspace` instance. So on, now both `User` and `Workspace` classes maintain both the `Argilla` and `httpx.Client` used initially, while the `allowed_for_roles` Python decorator is re-using those if available.

Disclaimer: we may iterate over this in future releases to avoid keeping the whole `Argilla`, but just a reduced version of it with the information we may need (for the moment we're just using `user.role` to see the role of the active user of that session).

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (change restructuring the codebase without changing functionality)
- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

- [X] Re-run unit tests (unit tests will be extended in the parent branch)

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

Disclaimer: No need to update the `CHANGELOG.md` as the `allowed_for_roles` decorator has not been released yet.
