### PR TITLE
chore: Fix `ruff` line length

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,7 @@ exclude = [
     "node_modules",
     "venv",
 ]
+line-length = 120
 
 [tool.ruff.per-file-ignores]
 # Ignore imported but unused;

--- a/src/argilla/client/api.py
+++ b/src/argilla/client/api.py
@@ -20,10 +20,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from argilla.client.client import Argilla
 from argilla.client.datasets import Dataset
-from argilla.client.models import (  # TODO Remove TextGenerationRecord
-    BulkResponse,
-    Record,
-)
+from argilla.client.models import BulkResponse, Record  # TODO Remove TextGenerationRecord
 from argilla.client.sdk.commons import errors
 from argilla.client.sdk.v1.datasets.api import list_datasets as list_datasets_api_v1
 from argilla.client.sdk.workspaces.api import list_workspaces as list_workspaces_api_v0
@@ -340,11 +337,7 @@ def load(
         raise e
 
 
-def copy(
-    dataset: str,
-    name_of_copy: str,
-    workspace: str = None,
-):
+def copy(dataset: str, name_of_copy: str, workspace: str = None):
     """
     Creates a copy of a dataset including its tags and metadata
 

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -65,9 +65,7 @@ from argilla.client.sdk.text2text.models import (
     CreationText2TextRecord,
     Text2TextBulkData,
 )
-from argilla.client.sdk.text2text.models import (
-    Text2TextRecord as SdkText2TextRecord,
-)
+from argilla.client.sdk.text2text.models import Text2TextRecord as SdkText2TextRecord
 from argilla.client.sdk.text_classification import api as text_classification_api
 from argilla.client.sdk.text_classification.models import (
     CreationTextClassificationRecord,
@@ -75,16 +73,12 @@ from argilla.client.sdk.text_classification.models import (
     LabelingRuleMetricsSummary,
     TextClassificationBulkData,
 )
-from argilla.client.sdk.text_classification.models import (
-    TextClassificationRecord as SdkTextClassificationRecord,
-)
+from argilla.client.sdk.text_classification.models import TextClassificationRecord as SdkTextClassificationRecord
 from argilla.client.sdk.token_classification.models import (
     CreationTokenClassificationRecord,
     TokenClassificationBulkData,
 )
-from argilla.client.sdk.token_classification.models import (
-    TokenClassificationRecord as SdkTokenClassificationRecord,
-)
+from argilla.client.sdk.token_classification.models import TokenClassificationRecord as SdkTokenClassificationRecord
 from argilla.client.sdk.users import api as users_api
 from argilla.client.sdk.workspaces import api as workspaces_api
 from argilla.client.sdk.workspaces.models import WorkspaceModel

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -26,12 +26,7 @@ import httpx
 from rich import print as rprint
 from rich.progress import Progress
 
-from argilla._constants import (
-    DEFAULT_API_KEY,
-    DEFAULT_USERNAME,
-    ES_INDEX_REGEX_PATTERN,
-    WORKSPACE_HEADER_NAME,
-)
+from argilla._constants import DEFAULT_API_KEY, DEFAULT_USERNAME, ES_INDEX_REGEX_PATTERN, WORKSPACE_HEADER_NAME
 from argilla.client.apis.datasets import Datasets
 from argilla.client.apis.metrics import MetricsAPI
 from argilla.client.apis.search import Search, VectorSearch
@@ -52,19 +47,12 @@ from argilla.client.models import (
 )
 from argilla.client.sdk.client import AuthenticatedClient
 from argilla.client.sdk.commons.api import bulk
-from argilla.client.sdk.commons.errors import (
-    AlreadyExistsApiError,
-    InputValueError,
-    NotFoundApiError,
-)
+from argilla.client.sdk.commons.errors import AlreadyExistsApiError, InputValueError, NotFoundApiError
 from argilla.client.sdk.datasets import api as datasets_api
 from argilla.client.sdk.datasets.models import CopyDatasetRequest, TaskType
 from argilla.client.sdk.metrics import api as metrics_api
 from argilla.client.sdk.metrics.models import MetricInfo
-from argilla.client.sdk.text2text.models import (
-    CreationText2TextRecord,
-    Text2TextBulkData,
-)
+from argilla.client.sdk.text2text.models import CreationText2TextRecord, Text2TextBulkData
 from argilla.client.sdk.text2text.models import Text2TextRecord as SdkText2TextRecord
 from argilla.client.sdk.text_classification import api as text_classification_api
 from argilla.client.sdk.text_classification.models import (

--- a/src/argilla/client/datasets.py
+++ b/src/argilla/client/datasets.py
@@ -20,10 +20,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 import pandas as pd
 
 from argilla._constants import OPENAI_END_TOKEN, OPENAI_SEPARATOR, OPENAI_WHITESPACE
-from argilla.client.apis.datasets import (
-    TextClassificationSettings,
-    TokenClassificationSettings,
-)
+from argilla.client.apis.datasets import TextClassificationSettings, TokenClassificationSettings
 from argilla.client.models import (
     Framework,
     Record,

--- a/src/argilla/client/feedback/dataset.py
+++ b/src/argilla/client/feedback/dataset.py
@@ -27,9 +27,7 @@ from argilla.client.feedback.schemas import (
     RankingQuestion,
     RatingQuestion,
 )
-from argilla.client.feedback.training.schemas import (
-    TrainingTaskMappingForTextClassification,
-)
+from argilla.client.feedback.training.schemas import TrainingTaskMappingForTextClassification
 from argilla.client.feedback.types import AllowedFieldTypes, AllowedQuestionTypes
 from argilla.client.feedback.unification import (
     LabelQuestionStrategy,

--- a/src/argilla/client/feedback/mixin.py
+++ b/src/argilla/client/feedback/mixin.py
@@ -21,10 +21,7 @@ from pydantic import ValidationError
 from tqdm import tqdm, trange
 
 from argilla.client.api import ArgillaSingleton
-from argilla.client.feedback.constants import (
-    FETCHING_BATCH_SIZE,
-    PUSHING_BATCH_SIZE,
-)
+from argilla.client.feedback.constants import FETCHING_BATCH_SIZE, PUSHING_BATCH_SIZE
 from argilla.client.feedback.schemas import (
     FeedbackRecord,
     LabelQuestion,
@@ -35,10 +32,7 @@ from argilla.client.feedback.schemas import (
     TextQuestion,
 )
 from argilla.client.feedback.types import AllowedQuestionTypes
-from argilla.client.feedback.utils import (
-    feedback_dataset_in_argilla,
-    generate_pydantic_schema,
-)
+from argilla.client.feedback.utils import feedback_dataset_in_argilla, generate_pydantic_schema
 from argilla.client.sdk.v1.datasets import api as datasets_api_v1
 from argilla.client.workspaces import Workspace
 

--- a/src/argilla/client/feedback/schemas/fields.py
+++ b/src/argilla/client/feedback/schemas/fields.py
@@ -15,13 +15,7 @@
 from typing import Any, Dict, Literal, Optional
 from uuid import UUID
 
-from pydantic import (
-    BaseModel,
-    Extra,
-    Field,
-    root_validator,
-    validator,
-)
+from pydantic import BaseModel, Extra, Field, root_validator, validator
 
 FieldTypes = Literal["text"]
 

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -15,15 +15,7 @@
 from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
 
-from pydantic import (
-    BaseModel,
-    Extra,
-    Field,
-    conint,
-    conlist,
-    root_validator,
-    validator,
-)
+from pydantic import BaseModel, Extra, Field, conint, conlist, root_validator, validator
 
 from argilla.client.feedback.schemas.utils import LabelMappingMixin
 

--- a/src/argilla/client/feedback/schemas/records.py
+++ b/src/argilla/client/feedback/schemas/records.py
@@ -16,16 +16,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 from uuid import UUID
 
-from pydantic import (
-    BaseModel,
-    Extra,
-    Field,
-    PrivateAttr,
-    StrictInt,
-    StrictStr,
-    conint,
-    validator,
-)
+from pydantic import BaseModel, Extra, Field, PrivateAttr, StrictInt, StrictStr, conint, validator
 
 if TYPE_CHECKING:
     from argilla.client.feedback.unification import UnifiedValueSchema

--- a/src/argilla/client/feedback/training/__init__.py
+++ b/src/argilla/client/feedback/training/__init__.py
@@ -13,9 +13,6 @@
 #  limitations under the License.
 
 from argilla.client.feedback.training.base import ArgillaTrainer
-from argilla.client.feedback.training.schemas import (
-    TrainingTaskMapping,
-    TrainingTaskMappingForTextClassification,
-)
+from argilla.client.feedback.training.schemas import TrainingTaskMapping, TrainingTaskMappingForTextClassification
 
 __all__ = ["ArgillaTrainer", "TrainingTaskMapping", "TrainingTaskMappingForTextClassification"]

--- a/src/argilla/client/feedback/training/base.py
+++ b/src/argilla/client/feedback/training/base.py
@@ -28,11 +28,13 @@ os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
 if TYPE_CHECKING:
     import spacy
 
+    from argilla.client.feedback.dataset import FeedbackDataset
+
 
 class ArgillaTrainer(ArgillaTrainerV1):
     def __init__(
         self,
-        dataset: "argilla.client.feedback.schemas.FeedbackDataset",
+        dataset: "FeedbackDataset",
         task_mapping: TrainingTaskMappingForTextClassification,
         framework: Framework,
         lang: Optional["spacy.Language"] = None,
@@ -232,7 +234,7 @@ class ArgillaTrainer(ArgillaTrainerV1):
 class ArgillaTrainerSkeleton(ABC):
     def __init__(
         self,
-        feedback_dataset: "argilla.client.feedback.schemas.FeedbackDataset",
+        feedback_dataset: "FeedbackDataset",
         task_mapping: TrainingTaskMappingForTextClassification,
         prepared_data=None,
         model: str = None,

--- a/src/argilla/client/feedback/training/base.py
+++ b/src/argilla/client/feedback/training/base.py
@@ -17,9 +17,7 @@ import textwrap
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, List, Optional, Union
 
-from argilla.client.feedback.training.schemas import (
-    TrainingTaskMappingForTextClassification,
-)
+from argilla.client.feedback.training.schemas import TrainingTaskMappingForTextClassification
 from argilla.client.models import Framework, TextClassificationRecord
 from argilla.training import ArgillaTrainer as ArgillaTrainerV1
 
@@ -92,9 +90,7 @@ class ArgillaTrainer(ArgillaTrainerV1):
         if framework is Framework.SETFIT:
             if not isinstance(task_mapping, TrainingTaskMappingForTextClassification):
                 raise NotImplementedError(f"{Framework.SETFIT} only supports `TextClassification` tasks.")
-            from argilla.client.feedback.training.frameworks.setfit import (
-                ArgillaSetFitTrainer,
-            )
+            from argilla.client.feedback.training.frameworks.setfit import ArgillaSetFitTrainer
 
             self._trainer = ArgillaSetFitTrainer(
                 feedback_dataset=self._dataset,
@@ -104,9 +100,7 @@ class ArgillaTrainer(ArgillaTrainerV1):
                 model=self._model,
             )
         elif framework is Framework.TRANSFORMERS:
-            from argilla.client.feedback.training.frameworks.transformers import (
-                ArgillaTransformersTrainer,
-            )
+            from argilla.client.feedback.training.frameworks.transformers import ArgillaTransformersTrainer
 
             self._trainer = ArgillaTransformersTrainer(
                 feedback_dataset=self._dataset,
@@ -116,9 +110,7 @@ class ArgillaTrainer(ArgillaTrainerV1):
                 model=self._model,
             )
         elif framework is Framework.PEFT:
-            from argilla.client.feedback.training.frameworks.peft import (
-                ArgillaPeftTrainer,
-            )
+            from argilla.client.feedback.training.frameworks.peft import ArgillaPeftTrainer
 
             self._trainer = ArgillaPeftTrainer(
                 feedback_dataset=self._dataset,
@@ -128,9 +120,7 @@ class ArgillaTrainer(ArgillaTrainerV1):
                 model=self._model,
             )
         elif framework is Framework.SPACY:
-            from argilla.client.feedback.training.frameworks.spacy import (
-                ArgillaSpaCyTrainer,
-            )
+            from argilla.client.feedback.training.frameworks.spacy import ArgillaSpaCyTrainer
 
             self._trainer = ArgillaSpaCyTrainer(
                 feedback_dataset=self._dataset,
@@ -142,9 +132,7 @@ class ArgillaTrainer(ArgillaTrainerV1):
                 framework_kwargs=framework_kwargs,  # freeze_tok2vec
             )
         elif framework is Framework.SPACY_TRANSFORMERS:
-            from argilla.client.feedback.training.frameworks.spacy import (
-                ArgillaSpaCyTransformersTrainer,
-            )
+            from argilla.client.feedback.training.frameworks.spacy import ArgillaSpaCyTransformersTrainer
 
             self._trainer = ArgillaSpaCyTransformersTrainer(
                 feedback_dataset=self._dataset,
@@ -156,9 +144,7 @@ class ArgillaTrainer(ArgillaTrainerV1):
                 framework_kwargs=framework_kwargs,  # update_transformer
             )
         elif framework is Framework.OPENAI:
-            from argilla.client.feedback.training.frameworks.openai import (
-                ArgillaOpenAITrainer,
-            )
+            from argilla.client.feedback.training.frameworks.openai import ArgillaOpenAITrainer
 
             self._trainer = ArgillaOpenAITrainer(
                 feedback_dataset=self._dataset,
@@ -168,9 +154,7 @@ class ArgillaTrainer(ArgillaTrainerV1):
                 model=self._model,
             )
         elif framework is Framework.SPAN_MARKER:
-            from argilla.client.feedback.training.frameworks.span_marker import (
-                ArgillaSpanMarkerTrainer,
-            )
+            from argilla.client.feedback.training.frameworks.span_marker import ArgillaSpanMarkerTrainer
 
             self._trainer = ArgillaSpanMarkerTrainer(
                 feedback_dataset=self._dataset,

--- a/src/argilla/client/feedback/training/frameworks/peft.py
+++ b/src/argilla/client/feedback/training/frameworks/peft.py
@@ -13,9 +13,7 @@
 #  limitations under the License.
 
 
-from argilla.client.feedback.training.frameworks.transformers import (
-    ArgillaTransformersTrainer,
-)
+from argilla.client.feedback.training.frameworks.transformers import ArgillaTransformersTrainer
 from argilla.training.peft import ArgillaPeftTrainer as ArgillaPeftTrainerV1
 
 

--- a/src/argilla/client/feedback/training/frameworks/setfit.py
+++ b/src/argilla/client/feedback/training/frameworks/setfit.py
@@ -14,9 +14,7 @@
 
 import logging
 
-from argilla.client.feedback.training.frameworks.transformers import (
-    ArgillaTransformersTrainer,
-)
+from argilla.client.feedback.training.frameworks.transformers import ArgillaTransformersTrainer
 from argilla.client.models import TextClassificationRecord
 from argilla.training.setfit import ArgillaSetFitTrainer as ArgillaSetFitTrainerV1
 from argilla.utils.dependency import require_version

--- a/src/argilla/client/feedback/training/frameworks/spacy.py
+++ b/src/argilla/client/feedback/training/frameworks/spacy.py
@@ -20,12 +20,8 @@ from typing_extensions import Literal
 from argilla.client.feedback.training.base import ArgillaTrainerSkeleton
 from argilla.client.models import TextClassificationRecord, TokenClassificationRecord
 from argilla.training.spacy import ArgillaSpaCyTrainer as ArgillaSpaCyTrainerV1
-from argilla.training.spacy import (
-    ArgillaSpaCyTransformersTrainer as ArgillaSpaCyTransformersTrainerV1,
-)
-from argilla.training.spacy import (
-    _ArgillaSpaCyTrainerBase as _ArgillaSpaCyTrainerBaseV1,
-)
+from argilla.training.spacy import ArgillaSpaCyTransformersTrainer as ArgillaSpaCyTransformersTrainerV1
+from argilla.training.spacy import _ArgillaSpaCyTrainerBase as _ArgillaSpaCyTrainerBaseV1
 from argilla.utils.dependency import require_version
 
 

--- a/src/argilla/client/feedback/training/frameworks/span_marker.py
+++ b/src/argilla/client/feedback/training/frameworks/span_marker.py
@@ -16,9 +16,7 @@ from datasets import DatasetDict
 
 from argilla.client.feedback.training.base import ArgillaTrainerSkeleton
 from argilla.client.models import TokenClassificationRecord
-from argilla.training.span_marker import (
-    ArgillaSpanMarkerTrainer as ArgillaSpanMarkerTrainerV1,
-)
+from argilla.training.span_marker import ArgillaSpanMarkerTrainer as ArgillaSpanMarkerTrainerV1
 
 
 class ArgillaSpanMarkerTrainer(ArgillaSpanMarkerTrainerV1, ArgillaTrainerSkeleton):

--- a/src/argilla/client/feedback/training/frameworks/transformers.py
+++ b/src/argilla/client/feedback/training/frameworks/transformers.py
@@ -16,12 +16,8 @@
 from datasets import Dataset, DatasetDict
 
 from argilla.client.feedback.training.base import ArgillaTrainerSkeleton
-from argilla.client.feedback.training.schemas import (
-    TrainingTaskMappingForTextClassification,
-)
-from argilla.training.transformers import (
-    ArgillaTransformersTrainer as ArgillaTransformersTrainerV1,
-)
+from argilla.client.feedback.training.schemas import TrainingTaskMappingForTextClassification
+from argilla.training.transformers import ArgillaTransformersTrainer as ArgillaTransformersTrainerV1
 
 
 class ArgillaTransformersTrainer(ArgillaTransformersTrainerV1, ArgillaTrainerSkeleton):

--- a/src/argilla/client/feedback/utils.py
+++ b/src/argilla/client/feedback/utils.py
@@ -21,12 +21,8 @@ from pydantic import (
 
 import argilla as rg
 from argilla.client.api import active_client
-from argilla.client.feedback.constants import (
-    FIELD_TYPE_TO_PYTHON_TYPE,
-)
-from argilla.client.feedback.schemas import (
-    FieldSchema,
-)
+from argilla.client.feedback.constants import FIELD_TYPE_TO_PYTHON_TYPE
+from argilla.client.feedback.schemas import FieldSchema
 from argilla.client.sdk.v1.datasets import api as datasets_api_v1
 from argilla.client.workspaces import Workspace
 

--- a/src/argilla/client/feedback/utils.py
+++ b/src/argilla/client/feedback/utils.py
@@ -14,10 +14,7 @@
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
-from pydantic import (
-    BaseModel,
-    create_model,
-)
+from pydantic import BaseModel, create_model
 
 import argilla as rg
 from argilla.client.api import active_client
@@ -72,10 +69,7 @@ def generate_pydantic_schema(fields: List[FieldSchema], name: Optional[str] = "F
 
 
 def feedback_dataset_in_argilla(
-    name: Optional[str] = None,
-    *,
-    workspace: Optional[Union[str, Workspace]] = None,
-    id: Optional[str] = None,
+    name: Optional[str] = None, *, workspace: Optional[Union[str, Workspace]] = None, id: Optional[str] = None
 ) -> Union["FeedbackDatasetModel", None]:
     """Checks whether a `FeedbackDataset` exists in Argilla or not, based on the `name`, `id`, or the combination of
     `name` and `workspace`.

--- a/src/argilla/client/models.py
+++ b/src/argilla/client/models.py
@@ -25,22 +25,10 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 from deprecated import deprecated
-from pydantic import (
-    BaseModel,
-    Field,
-    PrivateAttr,
-    conint,
-    constr,
-    root_validator,
-    validator,
-)
+from pydantic import BaseModel, Field, PrivateAttr, conint, constr, root_validator, validator
 
 from argilla import _messages
-from argilla._constants import (
-    _JS_MAX_SAFE_INTEGER,
-    DEFAULT_MAX_KEYWORD_LENGTH,
-    PROTECTED_METADATA_FIELD_PREFIX,
-)
+from argilla._constants import _JS_MAX_SAFE_INTEGER, DEFAULT_MAX_KEYWORD_LENGTH, PROTECTED_METADATA_FIELD_PREFIX
 from argilla.utils.span_utils import SpanUtils
 
 _LOGGER = logging.getLogger(__name__)

--- a/src/argilla/client/sdk/_helpers.py
+++ b/src/argilla/client/sdk/_helpers.py
@@ -18,16 +18,10 @@ import httpx
 
 from argilla.client.sdk.commons.errors import WrongResponseError
 from argilla.client.sdk.commons.errors_handler import handle_response_error
-from argilla.client.sdk.commons.models import (
-    ErrorMessage,
-    HTTPValidationError,
-    Response,
-)
+from argilla.client.sdk.commons.models import ErrorMessage, HTTPValidationError, Response
 
 
-def build_raw_response(
-    response: httpx.Response,
-) -> Response[Union[Dict[str, Any], ErrorMessage, HTTPValidationError]]:
+def build_raw_response(response: httpx.Response) -> Response[Union[Dict[str, Any], ErrorMessage, HTTPValidationError]]:
     return build_typed_response(response)
 
 
@@ -35,8 +29,7 @@ ResponseType = TypeVar("ResponseType")
 
 
 def build_typed_response(
-    response: httpx.Response,
-    response_type_class: Optional[Type[ResponseType]] = None,
+    response: httpx.Response, response_type_class: Optional[Type[ResponseType]] = None
 ) -> Response[Union[ResponseType, ErrorMessage, HTTPValidationError]]:
     parsed_response = check_response(response, expected_response=response_type_class)
     if response_type_class:

--- a/src/argilla/client/sdk/client.py
+++ b/src/argilla/client/sdk/client.py
@@ -249,11 +249,7 @@ ResponseType = TypeVar("ResponseType")
 
 
 @dataclasses.dataclass
-class AuthenticatedClient(
-    Client,
-    _ClientCommonDefaults,
-    _AuthenticatedClient,
-):
+class AuthenticatedClient(Client, _ClientCommonDefaults, _AuthenticatedClient):
     """A Client which has been authenticated for use on secured endpoints"""
 
     def __hash__(self):

--- a/src/argilla/client/sdk/commons/api.py
+++ b/src/argilla/client/sdk/commons/api.py
@@ -33,12 +33,7 @@ import httpx
 from argilla.client.sdk.client import AuthenticatedClient
 from argilla.client.sdk.commons.errors import GenericApiError
 from argilla.client.sdk.commons.errors_handler import handle_response_error
-from argilla.client.sdk.commons.models import (
-    BulkResponse,
-    ErrorMessage,
-    HTTPValidationError,
-    Response,
-)
+from argilla.client.sdk.commons.models import BulkResponse, ErrorMessage, HTTPValidationError, Response
 from argilla.client.sdk.text2text.models import Text2TextBulkData
 from argilla.client.sdk.text_classification.models import TextClassificationBulkData
 from argilla.client.sdk.token_classification.models import TokenClassificationBulkData
@@ -108,8 +103,7 @@ def build_data_response(response: httpx.Response, data_type: Type[T]) -> Respons
 
 
 def build_list_response(
-    response: httpx.Response,
-    item_class: Type[T],
+    response: httpx.Response, item_class: Type[T]
 ) -> Response[Union[List[T], HTTPValidationError, ErrorMessage]]:
     parsed_response = response.json()
 

--- a/src/argilla/client/sdk/datasets/api.py
+++ b/src/argilla/client/sdk/datasets/api.py
@@ -20,22 +20,12 @@ import httpx
 
 from argilla.client.sdk.client import AuthenticatedClient
 from argilla.client.sdk.commons.errors_handler import handle_response_error
-from argilla.client.sdk.commons.models import (
-    ErrorMessage,
-    HTTPValidationError,
-    Response,
-)
-from argilla.client.sdk.datasets.models import (
-    CopyDatasetRequest,
-    Dataset,
-)
+from argilla.client.sdk.commons.models import ErrorMessage, HTTPValidationError, Response
+from argilla.client.sdk.datasets.models import CopyDatasetRequest, Dataset
 
 
 @lru_cache(maxsize=None)
-def get_dataset(
-    client: AuthenticatedClient,
-    name: str,
-) -> Response[Dataset]:
+def get_dataset(client: AuthenticatedClient, name: str) -> Response[Dataset]:
     url = "{}/api/datasets/{name}".format(client.base_url, name=name)
 
     response = httpx.get(
@@ -48,11 +38,7 @@ def get_dataset(
     return _build_response(response=response, name=name)
 
 
-def copy_dataset(
-    client: AuthenticatedClient,
-    name: str,
-    json_body: CopyDatasetRequest,
-) -> Response[Dataset]:
+def copy_dataset(client: AuthenticatedClient, name: str, json_body: CopyDatasetRequest) -> Response[Dataset]:
     url = "{}/api/datasets/{name}:copy".format(client.base_url, name=name)
 
     response = httpx.put(
@@ -66,10 +52,7 @@ def copy_dataset(
     return _build_response(response=response, name=name)
 
 
-def delete_dataset(
-    client: AuthenticatedClient,
-    name: str,
-) -> httpx.Response:
+def delete_dataset(client: AuthenticatedClient, name: str) -> httpx.Response:
     url = "{}/api/datasets/{name}".format(client.base_url, name=name)
 
     response = httpx.delete(

--- a/src/argilla/client/sdk/metrics/api.py
+++ b/src/argilla/client/sdk/metrics/api.py
@@ -19,11 +19,7 @@ import httpx
 from argilla.client.sdk._helpers import build_raw_response
 from argilla.client.sdk.client import AuthenticatedClient
 from argilla.client.sdk.commons.api import build_list_response
-from argilla.client.sdk.commons.models import (
-    ErrorMessage,
-    HTTPValidationError,
-    Response,
-)
+from argilla.client.sdk.commons.models import ErrorMessage, HTTPValidationError, Response
 from argilla.client.sdk.metrics.models import MetricInfo
 
 
@@ -43,12 +39,7 @@ def get_dataset_metrics(
 
 
 def compute_metric(
-    client: AuthenticatedClient,
-    name: str,
-    task: str,
-    metric: str,
-    query: Optional[str] = None,
-    **query_params,
+    client: AuthenticatedClient, name: str, task: str, metric: str, query: Optional[str] = None, **query_params
 ) -> Response[Union[Dict[str, Any], ErrorMessage, HTTPValidationError]]:
     url = "{}/api/datasets/{task}/{name}/metrics/{metric}:summary".format(
         client.base_url, task=task, name=name, metric=metric

--- a/src/argilla/client/sdk/text_classification/api.py
+++ b/src/argilla/client/sdk/text_classification/api.py
@@ -18,16 +18,8 @@ import httpx
 
 from argilla.client.sdk._helpers import build_typed_response
 from argilla.client.sdk.client import AuthenticatedClient
-from argilla.client.sdk.commons.api import (
-    build_data_response,
-    build_list_response,
-    build_param_dict,
-)
-from argilla.client.sdk.commons.models import (
-    ErrorMessage,
-    HTTPValidationError,
-    Response,
-)
+from argilla.client.sdk.commons.api import build_data_response, build_list_response, build_param_dict
+from argilla.client.sdk.commons.models import ErrorMessage, HTTPValidationError, Response
 from argilla.client.sdk.text_classification.models import (
     LabelingRule,
     LabelingRuleMetricsSummary,
@@ -37,9 +29,7 @@ from argilla.client.sdk.text_classification.models import (
 
 
 def add_dataset_labeling_rule(
-    client: AuthenticatedClient,
-    name: str,
-    rule: LabelingRule,
+    client: AuthenticatedClient, name: str, rule: LabelingRule
 ) -> Response[Union[LabelingRule, HTTPValidationError, ErrorMessage]]:
     url = "{}/api/datasets/{name}/TextClassification/labeling/rules".format(client.base_url, name=name)
 
@@ -55,9 +45,7 @@ def add_dataset_labeling_rule(
 
 
 def update_dataset_labeling_rule(
-    client: AuthenticatedClient,
-    name: str,
-    rule: LabelingRule,
+    client: AuthenticatedClient, name: str, rule: LabelingRule
 ) -> Response[Union[HTTPValidationError, ErrorMessage]]:
     url = "{}/api/datasets/TextClassification/{name}/labeling/rules/{query}".format(
         client.base_url, name=name, query=rule.query
@@ -75,9 +63,7 @@ def update_dataset_labeling_rule(
 
 
 def delete_dataset_labeling_rule(
-    client: AuthenticatedClient,
-    name: str,
-    rule: LabelingRule,
+    client: AuthenticatedClient, name: str, rule: LabelingRule
 ) -> Response[Union[LabelingRule, HTTPValidationError, ErrorMessage]]:
     url = "{}/api/datasets/TextClassification/{name}/labeling/rules/{query}".format(
         client.base_url, name=name, query=rule.query
@@ -92,8 +78,7 @@ def delete_dataset_labeling_rule(
 
 
 def fetch_dataset_labeling_rules(
-    client: AuthenticatedClient,
-    name: str,
+    client: AuthenticatedClient, name: str
 ) -> Response[Union[List[LabelingRule], HTTPValidationError, ErrorMessage]]:
     url = "{}/api/datasets/TextClassification/{name}/labeling/rules".format(client.base_url, name=name)
 
@@ -108,10 +93,7 @@ def fetch_dataset_labeling_rules(
 
 
 def dataset_rule_metrics(
-    client: AuthenticatedClient,
-    name: str,
-    query: str,
-    label: str,
+    client: AuthenticatedClient, name: str, query: str, label: str
 ) -> Response[Union[LabelingRuleMetricsSummary, HTTPValidationError, ErrorMessage]]:
     url = "{}/api/datasets/TextClassification/{name}/labeling/rules/{query}/metrics?label={label}".format(
         client.base_url, name=name, query=query, label=label

--- a/src/argilla/client/sdk/text_classification/models.py
+++ b/src/argilla/client/sdk/text_classification/models.py
@@ -17,9 +17,7 @@ from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
 
-from argilla.client.models import (
-    TextClassificationRecord as ClientTextClassificationRecord,
-)
+from argilla.client.models import TextClassificationRecord as ClientTextClassificationRecord
 from argilla.client.models import TokenAttributions as ClientTokenAttributions
 from argilla.client.sdk.commons.models import (
     MACHINE_NAME,

--- a/src/argilla/client/sdk/token_classification/models.py
+++ b/src/argilla/client/sdk/token_classification/models.py
@@ -18,9 +18,7 @@ from typing import Dict, List, Optional, Union
 from pydantic import BaseModel, Field, validator
 
 from argilla._constants import DEFAULT_MAX_KEYWORD_LENGTH
-from argilla.client.models import (
-    TokenClassificationRecord as ClientTokenClassificationRecord,
-)
+from argilla.client.models import TokenClassificationRecord as ClientTokenClassificationRecord
 from argilla.client.sdk.commons.models import (
     MACHINE_NAME,
     BaseAnnotation,

--- a/src/argilla/client/sdk/users/api.py
+++ b/src/argilla/client/sdk/users/api.py
@@ -19,11 +19,7 @@ import httpx
 
 from argilla.client.sdk.client import AuthenticatedClient
 from argilla.client.sdk.commons.errors_handler import handle_response_error
-from argilla.client.sdk.commons.models import (
-    ErrorMessage,
-    HTTPValidationError,
-    Response,
-)
+from argilla.client.sdk.commons.models import ErrorMessage, HTTPValidationError, Response
 from argilla.client.sdk.users.models import UserCreateModel, UserModel, UserRole
 
 
@@ -71,9 +67,7 @@ def whoami_httpx(client: httpx.Client) -> Response[Union[UserModel, ErrorMessage
     return handle_response_error(response)
 
 
-def list_users(
-    client: httpx.Client,
-) -> Response[Union[List[UserModel], ErrorMessage, HTTPValidationError]]:
+def list_users(client: httpx.Client) -> Response[Union[List[UserModel], ErrorMessage, HTTPValidationError]]:
     """Sends a GET request to `/api/users` endpoint to get the list of users.
 
     Args:
@@ -148,10 +142,7 @@ def create_user(
     return handle_response_error(response)
 
 
-def delete_user(
-    client: httpx.Client,
-    user_id: UUID,
-) -> Response[Union[UserModel, ErrorMessage, HTTPValidationError]]:
+def delete_user(client: httpx.Client, user_id: UUID) -> Response[Union[UserModel, ErrorMessage, HTTPValidationError]]:
     """Sends a DELETE request to `/api/users/{user_id}` endpoint to delete a user.
 
     Args:

--- a/src/argilla/client/sdk/v1/datasets/api.py
+++ b/src/argilla/client/sdk/v1/datasets/api.py
@@ -19,11 +19,7 @@ from uuid import UUID
 import httpx
 
 from argilla.client.sdk.commons.errors_handler import handle_response_error
-from argilla.client.sdk.commons.models import (
-    ErrorMessage,
-    HTTPValidationError,
-    Response,
-)
+from argilla.client.sdk.commons.models import ErrorMessage, HTTPValidationError, Response
 from argilla.client.sdk.v1.datasets.models import (
     FeedbackDatasetModel,
     FeedbackFieldModel,
@@ -34,10 +30,7 @@ from argilla.client.sdk.v1.datasets.models import (
 
 
 def create_dataset(
-    client: httpx.Client,
-    name: str,
-    workspace_id: UUID,
-    guidelines: Optional[str] = None,
+    client: httpx.Client, name: str, workspace_id: UUID, guidelines: Optional[str] = None
 ) -> Response[Union[FeedbackDatasetModel, ErrorMessage, HTTPValidationError]]:
     """Sends a POST request to `/api/v1/datasets` endpoint to create a new `FeedbackDataset`.
 
@@ -71,8 +64,7 @@ def create_dataset(
 
 
 def get_dataset(
-    client: httpx.Client,
-    id: UUID,
+    client: httpx.Client, id: UUID
 ) -> Response[Union[FeedbackDatasetModel, ErrorMessage, HTTPValidationError]]:
     """Sends a GET request to `/api/v1/datasets/{id}` endpoint to retrieve a `FeedbackDataset`.
 
@@ -99,10 +91,7 @@ def get_dataset(
     return handle_response_error(response)
 
 
-def delete_dataset(
-    client: httpx.Client,
-    id: UUID,
-) -> Response[Union[ErrorMessage, HTTPValidationError]]:
+def delete_dataset(client: httpx.Client, id: UUID) -> Response[Union[ErrorMessage, HTTPValidationError]]:
     """Sends a DELETE request to `/api/v1/datasets/{id}` endpoint to delete a `FeedbackDataset`.
 
     Args:
@@ -126,8 +115,7 @@ def delete_dataset(
 
 
 def publish_dataset(
-    client: httpx.Client,
-    id: UUID,
+    client: httpx.Client, id: UUID
 ) -> Response[Union[FeedbackDatasetModel, ErrorMessage, HTTPValidationError]]:
     """Sends a PUT request to `/api/v1/datasets/{id}/publish` endpoint to publish a `FeedbackDataset`.
     Publishing in Argilla means setting the status of the dataset from `draft` to `ready`, so that
@@ -184,10 +172,7 @@ def list_datasets(
 
 
 def get_records(
-    client: httpx.Client,
-    id: UUID,
-    offset: int = 0,
-    limit: int = 50,
+    client: httpx.Client, id: UUID, offset: int = 0, limit: int = 50
 ) -> Response[Union[FeedbackRecordsModel, ErrorMessage, HTTPValidationError]]:
     """Sends a GET request to `/api/v1/datasets/{id}/records` endpoint to retrieve a list of `FeedbackTask` records.
 
@@ -219,9 +204,7 @@ def get_records(
 
 
 def add_records(
-    client: httpx.Client,
-    id: UUID,
-    records: List[Dict[str, Any]],
+    client: httpx.Client, id: UUID, records: List[Dict[str, Any]]
 ) -> Response[Union[ErrorMessage, HTTPValidationError]]:
     """Sends a POST request to `/api/v1/datasets/{id}/records` endpoint to add a list of `FeedbackTask` records.
 
@@ -274,8 +257,7 @@ def add_records(
 
 
 def get_fields(
-    client: httpx.Client,
-    id: UUID,
+    client: httpx.Client, id: UUID
 ) -> Response[Union[List[FeedbackFieldModel], ErrorMessage, HTTPValidationError]]:
     """Sends a GET request to `/api/v1/datasets/{id}/fields` endpoint to retrieve a list of `FeedbackTask` fields.
 
@@ -303,9 +285,7 @@ def get_fields(
 
 
 def add_field(
-    client: httpx.Client,
-    id: UUID,
-    field: Dict[str, Any],
+    client: httpx.Client, id: UUID, field: Dict[str, Any]
 ) -> Response[Union[FeedbackFieldModel, ErrorMessage, HTTPValidationError]]:
     """Sends a POST request to `/api/v1/datasets/{id}/fields` endpoint to add a `FeedbackTask` field.
 
@@ -334,8 +314,7 @@ def add_field(
 
 
 def get_questions(
-    client: httpx.Client,
-    id: UUID,
+    client: httpx.Client, id: UUID
 ) -> Response[Union[List[FeedbackQuestionModel], ErrorMessage, HTTPValidationError]]:
     """Sends a GET request to `/api/v1/datasets/{id}/questions` endpoint to retrieve a
     list of `FeedbackTask` questions.
@@ -364,9 +343,7 @@ def get_questions(
 
 
 def add_question(
-    client: httpx.Client,
-    id: UUID,
-    question: Dict[str, Any],
+    client: httpx.Client, id: UUID, question: Dict[str, Any]
 ) -> Response[Union[FeedbackQuestionModel, ErrorMessage, HTTPValidationError]]:
     """Sends a POST request to `/api/v1/datasets/{id}/questions` endpoint to add a
     question to the `FeedbackDataset`.

--- a/src/argilla/client/sdk/v1/users/api.py
+++ b/src/argilla/client/sdk/v1/users/api.py
@@ -18,11 +18,7 @@ from uuid import UUID
 import httpx
 
 from argilla.client.sdk.commons.errors_handler import handle_response_error
-from argilla.client.sdk.commons.models import (
-    ErrorMessage,
-    HTTPValidationError,
-    Response,
-)
+from argilla.client.sdk.commons.models import ErrorMessage, HTTPValidationError, Response
 from argilla.client.sdk.v1.workspaces.models import WorkspaceModel
 
 

--- a/src/argilla/client/sdk/v1/workspaces/api.py
+++ b/src/argilla/client/sdk/v1/workspaces/api.py
@@ -18,18 +18,11 @@ from uuid import UUID
 import httpx
 
 from argilla.client.sdk.commons.errors_handler import handle_response_error
-from argilla.client.sdk.commons.models import (
-    ErrorMessage,
-    HTTPValidationError,
-    Response,
-)
+from argilla.client.sdk.commons.models import ErrorMessage, HTTPValidationError, Response
 from argilla.client.sdk.v1.workspaces.models import WorkspaceModel
 
 
-def get_workspace(
-    client: httpx.Client,
-    id: UUID,
-) -> Response[Union[WorkspaceModel, ErrorMessage, HTTPValidationError]]:
+def get_workspace(client: httpx.Client, id: UUID) -> Response[Union[WorkspaceModel, ErrorMessage, HTTPValidationError]]:
     """Sends a GET request to `/api/v1/workspaces/{id}` endpoint to retrieve a workspace.
 
     Args:

--- a/src/argilla/client/sdk/workspaces/api.py
+++ b/src/argilla/client/sdk/workspaces/api.py
@@ -18,11 +18,7 @@ from uuid import UUID
 import httpx
 
 from argilla.client.sdk.commons.errors_handler import handle_response_error
-from argilla.client.sdk.commons.models import (
-    ErrorMessage,
-    HTTPValidationError,
-    Response,
-)
+from argilla.client.sdk.commons.models import ErrorMessage, HTTPValidationError, Response
 from argilla.client.sdk.workspaces.models import WorkspaceModel, WorkspaceUserModel
 
 

--- a/src/argilla/client/users.py
+++ b/src/argilla/client/users.py
@@ -18,11 +18,7 @@ from typing import TYPE_CHECKING, Iterator, List, Optional, Union
 from uuid import UUID
 
 from argilla.client import active_client
-from argilla.client.sdk.commons.errors import (
-    AlreadyExistsApiError,
-    BaseClientError,
-    NotFoundApiError,
-)
+from argilla.client.sdk.commons.errors import AlreadyExistsApiError, BaseClientError, NotFoundApiError
 from argilla.client.sdk.users import api as users_api
 from argilla.client.sdk.users.models import UserCreateModel, UserModel, UserRole
 from argilla.client.sdk.v1.users import api as users_api_v1

--- a/src/argilla/datasets/__init__.py
+++ b/src/argilla/datasets/__init__.py
@@ -15,11 +15,7 @@ import logging
 from typing import Optional
 
 from argilla.client import api
-from argilla.client.apis.datasets import (
-    Settings,
-    TextClassificationSettings,
-    TokenClassificationSettings,
-)
+from argilla.client.apis.datasets import Settings, TextClassificationSettings, TokenClassificationSettings
 
 __all__ = [TextClassificationSettings, TokenClassificationSettings, Settings]
 

--- a/src/argilla/labeling/text_classification/label_errors.py
+++ b/src/argilla/labeling/text_classification/label_errors.py
@@ -155,9 +155,7 @@ def _check_and_update_kwargs(version: str, record: TextClassificationRecord, sor
             kwargs["return_indices_ranked_by"] = "self_confidence"
 
 
-def _construct_s_and_psx(
-    records: List[TextClassificationRecord],
-) -> Tuple[np.ndarray, np.ndarray]:
+def _construct_s_and_psx(records: List[TextClassificationRecord]) -> Tuple[np.ndarray, np.ndarray]:
     """Helper function to construct the s array and psx matrix.
 
     Args:

--- a/src/argilla/listeners/listener.py
+++ b/src/argilla/listeners/listener.py
@@ -25,13 +25,7 @@ import schedule
 import argilla
 from argilla.client import api
 from argilla.client.sdk.commons.errors import NotFoundApiError
-from argilla.listeners.models import (
-    ListenerAction,
-    ListenerCondition,
-    Metrics,
-    RGListenerContext,
-    Search,
-)
+from argilla.listeners.models import ListenerAction, ListenerCondition, Metrics, RGListenerContext, Search
 
 
 @dataclasses.dataclass

--- a/src/argilla/metrics/commons.py
+++ b/src/argilla/metrics/commons.py
@@ -71,11 +71,7 @@ def records_status(name: str, query: Optional[str] = None) -> MetricSummary:
     )
 
 
-def keywords(
-    name: str,
-    query: Optional[str] = None,
-    size: int = 20,
-) -> MetricSummary:
+def keywords(name: str, query: Optional[str] = None, size: int = 20) -> MetricSummary:
     """Computes the keywords occurrence distribution in dataset
 
     Args:

--- a/src/argilla/metrics/helpers.py
+++ b/src/argilla/metrics/helpers.py
@@ -44,13 +44,7 @@ def bar(data: dict, title: str = "Bar", x_legend: str = "", y_legend: str = ""):
     return fig
 
 
-def stacked_bar(
-    x: list,
-    y_s: Dict[str, list],
-    title: str = "Bar",
-    x_legend: str = "",
-    y_legend: str = "",
-):
+def stacked_bar(x: list, y_s: Dict[str, list], title: str = "Bar", x_legend: str = "", y_legend: str = ""):
     import plotly.graph_objects as go
 
     if not x or not y_s:

--- a/src/argilla/metrics/token_classification/metrics.py
+++ b/src/argilla/metrics/token_classification/metrics.py
@@ -235,10 +235,7 @@ def mention_length(
 
 
 def entity_labels(
-    name: str,
-    query: Optional[str] = None,
-    compute_for: Union[str, ComputeFor] = Predictions,
-    labels: int = 50,
+    name: str, query: Optional[str] = None, compute_for: Union[str, ComputeFor] = Predictions, labels: int = 50
 ) -> MetricSummary:
     """Computes the entity labels distribution
 
@@ -276,10 +273,7 @@ def entity_labels(
 
 
 def entity_density(
-    name: str,
-    query: Optional[str] = None,
-    compute_for: Union[str, ComputeFor] = Predictions,
-    interval: float = 0.005,
+    name: str, query: Optional[str] = None, compute_for: Union[str, ComputeFor] = Predictions, interval: float = 0.005
 ) -> MetricSummary:
     """Computes the entity density distribution. Then entity density is calculated at
     record level for each mention as ``mention_length/tokens_length``
@@ -320,9 +314,7 @@ def entity_density(
 
 
 def entity_capitalness(
-    name: str,
-    query: Optional[str] = None,
-    compute_for: Union[str, ComputeFor] = Predictions,
+    name: str, query: Optional[str] = None, compute_for: Union[str, ComputeFor] = Predictions
 ) -> MetricSummary:
     """Computes the entity capitalness. The entity capitalness splits the entity mention shape in 4 groups:
 

--- a/src/argilla/monitoring/_flair.py
+++ b/src/argilla/monitoring/_flair.py
@@ -79,11 +79,7 @@ class FlairMonitor(BaseMonitor):
 
 
 def flair_monitor(
-    pl: SequenceTagger,
-    api: Api,
-    dataset: str,
-    sample_rate: float,
-    log_interval: float,
+    pl: SequenceTagger, api: Api, dataset: str, sample_rate: float, log_interval: float
 ) -> Optional[SequenceTagger]:
     return FlairMonitor(
         pl,

--- a/src/argilla/monitoring/_spacy.py
+++ b/src/argilla/monitoring/_spacy.py
@@ -99,13 +99,7 @@ class SpacyNERMonitor(BaseMonitor):
             return doc
 
 
-def ner_monitor(
-    nlp: Language,
-    api: Api,
-    dataset: str,
-    sample_rate: float,
-    log_interval: float,
-) -> Language:
+def ner_monitor(nlp: Language, api: Api, dataset: str, sample_rate: float, log_interval: float) -> Language:
     return SpacyNERMonitor(
         nlp,
         api=api,

--- a/src/argilla/monitoring/_transformers.py
+++ b/src/argilla/monitoring/_transformers.py
@@ -173,11 +173,7 @@ class TextClassificationMonitor(HuggingFaceMonitor):
 
 
 def huggingface_monitor(
-    pl: Pipeline,
-    api: Api,
-    dataset: str,
-    sample_rate: float,
-    log_interval: float,
+    pl: Pipeline, api: Api, dataset: str, sample_rate: float, log_interval: float
 ) -> Optional[Pipeline]:
     if isinstance(pl, TextClassificationPipeline):
         return TextClassificationMonitor(

--- a/src/argilla/monitoring/asgi.py
+++ b/src/argilla/monitoring/asgi.py
@@ -18,11 +18,7 @@ import logging
 import re
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from argilla.client.models import (
-    Record,
-    TextClassificationRecord,
-    TokenClassificationRecord,
-)
+from argilla.client.models import Record, TextClassificationRecord, TokenClassificationRecord
 from argilla.monitoring.base import BaseMonitor
 from argilla.utils.dependency import require_version
 

--- a/src/argilla/server/apis/v0/handlers/datasets.py
+++ b/src/argilla/server/apis/v0/handlers/datasets.py
@@ -25,12 +25,7 @@ from argilla.server.apis.v0.models.commons.params import (
 )
 from argilla.server.errors import EntityNotFoundError
 from argilla.server.models import User
-from argilla.server.schemas.datasets import (
-    CopyDatasetRequest,
-    CreateDatasetRequest,
-    Dataset,
-    UpdateDatasetRequest,
-)
+from argilla.server.schemas.datasets import CopyDatasetRequest, CreateDatasetRequest, Dataset, UpdateDatasetRequest
 from argilla.server.security import auth
 from argilla.server.services.datasets import DatasetsService
 
@@ -77,12 +72,7 @@ async def create_dataset(
     return Dataset.from_orm(dataset)
 
 
-@router.get(
-    "/{name}",
-    response_model=Dataset,
-    response_model_exclude_none=True,
-    operation_id="get_dataset",
-)
+@router.get("/{name}", response_model=Dataset, response_model_exclude_none=True, operation_id="get_dataset")
 async def get_dataset(
     name: str,
     ds_params: CommonTaskHandlerDependencies = Depends(),
@@ -92,12 +82,7 @@ async def get_dataset(
     return Dataset.from_orm(await service.find_by_name(user=current_user, name=name, workspace=ds_params.workspace))
 
 
-@router.patch(
-    "/{name}",
-    operation_id="update_dataset",
-    response_model=Dataset,
-    response_model_exclude_none=True,
-)
+@router.patch("/{name}", operation_id="update_dataset", response_model=Dataset, response_model_exclude_none=True)
 async def update_dataset(
     name: str,
     request: UpdateDatasetRequest,
@@ -110,10 +95,7 @@ async def update_dataset(
     return Dataset.from_orm(dataset)
 
 
-@router.delete(
-    "/{name}",
-    operation_id="delete_dataset",
-)
+@router.delete("/{name}", operation_id="delete_dataset")
 async def delete_dataset(
     name: str,
     ds_params: CommonTaskHandlerDependencies = Depends(),
@@ -127,10 +109,7 @@ async def delete_dataset(
         pass
 
 
-@router.put(
-    "/{name}:close",
-    operation_id="close_dataset",
-)
+@router.put("/{name}:close", operation_id="close_dataset")
 async def close_dataset(
     name: str,
     ds_params: CommonTaskHandlerDependencies = Depends(),
@@ -141,10 +120,7 @@ async def close_dataset(
     await service.close(user=current_user, dataset=found_ds)
 
 
-@router.put(
-    "/{name}:open",
-    operation_id="open_dataset",
-)
+@router.put("/{name}:open", operation_id="open_dataset")
 async def open_dataset(
     name: str,
     ds_params: CommonTaskHandlerDependencies = Depends(),
@@ -155,12 +131,7 @@ async def open_dataset(
     await service.open(user=current_user, dataset=found_ds)
 
 
-@router.put(
-    "/{name}:copy",
-    operation_id="copy_dataset",
-    response_model=Dataset,
-    response_model_exclude_none=True,
-)
+@router.put("/{name}:copy", operation_id="copy_dataset", response_model=Dataset, response_model_exclude_none=True)
 async def copy_dataset(
     name: str,
     copy_request: CopyDatasetRequest,

--- a/src/argilla/server/apis/v0/handlers/info.py
+++ b/src/argilla/server/apis/v0/handlers/info.py
@@ -20,14 +20,8 @@ from argilla.server.services.info import ApiInfo, ApiInfoService, ApiStatus
 router = APIRouter(tags=["status"])
 
 
-@router.get(
-    "/_status",
-    operation_id="api_status",
-    response_model=ApiStatus,
-)
-async def api_status(
-    service: ApiInfoService = Depends(ApiInfoService.get_instance),
-) -> ApiStatus:
+@router.get("/_status", operation_id="api_status", response_model=ApiStatus)
+async def api_status(service: ApiInfoService = Depends(ApiInfoService.get_instance)) -> ApiStatus:
     return service.api_status()
 
 

--- a/src/argilla/server/apis/v0/handlers/records.py
+++ b/src/argilla/server/apis/v0/handlers/records.py
@@ -20,10 +20,7 @@ from pydantic import BaseModel
 from argilla.client.sdk.token_classification.models import TokenClassificationQuery
 from argilla.server.apis.v0.models.commons.params import CommonTaskHandlerDependencies
 from argilla.server.apis.v0.models.text2text import Text2TextQuery, Text2TextRecord
-from argilla.server.apis.v0.models.text_classification import (
-    TextClassificationQuery,
-    TextClassificationRecord,
-)
+from argilla.server.apis.v0.models.text_classification import TextClassificationQuery, TextClassificationRecord
 from argilla.server.apis.v0.models.token_classification import TokenClassificationRecord
 from argilla.server.commons.config import TasksFactory
 from argilla.server.models import User

--- a/src/argilla/server/apis/v0/handlers/text2text.py
+++ b/src/argilla/server/apis/v0/handlers/text2text.py
@@ -17,10 +17,7 @@ from fastapi import APIRouter, Depends, Query, Security
 
 from argilla.server.apis.v0.handlers import metrics
 from argilla.server.apis.v0.models.commons.model import BulkResponse
-from argilla.server.apis.v0.models.commons.params import (
-    CommonTaskHandlerDependencies,
-    RequestPagination,
-)
+from argilla.server.apis.v0.models.commons.params import CommonTaskHandlerDependencies, RequestPagination
 from argilla.server.apis.v0.models.text2text import (
     Text2TextBulkRequest,
     Text2TextMetrics,
@@ -38,10 +35,7 @@ from argilla.server.schemas.datasets import CreateDatasetRequest
 from argilla.server.security import auth
 from argilla.server.services.datasets import DatasetsService
 from argilla.server.services.tasks.text2text import Text2TextService
-from argilla.server.services.tasks.text2text.models import (
-    ServiceText2TextQuery,
-    ServiceText2TextRecord,
-)
+from argilla.server.services.tasks.text2text.models import ServiceText2TextQuery, ServiceText2TextRecord
 
 
 def configure_router():

--- a/src/argilla/server/apis/v0/handlers/text_classification.py
+++ b/src/argilla/server/apis/v0/handlers/text_classification.py
@@ -49,9 +49,7 @@ from argilla.server.schemas.datasets import CreateDatasetRequest
 from argilla.server.security import auth
 from argilla.server.services.datasets import DatasetsService
 from argilla.server.services.tasks.text_classification import TextClassificationService
-from argilla.server.services.tasks.text_classification.metrics import (
-    TextClassificationMetrics,
-)
+from argilla.server.services.tasks.text_classification.metrics import TextClassificationMetrics
 from argilla.server.services.tasks.text_classification.model import (
     ServiceLabelingRule,
     ServiceTextClassificationQuery,

--- a/src/argilla/server/apis/v0/handlers/text_classification.py
+++ b/src/argilla/server/apis/v0/handlers/text_classification.py
@@ -17,16 +17,10 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query, Security
 
-from argilla.server.apis.v0.handlers import (
-    metrics,
-    text_classification_dataset_settings,
-)
+from argilla.server.apis.v0.handlers import metrics, text_classification_dataset_settings
 from argilla.server.apis.v0.helpers import deprecate_endpoint
 from argilla.server.apis.v0.models.commons.model import BulkResponse
-from argilla.server.apis.v0.models.commons.params import (
-    CommonTaskHandlerDependencies,
-    RequestPagination,
-)
+from argilla.server.apis.v0.models.commons.params import CommonTaskHandlerDependencies, RequestPagination
 from argilla.server.apis.v0.models.text_classification import (
     CreateLabelingRule,
     DatasetLabelingRulesMetricsSummary,

--- a/src/argilla/server/apis/v0/handlers/text_classification_dataset_settings.py
+++ b/src/argilla/server/apis/v0/handlers/text_classification_dataset_settings.py
@@ -15,10 +15,7 @@
 from fastapi import APIRouter, Body, Depends, Security
 
 from argilla.server.apis.v0.helpers import deprecate_endpoint
-from argilla.server.apis.v0.models.commons.params import (
-    DATASET_NAME_PATH_PARAM,
-    CommonTaskHandlerDependencies,
-)
+from argilla.server.apis.v0.models.commons.params import DATASET_NAME_PATH_PARAM, CommonTaskHandlerDependencies
 from argilla.server.apis.v0.models.dataset_settings import TextClassificationSettings
 from argilla.server.apis.v0.validators.text_classification import DatasetValidator
 from argilla.server.commons.models import TaskType

--- a/src/argilla/server/apis/v0/handlers/token_classification.py
+++ b/src/argilla/server/apis/v0/handlers/token_classification.py
@@ -15,15 +15,9 @@
 
 from fastapi import APIRouter, Depends, Query, Security
 
-from argilla.server.apis.v0.handlers import (
-    metrics,
-    token_classification_dataset_settings,
-)
+from argilla.server.apis.v0.handlers import metrics, token_classification_dataset_settings
 from argilla.server.apis.v0.models.commons.model import BulkResponse
-from argilla.server.apis.v0.models.commons.params import (
-    CommonTaskHandlerDependencies,
-    RequestPagination,
-)
+from argilla.server.apis.v0.models.commons.params import CommonTaskHandlerDependencies, RequestPagination
 from argilla.server.apis.v0.models.token_classification import (
     TokenClassificationAggregations,
     TokenClassificationBulkRequest,

--- a/src/argilla/server/apis/v0/handlers/token_classification.py
+++ b/src/argilla/server/apis/v0/handlers/token_classification.py
@@ -40,12 +40,8 @@ from argilla.server.models import User
 from argilla.server.schemas.datasets import CreateDatasetRequest
 from argilla.server.security import auth
 from argilla.server.services.datasets import DatasetsService
-from argilla.server.services.tasks.token_classification import (
-    TokenClassificationService,
-)
-from argilla.server.services.tasks.token_classification.metrics import (
-    TokenClassificationMetrics,
-)
+from argilla.server.services.tasks.token_classification import TokenClassificationService
+from argilla.server.services.tasks.token_classification.metrics import TokenClassificationMetrics
 from argilla.server.services.tasks.token_classification.model import (
     ServiceTokenClassificationQuery,
     ServiceTokenClassificationRecord,

--- a/src/argilla/server/apis/v0/handlers/token_classification_dataset_settings.py
+++ b/src/argilla/server/apis/v0/handlers/token_classification_dataset_settings.py
@@ -15,10 +15,7 @@
 from fastapi import APIRouter, Body, Depends, Security
 
 from argilla.server.apis.v0.helpers import deprecate_endpoint
-from argilla.server.apis.v0.models.commons.params import (
-    DATASET_NAME_PATH_PARAM,
-    CommonTaskHandlerDependencies,
-)
+from argilla.server.apis.v0.models.commons.params import DATASET_NAME_PATH_PARAM, CommonTaskHandlerDependencies
 from argilla.server.apis.v0.models.dataset_settings import TokenClassificationSettings
 from argilla.server.apis.v0.validators.token_classification import DatasetValidator
 from argilla.server.commons.models import TaskType

--- a/src/argilla/server/apis/v0/handlers/workspaces.py
+++ b/src/argilla/server/apis/v0/handlers/workspaces.py
@@ -24,12 +24,7 @@ from argilla.server.database import get_async_db
 from argilla.server.errors import EntityAlreadyExistsError, EntityNotFoundError
 from argilla.server.policies import WorkspacePolicy, WorkspaceUserPolicy, authorize
 from argilla.server.security import auth
-from argilla.server.security.model import (
-    User,
-    Workspace,
-    WorkspaceCreate,
-    WorkspaceUserCreate,
-)
+from argilla.server.security.model import User, Workspace, WorkspaceCreate, WorkspaceUserCreate
 
 router = APIRouter(tags=["workspaces"])
 

--- a/src/argilla/server/apis/v0/models/commons/model.py
+++ b/src/argilla/server/apis/v0/models/commons/model.py
@@ -27,11 +27,7 @@ from argilla.server.services.search.model import (
     ServiceSearchResultsAggregations,
     ServiceSortableField,
 )
-from argilla.server.services.tasks.commons import (
-    ServiceBaseAnnotation,
-    ServiceBaseRecord,
-    ServiceBaseRecordInputs,
-)
+from argilla.server.services.tasks.commons import ServiceBaseAnnotation, ServiceBaseRecord, ServiceBaseRecordInputs
 
 
 class SortableField(ServiceSortableField):

--- a/src/argilla/server/apis/v0/models/commons/params.py
+++ b/src/argilla/server/apis/v0/models/commons/params.py
@@ -16,10 +16,7 @@ from dataclasses import dataclass
 
 from fastapi import Header, Path, Query
 
-from argilla._constants import (
-    ES_INDEX_REGEX_PATTERN,
-    WORKSPACE_HEADER_NAME,
-)
+from argilla._constants import ES_INDEX_REGEX_PATTERN, WORKSPACE_HEADER_NAME
 from argilla.server.errors import BadRequestError, MissingInputParamError
 
 DATASET_NAME_PATH_PARAM = Path(..., regex=ES_INDEX_REGEX_PATTERN, description="The dataset name")

--- a/src/argilla/server/apis/v0/models/text2text.py
+++ b/src/argilla/server/apis/v0/models/text2text.py
@@ -28,10 +28,7 @@ from argilla.server.apis.v0.models.commons.model import (
 from argilla.server.commons.models import PredictionStatus
 from argilla.server.schemas.datasets import UpdateDatasetRequest
 from argilla.server.services.metrics.models import CommonTasksMetrics
-from argilla.server.services.search.model import (
-    ServiceBaseRecordsQuery,
-    ServiceBaseSearchResultsAggregations,
-)
+from argilla.server.services.search.model import ServiceBaseRecordsQuery, ServiceBaseSearchResultsAggregations
 
 
 class Text2TextPrediction(BaseModel):

--- a/src/argilla/server/apis/v0/models/text_classification.py
+++ b/src/argilla/server/apis/v0/models/text_classification.py
@@ -27,20 +27,14 @@ from argilla.server.apis.v0.models.commons.model import (
 )
 from argilla.server.commons.models import PredictionStatus
 from argilla.server.schemas.datasets import UpdateDatasetRequest
-from argilla.server.services.search.model import (
-    ServiceBaseRecordsQuery,
-    ServiceBaseSearchResultsAggregations,
-)
+from argilla.server.services.search.model import ServiceBaseRecordsQuery, ServiceBaseSearchResultsAggregations
 from argilla.server.services.tasks.text_classification.model import (
     DatasetLabelingRulesMetricsSummary as _DatasetLabelingRulesMetricsSummary,
 )
 from argilla.server.services.tasks.text_classification.model import (
     LabelingRuleMetricsSummary as _LabelingRuleMetricsSummary,
 )
-from argilla.server.services.tasks.text_classification.model import (
-    ServiceTextClassificationDataset,
-    TokenAttributions,
-)
+from argilla.server.services.tasks.text_classification.model import ServiceTextClassificationDataset, TokenAttributions
 from argilla.server.services.tasks.text_classification.model import (
     TextClassificationAnnotation as _TextClassificationAnnotation,
 )

--- a/src/argilla/server/apis/v0/models/token_classification.py
+++ b/src/argilla/server/apis/v0/models/token_classification.py
@@ -16,19 +16,11 @@ from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field, root_validator, validator
 
-from argilla.server.apis.v0.models.commons.model import (
-    BaseRecord,
-    BaseRecordInputs,
-    BaseSearchResults,
-    ScoreRange,
-)
+from argilla.server.apis.v0.models.commons.model import BaseRecord, BaseRecordInputs, BaseSearchResults, ScoreRange
 from argilla.server.commons.models import PredictionStatus
 from argilla.server.daos.backend.search.model import SortableField
 from argilla.server.schemas.datasets import UpdateDatasetRequest
-from argilla.server.services.search.model import (
-    ServiceBaseRecordsQuery,
-    ServiceBaseSearchResultsAggregations,
-)
+from argilla.server.services.search.model import ServiceBaseRecordsQuery, ServiceBaseSearchResultsAggregations
 from argilla.server.services.tasks.token_classification.model import (
     ServiceTokenClassificationAnnotation as _TokenClassificationAnnotation,
 )

--- a/src/argilla/server/apis/v0/validators/text_classification.py
+++ b/src/argilla/server/apis/v0/validators/text_classification.py
@@ -23,9 +23,7 @@ from argilla.server.schemas.datasets import Dataset
 from argilla.server.services.datasets import DatasetsService
 from argilla.server.services.metrics import MetricsService
 from argilla.server.services.tasks.text_classification.metrics import DatasetLabels
-from argilla.server.services.tasks.text_classification.model import (
-    ServiceTextClassificationRecord,
-)
+from argilla.server.services.tasks.text_classification.model import ServiceTextClassificationRecord
 
 
 # TODO(@frascuchon): Move validator and its models to the service layer

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -43,11 +43,7 @@ from argilla.server.schemas.v1.datasets import (
     SearchRecordsQuery,
     SearchRecordsResult,
 )
-from argilla.server.search_engine import (
-    SearchEngine,
-    UserResponseStatusFilter,
-    get_search_engine,
-)
+from argilla.server.search_engine import SearchEngine, UserResponseStatusFilter, get_search_engine
 from argilla.server.security import auth
 from argilla.utils.telemetry import TelemetryClient, get_telemetry_client
 
@@ -71,9 +67,7 @@ async def _get_dataset(
 
 @router.get("/me/datasets", response_model=Datasets)
 async def list_current_user_datasets(
-    *,
-    db: AsyncSession = Depends(get_async_db),
-    current_user: User = Security(auth.get_current_user),
+    *, db: AsyncSession = Depends(get_async_db), current_user: User = Security(auth.get_current_user)
 ):
     await authorize(current_user, DatasetPolicyV1.list)
 
@@ -87,10 +81,7 @@ async def list_current_user_datasets(
 
 @router.get("/datasets/{dataset_id}/fields", response_model=Fields)
 async def list_dataset_fields(
-    *,
-    db: AsyncSession = Depends(get_async_db),
-    dataset_id: UUID,
-    current_user: User = Security(auth.get_current_user),
+    *, db: AsyncSession = Depends(get_async_db), dataset_id: UUID, current_user: User = Security(auth.get_current_user)
 ):
     dataset = await _get_dataset(db, dataset_id, with_fields=True)
 
@@ -101,10 +92,7 @@ async def list_dataset_fields(
 
 @router.get("/datasets/{dataset_id}/questions", response_model=Questions)
 async def list_dataset_questions(
-    *,
-    db: AsyncSession = Depends(get_async_db),
-    dataset_id: UUID,
-    current_user: User = Security(auth.get_current_user),
+    *, db: AsyncSession = Depends(get_async_db), dataset_id: UUID, current_user: User = Security(auth.get_current_user)
 ):
     dataset = await _get_dataset(db, dataset_id, with_questions=True)
 
@@ -156,10 +144,7 @@ async def list_dataset_records(
 
 @router.get("/datasets/{dataset_id}", response_model=Dataset)
 async def get_dataset(
-    *,
-    db: AsyncSession = Depends(get_async_db),
-    dataset_id: UUID,
-    current_user: User = Security(auth.get_current_user),
+    *, db: AsyncSession = Depends(get_async_db), dataset_id: UUID, current_user: User = Security(auth.get_current_user)
 ):
     dataset = await _get_dataset(db, dataset_id)
 
@@ -170,10 +155,7 @@ async def get_dataset(
 
 @router.get("/me/datasets/{dataset_id}/metrics", response_model=Metrics)
 async def get_current_user_dataset_metrics(
-    *,
-    db: AsyncSession = Depends(get_async_db),
-    dataset_id: UUID,
-    current_user: User = Security(auth.get_current_user),
+    *, db: AsyncSession = Depends(get_async_db), dataset_id: UUID, current_user: User = Security(auth.get_current_user)
 ):
     dataset = await _get_dataset(db, dataset_id)
 

--- a/src/argilla/server/apis/v1/handlers/fields.py
+++ b/src/argilla/server/apis/v1/handlers/fields.py
@@ -29,10 +29,7 @@ router = APIRouter(tags=["fields"])
 
 @router.delete("/fields/{field_id}", response_model=Field)
 async def delete_field(
-    *,
-    db: AsyncSession = Depends(get_async_db),
-    field_id: UUID,
-    current_user: User = Security(auth.get_current_user),
+    *, db: AsyncSession = Depends(get_async_db), field_id: UUID, current_user: User = Security(auth.get_current_user)
 ):
     field = await datasets.get_field_by_id(db, field_id)
 

--- a/src/argilla/server/apis/v1/handlers/questions.py
+++ b/src/argilla/server/apis/v1/handlers/questions.py
@@ -29,10 +29,7 @@ router = APIRouter(tags=["questions"])
 
 @router.delete("/questions/{question_id}", response_model=Question)
 async def delete_question(
-    *,
-    db: AsyncSession = Depends(get_async_db),
-    question_id: UUID,
-    current_user: User = Security(auth.get_current_user),
+    *, db: AsyncSession = Depends(get_async_db), question_id: UUID, current_user: User = Security(auth.get_current_user)
 ):
     question = await datasets.get_question_by_id(db, question_id)
 

--- a/src/argilla/server/apis/v1/handlers/records.py
+++ b/src/argilla/server/apis/v1/handlers/records.py
@@ -23,11 +23,7 @@ from argilla.server.database import get_async_db
 from argilla.server.models import User
 from argilla.server.policies import RecordPolicyV1, authorize
 from argilla.server.schemas.v1.records import Response, ResponseCreate
-from argilla.server.schemas.v1.suggestions import (
-    Suggestion,
-    SuggestionCreate,
-    Suggestions,
-)
+from argilla.server.schemas.v1.suggestions import Suggestion, SuggestionCreate, Suggestions
 from argilla.server.search_engine import SearchEngine, get_search_engine
 from argilla.server.security import auth
 
@@ -78,10 +74,7 @@ async def create_record_response(
 
 @router.get("/records/{record_id}/suggestions", status_code=status.HTTP_200_OK, response_model=Suggestions)
 async def get_record_suggestions(
-    *,
-    db: AsyncSession = Depends(get_async_db),
-    record_id: UUID,
-    current_user: User = Security(auth.get_current_user),
+    *, db: AsyncSession = Depends(get_async_db), record_id: UUID, current_user: User = Security(auth.get_current_user)
 ):
     record = await _get_record(db, record_id, with_dataset=True, with_suggestions=True)
 

--- a/src/argilla/server/apis/v1/handlers/users.py
+++ b/src/argilla/server/apis/v1/handlers/users.py
@@ -29,10 +29,7 @@ router = APIRouter(tags=["users"])
 
 @router.get("/users/{user_id}/workspaces", response_model=Workspaces)
 async def list_user_workspaces(
-    *,
-    db: AsyncSession = Depends(get_async_db),
-    user_id: UUID,
-    current_user: User = Security(auth.get_current_user),
+    *, db: AsyncSession = Depends(get_async_db), user_id: UUID, current_user: User = Security(auth.get_current_user)
 ):
     await authorize(current_user, UserPolicyV1.list_workspaces)
 

--- a/src/argilla/server/apis/v1/handlers/workspaces.py
+++ b/src/argilla/server/apis/v1/handlers/workspaces.py
@@ -81,9 +81,7 @@ async def delete_workspace(
 
 @router.get("/me/workspaces", response_model=Workspaces)
 async def list_workspaces_me(
-    *,
-    db: AsyncSession = Depends(get_async_db),
-    current_user: User = Security(auth.get_current_user),
+    *, db: AsyncSession = Depends(get_async_db), current_user: User = Security(auth.get_current_user)
 ) -> Workspaces:
     await authorize(current_user, WorkspacePolicyV1.list_workspaces_me)
 

--- a/src/argilla/server/contexts/accounts.py
+++ b/src/argilla/server/contexts/accounts.py
@@ -20,11 +20,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
 from argilla.server.models import User, Workspace, WorkspaceUser
-from argilla.server.security.model import (
-    UserCreate,
-    WorkspaceCreate,
-    WorkspaceUserCreate,
-)
+from argilla.server.security.model import UserCreate, WorkspaceCreate, WorkspaceUserCreate
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -33,13 +33,7 @@ from argilla.server.models import (
     Suggestion,
 )
 from argilla.server.models.suggestions import SuggestionCreateWithRecordId
-from argilla.server.schemas.v1.datasets import (
-    DatasetCreate,
-    FieldCreate,
-    QuestionCreate,
-    RecordInclude,
-    RecordsCreate,
-)
+from argilla.server.schemas.v1.datasets import DatasetCreate, FieldCreate, QuestionCreate, RecordInclude, RecordsCreate
 from argilla.server.schemas.v1.records import ResponseCreate
 from argilla.server.schemas.v1.responses import ResponseUpdate
 from argilla.server.search_engine import SearchEngine
@@ -288,10 +282,7 @@ async def count_records_by_dataset_id(db: "AsyncSession", dataset_id: UUID) -> i
 
 
 async def create_records(
-    db: "AsyncSession",
-    search_engine: SearchEngine,
-    dataset: Dataset,
-    records_create: RecordsCreate,
+    db: "AsyncSession", search_engine: SearchEngine, dataset: Dataset, records_create: RecordsCreate
 ):
     if not dataset.is_ready:
         raise ValueError("Records cannot be created for a non published dataset")

--- a/src/argilla/server/daos/backend/client_adapters/elasticsearch.py
+++ b/src/argilla/server/daos/backend/client_adapters/elasticsearch.py
@@ -23,14 +23,7 @@ from argilla.server.daos.backend.search.query_builder import EsQueryBuilder
 
 ES_CLIENT_VERSION: str = elasticsearch8.__versionstr__
 
-from elasticsearch8 import (
-    ApiError,
-    Elasticsearch,
-    ElasticsearchWarning,
-    NotFoundError,
-    RequestError,
-    helpers,
-)
+from elasticsearch8 import ApiError, Elasticsearch, ElasticsearchWarning, NotFoundError, RequestError, helpers
 from elasticsearch8.helpers import BulkIndexError
 
 

--- a/src/argilla/server/daos/backend/client_adapters/factory.py
+++ b/src/argilla/server/daos/backend/client_adapters/factory.py
@@ -19,11 +19,7 @@ from opensearchpy import OpenSearch
 from packaging.version import parse
 
 from argilla.server.daos.backend.base import GenericSearchError
-from argilla.server.daos.backend.client_adapters import (
-    ElasticsearchClient,
-    IClientAdapter,
-    OpenSearchClient,
-)
+from argilla.server.daos.backend.client_adapters import ElasticsearchClient, IClientAdapter, OpenSearchClient
 
 _LOGGER = logging.getLogger("argilla")
 

--- a/src/argilla/server/daos/backend/client_adapters/opensearch.py
+++ b/src/argilla/server/daos/backend/client_adapters/opensearch.py
@@ -16,27 +16,15 @@ import dataclasses
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 from opensearchpy import OpenSearch, helpers
-from opensearchpy.exceptions import (
-    NotFoundError,
-    OpenSearchException,
-    OpenSearchWarning,
-    RequestError,
-)
+from opensearchpy.exceptions import NotFoundError, OpenSearchException, OpenSearchWarning, RequestError
 from opensearchpy.helpers import BulkIndexError
 
 from argilla.server.daos.backend import query_helpers
 from argilla.server.daos.backend.base import BackendErrorHandler, IndexNotFoundError
 from argilla.server.daos.backend.client_adapters.base import IClientAdapter
 from argilla.server.daos.backend.metrics.base import ElasticsearchMetric
-from argilla.server.daos.backend.search.model import (
-    BaseQuery,
-    SortableField,
-    SortConfig,
-)
-from argilla.server.daos.backend.search.query_builder import (
-    HighlightParser,
-    OpenSearchQueryBuilder,
-)
+from argilla.server.daos.backend.search.model import BaseQuery, SortableField, SortConfig
+from argilla.server.daos.backend.search.query_builder import HighlightParser, OpenSearchQueryBuilder
 
 
 @dataclasses.dataclass

--- a/src/argilla/server/daos/backend/generic_elastic.py
+++ b/src/argilla/server/daos/backend/generic_elastic.py
@@ -22,15 +22,8 @@ from argilla.server.commons.models import TaskType
 from argilla.server.daos.backend.base import IndexNotFoundError, InvalidSearchError
 from argilla.server.daos.backend.client_adapters.base import IClientAdapter
 from argilla.server.daos.backend.client_adapters.factory import ClientAdapterFactory
-from argilla.server.daos.backend.mappings.datasets import (
-    DATASETS_INDEX_NAME,
-    datasets_index_mappings,
-)
-from argilla.server.daos.backend.mappings.helpers import (
-    mappings,
-    tasks_common_mappings,
-    tasks_common_settings,
-)
+from argilla.server.daos.backend.mappings.datasets import DATASETS_INDEX_NAME, datasets_index_mappings
+from argilla.server.daos.backend.mappings.helpers import mappings, tasks_common_mappings, tasks_common_settings
 from argilla.server.daos.backend.mappings.text2text import text2text_mappings
 from argilla.server.daos.backend.mappings.text_classification import text_classification_mappings
 from argilla.server.daos.backend.mappings.token_classification import token_classification_mappings

--- a/src/argilla/server/daos/backend/generic_elastic.py
+++ b/src/argilla/server/daos/backend/generic_elastic.py
@@ -32,12 +32,8 @@ from argilla.server.daos.backend.mappings.helpers import (
     tasks_common_settings,
 )
 from argilla.server.daos.backend.mappings.text2text import text2text_mappings
-from argilla.server.daos.backend.mappings.text_classification import (
-    text_classification_mappings,
-)
-from argilla.server.daos.backend.mappings.token_classification import (
-    token_classification_mappings,
-)
+from argilla.server.daos.backend.mappings.text_classification import text_classification_mappings
+from argilla.server.daos.backend.mappings.token_classification import token_classification_mappings
 from argilla.server.daos.backend.metrics import ALL_METRICS
 from argilla.server.daos.backend.metrics.base import ElasticsearchMetric
 from argilla.server.daos.backend.search.model import (

--- a/src/argilla/server/daos/backend/mappings/helpers.py
+++ b/src/argilla/server/daos/backend/mappings/helpers.py
@@ -108,10 +108,7 @@ class mappings:
         return {"dynamic": True, "type": "object"}
 
 
-def configure_multilingual_stop_analyzer(
-    settings: Dict[str, Any],
-    supported_langs: List[str] = None,
-):
+def configure_multilingual_stop_analyzer(settings: Dict[str, Any], supported_langs: List[str] = None):
     lang2elastic_stop = {
         "en": english.STOPWORDS,
         "es": "_spanish_",

--- a/src/argilla/server/daos/backend/metrics/text_classification.py
+++ b/src/argilla/server/daos/backend/metrics/text_classification.py
@@ -15,10 +15,7 @@
 import dataclasses
 from typing import Any, Dict, List, Optional
 
-from argilla.server.daos.backend.metrics.base import (
-    ElasticsearchMetric,
-    TermsAggregation,
-)
+from argilla.server.daos.backend.metrics.base import ElasticsearchMetric, TermsAggregation
 from argilla.server.daos.backend.query_helpers import aggregations, filters
 from argilla.server.helpers import unflatten_dict
 

--- a/src/argilla/server/daos/records.py
+++ b/src/argilla/server/daos/records.py
@@ -23,11 +23,7 @@ from argilla.server.daos.backend.base import ClosedIndexError, IndexNotFoundErro
 from argilla.server.daos.backend.generic_elastic import PaginatedSortInfo
 from argilla.server.daos.backend.search.model import BaseRecordsQuery, SortableField
 from argilla.server.daos.models.datasets import DatasetDB
-from argilla.server.daos.models.records import (
-    DaoRecordsSearch,
-    DaoRecordsSearchResults,
-    RecordDB,
-)
+from argilla.server.daos.models.records import DaoRecordsSearch, DaoRecordsSearchResults, RecordDB
 from argilla.server.errors import ClosedDatasetError, MissingDatasetRecordsError
 
 

--- a/src/argilla/server/errors/adapter.py
+++ b/src/argilla/server/errors/adapter.py
@@ -16,12 +16,7 @@ import logging
 
 import pydantic
 
-from argilla.server.errors.base_errors import (
-    BadRequestError,
-    GenericServerError,
-    ServerError,
-    ValidationError,
-)
+from argilla.server.errors.base_errors import BadRequestError, GenericServerError, ServerError, ValidationError
 
 _LOGGER = logging.getLogger("argilla")
 

--- a/src/argilla/server/helpers.py
+++ b/src/argilla/server/helpers.py
@@ -135,12 +135,7 @@ def remove_suffix(text: str, suffix: str):
     return text
 
 
-def replace_string_in_file(
-    filename: str,
-    string: str,
-    replace_by: str,
-    encoding: str = "utf-8",
-):
+def replace_string_in_file(filename: str, string: str, replace_by: str, encoding: str = "utf-8"):
     """Read a file and replace an old value in file by a new one"""
     # Safely read the input filename using 'with'
     with open(filename, encoding=encoding) as f:

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -20,17 +20,7 @@ from sqlalchemy.ext.asyncio import async_object_session
 from argilla.server.contexts import accounts
 from argilla.server.daos.models.datasets import DatasetDB
 from argilla.server.errors import ForbiddenOperationError
-from argilla.server.models import (
-    Dataset,
-    Field,
-    Question,
-    Record,
-    Response,
-    User,
-    UserRole,
-    Workspace,
-    WorkspaceUser,
-)
+from argilla.server.models import Dataset, Field, Question, Record, Response, User, UserRole, Workspace, WorkspaceUser
 
 PolicyAction = Callable[[User], Awaitable[bool]]
 

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -29,13 +29,7 @@ try:
 except ImportError:
     from typing_extensions import Annotated
 
-from argilla.server.models import (
-    DatasetStatus,
-    FieldType,
-    QuestionSettings,
-    QuestionType,
-    ResponseStatus,
-)
+from argilla.server.models import DatasetStatus, FieldType, QuestionSettings, QuestionType, ResponseStatus
 
 DATASET_CREATE_GUIDELINES_MIN_LENGTH = 1
 DATASET_CREATE_GUIDELINES_MAX_LENGTH = 10000

--- a/src/argilla/server/security/auth_provider/local/provider.py
+++ b/src/argilla/server/security/auth_provider/local/provider.py
@@ -17,11 +17,7 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 from fastapi import APIRouter, Depends
-from fastapi.security import (
-    OAuth2PasswordBearer,
-    OAuth2PasswordRequestForm,
-    SecurityScopes,
-)
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm, SecurityScopes
 from jose import JWTError, jwt
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -29,19 +25,13 @@ from argilla.server.contexts import accounts
 from argilla.server.database import get_async_db
 from argilla.server.errors import UnauthorizedError
 from argilla.server.models import User
-from argilla.server.security.auth_provider.base import (
-    AuthProvider,
-    api_key_header,
-)
+from argilla.server.security.auth_provider.base import AuthProvider, api_key_header
 from argilla.server.security.model import Token
 
 from .settings import Settings
 from .settings import settings as local_security
 
-_oauth2_scheme = OAuth2PasswordBearer(
-    tokenUrl=local_security.public_oauth_token_url,
-    auto_error=False,
-)
+_oauth2_scheme = OAuth2PasswordBearer(tokenUrl=local_security.public_oauth_token_url, auto_error=False)
 
 
 class LocalAuthProvider(AuthProvider):

--- a/src/argilla/server/services/datasets.py
+++ b/src/argilla/server/services/datasets.py
@@ -23,18 +23,9 @@ from argilla.server.contexts import accounts
 from argilla.server.daos.datasets import BaseDatasetSettingsDB, DatasetsDAO
 from argilla.server.daos.models.datasets import BaseDatasetDB
 from argilla.server.database import get_async_db
-from argilla.server.errors import (
-    EntityAlreadyExistsError,
-    EntityNotFoundError,
-    ForbiddenOperationError,
-    WrongTaskError,
-)
+from argilla.server.errors import EntityAlreadyExistsError, EntityNotFoundError, ForbiddenOperationError, WrongTaskError
 from argilla.server.models import User, Workspace
-from argilla.server.policies import (
-    DatasetPolicy,
-    DatasetSettingsPolicy,
-    is_authorized,
-)
+from argilla.server.policies import DatasetPolicy, DatasetSettingsPolicy, is_authorized
 from argilla.server.schemas.datasets import CreateDatasetRequest, Dataset
 
 

--- a/src/argilla/server/services/metrics/models.py
+++ b/src/argilla/server/services/metrics/models.py
@@ -12,17 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import (
-    Any,
-    ClassVar,
-    Dict,
-    Generic,
-    Iterable,
-    List,
-    Optional,
-    TypeVar,
-    Union,
-)
+from typing import Any, ClassVar, Dict, Generic, Iterable, List, Optional, TypeVar, Union
 
 from pydantic import BaseModel, Field
 

--- a/src/argilla/server/services/metrics/service.py
+++ b/src/argilla/server/services/metrics/service.py
@@ -21,10 +21,7 @@ from argilla.server.daos.models.records import DaoRecordsSearch
 from argilla.server.daos.records import DatasetRecordsDAO
 from argilla.server.services.datasets import ServiceDataset
 from argilla.server.services.metrics.models import ServiceMetric, ServicePythonMetric
-from argilla.server.services.search.model import (
-    ServiceBaseRecordsQuery,
-    ServiceRecordsQuery,
-)
+from argilla.server.services.search.model import ServiceBaseRecordsQuery, ServiceRecordsQuery
 from argilla.server.services.tasks.commons import ServiceRecord
 
 

--- a/src/argilla/server/services/search/model.py
+++ b/src/argilla/server/services/search/model.py
@@ -16,12 +16,7 @@ from typing import Any, Dict, List, TypeVar
 
 from pydantic import BaseModel, Field
 
-from argilla.server.daos.backend.search.model import (
-    BaseRecordsQuery,
-    QueryRange,
-    SortableField,
-    SortConfig,
-)
+from argilla.server.daos.backend.search.model import BaseRecordsQuery, QueryRange, SortableField, SortConfig
 from argilla.server.services.tasks.commons import ServiceRecord
 
 

--- a/src/argilla/server/services/tasks/commons/models.py
+++ b/src/argilla/server/services/tasks/commons/models.py
@@ -16,11 +16,7 @@ from typing import Generic, TypeVar
 
 from pydantic import BaseModel
 
-from argilla.server.daos.models.records import (
-    BaseAnnotationDB,
-    BaseRecordDB,
-    BaseRecordInDB,
-)
+from argilla.server.daos.models.records import BaseAnnotationDB, BaseRecordDB, BaseRecordInDB
 
 
 class ServiceBaseAnnotation(BaseAnnotationDB):

--- a/src/argilla/server/services/tasks/text2text/models.py
+++ b/src/argilla/server/services/tasks/text2text/models.py
@@ -18,14 +18,8 @@ from pydantic import BaseModel, Field
 
 from argilla.server.commons.models import PredictionStatus, TaskType
 from argilla.server.services.datasets import ServiceBaseDataset
-from argilla.server.services.search.model import (
-    ServiceBaseRecordsQuery,
-    ServiceScoreRange,
-)
-from argilla.server.services.tasks.commons import (
-    ServiceBaseAnnotation,
-    ServiceBaseRecord,
-)
+from argilla.server.services.search.model import ServiceBaseRecordsQuery, ServiceScoreRange
+from argilla.server.services.tasks.commons import ServiceBaseAnnotation, ServiceBaseRecord
 
 
 class ServiceText2TextPrediction(BaseModel):

--- a/src/argilla/server/services/tasks/text2text/service.py
+++ b/src/argilla/server/services/tasks/text2text/service.py
@@ -19,18 +19,11 @@ from fastapi import Depends
 
 from argilla.server.commons.config import TasksFactory
 from argilla.server.services.datasets import ServiceDataset
-from argilla.server.services.search.model import (
-    ServiceSearchResults,
-    ServiceSortableField,
-    ServiceSortConfig,
-)
+from argilla.server.services.search.model import ServiceSearchResults, ServiceSortableField, ServiceSortConfig
 from argilla.server.services.search.service import SearchRecordsService
 from argilla.server.services.storage.service import RecordsStorageService
 from argilla.server.services.tasks.commons import BulkResponse
-from argilla.server.services.tasks.text2text.models import (
-    ServiceText2TextQuery,
-    ServiceText2TextRecord,
-)
+from argilla.server.services.tasks.text2text.models import ServiceText2TextQuery, ServiceText2TextRecord
 
 
 class Text2TextService:

--- a/src/argilla/server/services/tasks/text_classification/metrics.py
+++ b/src/argilla/server/services/tasks/text_classification/metrics.py
@@ -19,9 +19,7 @@ from pydantic import Field
 from argilla.server.services.metrics import ServiceBaseMetric, ServicePythonMetric
 from argilla.server.services.metrics.models import CommonTasksMetrics
 from argilla.server.services.search.model import ServiceRecordsQuery
-from argilla.server.services.tasks.text_classification.model import (
-    ServiceTextClassificationRecord,
-)
+from argilla.server.services.tasks.text_classification.model import ServiceTextClassificationRecord
 from argilla.utils.dependency import requires_version
 
 

--- a/src/argilla/server/services/tasks/text_classification/model.py
+++ b/src/argilla/server/services/tasks/text_classification/model.py
@@ -22,14 +22,8 @@ from argilla._constants import DEFAULT_MAX_KEYWORD_LENGTH
 from argilla.server.commons.models import PredictionStatus, TaskStatus, TaskType
 from argilla.server.helpers import flatten_dict
 from argilla.server.services.datasets import ServiceBaseDataset
-from argilla.server.services.search.model import (
-    ServiceBaseRecordsQuery,
-    ServiceScoreRange,
-)
-from argilla.server.services.tasks.commons import (
-    ServiceBaseAnnotation,
-    ServiceBaseRecord,
-)
+from argilla.server.services.search.model import ServiceBaseRecordsQuery, ServiceScoreRange
+from argilla.server.services.tasks.commons import ServiceBaseAnnotation, ServiceBaseRecord
 
 
 class ServiceLabelingRule(BaseModel):

--- a/src/argilla/server/services/tasks/text_classification/service.py
+++ b/src/argilla/server/services/tasks/text_classification/service.py
@@ -17,18 +17,10 @@ from typing import Iterable, List, Optional, Tuple
 
 from fastapi import Depends
 
-from argilla.server.errors.base_errors import (
-    EntityAlreadyExistsError,
-    EntityNotFoundError,
-    MissingDatasetRecordsError,
-)
+from argilla.server.errors.base_errors import EntityAlreadyExistsError, EntityNotFoundError, MissingDatasetRecordsError
 from argilla.server.services.datasets import DatasetsService
 from argilla.server.services.metrics import MetricsService
-from argilla.server.services.search.model import (
-    ServiceSearchResults,
-    ServiceSortableField,
-    ServiceSortConfig,
-)
+from argilla.server.services.search.model import ServiceSearchResults, ServiceSortableField, ServiceSortConfig
 from argilla.server.services.search.service import SearchRecordsService
 from argilla.server.services.storage.service import RecordsStorageService
 from argilla.server.services.tasks.commons import BulkResponse

--- a/src/argilla/server/services/tasks/text_classification/service.py
+++ b/src/argilla/server/services/tasks/text_classification/service.py
@@ -32,9 +32,7 @@ from argilla.server.services.search.model import (
 from argilla.server.services.search.service import SearchRecordsService
 from argilla.server.services.storage.service import RecordsStorageService
 from argilla.server.services.tasks.commons import BulkResponse
-from argilla.server.services.tasks.text_classification.metrics import (
-    TextClassificationMetrics,
-)
+from argilla.server.services.tasks.text_classification.metrics import TextClassificationMetrics
 from argilla.server.services.tasks.text_classification.model import (
     DatasetLabelingRulesMetricsSummary,
     DatasetLabelingRulesSummary,

--- a/src/argilla/server/services/tasks/token_classification/model.py
+++ b/src/argilla/server/services/tasks/token_classification/model.py
@@ -19,14 +19,8 @@ from pydantic import BaseModel, Field, validator
 from argilla._constants import DEFAULT_MAX_KEYWORD_LENGTH
 from argilla.server.commons.models import PredictionStatus, TaskType
 from argilla.server.services.datasets import ServiceBaseDataset
-from argilla.server.services.search.model import (
-    ServiceBaseRecordsQuery,
-    ServiceScoreRange,
-)
-from argilla.server.services.tasks.commons import (
-    ServiceBaseAnnotation,
-    ServiceBaseRecord,
-)
+from argilla.server.services.search.model import ServiceBaseRecordsQuery, ServiceScoreRange
+from argilla.server.services.tasks.commons import ServiceBaseAnnotation, ServiceBaseRecord
 from argilla.utils import SpanUtils
 
 PREDICTED_MENTIONS_ES_FIELD_NAME = "predicted_mentions"

--- a/src/argilla/tasks/users/create.py
+++ b/src/argilla/tasks/users/create.py
@@ -22,11 +22,7 @@ from typer import Typer
 from argilla.server.contexts import accounts
 from argilla.server.database import SessionLocal
 from argilla.server.models import User, UserRole, Workspace
-from argilla.server.security.model import (
-    USER_PASSWORD_MIN_LENGTH,
-    UserCreate,
-    WorkspaceCreate,
-)
+from argilla.server.security.model import USER_PASSWORD_MIN_LENGTH, UserCreate, WorkspaceCreate
 from argilla.tasks.users.utils import get_or_new_workspace
 
 USER_API_KEY_MIN_LENGTH = 8

--- a/src/argilla/training/base.py
+++ b/src/argilla/training/base.py
@@ -18,22 +18,9 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, List, Optional, Union
 
 from argilla.client.api import get_workspace, load
-from argilla.client.datasets import (
-    DatasetForText2Text,
-    DatasetForTextClassification,
-    DatasetForTokenClassification,
-)
-from argilla.client.models import (
-    Framework,
-    Text2TextRecord,
-    TextClassificationRecord,
-    TokenClassificationRecord,
-)
-from argilla.datasets import (
-    TextClassificationSettings,
-    TokenClassificationSettings,
-    load_dataset_settings,
-)
+from argilla.client.datasets import DatasetForText2Text, DatasetForTextClassification, DatasetForTokenClassification
+from argilla.client.models import Framework, Text2TextRecord, TextClassificationRecord, TokenClassificationRecord
+from argilla.datasets import TextClassificationSettings, TokenClassificationSettings, load_dataset_settings
 from argilla.utils.telemetry import get_telemetry_client
 
 os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"

--- a/src/argilla/training/peft.py
+++ b/src/argilla/training/peft.py
@@ -19,9 +19,7 @@ import numpy as np
 
 from argilla.client.models import TextClassificationRecord, TokenClassificationRecord
 from argilla.training.transformers import ArgillaTransformersTrainer
-from argilla.training.utils import (
-    filter_allowed_args,
-)
+from argilla.training.utils import filter_allowed_args
 from argilla.utils.dependency import require_version
 
 

--- a/src/argilla/training/transformers.py
+++ b/src/argilla/training/transformers.py
@@ -19,11 +19,7 @@ from datasets import DatasetDict
 
 from argilla.client.models import TextClassificationRecord, TokenClassificationRecord
 from argilla.training.base import ArgillaTrainerSkeleton
-from argilla.training.utils import (
-    _apply_column_mapping,
-    filter_allowed_args,
-    get_default_args,
-)
+from argilla.training.utils import _apply_column_mapping, filter_allowed_args, get_default_args
 from argilla.utils.dependency import require_version
 
 

--- a/src/argilla/training/utils.py
+++ b/src/argilla/training/utils.py
@@ -43,10 +43,7 @@ def get_default_args(fn) -> dict:
     return default_args
 
 
-def filter_allowed_args(
-    func,
-    **kwargs,
-):
+def filter_allowed_args(func, **kwargs):
     """
     It takes a function and a dictionary of arguments, and returns a dictionary of arguments that are
     allowed by the function

--- a/tests/client/feedback/test_dataset.py
+++ b/tests/client/feedback/test_dataset.py
@@ -27,9 +27,7 @@ from argilla.client.feedback.schemas import (
     TextField,
     TextQuestion,
 )
-from argilla.client.feedback.training.schemas import (
-    TrainingTaskMapping,
-)
+from argilla.client.feedback.training.schemas import TrainingTaskMapping
 from argilla.client.models import Framework
 
 if TYPE_CHECKING:

--- a/tests/client/sdk/text2text/test_models.py
+++ b/tests/client/sdk/text2text/test_models.py
@@ -25,12 +25,8 @@ from argilla.client.sdk.text2text.models import (
     Text2TextQuery,
 )
 from argilla.client.sdk.text2text.models import Text2TextRecord as SdkText2TextRecord
-from argilla.server.apis.v0.models.text2text import (
-    Text2TextBulkRequest as ServerText2TextBulkData,
-)
-from argilla.server.apis.v0.models.text2text import (
-    Text2TextQuery as ServerText2TextQuery,
-)
+from argilla.server.apis.v0.models.text2text import Text2TextBulkRequest as ServerText2TextBulkData
+from argilla.server.apis.v0.models.text2text import Text2TextQuery as ServerText2TextQuery
 
 
 def test_bulk_data_schema(helpers):

--- a/tests/client/sdk/text_classification/test_models.py
+++ b/tests/client/sdk/text_classification/test_models.py
@@ -26,21 +26,15 @@ from argilla.client.sdk.text_classification.models import (
     TextClassificationBulkData,
     TextClassificationQuery,
 )
-from argilla.client.sdk.text_classification.models import (
-    TextClassificationRecord as SdkTextClassificationRecord,
-)
-from argilla.server.apis.v0.models.text_classification import (
-    LabelingRule as ServerLabelingRule,
-)
+from argilla.client.sdk.text_classification.models import TextClassificationRecord as SdkTextClassificationRecord
+from argilla.server.apis.v0.models.text_classification import LabelingRule as ServerLabelingRule
 from argilla.server.apis.v0.models.text_classification import (
     LabelingRuleMetricsSummary as ServerLabelingRuleMetricsSummary,
 )
 from argilla.server.apis.v0.models.text_classification import (
     TextClassificationBulkRequest as ServerTextClassificationBulkData,
 )
-from argilla.server.apis.v0.models.text_classification import (
-    TextClassificationQuery as ServerTextClassificationQuery,
-)
+from argilla.server.apis.v0.models.text_classification import TextClassificationQuery as ServerTextClassificationQuery
 
 
 def test_bulk_data_schema(helpers):

--- a/tests/client/sdk/token_classification/test_models.py
+++ b/tests/client/sdk/token_classification/test_models.py
@@ -24,9 +24,7 @@ from argilla.client.sdk.token_classification.models import (
     TokenClassificationBulkData,
     TokenClassificationQuery,
 )
-from argilla.client.sdk.token_classification.models import (
-    TokenClassificationRecord as SdkTokenClassificationRecord,
-)
+from argilla.client.sdk.token_classification.models import TokenClassificationRecord as SdkTokenClassificationRecord
 from argilla.server.apis.v0.models.token_classification import (
     TokenClassificationBulkRequest as ServerTokenClassificationBulkData,
 )

--- a/tests/client/sdk/v1/datasets/test_models.py
+++ b/tests/client/sdk/v1/datasets/test_models.py
@@ -13,9 +13,7 @@
 #  limitations under the License.
 
 from argilla.client.sdk.v1.datasets.models import FeedbackDatasetModel as ClientSchema
-from argilla.client.sdk.v1.datasets.models import (
-    FeedbackQuestionModel as ClientQuestionSchema,
-)
+from argilla.client.sdk.v1.datasets.models import FeedbackQuestionModel as ClientQuestionSchema
 from argilla.server.schemas.v1.datasets import Dataset as ServerSchema
 from argilla.server.schemas.v1.datasets import Question as ServerQuestionSchema
 

--- a/tests/server/api/v1/test_workspaces.py
+++ b/tests/server/api/v1/test_workspaces.py
@@ -20,9 +20,7 @@ from argilla.server.commons.models import TaskType
 from argilla.server.models import UserRole
 from fastapi.testclient import TestClient
 
-from tests.factories import (
-    DatasetFactory,
-)
+from tests.factories import DatasetFactory
 
 
 @contextlib.contextmanager

--- a/tests/server/datasets/test_api.py
+++ b/tests/server/datasets/test_api.py
@@ -16,9 +16,7 @@ from typing import Any, Dict, List
 
 import pytest
 from argilla._constants import API_KEY_HEADER_NAME
-from argilla.server.apis.v0.models.text_classification import (
-    TextClassificationBulkRequest,
-)
+from argilla.server.apis.v0.models.text_classification import TextClassificationBulkRequest
 from argilla.server.commons.models import TaskType
 from argilla.server.models import UserRole
 from argilla.server.schemas.datasets import Dataset

--- a/tests/server/metrics/test_api.py
+++ b/tests/server/metrics/test_api.py
@@ -28,12 +28,8 @@ from argilla.server.apis.v0.models.token_classification import (
 from argilla.server.commons.models import TaskType
 from argilla.server.models import User
 from argilla.server.services.metrics.models import CommonTasksMetrics
-from argilla.server.services.tasks.text_classification.metrics import (
-    TextClassificationMetrics,
-)
-from argilla.server.services.tasks.token_classification.metrics import (
-    TokenClassificationMetrics,
-)
+from argilla.server.services.tasks.text_classification.metrics import TextClassificationMetrics
+from argilla.server.services.tasks.token_classification.metrics import TokenClassificationMetrics
 
 from tests.helpers import SecuredClient
 

--- a/tests/server/security/test_provider.py
+++ b/tests/server/security/test_provider.py
@@ -16,9 +16,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from argilla._constants import DEFAULT_API_KEY
-from argilla.server.security.auth_provider.local.provider import (
-    create_local_auth_provider,
-)
+from argilla.server.security.auth_provider.local.provider import create_local_auth_provider
 from fastapi.security import SecurityScopes
 
 if TYPE_CHECKING:


### PR DESCRIPTION
Hello!

# Description

While the `black` line length has been correctly set to [120](https://github.com/argilla-io/argilla/blob/6424bc72eab02c03717e445359599888fc6d6146/pyproject.toml#L192), that of `ruff` was still at the (lower) default. I've set it to 120 in 14db301f3694db7bc93023e6b4fcc5a9e607fe39 using [this](https://beta.ruff.rs/docs/settings/#line-length), and fixed some issues that were caused by this in 7a4efb3297533c8c53e48fdd1dcfd5c404ba2304 by searching for `(import \(\n[^,]+),(\n\S*\))` in all source code and replacing it with `$1$2`.
This finds all cases of
```python
... import (
BlaBlaBla,
)
```
where the following might also be possible
```python
... import BlaBlaBla
```

Beyond that, I fixed an issue with a broken type hint in bd7029a28a6a3fa3b2f36b2817eaf22bd0c95067.

**Type of change**

- [x] Refactor

**How Has This Been Tested**

N/A, no real code changes.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

---

- Tom Aarsen