### PR TITLE
fix: remove `default` from `boolean` values in `argilla_template.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ These are the section headers that we use:
 - Updated `POST /api/v1/me/datasets/{dataset_id}/records` endpoint to allow searching records matching one of the response statuses provided via query param.([#3359](https://github.com/argilla-io/argilla/pull/3359)).
 - Updated `SearchEngine.search` method to allow searching records matching one of the response statuses provided ([#3359](https://github.com/argilla-io/argilla/pull/3359)).
 
+### Fixed
+
+- Fixed issue with `bool` values and `default` from Jinja2 while generating the HuggingFace `DatasetCard` from `argilla_template.md` ([#3499](https://github.com/argilla-io/argilla/pull/3499)).
+
 ## [1.13.3](https://github.com/argilla-io/argilla/compare/v1.13.2...v1.13.3)
 
 ### Fixed

--- a/src/argilla/client/feedback/integrations/huggingface/card/argilla_template.md
+++ b/src/argilla/client/feedback/integrations/huggingface/card/argilla_template.md
@@ -68,14 +68,14 @@ The **fields** are the dataset records themselves, for the moment just text fiel
 
 | Field Name | Title | Type | Required | Markdown |
 | ---------- | ----- | ---- | -------- | -------- |
-{% for field in argilla_fields %}| {{ field.name }} | {{ field.title }} | {{ field.__class__.__name__ }} | {{ field.required | default(true, true) }} | {{ field.settings.use_markdown | default(false, true) }} |
+{% for field in argilla_fields %}| {{ field.name }} | {{ field.title }} | {{ field.__class__.__name__ }} | {{ field.required }} | {{ field.settings.use_markdown }} |
 {% endfor %}
 
 The **questions** are the questions that will be asked to the annotators. They can be of different types, such as rating, text, single choice, or multiple choice.
 
 | Question Name | Title | Type | Required | Description | Values/Labels |
 | ------------- | ----- | ---- | -------- | ----------- | ------------- |
-{% for question in argilla_questions %}| {{ question.name }} | {{ question.title }} | {{ question.__class__.__name__  }} | {{ question.required | default(true, true) }} | {{ question.description | default("N/A", true) }} | {% if question.settings.type in ["rating", "label_selection", "multi_label_selection", "ranking"] %}{{ question.settings.options | map(attribute="value") | list }}{% else %}N/A{% endif %} |
+{% for question in argilla_questions %}| {{ question.name }} | {{ question.title }} | {{ question.__class__.__name__  }} | {{ question.required }} | {{ question.description | default("N/A", true) }} | {% if question.settings.type in ["rating", "label_selection", "multi_label_selection", "ranking"] %}{{ question.settings.options | map(attribute="value") | list }}{% else %}N/A{% endif %} |
 {% endfor %}
 
 **✨ NEW** Additionally, we also have **suggestions**, which are linked to the existing questions, and so on, named appending "-suggestion" and "-suggestion-metadata" to those, containing the value/s of the suggestion and its metadata, respectively. So on, the possible values are the same as in the table above.


### PR DESCRIPTION
# Description

This PR solves an on-going issue when default replacements are not properly applied in the Jinja2 template `argilla_template.md` for the HuggingFace dataset card generation.

This was initially reported by @nataliaElv and even most of it was already solved at https://github.com/argilla-io/argilla/pull/3366, but the table was using the `default` statement from Jinja2 and it was not working as expected.

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [X] Re-generated card including different `boolean` options to see whether those are properly included in the table as is, instead of being replaced by `True` by default

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
