### PR TITLE
fix: Prevent vertical jump when removing suggestion emoji

### DIFF
--- a/frontend/components/commons/forms/questions-form/fields/shared-components/question-header/QuestionHeader.component.vue
+++ b/frontend/components/commons/forms/questions-form/fields/shared-components/question-header/QuestionHeader.component.vue
@@ -72,6 +72,7 @@ export default {
 
 span {
   word-break: break-word;
+  line-height: 1.2em;
 }
 
 .icon-info {


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

Small fix to prevent vertical jump when showing / removing suggestions emoji

Close #3420