### PR TITLE
ci: selective `runs-on` value for tests execution

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -53,18 +53,23 @@ jobs:
         - searchEngineDockerImage: docker.elastic.co/elasticsearch/elasticsearch:8.8.2
           searchEngineDockerEnv: '{"discovery.type": "single-node", "xpack.security.enabled": "false"}'
           coverageReport: coverage-elasticsearch-8.8.2
+          runsOn: extended-runner
         - searchEngineDockerImage: docker.elastic.co/elasticsearch/elasticsearch:8.0.1
           searchEngineDockerEnv: '{"discovery.type": "single-node", "xpack.security.enabled": "false"}'
           coverageReport: coverage-elasticsearch-8.0.1
+          runsOn: extended-runner
         - searchEngineDockerImage: docker.elastic.co/elasticsearch/elasticsearch:7.17.11
           searchEngineDockerEnv: '{"discovery.type": "single-node", "xpack.security.enabled": "false"}'
           coverageReport: coverage-elasticsearch-7.17.11
+          runsOn: ubuntu-latest
         - searchEngineDockerImage: opensearchproject/opensearch:2.4.1
           searchEngineDockerEnv: '{"discovery.type": "single-node", "plugins.security.disabled": "true"}'
           coverageReport: coverage-opensearch-2.4.1
+          runsOn: ubuntu-latest
         - searchEngineDockerImage: opensearchproject/opensearch:1.3.11
           searchEngineDockerEnv: '{"discovery.type": "single-node", "plugins.security.disabled": "true"}'
           coverageReport: coverage-opensearch-1.3.11
+          runsOn: ubuntu-latest
     name: Run base tests
     uses: ./.github/workflows/run-python-tests.yml
     needs:  check_repo_files
@@ -87,6 +92,7 @@ jobs:
     if: needs.check_repo_files.outputs.pythonChanges == 'true'
     # continue-on-error: true
     with:
+      runsOn: extended-runner
       coverageReport: coverage-extra
       pytestArgs: |
         tests/training \

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -80,6 +80,7 @@ jobs:
       searchEngineDockerImage: ${{ matrix.searchEngineDockerImage }}
       searchEngineDockerEnv: ${{ matrix.searchEngineDockerEnv }}
       coverageReport: coverage
+      runsOn: ${{ matrix.runsOn }}
       pytestArgs: |
         --ignore=tests/training \
         --ignore=tests/client/feedback/training \

--- a/.github/workflows/run-python-tests.yml
+++ b/.github/workflows/run-python-tests.yml
@@ -3,6 +3,10 @@ name: Run Argilla python tests
 on:
   workflow_call:
     inputs:
+      runsOn:
+        required: false
+        type: string
+        default: extended-runner
       pytestArgs:
         description: "Provide extra args to pytest command line"
         required: true
@@ -28,7 +32,7 @@ env:
 jobs:
   run-python-tests:
     name: Argilla python tests
-    runs-on: extended-runner
+    runs-on: $ {{ inputs.runsOn }}
     services:
       search_engine:
         image: ${{ inputs.searchEngineDockerImage }}

--- a/.github/workflows/run-python-tests.yml
+++ b/.github/workflows/run-python-tests.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   run-python-tests:
     name: Argilla python tests
-    runs-on: $ {{ inputs.runsOn }}
+    runs-on: ${{ inputs.runsOn }}
     services:
       search_engine:
         image: ${{ inputs.searchEngineDockerImage }}

--- a/src/argilla/_version.py
+++ b/src/argilla/_version.py
@@ -13,4 +13,4 @@
 #  limitations under the License.
 
 # coding: utf-8
-version = "1.14.1-dev"
+version = "1.14.0-dev"

--- a/src/argilla/_version.py
+++ b/src/argilla/_version.py
@@ -13,4 +13,4 @@
 #  limitations under the License.
 
 # coding: utf-8
-version = "1.14.0-dev"
+version = "1.14.1-dev"


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR introduces a minimal improvement on how runners are used for launching tests. Since all resource problems (that make some tests fail) occur when running tests with elasticsearch 8.x, the extended-runner will be used only for those cases, keeping the default `ubuntu-latest` one for the rest of the cases. 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

In this execution https://github.com/argilla-io/argilla/actions/runs/5669184766/job/15361372423?pr=3455, the runner used depends on the elasticsearch version used:

<img width="1185" alt="Screenshot 2023-07-26 at 15 20 33" src="https://github.com/argilla-io/argilla/assets/2518789/ab9c9dbd-4d2d-4e56-9299-84aa933c1402">


<img width="1112" alt="Screenshot 2023-07-26 at 15 20 48" src="https://github.com/argilla-io/argilla/assets/2518789/c2374357-7770-49ff-b2e0-02c79da9d3b5">



**Checklist**

- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
