### PR TITLE
refactor: 2x speedup for the training tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -277,7 +277,7 @@ def dataset_token_classification(mocked_client: SecuredClient) -> str:
 
     dataset_ds = load_dataset(
         "argilla/gutenberg_spacy-ner",
-        split="train[:100]",
+        split="train[:3]",
         # This revision does not includes the vectors info, so tests will pass
         revision="fff5f572e4cc3127f196f46ba3f9914c6fd0d763",
     )
@@ -305,7 +305,7 @@ def dataset_text_classification(mocked_client: SecuredClient) -> str:
 
     dataset_ds = load_dataset(
         f"argilla/{dataset}",
-        split="train[:100]",
+        split="train[:3]",
     )
     dataset_rb = [TextClassificationRecord(text=rec["text"], annotation=rec["label"]) for rec in dataset_ds]
     labels = set([rec.annotation for rec in dataset_rb])
@@ -323,7 +323,7 @@ def dataset_text_classification_multi_label(mocked_client: SecuredClient) -> str
 
     dataset = "research_titles_multi_label"
 
-    dataset_ds = load_dataset("argilla/research_titles_multi-label", split="train[:100]")
+    dataset_ds = load_dataset("argilla/research_titles_multi-label", split="train[:50]")
 
     dataset_rb = read_datasets(dataset_ds, task="TextClassification")
 
@@ -341,7 +341,7 @@ def dataset_text2text(mocked_client: SecuredClient) -> str:
 
     dataset = "news_summary"
 
-    dataset_ds = load_dataset("argilla/news-summary", split="train[:100]")
+    dataset_ds = load_dataset("argilla/news-summary", split="train[:3]")
 
     records = []
     for entry in dataset_ds:

--- a/tests/integration/training/test_openai.py
+++ b/tests/integration/training/test_openai.py
@@ -31,7 +31,7 @@ def test_update_config(dataset_text_classification):
     assert trainer._trainer.model_kwargs["prompt_loss_weight"] == 1
 
 
-def test_setfit_train(dataset_text_classification):
+def test_openai_train(dataset_text_classification):
     ArgillaTrainer(name=dataset_text_classification, model=MODEL, framework=FRAMEWORK)
 
 

--- a/tests/integration/training/test_span_marker.py
+++ b/tests/integration/training/test_span_marker.py
@@ -58,7 +58,7 @@ def test_evaluate_train_test(dataset_token_classification) -> None:
 
 
 def test_train_no_model(dataset_token_classification) -> None:
-    trainer = ArgillaTrainer(name=dataset_token_classification, framework=FRAMEWORK)
+    trainer = ArgillaTrainer(name=dataset_token_classification, model=MODEL, framework=FRAMEWORK)
     trainer.update_config(max_steps=1, num_train_epochs=1)
     record = trainer.predict("This is a text", as_argilla_records=True)
     assert isinstance(record, TokenClassificationRecord)


### PR DESCRIPTION
Hello!

# Description

This introduces a 2x speedup of the training tests, by:
1. Reducing the number of downloaded/logged samples of the `conftest` dataset fixtures.
2. Correctly initializing an ArgillaTrainer with SpanMarker with `bert-tiny` rather than `bert-base`.

I haven't reintroduced the spaCy tests: they completely break my `pytest` execution it seems. I'll investigate this more.

Closes #3494

