### PR TITLE
fix: value of responses are not updated

### DIFF
--- a/src/argilla/server/apis/v1/handlers/responses.py
+++ b/src/argilla/server/apis/v1/handlers/responses.py
@@ -19,9 +19,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from argilla.server.contexts import datasets
 from argilla.server.database import get_async_db
-from argilla.server.models import User
+from argilla.server.models import Response, User
 from argilla.server.policies import ResponsePolicyV1, authorize
-from argilla.server.schemas.v1.responses import Response, ResponseUpdate
+from argilla.server.schemas.v1.responses import Response as ResponseSchema
+from argilla.server.schemas.v1.responses import ResponseUpdate
 from argilla.server.search_engine import SearchEngine, get_search_engine
 from argilla.server.security import auth
 
@@ -38,7 +39,7 @@ async def _get_response(db: AsyncSession, response_id: UUID) -> Response:
     return response
 
 
-@router.put("/responses/{response_id}", response_model=Response)
+@router.put("/responses/{response_id}", response_model=ResponseSchema)
 async def update_response(
     *,
     db: AsyncSession = Depends(get_async_db),
@@ -59,7 +60,7 @@ async def update_response(
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(err))
 
 
-@router.delete("/responses/{response_id}", response_model=Response)
+@router.delete("/responses/{response_id}", response_model=ResponseSchema)
 async def delete_response(
     *,
     db: AsyncSession = Depends(get_async_db),

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -121,8 +121,8 @@ async def publish_dataset(db: "AsyncSession", search_engine: SearchEngine, datas
 
 
 async def delete_dataset(db: "AsyncSession", search_engine: SearchEngine, dataset: Dataset) -> Dataset:
-    dataset = await dataset.delete(db)
     async with db.begin_nested():
+        dataset = await dataset.delete(db, autocommit=False)
         await search_engine.delete_index(dataset)
     return dataset
 
@@ -411,16 +411,15 @@ async def create_response(
 ) -> Response:
     validate_response_values(record.dataset, values=response_create.values, status=response_create.status)
 
-    response = await Response.create(
-        db,
-        values=jsonable_encoder(response_create.values),
-        status=response_create.status,
-        record_id=record.id,
-        user_id=user.id,
-        autocommit=False,
-    )
-
     async with db.begin_nested():
+        response = await Response.create(
+            db,
+            values=jsonable_encoder(response_create.values),
+            status=response_create.status,
+            record_id=record.id,
+            user_id=user.id,
+            autocommit=False,
+        )
         await db.flush([response])
         await search_engine.update_record_response(response)
 
@@ -432,19 +431,18 @@ async def update_response(
 ):
     validate_response_values(response.record.dataset, values=response_update.values, status=response_update.status)
 
-    response = await response.update(
-        db, values=jsonable_encoder(response_update.values), status=response_update.status, autocommit=False
-    )
-
     async with db.begin_nested():
+        response = await response.update(
+            db, values=jsonable_encoder(response_update.values), status=response_update.status, autocommit=False
+        )
         await search_engine.update_record_response(response)
 
     return response
 
 
 async def delete_response(db: "AsyncSession", search_engine: SearchEngine, response: Response) -> Response:
-    response = await response.delete(db)
     async with db.begin_nested():
+        response = await response.delete(db, autocommit=False)
         await search_engine.delete_record_response(response)
     return response
 

--- a/src/argilla/server/models/models.py
+++ b/src/argilla/server/models/models.py
@@ -82,7 +82,7 @@ ResponseStatusEnum = SAEnum(ResponseStatus, name="response_status_enum")
 class Response(DatabaseModel):
     __tablename__ = "responses"
 
-    values: Mapped[Optional[dict]] = mapped_column(JSON)
+    values: Mapped[Optional[dict]] = mapped_column(MutableDict.as_mutable(JSON))
     status: Mapped[ResponseStatus] = mapped_column(ResponseStatusEnum, default=ResponseStatus.submitted, index=True)
     record_id: Mapped[UUID] = mapped_column(ForeignKey("records.id", ondelete="CASCADE"), index=True)
     user_id: Mapped[Optional[UUID]] = mapped_column(ForeignKey("users.id", ondelete="SET NULL"), index=True)

--- a/tests/unit/server/api/v1/test_responses.py
+++ b/tests/unit/server/api/v1/test_responses.py
@@ -20,7 +20,6 @@ import pytest
 from argilla._constants import API_KEY_HEADER_NAME
 from argilla.server.models import DatasetStatus, Response, ResponseStatus, UserRole
 from argilla.server.search_engine import SearchEngine
-from fastapi.testclient import TestClient
 from sqlalchemy import func, select
 
 from tests.factories import (
@@ -35,6 +34,7 @@ from tests.factories import (
 )
 
 if TYPE_CHECKING:
+    from httpx import AsyncClient
     from sqlalchemy.ext.asyncio import AsyncSession
 
 


### PR DESCRIPTION
# Description

This PR fixes the issue (reported by @damianpumar), where the values of an already created response for a given record were not updated, even the server returned a `200`. The bug was introduced in #3462, where the `try: ... db.commit() except Exception: ... db.rollback()` where replaced with `async with db.begin_nested()` block.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

The Docker image of this branch has been deployed in `dev.argilla.io`, where I was able to update the values of a response, refresh the page and see the updated values.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
