### PR TITLE
feat: add `delete` method to `FeedbackDataset` in Argilla

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ These are the section headers that we use:
 - Added `PATCH /api/v1/questions/{question_id}` endpoint to update question title, description and some settings (depending on the type of question) ([#3477](https://github.com/argilla-io/argilla/pull/3477)).
 - Added `DELETE /api/v1/records/{record_id}` endpoint to remove a record given its ID ([#3337](https://github.com/argilla-io/argilla/pull/3337)).
 - Added `pull` method in `RemoteFeedbackDataset` (a `FeedbackDataset` pushed to Argilla) to pull all the records from it and return it as a local copy as a `FeedbackDataset` ([#3465](https://github.com/argilla-io/argilla/pull/3465)).
+- Added `delete` method in `RemoteFeedbackDataset` (a `FeedbackDataset` pushed to Argilla) ([#3512](https://github.com/argilla-io/argilla/pull/3512)).
 
 ### Changed
 

--- a/src/argilla/client/feedback/dataset/remote.py
+++ b/src/argilla/client/feedback/dataset/remote.py
@@ -20,7 +20,9 @@ from tqdm import trange
 from argilla.client.feedback.constants import FETCHING_BATCH_SIZE, PUSHING_BATCH_SIZE
 from argilla.client.feedback.dataset.base import FeedbackDatasetBase
 from argilla.client.feedback.schemas.records import FeedbackRecord, RemoteFeedbackRecord
+from argilla.client.sdk.users.models import UserRole
 from argilla.client.sdk.v1.datasets import api as datasets_api_v1
+from argilla.client.utils import allowed_for_roles
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -367,3 +369,17 @@ class RemoteFeedbackDataset(FeedbackDatasetBase):
             ValueError: if the given records do not match the expected schema.
         """
         self._records.add(records=records, show_progress=show_progress)
+
+    @allowed_for_roles(roles=[UserRole.owner, UserRole.admin])
+    def delete(self) -> None:
+        """Deletes the current `FeedbackDataset` from Argilla. This method is just working
+        if the user has either `owner` or `admin` role.
+
+        Raises:
+            PermissionError: if the user does not have either `owner` or `admin` role.
+            Exception: if the `FeedbackDataset` cannot be deleted from Argilla.
+        """
+        try:
+            datasets_api_v1.delete_dataset(client=self._client, id=self.id)
+        except Exception as e:
+            raise Exception(f"Failed while deleting the `FeedbackDataaset` from Argilla with exception: {e}") from e

--- a/src/argilla/client/feedback/dataset/remote.py
+++ b/src/argilla/client/feedback/dataset/remote.py
@@ -377,9 +377,9 @@ class RemoteFeedbackDataset(FeedbackDatasetBase):
 
         Raises:
             PermissionError: if the user does not have either `owner` or `admin` role.
-            Exception: if the `FeedbackDataset` cannot be deleted from Argilla.
+            RuntimeError: if the `FeedbackDataset` cannot be deleted from Argilla.
         """
         try:
             datasets_api_v1.delete_dataset(client=self._client, id=self.id)
         except Exception as e:
-            raise Exception(f"Failed while deleting the `FeedbackDataaset` from Argilla with exception: {e}") from e
+            raise RuntimeError(f"Failed while deleting the `FeedbackDataset` from Argilla with exception: {e}") from e


### PR DESCRIPTION
# Description

This PR adds a `delete` method for `RemoteFeedbackDataset` which is a `FeedbackDataset` that has been pushed to Argilla. So on, the `delete` method deletes a dataset in Argilla, but it's just available for `owner` users and for `admin` users with that dataset within their workspace, otherwise the method won't work and will raise a `PermissionError`.

So on, now both `owner` and `admin` users can delete a `FeedbackDataset` from Argilla as:

```python
import argilla as rg

rg.init(...)

dataset = FeedbackDataset.from_argilla(...)
dataset.delete()
```

Or alternatively

```python
import argilla as rg

rg.init(...)

dataset = FeedbackDataset(...)
remote_dataset = dataset.push_to_argilla(...)
remote_dataset.delete()
```

Closes #3413

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [X] Add integration tests for `RemoteFeedbackDataset.delete` including every role

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [X] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
