### PR TITLE
chore: prepare tests with postgresql: 1 clean code and type defs

### DIFF
--- a/src/argilla/client/api.py
+++ b/src/argilla/client/api.py
@@ -25,8 +25,6 @@ from argilla.client.sdk.commons import errors
 from argilla.client.sdk.v1.datasets.api import list_datasets as list_datasets_api_v1
 from argilla.client.sdk.workspaces.api import list_workspaces as list_workspaces_api_v0
 
-_LOGGER = logging.getLogger(__name__)
-
 Api = Argilla  # Backward compatibility
 
 

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -350,7 +350,7 @@ class Argilla:
             batch_size = chunk_size
 
         if batch_size > self._MAX_BATCH_SIZE:
-            _LOGGER.warning(
+            warnings.warn(
                 "The requested batch size is noticeably large, timeout errors may occur. "
                 f"Consider a batch size smaller than {self._MAX_BATCH_SIZE}",
             )

--- a/src/argilla/client/datasets.py
+++ b/src/argilla/client/datasets.py
@@ -15,6 +15,7 @@
 import logging
 import random
 import uuid
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 import pandas as pd
@@ -37,8 +38,6 @@ if TYPE_CHECKING:
     import datasets
     import pandas
     import spacy
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class DatasetBase:
@@ -142,7 +141,7 @@ class DatasetBase:
         except Exception:
             del ds_dict["metadata"]
             dataset = datasets.Dataset.from_dict(ds_dict)
-            _LOGGER.warning(
+            warnings.warn(
                 "The 'metadata' of the records were removed, since it was incompatible with the 'datasets' format."
             )
 
@@ -224,7 +223,7 @@ class DatasetBase:
         ]
 
         if not_supported_columns:
-            _LOGGER.warning(
+            warnings.warn(
                 "Following columns are not supported by the"
                 f" {cls._RECORD_TYPE.__name__} model and are ignored:"
                 f" {not_supported_columns}"
@@ -309,7 +308,7 @@ class DatasetBase:
         """
         not_supported_columns = [col for col in dataframe.columns if col not in cls._record_init_args()]
         if not_supported_columns:
-            _LOGGER.warning(
+            warnings.warn(
                 "Following columns are not supported by the"
                 f" {cls._RECORD_TYPE.__name__} model and are ignored:"
                 f" {not_supported_columns}"
@@ -908,7 +907,7 @@ class DatasetForTextClassification(DatasetBase):
         self._verify_all_labels()  # verify that all labels are strings
 
         if len(self._records) <= len(self._SETTINGS.label_schema) * 100:
-            _LOGGER.warning("OpenAI recommends at least 100 examples per class for training a classification model.")
+            warnings.warn("OpenAI recommends at least 100 examples per class for training a classification model.")
 
         jsonl = []
         for rec in self._records:
@@ -948,8 +947,10 @@ class DatasetForTextClassification(DatasetBase):
         all_labels = list(all_labels)
         all_labels.sort()
 
-        _LOGGER.warning(
-            f"""No label schema provided. Using all_labels: TextClassificationSettings({all_labels}). We recommend providing a `TextClassificationSettings()` or setting `rg.configure_dataset_settings()`/`rg.load_dataset_settings()` to ensure reproducibility."""
+        warnings.warn(
+            f"No label schema provided. Using all_labels: TextClassificationSettings({all_labels}). "
+            "We recommend providing a `TextClassificationSettings()` or setting "
+            "`rg.configure_dataset_settings()`/`rg.load_dataset_settings()` to ensure reproducibility."
         )
         return TextClassificationSettings(all_labels)
 
@@ -1064,7 +1065,7 @@ class DatasetForTokenClassification(DatasetBase):
         for row in dataset:
             # TODO: fails with a KeyError if no tokens column is present and no mapping is indicated
             if not row["tokens"]:
-                _LOGGER.warning("Ignoring row with no tokens.")
+                warnings.warn("Ignoring row with no tokens.")
                 continue
 
             if row.get("tags"):
@@ -1196,7 +1197,7 @@ class DatasetForTokenClassification(DatasetBase):
         self._verify_all_labels()
 
         if len(self._records) <= 500:
-            _LOGGER.warning("OpenAI recommends at least 500 examples for training a conditional generation model.")
+            warnings.warn("OpenAI recommends at least 500 examples for training a conditional generation model.")
 
         jsonl = []
         for rec in self._records:
@@ -1223,8 +1224,10 @@ class DatasetForTokenClassification(DatasetBase):
                     all_labels.add(label)
         all_labels = list(all_labels)
         all_labels.sort()
-        _LOGGER.warning(
-            f"""No label schema provided. Using all_labels: TokenClassificationSettings({all_labels}). We recommend providing a `TokenClassificationSettings()` or setting `rg.configure_dataset_settings()`/`rg.load_dataset_settings()` to ensure reproducibility."""
+        warnings.warn(
+            f"No label schema provided. Using all_labels: TokenClassificationSettings({all_labels}). "
+            "We recommend providing a `TokenClassificationSettings()` or setting "
+            "`rg.configure_dataset_settings()`/`rg.load_dataset_settings()` to ensure reproducibility."
         )
         return TokenClassificationSettings(all_labels)
 
@@ -1481,7 +1484,7 @@ class DatasetForText2Text(DatasetBase):
         end_token = OPENAI_END_TOKEN
         whitespace = OPENAI_WHITESPACE
         if len(self._records) <= 500:
-            _LOGGER.warning("OpenAI recommends at least 500 examples for training a conditional generation model.")
+            warnings.warn("OpenAI recommends at least 500 examples for training a conditional generation model.")
 
         jsonl = []
         for rec in self._records:

--- a/src/argilla/client/sdk/commons/api.py
+++ b/src/argilla/client/sdk/commons/api.py
@@ -56,7 +56,6 @@ def bulk(
     return BulkResponse.parse_obj(response)
 
 
-
 T = TypeVar("T")
 
 

--- a/src/argilla/client/sdk/commons/api.py
+++ b/src/argilla/client/sdk/commons/api.py
@@ -45,15 +45,6 @@ _TASK_TO_ENDPOINT = {
 }
 
 
-def build_param_dict(id_from: Optional[str], limit: Optional[int]) -> Optional[Dict[str, Union[str, int]]]:
-    params = {}
-    if id_from:
-        params["id_from"] = id_from
-    if limit:
-        params["limit"] = limit
-    return params
-
-
 def bulk(
     client: AuthenticatedClient,
     name: str,
@@ -65,41 +56,8 @@ def bulk(
     return BulkResponse.parse_obj(response)
 
 
-def build_bulk_response(response: httpx.Response, name: str, body: Any) -> Response[BulkResponse]:
-    if 200 <= response.status_code < 400:
-        return Response(
-            status_code=response.status_code,
-            content=response.content,
-            headers=response.headers,
-            parsed=BulkResponse(**response.json()),
-        )
-
-    return handle_response_error(response, name=name, body=body)
-
 
 T = TypeVar("T")
-
-
-def build_data_response(response: httpx.Response, data_type: Type[T]) -> Response[List[T]]:
-    if 200 <= response.status_code < 400:
-        parsed_responses = []
-        for r in response.iter_lines():
-            parsed_record = json.loads(r)
-            try:
-                parsed_response = data_type(**parsed_record)
-            except Exception as err:  # noqa: F841
-                raise GenericApiError(**parsed_record) from None
-            parsed_responses.append(parsed_response)
-        return Response(
-            status_code=response.status_code,
-            content=b"",
-            headers=response.headers,
-            parsed=parsed_responses,
-        )
-
-    content = next(response.iter_lines())
-    data = json.loads(content)
-    return handle_response_error(response, **data, parse_response=False)
 
 
 def build_list_response(

--- a/src/argilla/client/sdk/text_classification/api.py
+++ b/src/argilla/client/sdk/text_classification/api.py
@@ -18,7 +18,7 @@ import httpx
 
 from argilla.client.sdk._helpers import build_typed_response
 from argilla.client.sdk.client import AuthenticatedClient
-from argilla.client.sdk.commons.api import build_data_response, build_list_response, build_param_dict
+from argilla.client.sdk.commons.api import build_list_response
 from argilla.client.sdk.commons.models import ErrorMessage, HTTPValidationError, Response
 from argilla.client.sdk.text_classification.models import (
     LabelingRule,

--- a/src/argilla/labeling/text_classification/label_errors.py
+++ b/src/argilla/labeling/text_classification/label_errors.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import logging
+import warnings
 from enum import Enum
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -22,8 +23,6 @@ from pkg_resources import parse_version
 from argilla.client.datasets import DatasetForTextClassification
 from argilla.client.models import TextClassificationRecord
 from argilla.utils.dependency import requires_version
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class SortBy(Enum):
@@ -124,7 +123,7 @@ def _check_and_update_kwargs(version: str, record: TextClassificationRecord, sor
         ValueError: If not supported kwargs ('sorted_index_method') are passed on.
     """
     if "multi_label" in kwargs:
-        _LOGGER.warning(
+        warnings.warn(
             "You provided the kwarg 'multi_label', but it is determined automatically. "
             f"We will set it to '{record.multi_label}'."
         )
@@ -148,7 +147,7 @@ def _check_and_update_kwargs(version: str, record: TextClassificationRecord, sor
             kwargs["return_indices_ranked_by"] = None
         # TODO: Remove this once https://github.com/cleanlab/cleanlab/issues/243 is solved
         elif kwargs["multi_label"]:
-            _LOGGER.warning(
+            warnings.warn(
                 "With cleanlab v2 and multi-label records there is an issue sorting records by 'likelihood' "
                 "(https://github.com/cleanlab/cleanlab/issues/243). We will sort by 'prediction' instead."
             )

--- a/src/argilla/server/daos/backend/search/query_builder.py
+++ b/src/argilla/server/daos/backend/search/query_builder.py
@@ -14,7 +14,7 @@
 import logging
 import re
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from luqum.elasticsearch import ElasticsearchQueryBuilder, SchemaAnalyzer
 from luqum.parser import parser
@@ -168,7 +168,7 @@ class EsQueryBuilder:
 
     def map_2_es_query(
         self,
-        schema: Dict[str, Any],
+        schema: Union[Dict[str, Any], None],
         query: BackendQuery,
         sort: SortConfig = SortConfig(),
         exclude_fields: Optional[List[str]] = None,

--- a/src/argilla/tasks/users/create.py
+++ b/src/argilla/tasks/users/create.py
@@ -19,7 +19,7 @@ from pydantic import constr
 
 from argilla.server.contexts import accounts
 from argilla.server.database import AsyncSessionLocal
-from argilla.server.models import User, UserRole, Workspace
+from argilla.server.models import User, UserRole
 from argilla.server.security.model import (
     USER_PASSWORD_MIN_LENGTH,
     UserCreate,

--- a/tests/database.py
+++ b/tests/database.py
@@ -30,5 +30,7 @@ def get_task() -> asyncio.Task:
     return task
 
 
-TestSession = async_scoped_session(async_sessionmaker(class_=AsyncSession, expire_on_commit=False, future=True), get_task)
+TestSession = async_scoped_session(
+    async_sessionmaker(class_=AsyncSession, expire_on_commit=False, future=True), get_task
+)
 SyncTestSession = orm.scoped_session(orm.sessionmaker(class_=orm.Session, expire_on_commit=False))

--- a/tests/database.py
+++ b/tests/database.py
@@ -31,6 +31,6 @@ def get_task() -> asyncio.Task:
 
 
 TestSession = async_scoped_session(
-    async_sessionmaker(class_=AsyncSession, expire_on_commit=False, future=True), get_task
+    async_sessionmaker(expire_on_commit=False, future=True), get_task
 )
 SyncTestSession = orm.scoped_session(orm.sessionmaker(class_=orm.Session, expire_on_commit=False))

--- a/tests/database.py
+++ b/tests/database.py
@@ -13,11 +13,12 @@
 #  limitations under the License.
 
 import asyncio
+from typing import Union
 
 from sqlalchemy import orm
-from sqlalchemy.ext.asyncio import AsyncSession, async_scoped_session
+from sqlalchemy.ext.asyncio import AsyncSession, async_scoped_session, async_sessionmaker
 
-task = None
+task: Union[asyncio.Task, None] = None
 
 
 def set_task(t: asyncio.Task):
@@ -29,5 +30,5 @@ def get_task() -> asyncio.Task:
     return task
 
 
-TestSession = async_scoped_session(orm.sessionmaker(class_=AsyncSession, expire_on_commit=False), get_task)
+TestSession = async_scoped_session(async_sessionmaker(class_=AsyncSession, expire_on_commit=False, future=True), get_task)
 SyncTestSession = orm.scoped_session(orm.sessionmaker(class_=orm.Session, expire_on_commit=False))

--- a/tests/database.py
+++ b/tests/database.py
@@ -30,7 +30,5 @@ def get_task() -> asyncio.Task:
     return task
 
 
-TestSession = async_scoped_session(
-    async_sessionmaker(expire_on_commit=False, future=True), get_task
-)
+TestSession = async_scoped_session(async_sessionmaker(expire_on_commit=False, future=True), get_task)
 SyncTestSession = orm.scoped_session(orm.sessionmaker(class_=orm.Session, expire_on_commit=False))


### PR DESCRIPTION
## Description

This is a first step of a series of changes to support running server tests using a PostgreSQL dataset. Since a lot of changes will be applied. I will push them grouped in different PRs  to the target branch `tests/configure-server-tests-with-postgresql`

This PR removes some unused code and reviews some imports and type definitions. Also, some logging warnings have been replaced by user warnings, for those cases which make more sense.

NOTE: Probably, tests will fail in these PRs. They will be fixed later 