### PR TITLE
[BUG] Resolve backwards compatibility TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ These are the section headers that we use:
 - Pin pydantic dependency to version < 2 (Closes [3348](https://github.com/argilla-io/argilla/issues/3348))
 - Big number ids are properly rendered in UI (Closes [#3265](https://github.com/argilla-io/argilla/issues/3265))
 - Fixed `ArgillaDatasetCard` to include the values/labels for all the existing questions ([#3366](https://github.com/argilla-io/argilla/pull/3265))
+- Fixed TypeError when loading an Argilla dataset from the Hub from Argilla 1.12.0 or lower ([#3414](https://github.com/argilla-io/argilla/issues/3414))
 
 ### Deprecated
 

--- a/src/argilla/client/feedback/config.py
+++ b/src/argilla/client/feedback/config.py
@@ -46,6 +46,7 @@ class DatasetConfig(BaseModel):
         return cls(**load(yaml, Loader=SafeLoader))
 
     # TODO(alvarobartt): here for backwards compatibility, remove in 1.14.0
+    @classmethod
     def from_json(self, json):
         warnings.warn(
             "`DatasetConfig` can just be loaded from YAML, so make sure that you are"

--- a/tests/client/feedback/test_config.py
+++ b/tests/client/feedback/test_config.py
@@ -74,7 +74,7 @@ def test_dataset_config_json_deprecated(
     assert f'"guidelines": "{feedback_dataset_guidelines}"' in to_json_config
 
     with pytest.warns(DeprecationWarning, match="`DatasetConfig` can just be loaded from YAML"):
-        from_json_config = config.from_json(to_json_config)
+        from_json_config = DatasetConfig.from_json(to_json_config)
     assert isinstance(from_json_config, DatasetConfig)
     assert from_json_config.fields == feedback_dataset_fields
     assert from_json_config.questions == feedback_dataset_questions


### PR DESCRIPTION
Closes #3414

Hello!

# Description
`DatasetConfig.from_json` is now a classmethod like you would expect. That said, I can't make a nice test for this, as now it fails with:
```python
ValidationError: 4 validation errors for DatasetConfig
questions -> 0
  Discriminator 'type' is missing in value (type=value_error.discriminated_union.missing_discriminator; discriminator_key=type)
questions -> 1
  Discriminator 'type' is missing in value (type=value_error.discriminated_union.missing_discriminator; discriminator_key=type)
questions -> 2
  Discriminator 'type' is missing in value (type=value_error.discriminated_union.missing_discriminator; discriminator_key=type)
questions -> 3
  Discriminator 'type' is missing in value (type=value_error.discriminated_union.missing_discriminator; discriminator_key=type)
```
Still, at least it can actually parse the file with this PR in place.

**Type of change**

- [x] Bug fix

**How Has This Been Tested**

Running
```python
from argilla.feedback import FeedbackDataset, TrainingTaskMapping

dataset = FeedbackDataset.from_huggingface(
    repo_id="argilla/stackoverflow_feedback_demo"
)
```
as well as 
```
pytest .\tests\client\feedback\test_config.py::test_dataset_config_json_deprecated
```

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

---

- Tom Aarsen