### PR TITLE
fix: `push_to_argilla` to return `RemoteFeedbackDataset` without re-assigning class

### DIFF
--- a/src/argilla/client/feedback/dataset/mixins.py
+++ b/src/argilla/client/feedback/dataset/mixins.py
@@ -192,8 +192,19 @@ class ArgillaToFromMixin:
             client=httpx_client, id=argilla_id, show_progress=show_progress, question_mapping=question_name2id
         )
 
-        self.__class__ = RemoteFeedbackDataset
-        self.__init__(
+        warnings.warn(
+            "Calling `push_to_argilla` no longer implies that the `FeedbackDataset` can"
+            " be updated in Argilla. If you want to push a `FeedbackDataset` and then"
+            " update it in Argilla, you need to catch the returned object and use it"
+            " instead as `remote_ds = ds.push_to_argilla(...)`. Otherwise, you can just"
+            " call `push_to_argilla` and then `from_argilla` to retrieve the"
+            " `FeedbackDataset` from Argilla, so the current `FeedbackDataset` can be"
+            f" retrieved as `FeedbackDataset.from_argilla(id='{argilla_id}')`.",
+            DeprecationWarning,
+            stacklevel=1,
+        )
+
+        return RemoteFeedbackDataset(
             client=httpx_client,
             id=argilla_id,
             name=name,
@@ -202,7 +213,6 @@ class ArgillaToFromMixin:
             questions=questions,
             guidelines=self.guidelines,
         )
-        return self
 
     @staticmethod
     def __get_fields(client: "httpx.Client", id: UUID) -> List["AllowedFieldTypes"]:

--- a/src/argilla/client/feedback/dataset/mixins.py
+++ b/src/argilla/client/feedback/dataset/mixins.py
@@ -196,7 +196,7 @@ class ArgillaToFromMixin:
             "Calling `push_to_argilla` no longer implies that the `FeedbackDataset` can"
             " be updated in Argilla. If you want to push a `FeedbackDataset` and then"
             " update it in Argilla, you need to catch the returned object and use it"
-            " instead as `remote_ds = ds.push_to_argilla(...)`. Otherwise, you can just"
+            " instead: `remote_ds = ds.push_to_argilla(...)`. Otherwise, you can just"
             " call `push_to_argilla` and then `from_argilla` to retrieve the"
             " `FeedbackDataset` from Argilla, so the current `FeedbackDataset` can be"
             f" retrieved as `FeedbackDataset.from_argilla(id='{argilla_id}')`.",

--- a/tests/integration/client/feedback/test_dataset.py
+++ b/tests/integration/client/feedback/test_dataset.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
     from argilla.server.models import User as ServerUser
     from sqlalchemy.ext.asyncio import AsyncSession
 
+    from tests.integration.helpers import SecuredClient
+
 
 def test_init(
     feedback_dataset_guidelines: str,
@@ -153,17 +155,19 @@ def test_create_dataset_with_suggestions(argilla_user: "ServerUser"):
         ]
     )
 
-    ds.push_to_argilla(name="new_dataset")
+    remote_dataset = ds.push_to_argilla(name="new_dataset")
 
     with pytest.warns(DeprecationWarning):
-        ds.fetch_records()
+        remote_dataset.fetch_records()
 
-    assert len(ds.records) == 1
-    for record in ds.records:
+    assert len(remote_dataset.records) == 1
+    for record in remote_dataset.records:
         assert record.id is not None
         assert record.suggestions == (
             SuggestionSchema(
-                question_id=ds.question_by_name("text").id, question_name="text", value="This is a suggestion"
+                question_id=remote_dataset.question_by_name("text").id,
+                question_name="text",
+                value="This is a suggestion",
             ),
         )
 
