### PR TITLE
refactor: improve suggestions workflow

### DIFF
--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -574,6 +574,20 @@ class FeedbackDataset(HuggingFaceDatasetMixin):
                         disable=show_progress,
                     ):
                         for record in updated_records[i : i + PUSHING_BATCH_SIZE]:
+                            if not record.id:
+                                warnings.warn(
+                                    "A record is already pushed to Argilla but no record id found, which means"
+                                    " that the `FeedbackRecord` has been pushed to  Argilla, but hasn't been fetched,"
+                                    " so the `id` is missing. Record update will be skipped for this record"
+                                )
+                                if record.suggestions:
+                                    warnings.warn(
+                                        "The `suggestions` have been provided, but the `id`"
+                                        " is not set. To solve that, you can simply call"
+                                        " `FeedbackDataset.fetch_records()` to fetch them and"
+                                        " automatically set the `id`, to call `set_suggestions` on top of that."
+                                    )
+                                continue
                             for suggestion in record.suggestions:
                                 suggestion.question_id = question_name2id[suggestion.question_name]
                                 datasets_api_v1.set_suggestion(

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -192,8 +192,10 @@ class FeedbackRecord(BaseModel):
     _updated: bool = PrivateAttr(default=False)
 
     @validator("suggestions", always=True)
-    def normalize_suggestions(cls, values) -> Tuple:
-        return tuple([v for v in values])
+    def normalize_suggestions(cls, values: Any) -> Tuple:
+        if not isinstance(values, tuple):
+            return tuple([v for v in values])
+        return values
 
     def set_suggestions(
         self, suggestions: Union[SuggestionSchema, List[SuggestionSchema], Dict[str, Any], List[Dict[str, Any]]]

--- a/src/argilla/client/feedback/schemas.py
+++ b/src/argilla/client/feedback/schemas.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 from uuid import UUID
 
 from pydantic import (
@@ -183,11 +183,17 @@ class FeedbackRecord(BaseModel):
     fields: Dict[str, str]
     metadata: Dict[str, Any] = Field(default_factory=dict)
     responses: List[ResponseSchema] = Field(default_factory=list)
-    suggestions: List[SuggestionSchema] = Field(default_factory=list, allow_mutation=True)
+    suggestions: Union[Tuple[SuggestionSchema], List[SuggestionSchema]] = Field(
+        default_factory=tuple, allow_mutation=False
+    )
     external_id: Optional[str] = None
 
     _unified_responses: Optional[Dict[str, List["UnifiedValueSchema"]]] = PrivateAttr(default_factory=dict)
     _updated: bool = PrivateAttr(default=False)
+
+    @validator("suggestions", always=True)
+    def normalize_suggestions(cls, values) -> Tuple:
+        return tuple([v for v in values])
 
     def set_suggestions(
         self, suggestions: Union[SuggestionSchema, List[SuggestionSchema], Dict[str, Any], List[Dict[str, Any]]]
@@ -199,41 +205,20 @@ class FeedbackRecord(BaseModel):
             if not isinstance(suggestion, SuggestionSchema):
                 suggestion = SuggestionSchema(**suggestion)
             parsed_suggestions.append(suggestion)
-        if not self.id:
-            warnings.warn(
-                "Ignore the following if you are creating a new `FeedbackDataset` with"
-                " `FeedbackRecord`s, or if you are just working with a `FeedbackRecord`."
-                " Otherwise, if the `FeedbackRecord` is already pushed"
-                " to Argilla, note that `suggestions` have been provided, but the `id`"
-                " is not set, which means that the `FeedbackRecord` has been pushed to"
-                " Argilla, but hasn't been fetched, so the `id` is missing. To solve that,"
-                " you can simply call `FeedbackDataset.fetch_records()` to fetch them and"
-                " automatically set the `id`, to call `set_suggestions` on top of that."
-            )
+
+        suggestions_dict = {suggestion.question_name: suggestion for suggestion in self.suggestions}
         for suggestion in parsed_suggestions:
-            for existing_suggestion in self.suggestions:
-                if (
-                    existing_suggestion.question_id == suggestion.question_id
-                    or existing_suggestion.question_name == suggestion.question_name
-                ):
-                    warnings.warn(
-                        f"A suggestion for question `{existing_suggestion.question_name}` has already"
-                        " been provided, so the provided suggestion will overwrite it."
-                    )
-                    self.suggestions.remove(existing_suggestion)
-                    break
-        self.suggestions += parsed_suggestions
+            if suggestion.question_name in suggestions_dict:
+                warnings.warn(
+                    f"A suggestion for question `{suggestion.question_name}` has already"
+                    " been provided, so the provided suggestion will overwrite it.",
+                    category=UserWarning,
+                )
+            suggestions_dict[suggestion.question_name] = suggestion
+
+        self.__dict__["suggestions"] = tuple(suggestions_dict.values())
         if self.id and not self._updated:
             self._updated = True
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        if name == "suggestions" and hasattr(self, name):
-            warnings.warn(
-                "Ignore this warning if you're already using `set_suggestions` method."
-                " Otherwise, if you are trying to set `suggestions` directly, which is"
-                " not allowed. You should use the `set_suggestions` method instead."
-            )
-        super().__setattr__(name, value)
 
     def _reset_updated(self) -> None:
         self._updated = False

--- a/tests/client/feedback/test_dataset.py
+++ b/tests/client/feedback/test_dataset.py
@@ -189,7 +189,7 @@ async def test_update_dataset_records_with_suggestions(argilla_user: "ServerUser
         record.set_suggestions([{"question_name": "text", "value": "This is a suggestion"}])
 
     ds.push_to_argilla()
-
+# TODO: Review this requirement for tests and explain, try to avoid use or at least, document.
     await db.refresh(argilla_user, attribute_names=["datasets"])
     dataset = argilla_user.datasets[0]
     await db.refresh(dataset, attribute_names=["records"])


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

hello, 

# Description

Given the following code snippet:
```python
from argilla.feedback import FeedbackRecord
​
record = FeedbackRecord(fields={"text": "this is a text"}, suggestions=[{"question_name": "qt", "value": 3}])
​
record.set_suggestions({"question_name": "dd", "value": 234})
#  /argilla/client/feedback/schemas.py:203: UserWarning: Ignore the following
# if you are creating a new `FeedbackDataset` with `FeedbackRecord`s, or if you are just working with a
# `FeedbackRecord`. Otherwise, if the `FeedbackRecord` is already pushed to Argilla, note that `suggestions` have
# been provided, but the `id` is not set, which means that the `FeedbackRecord` has been pushed to Argilla,
# but hasn't been fetched, so the `id` is missing. To solve that, you can simply call `FeedbackDataset.fetch_records()`
# to fetch them and automatically set the `id`, to call `set_suggestions` on top of that.
#   warnings.warn(
# /argilla/client/feedback/schemas.py:219: UserWarning: A suggestion for question
# `qt` has already been provided, so the provided suggestion will overwrite it.
#   warnings.warn(
# /argilla/client/feedback/schemas.py:231: UserWarning: Ignore this warning if
# you're already using `set_suggestions` method. Otherwise, if you are trying to set `suggestions` directly,
# which is not allowed. You should use the `set_suggestions` method instead.
#   warnings.warn(
​
records.suggestions = [{"question_name": "ab", "value": 33}]
```

improve the workflow to:

- Avoid suggestions assignation and force using `set_suggestions` to update the record suggestions
- Remove extra warnings (all related to suggestions assignment) 
- Move record-id-related warnings to the `push_to_argilla` method since in that context have more sense
- Skip updating a record in argilla if there is no id for the record (related to the previous point)

This enhancement is based on using tuples for store suggestions (since a tuple is not mutable), and the `allow_mutation=False` pydantic parameter (to avoid field assignment)

Also, some tests have been included to validate the flow when [creating](https://github.com/argilla-io/argilla/blob/refactor/improve-suggesions-workflow/tests/client/feedback/test_dataset.py#L146) or [updating](https://github.com/argilla-io/argilla/blob/refactor/improve-suggesions-workflow/tests/client/feedback/test_dataset.py#L173) records with suggestions (by checking the expected content instead of the expected local state after pushing the data). [One of those tests ](https://github.com/argilla-io/argilla/blob/refactor/improve-suggesions-workflow/tests/client/feedback/test_dataset.py#L173) is still failing but, testing the same flow outside the tests, it works. So, not sure about the error (this error happened before changes if a test check the expected suggestions for a record after updating them)

Finally, the bug fixed in https://github.com/argilla-io/argilla/pull/3428 is already resolved by using a dictionary structure in `set_suggestions` method. So the fix is not needed anymore.

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (change restructuring the codebase without changing functionality)
- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

Launching several workflows locally 

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
