### PR TITLE
fix: add `DeprecatedDatasetConfig` for backwards compatibility & improve `warnings`

### DIFF
--- a/src/argilla/client/feedback/config.py
+++ b/src/argilla/client/feedback/config.py
@@ -38,11 +38,11 @@ class DatasetConfig(BaseModel):
     questions: List[Annotated[AllowedQuestionTypes, Field(..., discriminator="type")]]
     guidelines: Optional[str] = None
 
-    def to_yaml(self):
+    def to_yaml(self) -> str:
         return dump(self.dict())
 
     @classmethod
-    def from_yaml(cls, yaml):
+    def from_yaml(cls, yaml: str) -> "DatasetConfig":
         return cls(**load(yaml, Loader=SafeLoader))
 
 
@@ -52,17 +52,7 @@ class DeprecatedDatasetConfig(BaseModel):
     questions: List[AllowedQuestionTypes]
     guidelines: Optional[str] = None
 
-    @classmethod
-    def from_json(self, json):
-        warnings.warn(
-            "`DatasetConfig` can just be loaded from YAML, so make sure that you are"
-            " loading a YAML file instead of a JSON file. `DatasetConfig` will be dumped"
-            " as YAML from now on, instead of JSON.",
-            DeprecationWarning,
-        )
-        return self.parse_raw(json)
-
-    def to_json(self):
+    def to_json(self) -> str:
         warnings.warn(
             "`DatasetConfig` can just be dumped to YAML, so make sure that you are"
             " dumping to a YAML file instead of a JSON file. `DatasetConfig` will come"
@@ -70,3 +60,13 @@ class DeprecatedDatasetConfig(BaseModel):
             DeprecationWarning,
         )
         return self.json()
+
+    @classmethod
+    def from_json(self, json: str) -> "DeprecatedDatasetConfig":
+        warnings.warn(
+            "`DatasetConfig` can just be loaded from YAML, so make sure that you are"
+            " loading a YAML file instead of a JSON file. `DatasetConfig` will be dumped"
+            " as YAML from now on, instead of JSON.",
+            DeprecationWarning,
+        )
+        return self.parse_raw(json)

--- a/src/argilla/client/feedback/config.py
+++ b/src/argilla/client/feedback/config.py
@@ -45,7 +45,14 @@ class DatasetConfig(BaseModel):
     def from_yaml(cls, yaml):
         return cls(**load(yaml, Loader=SafeLoader))
 
-    # TODO(alvarobartt): here for backwards compatibility, remove in 1.14.0
+
+# TODO(alvarobartt): here for backwards compatibility, remove in 1.14.0
+class DeprecatedDatasetConfig(BaseModel):
+    fields: List[AllowedFieldTypes]
+    questions: List[AllowedQuestionTypes]
+    guidelines: Optional[str] = None
+
+    @classmethod
     def from_json(self, json):
         warnings.warn(
             "`DatasetConfig` can just be loaded from YAML, so make sure that you are"
@@ -55,7 +62,6 @@ class DatasetConfig(BaseModel):
         )
         return self.parse_raw(json)
 
-    # TODO(alvarobartt): here for backwards compatibility, remove in 1.14.0
     def to_json(self):
         warnings.warn(
             "`DatasetConfig` can just be dumped to YAML, so make sure that you are"

--- a/src/argilla/client/feedback/integrations/huggingface/dataset.py
+++ b/src/argilla/client/feedback/integrations/huggingface/dataset.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any, Optional, Type
 
 from packaging.version import parse as parse_version
 
-from argilla.client.feedback.config import DatasetConfig
+from argilla.client.feedback.config import DatasetConfig, DeprecatedDatasetConfig
 from argilla.client.feedback.constants import FIELD_TYPE_TO_PYTHON_TYPE
 from argilla.client.feedback.schemas import FeedbackRecord
 from argilla.client.feedback.typing import AllowedQuestionTypes
@@ -307,7 +307,7 @@ class HuggingFaceDatasetMixin:
                 **hub_auth,
             )
             with open(config_path, "r") as f:
