### PR TITLE
feat: delete existing records from a `FeedbackDataset` in Argilla

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ These are the section headers that we use:
 - Added `DELETE /api/v1/records/{record_id}` endpoint to remove a record given its ID ([#3337](https://github.com/argilla-io/argilla/pull/3337)).
 - Added `pull` method in `RemoteFeedbackDataset` (a `FeedbackDataset` pushed to Argilla) to pull all the records from it and return it as a local copy as a `FeedbackDataset` ([#3465](https://github.com/argilla-io/argilla/pull/3465)).
 - Added `delete` method in `RemoteFeedbackDataset` (a `FeedbackDataset` pushed to Argilla) ([#3512](https://github.com/argilla-io/argilla/pull/3512)).
+- Added `delete_records` method in `RemoteFeedbackDataset`, and `delete` method in `RemoteFeedbackRecord` to delete records from Argilla ([#3526](https://github.com/argilla-io/argilla/pull/3526)).
 
 ### Changed
 

--- a/src/argilla/client/feedback/dataset/local.py
+++ b/src/argilla/client/feedback/dataset/local.py
@@ -166,8 +166,9 @@ class FeedbackDataset(FeedbackDatasetBase, ArgillaToFromMixin):
         those will be automatically uploaded to Argilla.
 
         Args:
-            records: the records to add to the dataset. Can be a single record, a list
-                of records or a dictionary with the fields of the record.
+            records: can be a single `FeedbackRecord`, a list of `FeedbackRecord`,
+                a single dictionary, or a list of dictionaries. If a dictionary is provided,
+                it will be converted to a `FeedbackRecord` internally.
 
         Raises:
             ValueError: if the given records are an empty list.

--- a/src/argilla/client/feedback/dataset/remote.py
+++ b/src/argilla/client/feedback/dataset/remote.py
@@ -172,13 +172,14 @@ class RemoteFeedbackRecords:
 
     def add(
         self,
-        records: List[FeedbackRecord],
+        records: Union[FeedbackRecord, Dict[str, Any], List[Union[FeedbackRecord, Dict[str, Any]]]],
         show_progress: bool = True,
     ) -> None:
         """Pushes a list of `FeedbackRecord`s to Argilla.
 
         Args:
-            records: A list of `FeedbackRecord`s to push to Argilla.
+            records: the records to add to the dataset. Can be a single record, a list
+                of records or a dictionary with the fields of the record.
             show_progress: Whether to show a `tqdm` progress bar while pushing the records.
 
         Raises:

--- a/src/argilla/client/feedback/dataset/remote.py
+++ b/src/argilla/client/feedback/dataset/remote.py
@@ -403,7 +403,7 @@ class RemoteFeedbackDataset(FeedbackDatasetBase):
         Raises:
             RuntimeError: If the deletion of the records from Argilla fails.
         """
-        self._records.delete(records=records[0] if not isinstance(records, list) else records)
+        self._records.delete(records=[records] if not isinstance(records, list) else records)
 
     @allowed_for_roles(roles=[UserRole.owner, UserRole.admin])
     def delete(self) -> None:

--- a/src/argilla/client/feedback/dataset/remote.py
+++ b/src/argilla/client/feedback/dataset/remote.py
@@ -392,6 +392,7 @@ class RemoteFeedbackDataset(FeedbackDatasetBase):
         """
         self._records.add(records=records, show_progress=show_progress)
 
+    @allowed_for_roles(roles=[UserRole.owner, UserRole.admin])
     def delete_records(self, records: Union["RemoteFeedbackRecord", List["RemoteFeedbackRecord"]]) -> None:
         """Deletes the given records from the dataset in Argilla.
 

--- a/src/argilla/client/feedback/dataset/remote.py
+++ b/src/argilla/client/feedback/dataset/remote.py
@@ -368,7 +368,9 @@ class RemoteFeedbackDataset(FeedbackDatasetBase):
             questions=self.questions,
             guidelines=self.guidelines,
         )
-        instance.add_records([record.dict(exclude={"client", "name2id"}) for record in self._records])
+        instance.add_records(
+            [record.dict(exclude={"client", "name2id", "id"}, exclude_none=True) for record in self._records]
+        )
         return instance
 
     def add_records(

--- a/src/argilla/client/feedback/dataset/remote.py
+++ b/src/argilla/client/feedback/dataset/remote.py
@@ -179,8 +179,9 @@ class RemoteFeedbackRecords:
         """Pushes a list of `FeedbackRecord`s to Argilla.
 
         Args:
-            records: the records to add to the dataset. Can be a single record, a list
-                of records or a dictionary with the fields of the record.
+            records: can be a single `FeedbackRecord`, a list of `FeedbackRecord`,
+                a single dictionary, or a list of dictionaries. If a dictionary is provided,
+                it will be converted to a `FeedbackRecord` internally.
             show_progress: Whether to show a `tqdm` progress bar while pushing the records.
 
         Raises:
@@ -381,8 +382,9 @@ class RemoteFeedbackDataset(FeedbackDatasetBase):
         """Adds the given records to the dataset and pushes those to Argilla.
 
         Args:
-            records: the records to add to the dataset. Can be a single record, a list
-                of records or a dictionary with the fields of the record.
+            records: can be a single `FeedbackRecord`, a list of `FeedbackRecord`,
+                a single dictionary, or a list of dictionaries. If a dictionary is provided,
+                it will be converted to a `FeedbackRecord` internally.
 
         Raises:
             ValueError: if the given records are an empty list.

--- a/src/argilla/client/feedback/schemas/records.py
+++ b/src/argilla/client/feedback/schemas/records.py
@@ -269,7 +269,7 @@ class RemoteFeedbackRecord(FeedbackRecord):
             response = records_api_v1.delete_record(client=self.client, id=self.id)
         except Exception as e:
             raise RuntimeError(f"Failed to delete record with ID `{self.id}` from Argilla.") from e
-        return FeedbackRecord(**response.parsed.dict(exclude={"id", "inserted_at", "updated_at"}))
+        return FeedbackRecord(**response.parsed.dict(exclude={"id", "inserted_at", "updated_at"}, exclude_none=True))
 
     class Config:
         arbitrary_types_allowed = True

--- a/src/argilla/client/feedback/schemas/records.py
+++ b/src/argilla/client/feedback/schemas/records.py
@@ -120,11 +120,9 @@ class SuggestionSchema(BaseModel):
 
 
 class FeedbackRecord(BaseModel):
-    """Schema for the records of a `FeedbackDataset` in Argilla.
+    """Schema for the records of a `FeedbackDataset` locally.
 
     Args:
-        id: The ID of the record in Argilla. Defaults to None, and is automatically
-            fulfilled internally once the record is pushed to Argilla.
         fields: Fields that match the `FeedbackDataset` defined fields. So this attribute
             contains the actual information shown in the UI for each record, being the
             record itself.
@@ -167,7 +165,6 @@ class FeedbackRecord(BaseModel):
 
     """
 
-    id: Optional[UUID] = None
     fields: Dict[str, str]
     metadata: Dict[str, Any] = Field(default_factory=dict)
     responses: List[ResponseSchema] = Field(default_factory=list)

--- a/src/argilla/client/feedback/schemas/records.py
+++ b/src/argilla/client/feedback/schemas/records.py
@@ -223,8 +223,23 @@ class FeedbackRecord(BaseModel):
 
 
 class RemoteFeedbackRecord(FeedbackRecord):
+    """Schema for the records of a `FeedbackDataset` remotely (in Argilla).
+
+    Note this schema shouldn't be instantiated directly, but just internally by the
+    `RemoteFeedbackDataset` class when fetching records from Argilla.
+
+    Args:
+        id: The ID of the record in Argilla. Defaults to None, and is automatically
+            fulfilled internally once the record is pushed to Argilla.
+        client: The Argilla client to use to push the record to Argilla. Is shared with
+            the `RemoteFeedbackDataset` that created this record.
+        name2id: A dictionary that maps the question names to their corresponding IDs.
+    """
+
     client: httpx.Client
     name2id: Dict[str, UUID]
+
+    id: UUID
 
     def update(
         self, suggestions: Union[SuggestionSchema, List[SuggestionSchema], Dict[str, Any], List[Dict[str, Any]]]

--- a/src/argilla/client/feedback/schemas/records.py
+++ b/src/argilla/client/feedback/schemas/records.py
@@ -121,7 +121,7 @@ class SuggestionSchema(BaseModel):
 
 
 class FeedbackRecord(BaseModel):
-    """Schema for the records of a `FeedbackDataset` locally.
+    """Schema for the records of a `FeedbackDataset`.
 
     Args:
         fields: Fields that match the `FeedbackDataset` defined fields. So this attribute
@@ -224,7 +224,7 @@ class FeedbackRecord(BaseModel):
 
 
 class RemoteFeedbackRecord(FeedbackRecord):
-    """Schema for the records of a `FeedbackDataset` remotely (in Argilla).
+    """Schema for the records of a `RemoteFeedbackDataset`.
 
     Note this schema shouldn't be instantiated directly, but just internally by the
     `RemoteFeedbackDataset` class when fetching records from Argilla.
@@ -245,6 +245,15 @@ class RemoteFeedbackRecord(FeedbackRecord):
     def update(
         self, suggestions: Union[SuggestionSchema, List[SuggestionSchema], Dict[str, Any], List[Dict[str, Any]]]
     ) -> None:
+        """Update a `RemoteFeedbackRecord`. Currently just `suggestions` are supported.
+
+        Note that this method will update the record in Argilla directly.
+
+        Args:
+            suggestions: can be a single `SuggestionSchema`, a list of `SuggestionSchema`,
+                a single dictionary, or a list of dictionaries. If a dictionary is provided,
+                it will be converted to a `SuggestionSchema` internally.
+        """
         super().update(suggestions)
         for suggestion in self.suggestions:
             suggestion.question_id = self.name2id[suggestion.question_name]
@@ -255,6 +264,7 @@ class RemoteFeedbackRecord(FeedbackRecord):
     def set_suggestions(
         self, suggestions: Union[SuggestionSchema, List[SuggestionSchema], Dict[str, Any], List[Dict[str, Any]]]
     ) -> None:
+        """Deprecated, use `update` instead."""
         warnings.warn(
             "`set_suggestions` is deprected in favor of `update` and will be removed in a future"
             " release.\n`set_suggestions` will be deprecated in Argilla v1.15.0, please"
@@ -265,6 +275,11 @@ class RemoteFeedbackRecord(FeedbackRecord):
         self.update(suggestions=suggestions)
 
     def delete(self) -> FeedbackRecord:
+        """Deletes the `RemoteFeedbackRecord` from Argilla.
+
+        Returns:
+            The deleted record formatted as a `FeedbackRecord`.
+        """
         try:
             response = records_api_v1.delete_record(client=self.client, id=self.id)
         except Exception as e:

--- a/src/argilla/client/feedback/schemas/records.py
+++ b/src/argilla/client/feedback/schemas/records.py
@@ -20,6 +20,7 @@ import httpx
 from pydantic import BaseModel, Extra, Field, PrivateAttr, StrictInt, StrictStr, conint, validator
 
 from argilla.client.sdk.v1.datasets import api as datasets_api_v1
+from argilla.client.sdk.v1.records import api as records_api_v1
 
 if TYPE_CHECKING:
     from argilla.client.feedback.unification import UnifiedValueSchema
@@ -262,6 +263,13 @@ class RemoteFeedbackRecord(FeedbackRecord):
             stacklevel=1,
         )
         self.update(suggestions=suggestions)
+
+    def delete(self) -> FeedbackRecord:
+        try:
+            response = records_api_v1.delete_record(client=self.client, id=self.id)
+        except Exception as e:
+            raise RuntimeError(f"Failed to delete record with ID `{self.id}` from Argilla.") from e
+        return FeedbackRecord(**response.parsed.dict(exclude={"id", "inserted_at", "updated_at"}))
 
     class Config:
         arbitrary_types_allowed = True

--- a/src/argilla/client/sdk/v1/datasets/__init__.py
+++ b/src/argilla/client/sdk/v1/datasets/__init__.py
@@ -1,4 +1,3 @@
-#  coding=utf-8
 #  Copyright 2021-present, the Recognai S.L. team.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/argilla/client/sdk/v1/records/__init__.py
+++ b/src/argilla/client/sdk/v1/records/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/src/argilla/client/sdk/v1/records/api.py
+++ b/src/argilla/client/sdk/v1/records/api.py
@@ -1,0 +1,49 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Union
+from uuid import UUID
+
+import httpx
+
+from argilla.client.sdk.commons.errors_handler import handle_response_error
+from argilla.client.sdk.commons.models import ErrorMessage, HTTPValidationError, Response
+from argilla.client.sdk.v1.records.models import FeedbackItemModel
+
+
+def delete_record(
+    client: httpx.Client, id: UUID
+) -> Response[Union[FeedbackItemModel, ErrorMessage, HTTPValidationError]]:
+    """Sends a DELETE request to `/api/v1/records/{id}` endpoint to delete a
+    record from Argilla.
+
+    Args:
+        client: the authenticated Argilla client to be used to send the request to the API.
+        id: the id of the record to be deleted in Argilla.
+
+    Returns:
+        A `Response` object with the response itself, and/or the error codes if applicable.
+    """
+    url = f"/api/v1/records/{id}"
+
+    response = client.delete(url=url)
+
+    if response.status_code == 200:
+        return Response(
+            parsed=FeedbackItemModel.parse_raw(response.content),
+            status_code=response.status_code,
+            content=response.content,
+            headers=response.headers,
+        )
+    return handle_response_error(response)

--- a/src/argilla/client/sdk/v1/records/models.py
+++ b/src/argilla/client/sdk/v1/records/models.py
@@ -1,0 +1,19 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""`pydantic.BaseModel`s defined here are shared between `argilla.client.sdk.v1.records`
+and `argilla.client.sdk.v1.datasets` modules, so those should be equal, and defined in
+`argilla.client.sdk.v1.datasets.models` module instead."""
+
+from argilla.client.sdk.v1.datasets.models import FeedbackItemModel  # noqa: F401

--- a/tests/integration/client/feedback/dataset/__init__.py
+++ b/tests/integration/client/feedback/dataset/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/integration/client/feedback/dataset/test_remote.py
+++ b/tests/integration/client/feedback/dataset/test_remote.py
@@ -1,0 +1,72 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+from argilla.client import api
+from argilla.client.feedback.dataset import FeedbackDataset
+from argilla.client.sdk.users.models import UserRole
+
+from tests.factories import DatasetFactory, RecordFactory, TextFieldFactory, TextQuestionFactory, UserFactory
+
+
+@pytest.mark.parametrize("role", [UserRole.owner, UserRole.admin])
+@pytest.mark.asyncio
+async def test_delete_records(role: UserRole) -> None:
+    text_field = await TextFieldFactory.create(required=True)
+    rating_question = await TextQuestionFactory.create(required=True)
+    dataset = await DatasetFactory.create(
+        fields=[text_field],
+        questions=[rating_question],
+        records=RecordFactory.create_batch(size=10),
+    )
+    user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
+
+    api.init(api_key=user.api_key)
+    remote_dataset = FeedbackDataset.from_argilla(id=dataset.id)
+    remote_records = [record for record in remote_dataset.records]
+    assert all(record.id for record in remote_records)
+
+    remote_dataset.delete_records(remote_records)
+    assert len(remote_dataset.records) == 0
+
+
+@pytest.mark.parametrize("role", [UserRole.owner, UserRole.admin])
+@pytest.mark.asyncio
+async def test_delete(role: UserRole) -> None:
+    text_field = await TextFieldFactory.create(required=True)
+    rating_question = await TextQuestionFactory.create(required=True)
+    dataset = await DatasetFactory.create(fields=[text_field], questions=[rating_question])
+    user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
+
+    api.init(api_key=user.api_key)
+    remote_dataset = FeedbackDataset.from_argilla(id=dataset.id)
+    remote_dataset.delete()
+
+    datasets = api.active_api().http_client.get("/api/v1/me/datasets")["items"]
+    assert not any(ds["name"] == remote_dataset.name for ds in datasets)
+
+
+@pytest.mark.parametrize("role", [UserRole.annotator])
+@pytest.mark.asyncio
+async def test_delete_not_allowed_role(role: UserRole) -> None:
+    text_field = await TextFieldFactory.create(required=True)
+    rating_question = await TextQuestionFactory.create(required=True)
+    dataset = await DatasetFactory.create(fields=[text_field], questions=[rating_question])
+    user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
+
+    api.init(api_key=user.api_key)
+    remote_dataset = FeedbackDataset.from_argilla(id=dataset.id)
+
+    with pytest.raises(PermissionError, match=f"User with role={role} is not allowed to call `delete`"):
+        remote_dataset.delete()

--- a/tests/integration/client/feedback/dataset/test_remote.py
+++ b/tests/integration/client/feedback/dataset/test_remote.py
@@ -37,7 +37,10 @@ async def test_delete_records(role: UserRole) -> None:
     remote_records = [record for record in remote_dataset.records]
     assert all(record.id for record in remote_records)
 
-    remote_dataset.delete_records(remote_records)
+    remote_dataset.delete_records(remote_records[0])
+    assert len(remote_dataset.records) == len(remote_records) - 1
+
+    remote_dataset.delete_records(remote_records[1:])
     assert len(remote_dataset.records) == 0
 
 

--- a/tests/integration/client/feedback/schemas/__init__.py
+++ b/tests/integration/client/feedback/schemas/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/integration/client/feedback/schemas/test_records.py
+++ b/tests/integration/client/feedback/schemas/test_records.py
@@ -1,0 +1,102 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+from argilla.client import api
+from argilla.client.feedback.dataset import FeedbackDataset
+from argilla.client.feedback.schemas.records import FeedbackRecord, RemoteFeedbackRecord, SuggestionSchema
+from argilla.client.sdk.users.models import UserRole
+
+from tests.factories import DatasetFactory, RecordFactory, TextFieldFactory, TextQuestionFactory, UserFactory
+
+
+@pytest.mark.parametrize("role", [UserRole.owner, UserRole.admin])
+@pytest.mark.asyncio
+async def test_delete(role: UserRole) -> None:
+    text_field = await TextFieldFactory.create(required=True)
+    rating_question = await TextQuestionFactory.create(required=True)
+    dataset = await DatasetFactory.create(
+        fields=[text_field],
+        questions=[rating_question],
+        records=RecordFactory.create_batch(size=10),
+    )
+    user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
+
+    api.init(api_key=user.api_key)
+    remote_dataset = FeedbackDataset.from_argilla(id=dataset.id)
+    remote_records = [record for record in remote_dataset.records]
+    assert all(isinstance(record, RemoteFeedbackRecord) for record in remote_records)
+
+    deleted_records = []
+    for record in remote_records:
+        deleted_records.append(record.delete())
+    assert all(isinstance(record, FeedbackRecord) for record in deleted_records)
+    assert len(remote_dataset.records) == 0
+
+
+@pytest.mark.parametrize("role", [UserRole.owner, UserRole.admin])
+@pytest.mark.asyncio
+async def test_update(role: UserRole) -> None:
+    text_field = await TextFieldFactory.create(required=True)
+    text_question = await TextQuestionFactory.create(required=True)
+    dataset = await DatasetFactory.create(
+        fields=[text_field],
+        questions=[text_question],
+        records=RecordFactory.create_batch(size=10),
+    )
+    user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
+
+    api.init(api_key=user.api_key)
+    remote_dataset = FeedbackDataset.from_argilla(id=dataset.id)
+    remote_records = [record for record in remote_dataset.records]
+    assert all(isinstance(record, RemoteFeedbackRecord) for record in remote_records)
+    assert all(record.suggestions == () for record in remote_records)
+
+    suggestion = SuggestionSchema(
+        question_id=text_question.id,
+        question_name=text_question.name,
+        value="suggestion",
+    )
+    for record in remote_records:
+        record.update(suggestions=[suggestion])
+    assert all(record.suggestions == (suggestion) for record in remote_dataset.records)
+
+
+@pytest.mark.parametrize("role", [UserRole.owner, UserRole.admin])
+@pytest.mark.asyncio
+async def test_set_suggestions_deprecated(role: UserRole) -> None:
+    text_field = await TextFieldFactory.create(required=True)
+    text_question = await TextQuestionFactory.create(required=True)
+    dataset = await DatasetFactory.create(
+        fields=[text_field],
+        questions=[text_question],
+        records=RecordFactory.create_batch(size=10),
+    )
+    user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
+
+    api.init(api_key=user.api_key)
+    remote_dataset = FeedbackDataset.from_argilla(id=dataset.id)
+    remote_records = [record for record in remote_dataset.records]
+    assert all(isinstance(record, RemoteFeedbackRecord) for record in remote_records)
+    assert all(record.suggestions == () for record in remote_records)
+
+    suggestion = SuggestionSchema(
+        question_id=text_question.id,
+        question_name=text_question.name,
+        value="suggestion",
+    )
+    with pytest.warns(DeprecationWarning, match="`set_suggestions` is deprected in favor of `update`"):
+        for record in remote_records:
+            record.set_suggestions(suggestions=[suggestion])
+    assert all(record.suggestions == (suggestion) for record in remote_dataset.records)

--- a/tests/integration/client/feedback/test_dataset.py
+++ b/tests/integration/client/feedback/test_dataset.py
@@ -29,9 +29,6 @@ from argilla.client.feedback.schemas import (
 )
 from argilla.client.feedback.training.schemas import TrainingTaskMapping
 from argilla.client.models import Framework
-from argilla.client.sdk.users.models import UserRole
-
-from tests.factories import DatasetFactory, TextFieldFactory, TextQuestionFactory, UserFactory
 
 if TYPE_CHECKING:
     from argilla.client.feedback.types import AllowedFieldTypes, AllowedQuestionTypes
@@ -691,34 +688,3 @@ def test_prepare_for_training_text_classification(
     task_mapping = TrainingTaskMapping.for_text_classification(text=dataset.fields[0], label=label)
 
     dataset.prepare_for_training(framework=framework, task_mapping=task_mapping, fetch_records=False)
-
-
-@pytest.mark.parametrize("role", [UserRole.owner, UserRole.admin])
-@pytest.mark.asyncio
-async def test_delete(role: UserRole) -> None:
-    text_field = await TextFieldFactory.create(required=True)
-    rating_question = await TextQuestionFactory.create(required=True)
-    dataset = await DatasetFactory.create(fields=[text_field], questions=[rating_question])
-    user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
-
-    api.init(api_key=user.api_key)
-    remote_dataset = FeedbackDataset.from_argilla(id=dataset.id)
-    remote_dataset.delete()
-
-    datasets = api.active_api().http_client.get("/api/v1/me/datasets")["items"]
-    assert not any(ds["name"] == remote_dataset.name for ds in datasets)
-
-
-@pytest.mark.parametrize("role", [UserRole.annotator])
-@pytest.mark.asyncio
-async def test_delete_not_allowed_role(role: UserRole) -> None:
-    text_field = await TextFieldFactory.create(required=True)
-    rating_question = await TextQuestionFactory.create(required=True)
-    dataset = await DatasetFactory.create(fields=[text_field], questions=[rating_question])
-    user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
-
-    api.init(api_key=user.api_key)
-    remote_dataset = FeedbackDataset.from_argilla(id=dataset.id)
-
-    with pytest.raises(PermissionError, match=f"User with role={role} is not allowed to call `delete`"):
-        remote_dataset.delete()

--- a/tests/unit/client/feedback/schemas/test_records.py
+++ b/tests/unit/client/feedback/schemas/test_records.py
@@ -87,7 +87,6 @@ def test_feedback_record(schema_kwargs: Dict[str, Any]) -> None:
     [
         (
             {
-                "id": "00000000-0000-0000-0000-000000000000",
                 "fields": {"text": "This is the first record", "label": "positive"},
             },
             {


### PR DESCRIPTION
# Description

This PR adds `delete_record` function in the SDK covering `DELETE /api/v1/records/{record_id}` to also include: a `delete` method for `RemoteFeedbackRecord` to delete records from Argilla, a `delete` method for `RemoteFeedbackRecords`, a `delete_records` method in `RemoteFeedbackDataset` as a shortcut for the previous one.

So on, this implies that now we can either do in place deletions as:

```python
import argilla as rg

dataset = rg.FeedbackDataset.from_argilla(name="my-dataset", workspace="my-workspace")
dataset.records[0].delete()
```

Or also deleting a list of records via `delete_records` as:

```python
import argilla as rg

dataset = rg.FeedbackDataset.from_argilla(name="my-dataset", workspace="my-workspace")

dataset.delete_records([record for record in dataset.records])
```

Additionally, note that when calling `.delete()` over a `RemoteFeedbackRecord`, it will return the record instance as a `FeedbackRecord` so that it can be used locally and pushed again, if applicable.

```python
deleted_record = dataset.records[0].delete()
```

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [X] Create `tests/integration/client/feedback/dataset/test_remote.py` with the `RemoteFeedbackDataset` integration tests for the methods `delete_records` and `delete` methods
- [X] Create `tests/integration/client/feedback/schemas/test_records.py` with the `RemoteFeedbackRecord` integration tests for the methods `delete` and `update`, also ensuring `set_suggestions` is still working but throwing a `DeprecationWarning`

**Checklist**

- [X] I added relevant documentation
- [ ] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)