### PR TITLE
docs: align docs with `FeedbackDataset` refactor using `tab-set` 

### DIFF
--- a/docs/_source/getting_started/installation/configurations/database_migrations.md
+++ b/docs/_source/getting_started/installation/configurations/database_migrations.md
@@ -112,9 +112,25 @@ rg.log(ds, new_dataset)
 
 If you are using new feedback datasets and you want to update the search engine info, you should copy your dataset:
 
+::::{tab-set}
+
+:::{tab-item} Argilla 1.14.0 or higher
+```python
+import argilla as rg
+
+dataset = rg.FeedbackDataset.from_argilla(name="feedback-dataset")
+dataset = dataset.pull()
+dataset.push_to_argilla(name=f"{dataset.name}_copy")
+```
+:::
+
+:::{tab-item} Lower than Argilla 1.14.0
 ```python
 import argilla as rg
 
 dataset = rg.FeedbackDataset.from_argilla(name="feedback-dataset")
 dataset.push_to_argilla(name=f"{dataset.name}_copy")
 ```
+:::
+
+::::

--- a/docs/_source/getting_started/installation/deployments/deployments.md
+++ b/docs/_source/getting_started/installation/deployments/deployments.md
@@ -6,8 +6,8 @@
 ```{grid-item-card} Python
 :link: python.md
 
-- package extras
-- install from `develop`
+- Install extras
+- Install from `develop`
 ```
 ```{grid-item-card} Docker
 :link: docker.md
@@ -18,7 +18,7 @@
 ```{grid-item-card} Docker Quickstart
 :link: docker.md
 
-- A combined docker image
+- A combined Docker image
 - Environment Variables
 ```
 ```{grid-item-card} Docker-compose

