### PR TITLE
Fix: Lift rich version restriction, see #3407

### DIFF
--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -54,6 +54,6 @@ dependencies:
       - openai
       - peft
       - autotrain-advanced==0.5.2
-      - rich==13.0.1
+      - rich
       # install Argilla in editable mode
       - -e .[server,listeners]

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -54,6 +54,6 @@ dependencies:
       - openai
       - peft
       - autotrain-advanced==0.5.2
-      - rich
+      - rich!=13.1.0
       # install Argilla in editable mode
       - -e .[server,listeners]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "backoff",
     "monotonic",
     # for logging, tracebacks, printing, progressbars
-    "rich",
+    "rich != 13.1.0",
     # for CLI
     "typer >= 0.6.0, < 0.8.0", # spaCy only supports typer<0.8.0
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "backoff",
     "monotonic",
     # for logging, tracebacks, printing, progressbars
-    "rich <= 13.0.1",
+    "rich",
     # for CLI
     "typer >= 0.6.0, < 0.8.0", # spaCy only supports typer<0.8.0
 ]


### PR DESCRIPTION
Closes #3407

Hello!

# Description

List version restriction of `rich`. This restriction of `<= 13.0.1` was introduced in #2350 due to a [bug](https://github.com/Textualize/rich/issues/2800#issuecomment-1428764064) in the version that was most recent back then: version 13.1.0.
However, the issue has been resolved as of the current most recent version: 13.4.2.
Additionally, #3407 suggests allowing at least up to 13.3.1.

I think the best solution is just to let go of the version restriction and let pip/conda/poetry install the most recent version.

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix

**How Has This Been Tested**

I installed the most recent `rich` and experimented a bit with some scripts by making them crash etc.

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

I'm of the opinion that this is not worthy of a changelog entry.

---

- Tom Aarsen