@@ -176,17 +180,15 @@ async def test_update_dataset_records_with_suggestions(argilla_user: "ServerUser
 
     ds.add_records(records=[FeedbackRecord(fields={"text": "this is a text"})])
 
-    ds.push_to_argilla(name="new_dataset", workspace="argilla")
+    remote_dataset = ds.push_to_argilla(name="new_dataset", workspace="argilla")
 
-    ds.fetch_records()
-    assert len(ds.records) == 1
-    for record in ds.records:
+    assert len(remote_dataset.records) == 1
+    for record in remote_dataset.records:
         assert record.id is not None
         assert record.suggestions == ()
 
         record.set_suggestions([{"question_name": "text", "value": "This is a suggestion"}])
 
-    ds.push_to_argilla()
     # TODO: Review this requirement for tests and explain, try to avoid use or at least, document.
     await db.refresh(argilla_user, attribute_names=["datasets"])
     dataset = argilla_user.datasets[0]
@@ -194,11 +196,12 @@ async def test_update_dataset_records_with_suggestions(argilla_user: "ServerUser
     record = dataset.records[0]
     await db.refresh(record, attribute_names=["suggestions"])
 
-    ds.fetch_records()
-    for record in ds.records:
+    for record in remote_dataset.records:
         assert record.suggestions == (
             SuggestionSchema(
-                question_id=ds.question_by_name("text").id, question_name="text", value="This is a suggestion"
+                question_id=remote_dataset.question_by_name("text").id,
+                question_name="text",
+                value="This is a suggestion",
             ),
         )
 
@@ -415,10 +418,11 @@ async def test_push_to_argilla_and_from_argilla(
         ]
     )
 
+    remote_dataset = dataset.push_to_argilla(name="my-dataset")
     with pytest.warns(UserWarning, match="Multiple responses without `user_id`"):
         dataset.push_to_argilla(name="test-dataset")
 
-    dataset_from_argilla = FeedbackDataset.from_argilla(id=dataset.argilla_id)
+    dataset_from_argilla = FeedbackDataset.from_argilla(id=remote_dataset.id)
 
     assert dataset_from_argilla.guidelines == dataset.guidelines
     assert len(dataset_from_argilla.fields) == len(dataset.fields)
@@ -486,11 +490,10 @@ async def test_update_dataset_records_in_argilla(
         questions=feedback_dataset_questions,
     )
     dataset.add_records(records=feedback_dataset_records)
-    dataset.push_to_argilla(name="test-dataset")
+    remote_dataset = dataset.push_to_argilla(name="test-dataset")
     await db.refresh(argilla_user, attribute_names=["datasets"])
 
-    dataset.fetch_records()
-    for record in dataset.records:
+    for record in remote_dataset.records:
         record.set_suggestions(
             [
                 {
@@ -500,11 +503,10 @@ async def test_update_dataset_records_in_argilla(
             ]
         )
 
-    dataset.push_to_argilla()
     await db.refresh(argilla_user, attribute_names=["datasets"])
 
-    dataset = FeedbackDataset.from_argilla("test-dataset")
-    for record in dataset.records:
+    remote_dataset = FeedbackDataset.from_argilla("test-dataset")
+    for record in remote_dataset.records:
         record.set_suggestions(
             [
                 {
@@ -514,10 +516,9 @@ async def test_update_dataset_records_in_argilla(
             ]
         )
 
-    dataset.push_to_argilla()
     await db.refresh(argilla_user, attribute_names=["datasets"])
 
-    for record in dataset.records:
+    for record in remote_dataset.records:
         record.set_suggestions(
             [
                 {
@@ -527,10 +528,10 @@ async def test_update_dataset_records_in_argilla(
             ]
         )
 
-    dataset.push_to_argilla("new-test-dataset")
+    new_remote_dataset = dataset.push_to_argilla("new-test-dataset")
     await db.refresh(argilla_user, attribute_names=["datasets"])
 
-    record = dataset.records[0]
+    record = new_remote_dataset.records[0]
     with pytest.warns(UserWarning, match="A suggestion for question `question-1`"):
         record.set_suggestions(
             [

--- a/tests/integration/client/feedback/test_dataset.py
+++ b/tests/integration/client/feedback/test_dataset.py
@@ -418,7 +418,11 @@ async def test_push_to_argilla_and_from_argilla(
         ]
     )
 
-    remote_dataset = dataset.push_to_argilla(name="my-dataset")
+    with pytest.warns(
+        DeprecationWarning, match="Calling `push_to_argilla` no longer implies that the `FeedbackDataset`"
+    ):
+        remote_dataset = dataset.push_to_argilla(name="my-dataset")
+
     with pytest.warns(UserWarning, match="Multiple responses without `user_id`"):
         dataset.push_to_argilla(name="test-dataset")
 


### PR DESCRIPTION
# Description

This PR adds a `warnings.warn` message to let the users know that the returned object from `FeedbackDataset.push_to_argilla` needs to be handled, otherwise the dataset instance will remain local, as `push_to_argilla` with no arguments won't do anything.

So on, before we had to `push_to_argilla` a new `FeedbackDataset` with name and/or workspaces, and then we could `push_to_argilla` with no arguments to push the updates, but we no longer need to do that, as now we can re-use the returned `FeedbackDataset` from `push_to_argilla` to have a `FeedbackDataset` fully integrated with Argilla.

```diff
import argilla as rg

dataset = rg.FeedbackDataset(...)
- dataset.push_to_argilla(name="my-dataset", workspace="my-workspace")
+ remote_dataset = dataset.push_to_argilla(name="my-dataset", workspace="my-workspace")

dataset.add_records(...)
- dataset.push_to_argilla()
```

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

- [X] Catch returned object in `push_to_argilla` and handle `DeprecationWarning`

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