## Timings
### Old (03:53 total)
```
32.67s call     tests/integration/training/test_span_marker.py::test_evaluate_train_test
28.25s call     tests/integration/training/test_setfit.py::test_setfit_train
13.29s call     tests/integration/training/test_span_marker.py::test_train_no_model
7.77s call     tests/integration/training/test_span_marker.py::test_train_tokencat
6.26s call     tests/integration/training/test_transformers.py::test_train_tokencat
4.67s call     tests/integration/training/test_span_marker.py::test_various_inputs
4.65s call     tests/integration/training/test_setfit.py::test_setfit_train_multi_label
4.14s call     tests/integration/training/test_transformers.py::test_train_textcat
4.07s call     tests/integration/training/test_transformers.py::test_train_textcat_multi_label
3.93s setup    tests/integration/training/test_base.py::test_wrong_framework
3.90s setup    tests/integration/training/test_base.py::test_base_token_classification[setfit]
3.78s setup    tests/integration/training/test_span_marker.py::test_various_inputs
3.78s setup    tests/integration/training/test_span_marker.py::test_train_no_model
3.78s call     tests/integration/training/test_base.py::test_base_token_classification[setfit]
3.77s setup    tests/integration/training/test_span_marker.py::test_train_tokencat
3.77s setup    tests/integration/training/test_base.py::test_base_token_classification[spacy]
3.76s setup    tests/integration/training/test_base.py::test_base_text_classification_without_split[spacy]
3.76s call     tests/integration/training/test_base.py::test_base_token_classification[transformers]
3.75s setup    tests/integration/training/test_span_marker.py::test_evaluate_train_test
3.74s setup    tests/integration/training/test_span_marker.py::test_update_config
3.72s setup    tests/integration/training/test_openai.py::test_openai_train_token
3.71s setup    tests/integration/training/test_base.py::test_base_token_classification[transformers]
3.70s call     tests/integration/training/test_span_marker.py::test_update_config
3.64s setup    tests/integration/training/test_transformers.py::test_train_tokencat
3.43s setup    tests/integration/training/test_transformers.py::test_update_config
3.42s setup    tests/integration/training/test_openai.py::test_update_config
3.41s setup    tests/integration/training/test_openai.py::test_setfit_train
3.39s setup    tests/integration/training/test_base.py::test_base_text_classification_without_split[transformers]
3.38s setup    tests/integration/training/test_setfit.py::test_update_config
3.38s setup    tests/integration/training/test_base.py::test_base_text_classification_with_split[setfit]
3.38s setup    tests/integration/training/test_setfit.py::test_setfit_train
3.37s setup    tests/integration/training/test_base.py::test_base_text_classification_with_split[transformers]
3.34s setup    tests/integration/training/test_transformers.py::test_train_textcat
3.33s setup    tests/integration/training/test_base.py::test_base_text_classification_without_split[setfit]
3.31s setup    tests/integration/training/test_base.py::test_base_text_classification_with_split[spacy]
3.31s setup    tests/integration/training/test_openai.py::test_openai_train_multi_label
3.27s setup    tests/integration/training/test_transformers.py::test_predict_wo_training
3.26s setup    tests/integration/training/test_transformers.py::test_train_textcat_multi_label
3.25s setup    tests/integration/training/test_setfit.py::test_setfit_train_multi_label
3.22s setup    tests/integration/training/test_openai.py::test_openai_train_text2text
3.20s call     tests/integration/training/test_base.py::test_base_text_classification_without_split[spacy]
1.63s call     tests/integration/training/test_base.py::test_base_token_classification[spacy]
1.26s call     tests/integration/training/test_openai.py::test_openai_train_token
1.07s call     tests/integration/training/test_transformers.py::test_predict_wo_training
1.07s call     tests/integration/training/test_base.py::test_base_text_classification_with_split[spacy]
1.03s call     tests/integration/training/test_base.py::test_base_text_classification_without_split[setfit]
0.82s call     tests/integration/training/test_setfit.py::test_update_config
0.81s call     tests/integration/training/test_openai.py::test_setfit_train
0.81s call     tests/integration/training/test_openai.py::test_openai_train_text2text
0.81s call     tests/integration/training/test_openai.py::test_update_config
0.81s call     tests/integration/training/test_transformers.py::test_update_config
0.81s call     tests/integration/training/test_base.py::test_base_text_classification_with_split[transformers]
0.80s call     tests/integration/training/test_base.py::test_base_text_classification_with_split[setfit]
0.78s call     tests/integration/training/test_base.py::test_base_text_classification_without_split[transformers]
0.77s call     tests/integration/training/test_openai.py::test_openai_train_multi_label
0.74s call     tests/integration/training/test_base.py::test_wrong_framework
0.10s teardown tests/integration/training/test_transformers.py::test_predict_wo_training
0.01s teardown tests/integration/training/test_openai.py::test_openai_train_token
0.01s teardown tests/integration/training/test_base.py::test_base_text_classification_with_split[transformers]
0.01s teardown tests/integration/training/test_base.py::test_base_text_classification_with_split[setfit]
0.01s teardown tests/integration/training/test_span_marker.py::test_train_no_model
0.01s teardown tests/integration/training/test_openai.py::test_openai_train_multi_label
0.01s teardown tests/integration/training/test_base.py::test_base_text_classification_without_split[setfit]
0.01s teardown tests/integration/training/test_openai.py::test_openai_train_text2text
0.01s teardown tests/integration/training/test_openai.py::test_setfit_train
0.01s teardown tests/integration/training/test_base.py::test_base_text_classification_with_split[spacy]
0.01s teardown tests/integration/training/test_transformers.py::test_train_textcat_multi_label
0.01s teardown tests/integration/training/test_span_marker.py::test_train_tokencat
0.01s teardown tests/integration/training/test_base.py::test_base_token_classification[spacy]
0.01s teardown tests/integration/training/test_base.py::test_base_text_classification_without_split[spacy]
0.01s teardown tests/integration/training/test_base.py::test_base_token_classification[setfit]
0.01s teardown tests/integration/training/test_span_marker.py::test_update_config
0.01s teardown tests/integration/training/test_openai.py::test_update_config

(43 durations < 0.005s hidden.  Use -vv to show these durations.)
============================================================== 28 passed, 16 skipped, 630 warnings in 233.31s (0:03:53) ===============================================================
```