-                config = DatasetConfig.from_json(f.read())
+                config = DeprecatedDatasetConfig.from_json(f.read())
         except Exception as e:
             raise FileNotFoundError(
                 "Neither `argilla.yaml` nor `argilla.cfg` files were found in the"

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -229,16 +229,10 @@ class FeedbackRecord(BaseModel):
     def __setattr__(self, name: str, value: Any) -> None:
         if name == "suggestions" and hasattr(self, name):
             warnings.warn(
-                "You are trying to set `suggestions` directly, which is not allowed. You"
-                " should use the `set_suggestions` method instead."
+                "Ignore this warning if you're already using `set_suggestions` method."
+                " Otherwise, if you are trying to set `suggestions` directly, which is"
+                " not allowed. You should use the `set_suggestions` method instead."
             )
-            if getattr(self, name) != value:
-                warnings.warn(
-                    "You are trying to update the existing `suggestions` with a new value,"
-                    " which is not allowed. You should use the `set_suggestions` method"
-                    " instead, and the existing `suggestions` will be overwritten based"
-                    " on the provided `question_id`s/`question_name`/s for those `suggestions`."
-                )
         super().__setattr__(name, value)
 
     def _reset_updated(self) -> None:

--- a/tests/client/feedback/test_config.py
+++ b/tests/client/feedback/test_config.py
@@ -15,7 +15,7 @@
 from typing import TYPE_CHECKING, List
 
 import pytest
-from argilla.client.feedback.config import DatasetConfig
+from argilla.client.feedback.config import DatasetConfig, DeprecatedDatasetConfig
 
 if TYPE_CHECKING:
     from argilla.client.feedback.schemas import FieldSchema, QuestionSchema
@@ -56,12 +56,12 @@ def test_dataset_config_json_deprecated(
     feedback_dataset_questions: List["QuestionSchema"],
     feedback_dataset_guidelines: str,
 ) -> None:
-    config = DatasetConfig(
+    config = DeprecatedDatasetConfig(
         fields=feedback_dataset_fields,
         questions=feedback_dataset_questions,
         guidelines=feedback_dataset_guidelines,
     )
-    assert isinstance(config, DatasetConfig)
+    assert isinstance(config, DeprecatedDatasetConfig)
     assert config.fields == feedback_dataset_fields
     assert config.questions == feedback_dataset_questions
     assert config.guidelines == feedback_dataset_guidelines
@@ -75,7 +75,7 @@ def test_dataset_config_json_deprecated(
 
     with pytest.warns(DeprecationWarning, match="`DatasetConfig` can just be loaded from YAML"):
         from_json_config = config.from_json(to_json_config)
-    assert isinstance(from_json_config, DatasetConfig)
+    assert isinstance(from_json_config, DeprecatedDatasetConfig)
     assert from_json_config.fields == feedback_dataset_fields
     assert from_json_config.questions == feedback_dataset_questions
     assert from_json_config.guidelines == feedback_dataset_guidelines

--- a/tests/client/feedback/test_dataset.py
+++ b/tests/client/feedback/test_dataset.py
@@ -554,7 +554,7 @@ async def test_update_dataset_records_in_argilla(
                 },
             ]
         )
-    with pytest.warns(UserWarning, match="You are trying to set `suggestions` directly, which is not allowed"):
+    with pytest.warns(UserWarning, match="if you are trying to set `suggestions` directly"):
         record.suggestions = [
             {
                 "question_name": "question-1",

--- a/tests/client/feedback/test_dataset.py
+++ b/tests/client/feedback/test_dataset.py
@@ -527,6 +527,19 @@ async def test_update_dataset_records_in_argilla(
             ]
         )
 
+    with pytest.warns(UserWarning, match="Ignore this warning if you're already using `set_suggestions` method"):
+        record = FeedbackRecord(
+            fields={"prompt": "text"},
+        )
+        record.set_suggestions(
+            [
+                {
+                    "question_name": "question-1",
+                    "value": "This is a suggestion to question 1",
+                },
+            ]
+        )
+
     record = dataset.records[0]
     with pytest.warns(UserWarning, match="A suggestion for question `question-1`"):
         record.set_suggestions(
@@ -546,13 +559,6 @@ async def test_update_dataset_records_in_argilla(
             {
                 "question_name": "question-1",
                 "value": "This is a suggestion to question 1",
-            },
-        ]
-    with pytest.warns(UserWarning, match="You are trying to update the existing `suggestions` with a new value"):
-        record.suggestions = [
-            {
-                "question_name": "question-1",
-                "value": "This is another suggestion to question 1",
             },
         ]
 


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR addresses the bug fix reported by @tomaarsen at #3414, so that we use `DeprecatedDatasetConfig` instead of `DatasetConfig` and to make `from_json` a `classmethod`, to make sure that previously uploaded `FeedbackDataset`s to the HuggingFace Hub can still be loaded with `FeedbackDataset.from_huggingface`.

Additionally, as reported by @nataliaElv the warning messages when adding `suggestions` to a `FeedbackRecord` could be improved, so we've kept just the necessary and adding an `Ignore this exception ...` in cases where warning is not needed.

Closes #3414

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [X] Run `FeedbackDataset.from_huggingface("argilla/stackoverflow_feedback_demo")
- [X] Update unit tests to catch updated warnings

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
