### PR TITLE
fix: PR message not found

### DIFF
--- a/.github/actions/slack-post-credentials/app/main.py
+++ b/.github/actions/slack-post-credentials/app/main.py
@@ -88,7 +88,7 @@ def get_pr_url(pr_number: int) -> str:
 
 
 def get_thread_ts_pr_message(client: WebClient, channel_id: str, pr_number: int) -> Union[str, None]:
-    response = client.conversations_history(channel=channel_id)
+    response = client.conversations_history(channel=channel_id, limit=500)
     response.validate()
 
     pr_url = get_pr_url(pr_number)


### PR DESCRIPTION
# Description

This PR updates the code of the `slack-post-credentials` actions to retrieve 500 messages in order to ensure that the PR opened message is found in the Slack channel.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

N/A

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