### New (02:16 total)
```
6.27s call     tests/integration/training/test_span_marker.py::test_evaluate_train_test
4.30s call     tests/integration/training/test_transformers.py::test_train_textcat_multi_label
4.11s call     tests/integration/training/test_transformers.py::test_train_textcat
4.01s call     tests/integration/training/test_setfit.py::test_setfit_train_multi_label
3.87s call     tests/integration/training/test_span_marker.py::test_train_tokencat
3.74s setup    tests/integration/training/test_base.py::test_wrong_framework
3.53s setup    tests/integration/training/test_transformers.py::test_update_config
3.43s setup    tests/integration/training/test_span_marker.py::test_train_no_model
3.38s setup    tests/integration/training/test_setfit.py::test_setfit_train_multi_label
3.33s setup    tests/integration/training/test_setfit.py::test_update_config
3.31s setup    tests/integration/training/test_transformers.py::test_predict_wo_training
3.29s setup    tests/integration/training/test_transformers.py::test_train_textcat
3.27s setup    tests/integration/training/test_setfit.py::test_setfit_train
3.23s setup    tests/integration/training/test_openai.py::test_openai_train_text2text
3.21s setup    tests/integration/training/test_transformers.py::test_train_textcat_multi_label
3.20s setup    tests/integration/training/test_transformers.py::test_train_tokencat
3.16s setup    tests/integration/training/test_span_marker.py::test_evaluate_train_test
3.15s setup    tests/integration/training/test_span_marker.py::test_train_tokencat
3.14s setup    tests/integration/training/test_span_marker.py::test_update_config
3.11s setup    tests/integration/training/test_base.py::test_base_text_classification_with_split[spacy]
3.09s setup    tests/integration/training/test_span_marker.py::test_various_inputs
3.07s setup    tests/integration/training/test_base.py::test_base_text_classification_without_split[spacy]
3.05s call     tests/integration/training/test_transformers.py::test_train_tokencat
3.05s call     tests/integration/training/test_setfit.py::test_setfit_train
2.92s setup    tests/integration/training/test_base.py::test_base_text_classification_without_split[transformers]
2.92s setup    tests/integration/training/test_openai.py::test_openai_train
2.91s setup    tests/integration/training/test_base.py::test_base_text_classification_with_split[transformers]
2.90s setup    tests/integration/training/test_base.py::test_base_text_classification_without_split[setfit]
2.89s setup    tests/integration/training/test_openai.py::test_update_config
2.87s setup    tests/integration/training/test_base.py::test_base_text_classification_with_split[setfit]
2.81s setup    tests/integration/training/test_openai.py::test_openai_train_multi_label
2.77s setup    tests/integration/training/test_base.py::test_base_token_classification[transformers]
2.76s setup    tests/integration/training/test_openai.py::test_openai_train_token
2.76s setup    tests/integration/training/test_base.py::test_base_token_classification[spacy]
2.74s setup    tests/integration/training/test_base.py::test_base_token_classification[setfit]
2.69s call     tests/integration/training/test_base.py::test_base_text_classification_without_split[spacy]
1.83s call     tests/integration/training/test_span_marker.py::test_various_inputs
1.67s call     tests/integration/training/test_span_marker.py::test_train_no_model
1.07s call     tests/integration/training/test_transformers.py::test_predict_wo_training
0.93s call     tests/integration/training/test_span_marker.py::test_update_config
0.92s call     tests/integration/training/test_base.py::test_base_text_classification_without_split[setfit]
0.87s call     tests/integration/training/test_base.py::test_base_token_classification[spacy]
0.85s call     tests/integration/training/test_base.py::test_base_text_classification_with_split[spacy]
0.82s call     tests/integration/training/test_openai.py::test_openai_train_token
0.79s call     tests/integration/training/test_openai.py::test_openai_train_text2text
0.79s call     tests/integration/training/test_base.py::test_base_token_classification[setfit]
0.79s call     tests/integration/training/test_setfit.py::test_update_config
0.79s call     tests/integration/training/test_transformers.py::test_update_config
0.76s call     tests/integration/training/test_base.py::test_base_token_classification[transformers]
0.73s call     tests/integration/training/test_base.py::test_wrong_framework
0.72s call     tests/integration/training/test_openai.py::test_update_config
0.72s call     tests/integration/training/test_openai.py::test_openai_train
0.72s call     tests/integration/training/test_base.py::test_base_text_classification_without_split[transformers]
0.72s call     tests/integration/training/test_openai.py::test_openai_train_multi_label
0.71s call     tests/integration/training/test_base.py::test_base_text_classification_with_split[transformers]
0.71s call     tests/integration/training/test_base.py::test_base_text_classification_with_split[setfit]
0.09s teardown tests/integration/training/test_transformers.py::test_predict_wo_training
0.01s teardown tests/integration/training/test_openai.py::test_openai_train_token
0.01s teardown tests/integration/training/test_transformers.py::test_train_textcat
0.01s teardown tests/integration/training/test_span_marker.py::test_various_inputs
0.01s teardown tests/integration/training/test_span_marker.py::test_update_config
0.01s teardown tests/integration/training/test_openai.py::test_openai_train_text2text
0.01s teardown tests/integration/training/test_setfit.py::test_setfit_train
0.01s teardown tests/integration/training/test_span_marker.py::test_train_no_model
0.01s teardown tests/integration/training/test_setfit.py::test_update_config
0.01s teardown tests/integration/training/test_base.py::test_wrong_framework
0.01s teardown tests/integration/training/test_transformers.py::test_update_config
0.01s teardown tests/integration/training/test_span_marker.py::test_train_tokencat

(48 durations < 0.005s hidden.  Use -vv to show these durations.)
============================================================== 28 passed, 16 skipped, 558 warnings in 136.51s (0:02:16) ===============================================================
```

## The core issue
As you can see in the new timings, the most time-intensive thing is now the `setup` for the tests:
https://github.com/argilla-io/argilla/blob/265c801271a1837434ba2c2492a537ec1f85c9cc/tests/integration/conftest.py#L272-L353
These fixtures create the datasets, and they take about 3 seconds each (1.5s download, 0.5s configure/delete, 1s log). Speeding this up is possible, e.g. by having the data locally, shipped with the repository, rather than downloading it on the fly. Another big speedup is to stop using "function fixtures", but have fixtures that stay for the entire module or session. However, this also requires the mocked_client and many other fixtures to become module or session fixtures, and it eventually kind of stops working like you'd want.

## Memory usage
I didn't encounter any tests that use considerable memory, the highest was about 960MB. Considering the tests load (tiny, but still) transformer models, I don't think this is unreasonable.

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Refactor

**How Has This Been Tested**

`pytest tests/integration/training --durations=0` and via the `pytest-monitor` Python package.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

---

- Tom Aarsen