### PR TITLE
fix: `DatasetConfig.to_yaml` and `DatasetConfig.from_yaml` to ignore `UUID`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ These are the section headers that we use:
 ### Fixed
 
 - Fixed issue with `bool` values and `default` from Jinja2 while generating the HuggingFace `DatasetCard` from `argilla_template.md` ([#3499](https://github.com/argilla-io/argilla/pull/3499)).
+- Fixed `DatasetConfig.from_yaml` which was failing when calling `FeedbackDataset.from_huggingface` as the UUIDs cannot be deserialized automatically by `PyYAML`, so UUIDs are neither dumped nor loaded anymore ([#3502](https://github.com/argilla-io/argilla/pull/3502)).
 
 ## [1.13.3](https://github.com/argilla-io/argilla/compare/v1.13.2...v1.13.3)
 

--- a/src/argilla/client/feedback/config.py
+++ b/src/argilla/client/feedback/config.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import re
 import warnings
 from typing import List, Optional
 
@@ -43,6 +44,7 @@ class DatasetConfig(BaseModel):
 
     @classmethod
     def from_yaml(cls, yaml: str) -> "DatasetConfig":
+        yaml = re.sub(r"(\n\s*|)id: !!python/object:uuid\.UUID\s+int: \d+", "", yaml)
         return cls(**load(yaml, Loader=SafeLoader))
 
 

--- a/src/argilla/client/feedback/config.py
+++ b/src/argilla/client/feedback/config.py
@@ -40,7 +40,7 @@ class DatasetConfig(BaseModel):
     guidelines: Optional[str] = None
 
     def to_yaml(self) -> str:
-        return dump(self.dict({"fields": {"__all__": {"id"}}, "questions": {"__all__": {"id"}}}))
+        return dump(self.dict(exclude={"fields": {"__all__": {"id"}}, "questions": {"__all__": {"id"}}}))
 
     @classmethod
     def from_yaml(cls, yaml: str) -> "DatasetConfig":

--- a/src/argilla/client/feedback/config.py
+++ b/src/argilla/client/feedback/config.py
@@ -39,7 +39,7 @@ class DatasetConfig(BaseModel):
     guidelines: Optional[str] = None
 
     def to_yaml(self) -> str:
-        return dump(self.dict())
+        return dump(self.dict({"fields": {"__all__": {"id"}}, "questions": {"__all__": {"id"}}}))
 
     @classmethod
     def from_yaml(cls, yaml: str) -> "DatasetConfig":

--- a/tests/unit/client/feedback/conftest.py
+++ b/tests/unit/client/feedback/conftest.py
@@ -15,15 +15,9 @@
 from typing import List
 
 import pytest
-from argilla.feedback import (
-    FeedbackRecord,
-    LabelQuestion,
-    MultiLabelQuestion,
-    RankingQuestion,
-    RatingQuestion,
-    TextField,
-    TextQuestion,
-)
+from argilla.client.feedback.schemas.fields import TextField
+from argilla.client.feedback.schemas.questions import TextQuestion
+from argilla.client.feedback.types import AllowedFieldTypes, AllowedQuestionTypes
 
 
 @pytest.fixture
@@ -54,3 +48,22 @@ def ranking_question_payload() -> dict:
         "required": True,
         "values": ["1", "2"],
     }
+
+
+@pytest.fixture
+def feedback_dataset_guidelines() -> str:
+    return "guidelines"
+
+
+@pytest.fixture
+def feedback_dataset_fields() -> List[AllowedFieldTypes]:
+    return [
+        TextField(name="text-field", required=True),
+    ]
+
+
+@pytest.fixture
+def feedback_dataset_questions() -> List[AllowedQuestionTypes]:
+    return [
+        TextQuestion(name="text-question", description="text", required=True),
+    ]

--- a/tests/unit/client/feedback/test_config.py
+++ b/tests/unit/client/feedback/test_config.py
@@ -43,10 +43,15 @@ def test_dataset_config_yaml(
     assert all(f"name: {question.name}" in to_yaml_config for question in feedback_dataset_questions)
     assert f"guidelines: {feedback_dataset_guidelines}" in to_yaml_config
 
+    assert "id" not in to_yaml_config
+    assert "!!python/object:uuid.UUID" not in to_yaml_config
+
     from_yaml_config = DatasetConfig.from_yaml(to_yaml_config)
     assert isinstance(from_yaml_config, DatasetConfig)
     assert from_yaml_config.fields == feedback_dataset_fields
+    assert all(field.id is None for field in from_yaml_config.fields)
     assert from_yaml_config.questions == feedback_dataset_questions
+    assert all(question.id is None for question in from_yaml_config.questions)
     assert from_yaml_config.guidelines == feedback_dataset_guidelines
 
 

--- a/tests/unit/client/feedback/test_config.py
+++ b/tests/unit/client/feedback/test_config.py
@@ -43,7 +43,6 @@ def test_dataset_config_yaml(
     assert all(f"name: {question.name}" in to_yaml_config for question in feedback_dataset_questions)
     assert f"guidelines: {feedback_dataset_guidelines}" in to_yaml_config
 
-    assert "id" not in to_yaml_config
     assert "!!python/object:uuid.UUID" not in to_yaml_config
 
     from_yaml_config = DatasetConfig.from_yaml(to_yaml_config)


### PR DESCRIPTION
# Description

As recently reported by @nataliaElv we had some issues while calling `FeedbackDataset.from_huggingface` as the `argilla.yaml` file couldn't be read properly. This was due to an incompatibility between the UUIDs and PyYAML, which is now patched.

We will no longer be dumping the `id` fields for both `fields` and `questions` since those are useless outside Argilla and we cannot use those to recreate a `FeedbackDataset` in Argilla, and when loading those back from HuggingFace we'll remove the `id` first with a regex to avoid loading issues.

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

- [X] Move `test_config.py` to unit tests as it's not calling the API
- [X] Add some assertions in `test_config.py` to ensure that the `id`s are neither dumped nor loaded from `argilla.yaml`

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [X] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
