### PR TITLE
chore: Fix missing spaces in warnings/errors

### DIFF
--- a/src/argilla/client/models.py
+++ b/src/argilla/client/models.py
@@ -122,7 +122,7 @@ class _Validators(BaseModel):
         if isinstance(v, int):
             message = (
                 f"Integer ids won't be supported in future versions. We recommend to start using strings instead. "
-                "For datasets already containing integer values we recommend migrating them to avoid deprecation issues."
+                "For datasets already containing integer values we recommend migrating them to avoid deprecation issues. "
                 "See https://docs.argilla.io/en/latest/getting_started/installation/configurations"
                 "/database_migrations.html#elasticsearch"
             )

--- a/src/argilla/client/workspaces.py
+++ b/src/argilla/client/workspaces.py
@@ -321,7 +321,7 @@ class Workspace:
 
         raise ValueError(
             f"Workspace with name=`{name}` doesn't exist in Argilla, so please"
-            "create it via the `Workspace.create` method as follows:"
+            " create it via the `Workspace.create` method as follows:"
             f" `Workspace.create('{name}')`."
         )
 

--- a/src/argilla/server/daos/models/records.py
+++ b/src/argilla/server/daos/models/records.py
@@ -66,20 +66,20 @@ class BaseRecordInDB(GenericModel, Generic[AnnotationDB]):
 
     vectors: Optional[Dict[str, BaseEmbeddingVectorDB]] = Field(
         None,
-        description="Provide the vector info as a list of key - value dictionary."
+        description="Provide the vector info as a list of key - value dictionary. "
         "The dictionary contains the dimension and dimension sized vector float list",
     )
 
     predictions: Optional[Dict[str, AnnotationDB]] = Field(
         None,
-        description="Provide the prediction info as a key-value dictionary."
-        "The key will represent the agent ant the value the prediction."
+        description="Provide the prediction info as a key-value dictionary. "
+        "The key will represent the agent ant the value the prediction. "
         "Using this way you can skip passing the agent inside of the prediction",
     )
     annotations: Optional[Dict[str, AnnotationDB]] = Field(
         None,
-        description="Provide the annotation info as a key-value dictionary."
-        "The key will represent the agent ant the value the annotation."
+        description="Provide the annotation info as a key-value dictionary. "
+        "The key will represent the agent ant the value the annotation. "
         "Using this way you can skip passing the agent inside the annotation",
     )
 
@@ -121,7 +121,7 @@ class BaseRecordInDB(GenericModel, Generic[AnnotationDB]):
         if isinstance(v, int):
             message = (
                 f"Integer ids won't be supported in future versions. We recommend to start using strings instead. "
-                "For datasets already containing integer values we recommend migrating them to avoid deprecation issues."
+                "For datasets already containing integer values we recommend migrating them to avoid deprecation issues. "
                 "See https://docs.argilla.io/en/latest/getting_started/installation/configurations"
                 "/database_migrations.html#elasticsearch"
             )


### PR DESCRIPTION
Hello!

# Description

I've used a regex to find some more missing spaces in warnings and errors, after I encountered one of them naturally earlier.

**Type of change**

- [x] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

N/A

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

---

- Tom Aarsen