### PR TITLE
Docs: Remove duplicate spaces

### DIFF
--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -151,7 +151,7 @@ class Argilla:
             self.set_workspace(workspace or self._user.username)
         else:
             warnings.warn(
-                "No workspace configuration was detected. To work with Argilla "
+                "No workspace configuration was detected. To work with Argilla"
                 " datasets, specify a valid workspace name on `rg.init` or set it"
                 " up through the `rg.set_workspace` function.",
                 category=UserWarning,

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -88,7 +88,7 @@ class ResponseSchema(BaseModel):
         if not v:
             warnings.warn(
                 "`user_id` not provided, so it will be set to `None`. Which is not an"
-                " issue, unless you're planning to log the response in Argilla, as "
+                " issue, unless you're planning to log the response in Argilla, as"
                 " it will be automatically set to the active `user_id`.",
             )
         return v


### PR DESCRIPTION
Hello!

# Description

This PR removes some duplicate spaces in warnings. I encountered the first one myself, and then used ` ["']\n\s*["'] ` to find the second one.

**Type of change**

- [ ] Documentation update

**How Has This Been Tested**

N/A

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

This does not need a changelog entry.

- Tom Aarsen
