### PR TITLE
chore: Add revision tag for 1.13

### DIFF
--- a/src/argilla/server/database.py
+++ b/src/argilla/server/database.py
@@ -28,7 +28,14 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
 ALEMBIC_CONFIG_FILE = os.path.normpath(os.path.join(os.path.dirname(argilla.__file__), "alembic.ini"))
-TAGGED_REVISIONS = OrderedDict({"1.7": "1769ee58fbb4", "1.8": "ae5522b4c674", "1.11": "3ff6484f8b37"})
+TAGGED_REVISIONS = OrderedDict(
+    {
+        "1.7": "1769ee58fbb4",
+        "1.8": "ae5522b4c674",
+        "1.11": "3ff6484f8b37",
+        "1.13": "3fc3c0839959",
+    }
+)
 
 
 @event.listens_for(Engine, "connect")

--- a/tests/client/feedback/test_dataset.py
+++ b/tests/client/feedback/test_dataset.py
@@ -189,7 +189,7 @@ async def test_update_dataset_records_with_suggestions(argilla_user: "ServerUser
         record.set_suggestions([{"question_name": "text", "value": "This is a suggestion"}])
 
     ds.push_to_argilla()
-# TODO: Review this requirement for tests and explain, try to avoid use or at least, document.
+    # TODO: Review this requirement for tests and explain, try to avoid use or at least, document.
     await db.refresh(argilla_user, attribute_names=["datasets"])
     dataset = argilla_user.datasets[0]
     await db.refresh(dataset, attribute_names=["records"])


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR defines a tag for the database revision corresponding to the `1.13` version


```bash
python -m argilla database revisions
```
```bash
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.

Tagged revisions
-----------------
• 1.7 (revision: '1769ee58fbb4')
• 1.8 (revision: 'ae5522b4c674')
• 1.11 (revision: '3ff6484f8b37')
• 1.13 (revision: '3fc3c0839959')

Alembic revisions
-----------------
8c574ada5e5f -> 3fc3c0839959 (head), create suggestions table
3ff6484f8b37 -> 8c574ada5e5f, update_enum_columns
ae5522b4c674 -> 3ff6484f8b37, add record metadata column
e402e9d9245e -> ae5522b4c674, create fields table
8be56284dac0 -> e402e9d9245e, create responses table
3a8e2f9b5dea -> 8be56284dac0, create records table
b9099dc08489 -> 3a8e2f9b5dea, create questions table
1769ee58fbb4 -> b9099dc08489, create datasets table
82a5a88a3fa5 -> 1769ee58fbb4, create workspaces_users table
74694870197c -> 82a5a88a3fa5, create workspaces table
<base> -> 74694870197c, create users table

...
```


