### PR TITLE
fix: ensure `suggestions` provided to `FeedbackRecord.set_suggestions` are unique

### DIFF
--- a/src/argilla/client/feedback/schemas/records.py
+++ b/src/argilla/client/feedback/schemas/records.py
@@ -189,9 +189,17 @@ class FeedbackRecord(BaseModel):
         if isinstance(suggestions, (dict, SuggestionSchema)):
             suggestions = [suggestions]
         parsed_suggestions = []
+        suggestion_names = set()
         for suggestion in suggestions:
             if not isinstance(suggestion, SuggestionSchema):
                 suggestion = SuggestionSchema(**suggestion)
+            if suggestion.question_name in suggestion_names:
+                warnings.warn(
+                    f"More than one suggestion for `{suggestion.question_name}`"
+                    " has been provided, so just the first one will be kept."
+                )
+                continue
+            suggestion_names.add(suggestion.question_name)
             parsed_suggestions.append(suggestion)
         if not self.id:
             warnings.warn(


### PR DESCRIPTION
# Description

This PR makes sure that the `suggestions` argument provided to `FeedbackRecord.set_suggestions` are unique once parsed to `SuggestionSchema`, to ensure that we're not sending bad requests to the API.

As of now, even though seems like an edge case, the code below would fail:

```python
FeedbackRecord.set_suggestions(suggestions=[{"question_name": "question-1", "value": 1}, {"question_name": "question-1", "value": 2}])
```

While the following works fine:

```python
FeedbackRecord.set_suggestions(suggestions={"question_name": "question-1", "value": 1})
FeedbackRecord.set_suggestions(suggestions={"question_name": "question-1", "value": 2})
```

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [x] Unit tests included on `FeedbackRecord.set_suggestions` at #3427

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
