### PR TITLE
:bug: FIX : add missing data `datasetId` on delete dataset

### DIFF
--- a/frontend/components/commons/dataset-deletion-feedback-task/DatasetDeleteFeedbackTask.component.vue
+++ b/frontend/components/commons/dataset-deletion-feedback-task/DatasetDeleteFeedbackTask.component.vue
@@ -55,6 +55,7 @@ export default {
     return {
       showDeleteModal: false,
       sectionTitle: "Danger zone",
+      datasetId: this.dataset.id,
       datasetName: this.dataset.name,
       workspace: this.dataset.workspace,
       datasetDeleteTitle: `Delete <strong>${this.dataset.name}</strong>`,


### PR DESCRIPTION
# Description

Since the datasetId connection with the dataset props was missing, there is a bug on delete dataset (since datasetId was undefined)

Closes #3406 

**Type of change**

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

- be able to delete dataset (the `datasetId` variable in the component DatasetDeleteFeedbackTask.component was `undefined`)

