### PR TITLE
refactor: using more general 409 api error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ These are the section headers that we use:
 - `User.workspaces` is no longer an attribute but a property, and is calling `list_user_workspaces` to list all the workspace names for a given user ID ([#3334](https://github.com/argilla-io/argilla/pull/3334))
 - Renamed `FeedbackDatasetConfig` to `DatasetConfig` and export/import from YAML as default instead of JSON (just used internally on `push_to_huggingface` and `from_huggingface` methods of `FeedbackDataset`) ([#3326](https://github.com/argilla-io/argilla/pull/3326)).
 - The protected metadata fields support other than textual info - existing datasets must be reindex. See [docs](https://docs.argilla.io/en/latest/getting_started/installation/configurations/database_migrations.html#elasticsearch) for more detail (Closes [#3332](https://github.com/argilla-io/argilla/issues/3332)).
+- The `AlreadyExistsApiError` is replaced by a more general error `EntityConflictApiError` (with backward support). ([#3426](https://github.com/argilla-io/argilla/pull/3426))
 
 ### Removed
 

--- a/src/argilla/client/apis/datasets.py
+++ b/src/argilla/client/apis/datasets.py
@@ -22,8 +22,8 @@ from pydantic import BaseModel, Field
 
 from argilla.client.apis import AbstractApi, api_compatibility
 from argilla.client.sdk.commons.errors import (
-    AlreadyExistsApiError,
     ApiCompatibilityError,
+    EntityConflictApiError,
     ForbiddenApiError,
     NotFoundApiError,
 )
@@ -155,7 +155,7 @@ class Datasets(AbstractApi):
                 else TaskType.token_classification
             )
             ds = self.create(name=name, task=task, workspace=workspace)
-        except AlreadyExistsApiError:
+        except EntityConflictApiError:
             ds = self.find_by_name(name)
         self._save_settings(dataset=ds, settings=settings)
 

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -53,7 +53,7 @@ from argilla.client.models import (
 from argilla.client.sdk.client import AuthenticatedClient
 from argilla.client.sdk.commons.api import bulk
 from argilla.client.sdk.commons.errors import (
-    AlreadyExistsApiError,
+    EntityConflictApiError,
     InputValueError,
     NotFoundApiError,
 )
@@ -399,7 +399,7 @@ class Argilla:
 
         try:
             self.datasets.create(name=name, task=task, workspace=workspace)
-        except AlreadyExistsApiError:
+        except EntityConflictApiError:
             pass
 
         results = []
@@ -605,7 +605,7 @@ class Argilla:
                     name=dataset,
                     rule=rule,
                 )
-            except AlreadyExistsApiError:
+            except EntityConflictApiError:
                 _LOGGER.warning(f"Rule {rule} already exists. Please, update the rule instead.")
             except Exception as ex:
                 _LOGGER.warning(f"Cannot create rule {rule}: {ex}")

--- a/src/argilla/client/sdk/commons/errors.py
+++ b/src/argilla/client/sdk/commons/errors.py
@@ -92,8 +92,12 @@ class MethodNotAllowedApiError(ArApiResponseError):
     HTTP_STATUS = 405
 
 
-class AlreadyExistsApiError(ArApiResponseError):
+class EntityConflictApiError(ArApiResponseError):
     HTTP_STATUS = 409
+
+
+# backward compatibility
+AlreadyExistsApiError = EntityConflictApiError
 
 
 class ValidationApiError(ArApiResponseError):

--- a/src/argilla/client/sdk/commons/errors_handler.py
+++ b/src/argilla/client/sdk/commons/errors_handler.py
@@ -17,8 +17,8 @@ from json import JSONDecodeError
 import httpx
 
 from argilla.client.sdk.commons.errors import (
-    AlreadyExistsApiError,
     BadRequestApiError,
+    EntityConflictApiError,
     ForbiddenApiError,
     GenericApiError,
     HttpResponseError,
@@ -45,8 +45,8 @@ def handle_response_error(response: httpx.Response, parse_response: bool = True,
         error_type = BadRequestApiError
     elif response.status_code == UnauthorizedApiError.HTTP_STATUS:
         error_type = UnauthorizedApiError
-    elif response.status_code == AlreadyExistsApiError.HTTP_STATUS:
-        error_type = AlreadyExistsApiError
+    elif response.status_code == EntityConflictApiError.HTTP_STATUS:
+        error_type = EntityConflictApiError
     elif response.status_code == ForbiddenApiError.HTTP_STATUS:
         error_type = ForbiddenApiError
     elif response.status_code == NotFoundApiError.HTTP_STATUS:

--- a/src/argilla/client/users.py
+++ b/src/argilla/client/users.py
@@ -19,8 +19,8 @@ from uuid import UUID
 
 from argilla.client import active_client
 from argilla.client.sdk.commons.errors import (
-    AlreadyExistsApiError,
     BaseClientError,
+    EntityConflictApiError,
     NotFoundApiError,
 )
 from argilla.client.sdk.users import api as users_api
@@ -223,7 +223,7 @@ class User:
                 ).dict(),
             ).parsed
             return cls.__new_instance(client, user)
-        except AlreadyExistsApiError as e:
+        except EntityConflictApiError as e:
             raise ValueError(
                 f"User with username=`{username}` already exists in Argilla, so please"
                 " make sure that the name you provided is a unique one."

--- a/src/argilla/client/workspaces.py
+++ b/src/argilla/client/workspaces.py
@@ -18,8 +18,8 @@ from uuid import UUID
 
 from argilla.client import active_client
 from argilla.client.sdk.commons.errors import (
-    AlreadyExistsApiError,
     BaseClientError,
+    EntityConflictApiError,
     NotFoundApiError,
     ValidationApiError,
 )
@@ -144,7 +144,7 @@ class Workspace:
                 id=self.id,
                 user_id=user_id,
             )
-        except AlreadyExistsApiError as e:
+        except EntityConflictApiError as e:
             raise ValueError(f"User with id=`{user_id}` already exists in workspace with id=`{self.id}`.") from e
         except BaseClientError as e:
             raise RuntimeError(f"Error while adding user with id=`{user_id}` to workspace with id=`{self.id}`.") from e
@@ -200,8 +200,7 @@ class Workspace:
             workspaces_api_v1.delete_workspace(client=self.__client, id=self.id)
         except NotFoundApiError as e:
             raise ValueError(f"Workspace with id {self.id} doesn't exist in Argilla.") from e
-        except AlreadyExistsApiError as e:
-            # TODO: the already exists is to explicit for this context and should be generalized
+        except EntityConflictApiError as e:
             raise ValueError(
                 f"Cannot delete workspace with id {self.id}. Some datasets are still linked to this workspace."
             ) from e
@@ -249,7 +248,7 @@ class Workspace:
         try:
             ws = workspaces_api.create_workspace(client, name).parsed
             return cls.__new_instance(client, ws)
-        except AlreadyExistsApiError as e:
+        except EntityConflictApiError as e:
             raise ValueError(f"Workspace with name=`{name}` already exists, so please use a different name.") from e
         except (ValidationApiError, BaseClientError) as e:
             raise RuntimeError(f"Error while creating workspace with name=`{name}`.") from e

--- a/src/argilla/server/errors/base_errors.py
+++ b/src/argilla/server/errors/base_errors.py
@@ -145,8 +145,8 @@ class MissingInputParamError(BadRequestError):
     pass
 
 
-class EntityConflictError(ServerError):
-    """Error raised when a conflict occurs on a entity operation"""
+class EntityAlreadyExistsError(ServerError):
+    """Error raised when entity was created"""
 
     HTTP_STATUS = status.HTTP_409_CONFLICT
 
@@ -154,9 +154,6 @@ class EntityConflictError(ServerError):
         self.name = name
         self.type = type.__name__
         self.workspace = workspace
-
-
-EntityAlreadyExistsError = EntityConflictError
 
 
 class EntityNotFoundError(ServerError):

--- a/src/argilla/server/errors/base_errors.py
+++ b/src/argilla/server/errors/base_errors.py
@@ -145,8 +145,8 @@ class MissingInputParamError(BadRequestError):
     pass
 
 
-class EntityAlreadyExistsError(ServerError):
-    """Error raised when entity was created"""
+class EntityConflictError(ServerError):
+    """Error raised when a conflict occurs on a entity operation"""
 
     HTTP_STATUS = status.HTTP_409_CONFLICT
 
@@ -154,6 +154,9 @@ class EntityAlreadyExistsError(ServerError):
         self.name = name
         self.type = type.__name__
         self.workspace = workspace
+
+
+EntityAlreadyExistsError = EntityConflictError
 
 
 class EntityNotFoundError(ServerError):

--- a/tests/client/test_api.py
+++ b/tests/client/test_api.py
@@ -54,6 +54,7 @@ from argilla.client.sdk.client import AuthenticatedClient
 from argilla.client.sdk.commons.api import Response
 from argilla.client.sdk.commons.errors import (
     AlreadyExistsApiError,
+    EntityConflictApiError,
     ForbiddenApiError,
     GenericApiError,
     HttpResponseError,
@@ -567,7 +568,9 @@ async def test_dataset_copy(role: UserRole):
 
     api.log(record, name=dataset_copy_name)
 
-    with pytest.raises(AlreadyExistsApiError):
+    with pytest.raises(EntityConflictApiError):
+        api.copy(dataset_name, name_of_copy=dataset_copy_name)
+    with pytest.raises(AlreadyExistsApiError):  # Backward compatibility
         api.copy(dataset_name, name_of_copy=dataset_copy_name)
     with pytest.raises(NotFoundApiError, match="other-workspace"):
         api.copy(dataset_name, name_of_copy=dataset_copy_name, workspace="other-workspace")
@@ -602,7 +605,9 @@ async def test_dataset_copy_to_another_workspace(role: UserRole):
     api.set_workspace(workspace_02.name)
     df_copy = api.load(dataset_copy).to_pandas()
     assert df.equals(df_copy)
-    with pytest.raises(AlreadyExistsApiError):
+    with pytest.raises(EntityConflictApiError):
+        api.copy(dataset_copy, name_of_copy=dataset_copy, workspace=workspace_02.name)
+    with pytest.raises(AlreadyExistsApiError):  # Backward compatibility
         api.copy(dataset_copy, name_of_copy=dataset_copy, workspace=workspace_02.name)
 
 


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

After changes included from #3260, the 409 is used in a more generic way notifying an error related to an entity status conflict. This PR introduces this by renaming the `AlreadyExists...` errors to `EntityConflict...` ones. 


**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)


- [X] Refactor (change restructuring the codebase without changing functionality)


**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
