### PR TITLE
refactor: Use 'cls' as first argument in classmethods

### DIFF
--- a/src/argilla/client/feedback/config.py
+++ b/src/argilla/client/feedback/config.py
@@ -62,11 +62,11 @@ class DeprecatedDatasetConfig(BaseModel):
         return self.json()
 
     @classmethod
-    def from_json(self, json: str) -> "DeprecatedDatasetConfig":
+    def from_json(cls, json: str) -> "DeprecatedDatasetConfig":
         warnings.warn(
             "`DatasetConfig` can just be loaded from YAML, so make sure that you are"
             " loading a YAML file instead of a JSON file. `DatasetConfig` will be dumped"
             " as YAML from now on, instead of JSON.",
             DeprecationWarning,
         )
-        return self.parse_raw(json)
+        return cls.parse_raw(json)

--- a/src/argilla/client/feedback/unification.py
+++ b/src/argilla/client/feedback/unification.py
@@ -214,7 +214,7 @@ class LabelQuestionStrategy(LabelQuestionStrategyMixin, Enum):
         return rec
 
     @classmethod
-    def _majority_weighted(self, records: List[FeedbackRecord], question: LabelQuestion):
+    def _majority_weighted(cls, records: List[FeedbackRecord], question: LabelQuestion):
         raise NotImplementedError("'majority_weighted'-strategy not implemented yet")
 
 
@@ -255,7 +255,7 @@ class MultiLabelQuestionStrategy(LabelQuestionStrategyMixin, Enum):
         return records
 
     @classmethod
-    def _majority_weighted(self, records: List[FeedbackRecord], question: MultiLabelQuestion):
+    def _majority_weighted(cls, records: List[FeedbackRecord], question: MultiLabelQuestion):
         raise NotImplementedError("'majority_weighted'-strategy not implemented yet")
 
 


### PR DESCRIPTION
Hello!

# Description

Use `cls` as the first argument in classmethods, rather than `self`. Found via `@classmethod\n\s+def \S+\(self,`.
I spotted this just after #3416 was merged (cc: @alvarobartt).

**Type of change**

- [x] Refactor

**How Has This Been Tested**
n/a

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

---

- Tom Aarsen