--- a/docs/_source/getting_started/quickstart_workflow.ipynb
+++ b/docs/_source/getting_started/quickstart_workflow.ipynb
@@ -1143,7 +1143,7 @@
    "source": [
     "Argilla helps you to create and curate training data. **It is not a framework for training a model.** You can use Argilla complementary with other excellent open-source frameworks that focus on developing and training NLP models.\n",
     "\n",
-    "Train/fine-tune a model from a `FeedbackDataset` as explained [here](/guides/llms/practical_guides/practical_guides.html), or either a `TextClassificationDataset` or a `TokenClassificationDataset`[here](/guides/train_a_model.md).\n",
+    "Train/fine-tune a model from a `FeedbackDataset` as explained [here](/guides/llms/practical_guides/practical_guides.html), or either a `TextClassificationDataset` or a `TokenClassificationDataset` [here](/guides/train_a_model.md).\n",
     "\n",
     "Here we list three of the most commonly used open-source libraries, but many more are available and may be more suited for your specific use case:\n",
     "\n",

--- a/docs/_source/getting_started/quickstart_workflow.ipynb
+++ b/docs/_source/getting_started/quickstart_workflow.ipynb
@@ -79,26 +79,7 @@
     "In Argilla, records are created programmatically using the [client library](../reference/python/python_client.rst) within a Python script, a [Jupyter notebook](https://jupyter.org/), or another IDE.\n",
     "\n",
     "\n",
-    "Let's see how to create and upload a basic record to the Argilla web app  (make sure Argilla is already installed on your machine as described in the [setup guide](../getting_started/installation/installation.md):"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "cce5ca4c",
-   "metadata": {},
-   "source": [
-    "````{tab-set-code}\n",
-    "\n",
-    "```{literalinclude} ./snippet.py\n",
-    ":language: python\n",
-    "```\n",
-    "\n",
-    "```{code-block} javascript\n",
-    "a = 1;\n",
-    "```\n",
-    "\n",
-    "````\n"
+    "Let's see how to create and upload a basic record to the Argilla web app  (make sure Argilla is already installed on your machine as described in the [setup guide](../getting_started/quickstart_installation.html)):"
    ]
   },
   {

--- a/docs/_source/guides/llms/conceptual_guides/rm.md
+++ b/docs/_source/guides/llms/conceptual_guides/rm.md
@@ -80,7 +80,6 @@ The responses can be generated using a pre-trained LLM, fine-tuned on a prior da
 
 Assuming that you have a pre-trained LLM, here's how you can **generate the responses using the instruction-following model Falcon-7B-instruct**:
 
-
 ```python
 from transformers import AutoTokenizer, AutoModelForCausalLM, pipeline
 import torch
@@ -121,10 +120,24 @@ for record in prompts:
 
 # Add records to the dataset
 dataset.add_records(records)
+```
 
-# This publishes the dataset and pushes the records into Argilla
+::::{tab-set}
+
+:::{tab-item} Argilla 1.14.0 or higher
+```python
+# This publishes the dataset with the records into Argilla and returns the dataset in Argilla
+remote_dataset = dataset.push_to_argilla(name="my-dataset", workspace="my-workspace")
+```
+:::
+
+:::{tab-item} Lower than Argilla 1.14.0
+```python
+# This publishes the dataset with the records into Argilla and turns the dataset objetct into a dataset in Argilla
 dataset.push_to_argilla(name="my-dataset", workspace="my-workspace")
 ```
+:::
+::::
 
 The above code will generate two responses for each prompt and push these records to Argilla. Labelers will see these prompts and responses, and rank the responses according to the instructions provided in the dataset.
 
@@ -133,7 +146,6 @@ Here's an example of a record generated with the above code:
 | Prompt | Response 1 | Response 2 |
 |--------|------------|------------|
 | Write a follow-up for a sales email | Dear [Customer Name],<br/><br/>Thank you for purchasing [Product Name] from us last week. We hope you have been enjoying using it!<br/><br/>If you have any questions or feedback about your purchase, please do not hesitate to let us know. We are always happy to help.<br/><br/>Best regards,<br/>[Sales Team] | Dear [Customer Name],<br/><br/>Thank you for your recent purchase [Product Name]. We hope you"re enjoying your [Product Name] as much as we are here at [Company Name].<br/><br/>If you have any questions or feedback regarding your purchase, please don"t hesitate to let us know. We"d love the chance to make your shopping experience even better.<br/><br/>Thank you again for your purchase,<br/>[Company Name] |
-
 
 :::{note}
 The ranking task can be challenging for labelers if the two responses are very similar. Consider adjusting the parameters of the generation process (e.g., the temperature) to produce more varied responses.
@@ -201,6 +213,7 @@ In addition, each record contains a `fields` attribute, which includes all the f
 Upon resolving conflicts, the aim is to have a list of records each indicating a preference for one response over the other to a prompt. These will be used for training the reward model.
 
 For demonstration purposes, here is a step-by-step code snippet to create a dataset of triplets `(prompt, preferred response, less preferred response)` from a single dataset without overlapping annotations:
+
 ```python
 # Define an empty list to store the triplets
 triplets = []

--- a/docs/_source/guides/llms/conceptual_guides/rm.md
+++ b/docs/_source/guides/llms/conceptual_guides/rm.md
@@ -126,14 +126,14 @@ dataset.add_records(records)
 
 :::{tab-item} Argilla 1.14.0 or higher
 ```python
-# This publishes the dataset with the records into Argilla and returns the dataset in Argilla
+# This publishes the dataset with its records to Argilla and returns the dataset in Argilla
 remote_dataset = dataset.push_to_argilla(name="my-dataset", workspace="my-workspace")
 ```
 :::
 
 :::{tab-item} Lower than Argilla 1.14.0
 ```python
-# This publishes the dataset with the records into Argilla and turns the dataset objetct into a dataset in Argilla
+# This publishes the dataset with its records to Argilla and turns the dataset object into a dataset in Argilla
 dataset.push_to_argilla(name="my-dataset", workspace="my-workspace")
 ```
 :::

--- a/docs/_source/guides/llms/conceptual_guides/sft.md
+++ b/docs/_source/guides/llms/conceptual_guides/sft.md
@@ -125,7 +125,7 @@ dataset.add_records(records)
 
 :::{tab-item} Argilla 1.14.0 or higher
 ```python
-# This publishes the dataset with the records into Argilla and returns the dataset in Argilla
+# This publishes the dataset with its records to Argilla and returns the dataset in Argilla
 remote_dataset = dataset.push_to_argilla(name="my-dataset", workspace="my-workspace")
 ```
 :::

--- a/docs/_source/guides/llms/conceptual_guides/sft.md
+++ b/docs/_source/guides/llms/conceptual_guides/sft.md
@@ -1,4 +1,5 @@
 # Collecting demonstration data
+
 This guide explains how to implement workflows for collecting demonstration data. As covered in the ["Data Collection for Large Language Models" guide](rlhf.md), the importance of demonstration data - **prompts and demonstrations** - is paramount for improving LLMs. This data aids in supervised fine-tuning, also known as instruction-tuning or behavior cloning, where models learn to respond based on human examples. Despite being seen as labor-intensive, recent research like the LIMA work indicates that even a small set of 1,000 diverse, high-quality examples can efficiently train a model. Argilla Feedback was developed to **simplify this process, distributing it among multiple labelers in your organization**.
 
 :::{tip}
@@ -6,7 +7,6 @@ You can add unlimited users to Argilla datasets so it can be seamlessly used to 
 :::
 
 The following figure illustrates the steps to collect feedback from a team of labelers and perform supervised fine-tuning. The steps are: **configure the dataset**, **add records**, **labelers write demonstrations**, **prepare the dataset**, and **fine-tune the SFT model**.
-
 
 <img src="../../../_static/images/llms/sft.svg" alt="Demonstration collection for SFT" style="display:block;margin-left:auto;margin-right:auto;">
 
@@ -65,12 +65,12 @@ For collecting **prompts** or instructions, there are at least the following opt
 ### Use an existing internal database of prompts or user queries related to your use case
 If your goal is to fine-tune an LLM for your use case, this is the best option. As shown by the recent “LIMA: Less is More for Alignment” paper, you can get good results by collecting a diverse, high-quality, consistent dataset of 1,000-5,000 examples. Previous research uses 13,000 to 20,000 examples.
 
-
 :::{tip}
 As the field is rapidly evolving and lacking consensus, we suggest beginning with a small dataset of the highest quality. Argilla Feedback is built for iteration. Starting small allows for faster iteration: training is cheaper and faster, and the length of the feedback loop is reduced.
 :::
 
 ### Use an open dataset of prompts or user queries
+
 If you don’t have an internal database for your use case, you can sample and select prompts from an open dataset. The steps here can include: (1) **finding an open dataset** that might contain prompts related to your use case, (2) performing** exploratory data** analysis and topic extraction** to understand the data, and (3) **filtering and selecting prompts** based on topic, quality, text descriptives, etc.
 
 Some available datasets are [ShareGPT](https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered), [Open Assistant Conversation Dataset](https://huggingface.co/datasets/OpenAssistant/oasst1), or [Stack Exchange](https://huggingface.co/datasets/HuggingFaceH4/stack-exchange-preferences). Please be aware that some of these datasets might contain inappropriate, irrelevant, or bad-quality examples for your use case.
@@ -82,6 +82,7 @@ Open datasets might contain responses, so you might think about skipping the dat
 An alternative is to obtain a dataset of user queries in your domain and apply the same process of data analysis and sampling. A good strategy is to search for datasets of user intent or utterances. For example, if you plan to fine-tune an LLM for a customer service banking assistant, you might start with the [banking77](https://huggingface.co/datasets/banking77) dataset.
 
 ### Ask humans to write prompts or instructions
+
 If none of the above is possible, a third option is to ask humans to write prompts for your use case. This option is expensive and has limitations. The main limitation is the risk of creating artificial prompts that won't match the diversity, topics, or writing style of end-users if the prompts are not written by them. Besides involving end-users in the process, this limitation might be overcome by defining clear guidelines and preparing a diverse set of topics. Such effort can be easily set up with Argilla Feedback by using **guidelines** and creating records with a **text field** indicating the labeler what to write the prompt about. By adding this field, you can control the diversity and desired distribution of prompt topics. This is how you can set up the field and the question using the Python SDK:
 
 ```python
@@ -118,10 +119,24 @@ records = [
 ]
 
 dataset.add_records(records)
+```
 
-# This publishes the dataset and pushes the records into Argilla
+::::{tab-set}
+
+:::{tab-item} Argilla 1.14.0 or higher
+```python
+# This publishes the dataset with the records into Argilla and returns the dataset in Argilla
+remote_dataset = dataset.push_to_argilla(name="my-dataset", workspace="my-workspace")
+```
+:::
+
+:::{tab-item} Lower than Argilla 1.14.0
+```python
+# This publishes the dataset with the records into Argilla and turns the dataset objetct into a dataset in Argilla
 dataset.push_to_argilla(name="my-dataset", workspace="my-workspace")
 ```
+:::
+::::
 
 ## Labelers write completions
 The aim of this phase is to provide human demonstrations for each `prompt` using Argilla UI.
@@ -130,7 +145,7 @@ Once you upload your dataset to Argilla, it becomes accessible via the Argilla U
 
 However, when resources are scarce, workload distribution among various labelers is recommended. This strategy entails assigning each labeler a subset of records to label. This [how-to guide](../practical_guides/set_up_annotation_team.html) provides detailed instructions on setting up these workload distribution options effectively.
 
-For a comprehensive understanding of the Argilla UI's main features, refer to this [how-to guide](../practical_guides/annotate_dataset.html)](../practical_guides/annotate_dataset.html).
+For a comprehensive understanding of the Argilla UI's main features, refer to this [how-to guide](../practical_guides/annotate_dataset.html).
 
 ## Prepare the dataset
 

--- a/docs/_source/guides/llms/conceptual_guides/sft.md
+++ b/docs/_source/guides/llms/conceptual_guides/sft.md
@@ -132,7 +132,7 @@ remote_dataset = dataset.push_to_argilla(name="my-dataset", workspace="my-worksp
 
 :::{tab-item} Lower than Argilla 1.14.0
 ```python
-# This publishes the dataset with the records into Argilla and turns the dataset objetct into a dataset in Argilla
+# This publishes the dataset with its records to Argilla and turns the dataset object into a dataset in Argilla
 dataset.push_to_argilla(name="my-dataset", workspace="my-workspace")
 ```
 :::

--- a/docs/_source/guides/llms/practical_guides/create_dataset.md
+++ b/docs/_source/guides/llms/practical_guides/create_dataset.md
@@ -265,12 +265,25 @@ import argilla as rg
 rg.init(api_url="<ARGILLA_API_URL>", api_key="<ARGILLA_API_KEY>")
 
 dataset = rg.FeedbackDataset.from_argilla(name="my_dataset", workspace="my_workspace")
+```
 
+::::{tab-set}
+
+:::{tab-item} Argilla 1.14.0 or higher
+```python
+for record in dataset.records:
+    record.update(suggestions=[{"question_name": "question", "value": ...}]) # Directly pushes the update to Argilla
+```
+:::
+
+:::{tab-item} Lower than Argilla 1.14.0
+```python
 for record in dataset.records:
     record.set_suggestions([{"question_name": "question", "value": ...}])
-
 dataset.push_to_argilla() # No need to provide `name` and `workspace` as has been retrieved via `from_argilla` classmethod
 ```
+:::
+::::
 
 ## Add responses
 If your dataset includes some annotations, you can add those to the records as you create them. Make sure that the responses adhere to the same format as Argilla's output and meet the schema requirements for the specific type of question being answered. Note that just one response with an empty `user_id` can be specified, as the first occurrence of `user_id=None` will be set to the active `user_id`, while the rest of the responses with `user_id=None` will be discarded.
@@ -381,8 +394,19 @@ record = rg.FeedbackRecord(
 
 To import the dataset to your Argilla instance with the `FeedbackDataset.push_to_argilla()` method. Once pushed, you will be able to see your dataset in the UI.
 
+::::{tab-set}
+
+:::{tab-item} Argilla 1.14.0 or higher
+```python
+remote_dataset = dataset.push_to_argilla(name="my-dataset", workspace="my-workspace")
+```
+:::
+
+:::{tab-item} Lower than Argilla 1.14.0
 ```python
 dataset.push_to_argilla(name="my-dataset", workspace="my-workspace")
 ```
+:::
+::::
 
 Now you're ready to start [the annotation process](annotate_dataset.ipynb).

--- a/docs/_source/guides/llms/practical_guides/create_dataset.md
+++ b/docs/_source/guides/llms/practical_guides/create_dataset.md
@@ -286,6 +286,7 @@ dataset.push_to_argilla() # No need to provide `name` and `workspace` as has bee
 ::::
 
 ## Add responses
+
 If your dataset includes some annotations, you can add those to the records as you create them. Make sure that the responses adhere to the same format as Argilla's output and meet the schema requirements for the specific type of question being answered. Note that just one response with an empty `user_id` can be specified, as the first occurrence of `user_id=None` will be set to the active `user_id`, while the rest of the responses with `user_id=None` will be discarded.
 
 ::::{tab-set}

--- a/docs/_source/guides/llms/practical_guides/export_dataset.md
+++ b/docs/_source/guides/llms/practical_guides/export_dataset.md
@@ -19,7 +19,25 @@ At this point, you can do any post-processing you may need with this dataset e.g
 
 ## Push back to Argilla
 
-You can always push the dataset back to Argilla in case you want to clone the dataset or explore it after post-processing.
+When using a `FeedbackDataset` pulled from Argilla via `FeedbackDataset.from_argilla`, you can always push the dataset back to Argilla in case you want to clone the dataset or explore it after post-processing.
+
+::::{tab-set}
+
+:::{tab-item} Argilla 1.14.0 or higher
+```python
+dataset = dataset.pull()
+remote_dataset = dataset.push_to_argilla(name="my-dataset-clone", workspace="my-workspace")
+```
+:::
+
+:::{tab-item} Lower than Argilla 1.14.0
+```python
+dataset.push_to_argilla(name="my-dataset-clone", workspace="my-workspace")
+```
+:::
+::::
+
+Additionally, you can still clone local `FeedbackDataset` datasets that have neither been pushed nor pulled to/from Argilla, respectively; via calling `push_to_argilla`.
 
 ```python
 dataset.push_to_argilla(name="my-dataset-clone", workspace="my-workspace")

--- a/docs/_source/guides/llms/practical_guides/fine_tune.md
+++ b/docs/_source/guides/llms/practical_guides/fine_tune.md
@@ -1,10 +1,10 @@
 # Fine-tune an LLM
 
-After [collecting the responses](/guides/llms/practical_guides/collect_responses) from our `FeedbackDataset` we can start fine-tuning our LLM. Due to the customizability of the task, this might require setting up a custom post-processing workflow but we will provide some good toy examples for the [classic LLM approaches](/guides/llms/conceptual_guides/rlhf): pre-training, supervised fine-tuning, reward modeling, and reinforcement learning.
+After [collecting the responses](./collect_responses.html) from our `FeedbackDataset` we can start fine-tuning our LLM. Due to the customizability of the task, this might require setting up a custom post-processing workflow but we will provide some good toy examples for the [classic LLM approaches](../conceptual_guides/rlhf.html): pre-training, supervised fine-tuning, reward modeling, and reinforcement learning.
 
 ## Supervised finetuning
 
-The goal of Supervised Fine Tuning (SFT) is to optimize this pre-trained model to generate the responses that users are looking for. After pre-training a causal language model, it can generate feasible human text, but it will not be able to have proper `answers` to `question` phrases posed by the user in a conversational or instruction set. Therefore, we need to collect and curate data tailored to this use case to teach the model to mimic this data. We have a section in our docs about [collecting data for this task](/guides/llms/conceptual_guides/sft.html) and there are many good [pre-trained causal language models](https://huggingface.co/models?pipeline_tag=text-generation&sort=downloads) available on Hugging Face.
+The goal of Supervised Fine Tuning (SFT) is to optimize this pre-trained model to generate the responses that users are looking for. After pre-training a causal language model, it can generate feasible human text, but it will not be able to have proper `answers` to `question` phrases posed by the user in a conversational or instruction set. Therefore, we need to collect and curate data tailored to this use case to teach the model to mimic this data. We have a section in our docs about [collecting data for this task](../conceptual_guides/sft.html) and there are many good [pre-trained causal language models](https://huggingface.co/models?pipeline_tag=text-generation&sort=downloads) available on Hugging Face.
 
 ### Data
 
@@ -69,7 +69,6 @@ This dataset only contains a single annotator response per record. We gave some 
 ```python
 import argilla as rg
 from datasets import Dataset
-
 
 feedback_dataset = rg.FeedbackDataset.from_huggingface("argilla/databricks-dolly-15k-curated-en")
 
@@ -144,13 +143,16 @@ trainer = trlx.train('gpt2', samples=samples)
 
 AutoTrain offers an option for users who prefer a simpler and more automated approach. It offers a no-code solution for fine-tuning models wrapped and enabled by a nice [streamlit UI](https://huggingface.co/spaces/autotrain-projects/autotrain-advanced), or by a low-code option with the [AutoTrain Advanced package](https://github.com/huggingface/autotrain-advanced). This tool leverages techniques to automatically optimize the model's performance without requiring users to have extensive knowledge of reinforcement learning or coding skills. It streamlines the fine-tuning process by automatically adjusting the model's parameters and optimizing its performance based on user-provided feedback.
 
-First, export the data.
+First, export the data into CSV or any other supported format.
+
 ```python
 dataset = ...
 
 dataset.to_csv("databricks-dolly-15k-curated-en.csv", index=False)
 ```
-Second, start the UI for training.
+
+Then, go to the AutoTrain UI for training.
+
 <iframe width="100%" height="600" src="https://www.youtube.com/embed/T_Lq8Zq-pwQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ## RLHF
@@ -193,7 +195,6 @@ dataset
 ### Training
 
 Fine-tuning using a Reward Model can be done in different ways. We can either get the annotator to rate output completely manually, we can use a simple heuristic or we can use a stochastic preference model. Both TRL and TRLX provide decent options for incorporating rewards. The [DeepSpeed library of Microsoft](https://github.com/microsoft/DeepSpeed/tree/master/blogs/deepspeed-chat) is a worthy mention too but will not be covered in our docs.
-
 
 #### TRL
 
@@ -332,7 +333,6 @@ for epoch, batch in enumerate(ppo_trainer.dataloader):
 
 ::::
 
-
 #### TRLX
 
 [TRLX](https://github.com/CarperAI/trlx) gives the option to use a `reward function` or a `reward-labeled` dataset in combination with Proximal Policy Optimization (PPO) for the reinforcement learning step, which can be used by defining a PPO policy configuration. During this step, we infer rewards to mimic the human evaluation of generated texts. Additionally, [Hugging Face Accelerate](https://huggingface.co/docs/accelerate/index) can be used to speed up training or [Ray Tune](https://docs.ray.io/en/latest/tune/index.html) to optimize hyperparameter tuning.
@@ -344,7 +344,6 @@ config = default_ppo_config()
 config.model.model_path = 'gpt2'
 config.train.batch_size = 16
 ```
-
 
 ::::{tab-set}
 
@@ -371,7 +370,6 @@ trainer = trlx.train(
 ```
 
 :::
-
 
 :::{tab-item} reward-labeled dataset
 
@@ -414,7 +412,8 @@ Many training datasets for this task can be found online (e.g., [Hugging Face](h
 When it comes to pre-training an LLM, we generally do not need data of highest quality, but it is always smart to use domain-specfic data and to avoid data that might lead to undecired effect like hallucination and bias.
 ```
 
-First, create a dataset.
+First, create a `FeedbackDataset` with records.
+
 ```python
 import argilla as rg
 
@@ -434,10 +433,26 @@ record = rg.FeedbackRecord(
 )
 
 rg.add_records([record])
-dataset.push_to_argilla(name="pre-training")
 ```
 
-Second, load the dataset from Argilla.
+Then push it to Argilla via `push_to_argilla`.
+
+::::{tab-set}
+
+:::{tab-item} Argilla 1.14.0 or higher
+```python
+remote_dataset = dataset.push_to_argilla(name="pre-training")
+```
+:::
+
+:::{tab-item} Lower than Argilla 1.14.0
+```python
+dataset.push_to_argilla(name="pre-training")
+```
+:::
+::::
+
+And, finally, load the `FeedbackDataset` from Argilla.
 
 ```python
 import argilla as rg
@@ -456,4 +471,3 @@ dataset
 ### Training
 
 There are many ways and great packages to deal with this `pre-training` phase, but generally, NLP training frameworks like [KerasNLP](https://keras.io/keras_nlp/) and [Hugging Face](https://huggingface.co/) offer great out-of-the-box methods for training a causal language model. In our guide, we will refer to the great docs off using Hugging Face `transformers` and `datasets` library and prepare our training data in the format they require for [training a causal language model](https://huggingface.co/learn/nlp-course/chapter7/6#training-a-causal-language-model-from-scratch).
-

--- a/docs/_source/guides/llms/practical_guides/fine_tune.md
+++ b/docs/_source/guides/llms/practical_guides/fine_tune.md
@@ -373,8 +373,7 @@ trainer = trlx.train(
 
 :::{tab-item} reward-labeled dataset
 
-In this case, TRLX relies on reward-labeled data to infer the alignment with human preference. This is a good approach but it is not recommended to only collect these labels via human feedback because this is likely too costly to scale. Therefore, we recommend using an automated reward function or creating a reward-labeled dataset using our [roberta-base-reward-model-falcon-dolly model](https://huggingface.co/argilla/roberta-base-reward-model-falcon-dolly). For demo purposes, we now infer the rewards from the corrected response, but we can also set up [specific ranking](guides/llms/conceptual_guides/rm) datasets](guides/llms/conceptual_guides/rm) using the Argilla UI.
-```
+In this case, TRLX relies on reward-labeled data to infer the alignment with human preference. This is a good approach but it is not recommended to only collect these labels via human feedback because this is likely too costly to scale. Therefore, we recommend using an automated reward function or creating a reward-labeled dataset using our [roberta-base-reward-model-falcon-dolly model](https://huggingface.co/argilla/roberta-base-reward-model-falcon-dolly). For demo purposes, we now infer the rewards from the corrected response, but we can also set up [specific ranking](../conceptual_guides/rm.html) using the Argilla UI.
 
 ```python
 import trlx
@@ -421,18 +420,21 @@ import argilla as rg
 dataset = rg.FeedbackDataset(
     guidelines="Please, complete the following prompt fields with a brief text answer.",
     fields=[
-        rg.TextField(name="content"),
+        rg.TextField(name="prompt"),
     ],
+    questions=[
+        rg.TextQuestion(name="completion", title="Add a brief text answer."),
+    ]
 )
 
 # create a Feedback Records
 record = rg.FeedbackRecord(
     fields={
-        "content": "The base ingredient of paella is rice."
+        "prompt": "The base ingredient of paella is rice."
     }
 )
 
-rg.add_records([record])
+dataset.add_records([record])
 ```
 
 Then push it to Argilla via `push_to_argilla`.
@@ -458,12 +460,12 @@ And, finally, load the `FeedbackDataset` from Argilla.
 import argilla as rg
 from datasets import Dataset
 
-feedback = rg.FeedbackDataset.from_argilla("pre-training")
-content = {"content": [rec.get("fields").get("content") for rec in feedback]}
-dataset = Dataset.from_dict(content)
+dataset = rg.FeedbackDataset.from_argilla("pre-training")
+prompts = {"prompt": [record.fields.get("prompt") for record in dataset.records]}
+dataset = Dataset.from_dict(prompts)
 dataset
 # Dataset({
-#     features: ['content'],
+#     features: ['prompt'],
 #     num_rows: 1
 # })
 ```

--- a/docs/_source/guides/llms/practical_guides/fine_tune_others.md
+++ b/docs/_source/guides/llms/practical_guides/fine_tune_others.md
@@ -1,6 +1,6 @@
 # Fine-tune other models
 
-After [collecting the responses](/guides/llms/practical_guides/collect_responses) from our `FeedbackDataset` we can start fine-tuning our basic models. Due to the customizability of the `FeedbackDataset`, this might require setting up a custom post-processing workflow but we will provide some good toy examples for the text classification task. We will add additional support for other tasks in the future.
+After [collecting the responses](./collect_responses.html) from our `FeedbackDataset` we can start fine-tuning our basic models. Due to the customizability of the `FeedbackDataset`, this might require setting up a custom post-processing workflow but we will provide some good toy examples for the text classification task. We will add additional support for other tasks in the future.
 
 Generally, this is as easy as one-two-three but does slightly differ per task.
 
@@ -15,9 +15,11 @@ Generally, this is as easy as one-two-three but does slightly differ per task.
 Text classification is a widely used NLP task where labels are assigned to text. Major companies rely on it for various applications. Sentiment analysis, a popular form of text classification, assigns labels like 🙂 positive, 🙁 negative, or 😐 neutral to text. Additionally, we distinguish between single- and multi-label text classification.
 
 #### Single-label
+
 Single-label text classification refers to the task of assigning a single category or label to a given text sample. Each text is associated with only one predefined class or category. For example, in sentiment analysis, a single-label text classification task would involve assigning labels such as "positive," "negative," or "neutral" to individual texts based on their sentiment.
 
 #### Multi-label
+
 Multi-label text classification is generally more complex than single-label classification due to the challenge of determining and predicting multiple relevant labels for each text. It finds applications in various domains, including document tagging, topic labeling, and content recommendation systems.
 
 ### Training
@@ -91,14 +93,12 @@ task_mapping = TrainingTaskMapping.for_text_classification(
 
 ::::
 
-
-
 #### Use ArgillaTrainer
 
 Next, we can use our `FeedbackDataset` and `TrainingTaskMappingForTextClassification` to initialize our `argilla.ArgillaTrainer`. We support the frameworks "openai", "setfit", "peft", "spacy" and "transformers".
 
 ````{note}
-This is a newer version and can be imported via `from argilla.feedback import ArgillaTrainer`. The old trainer can be imported via `from argilla.training import ArgillaTrainer`. Our docs, contain some [additional information on usage of the ArgillaTrainer](/guides/train_a_model).
+This is a newer version and can be imported via `from argilla.feedback import ArgillaTrainer`. The old trainer can be imported via `from argilla.training import ArgillaTrainer`. Our docs, contain some [additional information on usage of the ArgillaTrainer](../../train_a_model.html).
 ````
 
 ```python
@@ -122,7 +122,7 @@ trainer.train(output_dir="my_awesone_model")
 ```
 
 ````{note}
-The `FeedbackDataset` also allows for custom workflows via the `prepare_for_training()`-method.
+The `FeedbackDataset` also allows for custom workflows via the `prepare_for_training()` method.
 ```python
 task_mapping = ...
 dataset = rg.FeedbackDataset.from_huggingface(
@@ -137,7 +137,7 @@ dataset.prepare_for_training(
 
 ### An end-to-end example
 
-Underneath, you can also find an end-to-end example of how to use the `ArgillaTrainer`.
+Below you can also find an end-to-end example of how to use the `ArgillaTrainer`.
 
 ```python
 from argilla.feedback import (
@@ -202,5 +202,3 @@ trainer = ArgillaTrainer(
 trainer.update_config(num_train_epochs=2)
 trainer.train(output_dir="my_awesone_model")
 ```
-
-

--- a/docs/_source/guides/llms/practical_guides/set_up_annotation_team.md
+++ b/docs/_source/guides/llms/practical_guides/set_up_annotation_team.md
@@ -76,6 +76,9 @@ for chunk in chunked_records:
 If you haven't done so already, decide on the settings of the project (the `fields`, `questions` and `guidelines`) as detailed in the [Create a Feedback Dataset guide](./create_dataset.html) and set those as variables.
 ```
 
+::::{tab-set}
+
+:::{tab-item} Argilla 1.14.0 or higher
 ```python
 fields = [...]
 questions = [...]
@@ -91,23 +94,31 @@ for username, records in assignments.items():
         workspace.add_user(user.id)
 
     # create a dataset with their assingment and push to their workspace
-    ds = rg.FeedbackDataset(fields=fields, questions=questions, guidelines=guidelines)
-    ds.add_records(records)
-```
-
-Then push the `FeedbackDataset` with the records to Argilla:
-
-::::{tab-set}
-
-:::{tab-item} Argilla 1.14.0 or higher
-```python
-remote_dataset = dataset.push_to_argilla(name="my_dataset", workspace=workspace.name)
+    dataset = rg.FeedbackDataset(fields=fields, questions=questions, guidelines=guidelines)
+    dataset.add_records(records)
+    remote_dataset = dataset.push_to_argilla(name="my_dataset", workspace=workspace.name)
 ```
 :::
 
 :::{tab-item} Lower than Argilla 1.14.0
 ```python
-dataset.push_to_argilla(name="my_dataset", workspace=workspace.name)
+fields = [...]
+questions = [...]
+guidelines = "..."
+
+for username, records in assignments.items():
+    # check that the user has a personal workspace and create it if not
+    try:
+        workspace = rg.Workspace.from_name(username)
+    except:
+        workspace = rg.Workspace.create(username)
+        user = rg.User.from_name(username)
+        workspace.add_user(user.id)
+
+    # create a dataset with their assingment and push to their workspace
+    dataset = rg.FeedbackDataset(fields=fields, questions=questions, guidelines=guidelines)
+    dataset.add_records(records)
+    dataset.push_to_argilla(name="my_dataset", workspace=workspace.name)
 ```
 :::
 ::::

--- a/docs/_source/guides/llms/practical_guides/set_up_annotation_team.md
+++ b/docs/_source/guides/llms/practical_guides/set_up_annotation_team.md
@@ -10,6 +10,7 @@ You will need to decide the level of overlap before creating or pushing a datase
 The Feedback Task supports having multiple annotations for your records by default. This means that all users with access to the dataset can give responses to all the records in the dataset. To have this full overlap just push the dataset (as detailed in [Create a Feedback Dataset](create_dataset.md#push-to-argilla)) in a workspace where all team members have access. Learn more about managing user access to workspaces [here](../../../getting_started/installation/configurations/user_management.md#assign-a-user-to-a-workspace).
 
 ## Zero overlap
+
 If you only want one annotation per record, we recommend that you split your records into chunks and assign each of them to a single annotator. Then, you can create several datasets, one in each annotator's personal workspace with the records assigned to them.
 
 ```{note}
@@ -72,7 +73,7 @@ for chunk in chunked_records:
 3. Loop through the dictionary of assignments to create one dataset per user:
 
 ```{note}
-If you haven't done so already, decide on the settings of the project (the `fields`, `questions` and `guidelines`) as detailed in the [Create a Feedback Dataset guide](create_dataset.ipynb) and set them as variables.
+If you haven't done so already, decide on the settings of the project (the `fields`, `questions` and `guidelines`) as detailed in the [Create a Feedback Dataset guide](./create_dataset.html) and set those as variables.
 ```
 
 ```python
@@ -92,14 +93,31 @@ for username, records in assignments.items():
     # create a dataset with their assingment and push to their workspace
     ds = rg.FeedbackDataset(fields=fields, questions=questions, guidelines=guidelines)
     ds.add_records(records)
-    ds.push_to_argilla(name="my_dataset", workspace=workspace.name)
 ```
+
+Then push the `FeedbackDataset` with the records to Argilla:
+
+::::{tab-set}
+
+:::{tab-item} Argilla 1.14.0 or higher
+```python
+remote_dataset = dataset.push_to_argilla(name="my_dataset", workspace=workspace.name)
+```
+:::
+
+:::{tab-item} Lower than Argilla 1.14.0
+```python
+dataset.push_to_argilla(name="my_dataset", workspace=workspace.name)
+```
+:::
+::::
 
 ```{note}
 The `Workspace` class was introduced in Argilla's Python SDK in version 1.11.0. To manage and create workspaces in earlier versions of Argilla check our [User Management Guide](../../../getting_started/installation/configurations/user_management.md)
 ```
 
 ## Controlled overlap
+
 Sometimes you prefer to have more control over the annotation overlap and decide on a limited number of responses you want for each record. You may opt for this option because you want your team to be more efficient or perhaps to calculate the agreement between pairs of annotators. In this case, you also need to create several datasets and push them to the annotators' personal workspaces with the difference that each record will appear in multiple datasets.
 
 For this method, follow the same steps as in the [zero overlap](#zero-overlap) solution, substituting the second step with the following code:

--- a/docs/_source/guides/llms/practical_guides/use_argilla_callback_in_langchain.md
+++ b/docs/_source/guides/llms/practical_guides/use_argilla_callback_in_langchain.md
@@ -2,6 +2,10 @@
 
 This guide explains how to use the `ArgillaCallbackHandler` to integrate Argilla with LangChain apps. With this integration, Argilla can be used evaluate and fine-tune LLMs. It works by collecting the interactions with LLMs and pushing them into a `FeedbackDataset` for continuous monitoring and human feedback. You just need to create a Langchain-compatible `FeedbackDataset` in Argilla and then instantiate the `ArgillaCallbackHandler` to be provided to `LangChain` LLMs, Chains, and/or Agents.
 
+:::{warning}
+As of Argilla 1.14.0 the `FeedbackDataset` has been refactored to improve its usage, so if you're using Argilla 1.14.0 or higher, you won't be able to use the `ArgillaCallbackHandler` as it's not been updated in `LangChain` yet.
+:::
+
 ## How to create a `LangChain`-compatible `FeedbackDataset`
 
 Due to the way `LangChain` callbacks and `FeedbackDataset`s work, we need to create a `FeedbackDataset` in Argilla with a certain structure for the fields, while the questions and the guidelines remain open and can be defined by the user.

--- a/docs/_source/guides/log_load_and_prepare_data.md
+++ b/docs/_source/guides/log_load_and_prepare_data.md
@@ -34,7 +34,7 @@ Some other cool attributes for a record are:
 In Argilla, records are created programmatically using the [client library](../reference/python/python_client.rst) within a Python script, a [Jupyter notebook](https://jupyter.org/), or another IDE.
 
 
-Let's see how to create and upload a basic record to the Argilla web app  (make sure Argilla is already installed on your machine as described in the [setup guide](../getting_started/installation/installation.md)):
+Let's see how to create and upload a basic record to the Argilla web app  (make sure Argilla is already installed on your machine as described in the [setup guide](../getting_started/quickstart_installation.html)):
 
 ### Create records
 

--- a/docs/_source/reference/datamodel.md
+++ b/docs/_source/reference/datamodel.md
@@ -5,7 +5,6 @@ Argilla is built around a few simple concepts. This section clarifies what those
 
 ![A sketch of the Argilla data model](/_static/images/main/argilla_data_model.png)
 
-
 ## Dataset
 
 A dataset is a collection of [records](#record) of a common type.
@@ -24,7 +23,7 @@ Records are defined by the type of **task** they are related to. Let's see three
 ### Examples
 
 ```{note}
-For information about the Data model for the new `FeedbackDataset`, check [this guide](../guides/llms/practical_guides/create_dataset.ipynb) instead.
+For information about the Data model for the new `FeedbackDataset`, check [this guide](../guides/llms/practical_guides/create_dataset.html) instead.
 ```
 
 #### Text classification record
@@ -67,7 +66,6 @@ record = rg.TextClassificationRecord(
     annotation_agent= "link or reference to annotator",
 )
 ```
-
 
 #### Token classification record
 
@@ -113,11 +111,9 @@ record = rg.Text2TextRecord(
 
 An annotation is a piece information assigned to a record, a label, token-level tags, or a set of labels, and typically by a human agent.
 
-
 ### Prediction
 
 A prediction is a piece information assigned to a record, a label or a set of labels and typically by a machine process.
-
 
 ### Metadata
 
@@ -128,10 +124,6 @@ Metadata will hold extra information that you want your record to have: if it be
 A task defines the objective and shape of the predictions and annotations inside a record.
 You can see our supported tasks at {ref}`tasks`.
 
-
 ## Settings
 
 For now, only a set of the predefined labels (labels schema) is configurable. Still, other settings like annotators, and metadata schema, are planned to be supported as part of dataset settings.
-
-
-

--- a/docs/_source/reference/python/python_client.rst
+++ b/docs/_source/reference/python/python_client.rst
@@ -41,12 +41,26 @@ Datasets
 FeedbackDataset
 ---------------
 
-.. automodule:: argilla.client.feedback.dataset
+.. automodule:: argilla.client.feedback.dataset.local
    :members: FeedbackDataset
 
-.. automodule:: argilla.client.feedback.schemas
-   :members: RatingQuestion, TextQuestion, LabelQuestion, MultiLabelQuestion, RankingQuestion, QuestionSchema, TextField, FieldSchema, FeedbackRecord
+.. automodule:: argilla.client.feedback.dataset.remote
+   :members: RemoteFeedbackDataset, RemoteFeedbackRecords
+
+.. automodule:: argilla.client.feedback.dataset.mixins
+   :members: ArgillaToFromMixin
+
+.. automodule:: argilla.client.feedback.dataset.integrations.huggingface
+   :members: HuggingFaceDatasetMixin
+
+.. automodule:: argilla.client.feedback.schemas.questions
+   :members: RatingQuestion, TextQuestion, LabelQuestion, MultiLabelQuestion, RankingQuestion, QuestionSchema
+
+.. automodule:: argilla.client.feedback.schemas.fields
+   :members: TextField, FieldSchema
+
+.. automodule:: argilla.client.feedback.schemas.records
+   :members: FeedbackRecord, RemoteFeedbackRecord, ResponseSchema, SuggestionSchema, ValueSchema, RankingValueSchema
 
 .. automodule:: argilla.client.feedback.config
    :members: FeedbackDatasetConfig
-


### PR DESCRIPTION
# Description

This PR adds the `tab-set` for the outdated code-blocks with the upcoming release of Argilla v1.14.0 so as to showcase both the previous and the new code-blocks for users that are still using Argilla v1.14.0 or lower.

Additionally, the style has been fixed in some documents while reviewing the outdated code-blocks, some file paths references have been fixed to point to the HTML files via relative paths, and some minor details.

Finally, a `warning` has also been included to let the users know that Argilla v1.14.0 won't work for the moment with the `ArgillaCallbackHandler` in `LangChain`. 

**Type of change**

- [X] Documentation update