### PR TITLE
feat: add `get_metrics` function in SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ These are the section headers that we use:
 
 ## [Unreleased]
 
+### Added
+
+- Added `get_metrics` function in the SDK to get `FeedbackDataset` metrics calling `GET /api/v1/me/{dataset_id}/metrics` endpoint ([#3469](https://github.com/argilla-io/argilla/pull/3469))
+
 ### Changed
 
 - Improved efficiency of weak labeling when dataset contains vectors ([#3444](https://github.com/argilla-io/argilla/pull/3444)).

--- a/src/argilla/client/sdk/v1/datasets/api.py
+++ b/src/argilla/client/sdk/v1/datasets/api.py
@@ -23,6 +23,7 @@ from argilla.client.sdk.commons.models import ErrorMessage, HTTPValidationError,
 from argilla.client.sdk.v1.datasets.models import (
     FeedbackDatasetModel,
     FeedbackFieldModel,
+    FeedbackMetricsModel,
     FeedbackQuestionModel,
     FeedbackRecordsModel,
     FeedbackSuggestionModel,
@@ -412,6 +413,36 @@ def set_suggestion(
 
     if response.status_code in [200, 201]:
         parsed_response = FeedbackSuggestionModel(**response.json())
+        return Response(
+            status_code=response.status_code,
+            content=response.content,
+            headers=response.headers,
+            parsed=parsed_response,
+        )
+    return handle_response_error(response)
+
+
+def get_metrics(
+    client: httpx.Client,
+    id: UUID,
+) -> Response[Union[FeedbackMetricsModel, ErrorMessage, HTTPValidationError]]:
+    """Sends a GET request to `/api/v1/datasets/{id}/metrics` endpoint to retrieve the metrics
+    of a `FeedbackDataset`.
+
+    Args:
+        client: the authenticated Argilla client to be used to send the request to the API.
+        id: the id of the dataset to retrieve the metrics from.
+
+    Returns:
+        A `Response` object containing a `parsed` attribute with the parsed response if the
+        request was successful, which is a `FeedbackMetricsModel`.
+    """
+    url = f"/api/v1/me/datasets/{id}/metrics"
+
+    response = client.get(url=url)
+
+    if response.status_code == 200:
+        parsed_response = FeedbackMetricsModel(**response.json())
         return Response(
             status_code=response.status_code,
             content=response.content,

--- a/src/argilla/client/sdk/v1/datasets/models.py
+++ b/src/argilla/client/sdk/v1/datasets/models.py
@@ -100,3 +100,19 @@ class FeedbackSuggestionModel(BaseModel):
     score: Optional[float] = None
     value: Any
     agent: Optional[str] = None
+
+
+class FeedbackRecordsMetricsModel(BaseModel):
+    count: int
+
+
+class FeedbackResponsesMetricsModel(BaseModel):
+    count: int
+    submitted: int
+    discarded: int
+    draft: int
+
+
+class FeedbackMetricsModel(BaseModel):
+    records: FeedbackRecordsMetricsModel
+    responses: FeedbackResponsesMetricsModel

--- a/src/argilla/client/sdk/v1/datasets/models.py
+++ b/src/argilla/client/sdk/v1/datasets/models.py
@@ -106,13 +106,5 @@ class FeedbackRecordsMetricsModel(BaseModel):
     count: int
 
 
-class FeedbackResponsesMetricsModel(BaseModel):
-    count: int
-    submitted: int
-    discarded: int
-    draft: int
-
-
 class FeedbackMetricsModel(BaseModel):
     records: FeedbackRecordsMetricsModel
-    responses: FeedbackResponsesMetricsModel

--- a/tests/client/sdk/v1/datasets/test_models.py
+++ b/tests/client/sdk/v1/datasets/test_models.py
@@ -13,8 +13,10 @@
 #  limitations under the License.
 
 from argilla.client.sdk.v1.datasets.models import FeedbackDatasetModel as ClientSchema
+from argilla.client.sdk.v1.datasets.models import FeedbackMetricsModel as ClientMetricsSchema
 from argilla.client.sdk.v1.datasets.models import FeedbackQuestionModel as ClientQuestionSchema
 from argilla.server.schemas.v1.datasets import Dataset as ServerSchema
+from argilla.server.schemas.v1.datasets import Metrics as ServerMetricsSchema
 from argilla.server.schemas.v1.datasets import Question as ServerQuestionSchema
 
 
@@ -33,3 +35,7 @@ def test_feedback_dataset_schema(helpers) -> None:
 
 def test_feedback_questions_schema(helpers) -> None:
     assert helpers.are_compatible_api_schemas(ClientQuestionSchema.schema(), ServerQuestionSchema.schema())
+
+
+def test_feedback_metrics_schema(helpers) -> None:
+    assert helpers.are_compatible_api_schemas(ClientMetricsSchema.schema(), ServerMetricsSchema.schema())

--- a/tests/client/sdk/v1/datasets/test_models.py
+++ b/tests/client/sdk/v1/datasets/test_models.py
@@ -13,10 +13,8 @@
 #  limitations under the License.
 
 from argilla.client.sdk.v1.datasets.models import FeedbackDatasetModel as ClientSchema
-from argilla.client.sdk.v1.datasets.models import FeedbackMetricsModel as ClientMetricsSchema
 from argilla.client.sdk.v1.datasets.models import FeedbackQuestionModel as ClientQuestionSchema
 from argilla.server.schemas.v1.datasets import Dataset as ServerSchema
-from argilla.server.schemas.v1.datasets import Metrics as ServerMetricsSchema
 from argilla.server.schemas.v1.datasets import Question as ServerQuestionSchema
 
 
@@ -35,7 +33,3 @@ def test_feedback_dataset_schema(helpers) -> None:
 
 def test_feedback_questions_schema(helpers) -> None:
     assert helpers.are_compatible_api_schemas(ClientQuestionSchema.schema(), ServerQuestionSchema.schema())
-
-
-def test_feedback_metrics_schema(helpers) -> None:
-    assert helpers.are_compatible_api_schemas(ClientMetricsSchema.schema(), ServerMetricsSchema.schema())


### PR DESCRIPTION
# Description

This PR adds a function in the SDK named `get_metrics` that calls `GET /api/v1/me/datasets/{dataset_id}/metrics` to get the metrics of a certain dataset from a certain user, meaning that each user would just see what can be seen according to its permissions.

This PR is created on top of #3465 since we will need to get the `records.count` to override the magic method `__len__` in `_ArgillaFeedbackDataset` so that the length of a dataset is directly retrieved from the record count of the dataset, since we're no longer keeping local data when working with a remote dataset.

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [X] Add unit tests for the `get_metrics` function

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
