### PR TITLE
fix: `thread_ts` is not always present

### DIFF
--- a/.github/actions/slack-post-credentials/app/main.py
+++ b/.github/actions/slack-post-credentials/app/main.py
@@ -101,7 +101,7 @@ def get_thread_ts_pr_message(client: WebClient, channel_id: str, pr_number: int)
             if not title or not callback_id:
                 continue
             if pr_url in title and callback_id == "pr-opened-interaction":
-                return message["thread_ts"]
+                return message["ts"]
 
     return None
 


### PR DESCRIPTION
# Description

The `slack-post-credentials` action is failing from time to time because not all the messages have the `thread_ts` key. This PR fixes this issue using the `ts` key instead of the `thread_ts`.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

The deployment job got executed fine for this PR: https://github.com/argilla-io/argilla/actions/runs/5818199084/job/15774977297?pr=3538

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
