### PR TITLE
ci: using extended-runner for tests

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -34,7 +34,7 @@ jobs:
 
   deployable_check:
     name: Check if must build & deploy from environment
-    runs-on: extended-runner
+    runs-on: ubuntu-latest
     needs: check_repo_files
     env:
       IS_DEPLOYABLE: ${{ secrets.AR_DOCKER_USERNAME != '' && needs.check_repo_files.outputs.buildChanges == 'true' }}

--- a/.github/workflows/run-python-tests.yml
+++ b/.github/workflows/run-python-tests.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   run-python-tests:
     name: Argilla python tests
-    runs-on: ubuntu-latest
+    runs-on: extended-runner
     services:
       search_engine:
         image: ${{ inputs.searchEngineDockerImage }}

--- a/src/argilla/_version.py
+++ b/src/argilla/_version.py
@@ -13,4 +13,4 @@
 #  limitations under the License.
 
 # coding: utf-8
-version = "1.13.1-dev"
+version = "1.13.0-dev"

--- a/src/argilla/_version.py
+++ b/src/argilla/_version.py
@@ -13,4 +13,4 @@
 #  limitations under the License.
 
 # coding: utf-8
-version = "1.13.0-dev"
+version = "1.13.1-dev"


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

Forcing the use of extended-runner for running tests. This will help to random errors in ci pipelines.


