### PR TITLE
fix: restore `suggestions` and `responses` as rows in `HuggingFaceDatasetMixin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ These are the section headers that we use:
 ### Fixed
 
 - `TextClassificationSettings` and `TokenClassificationSettings` labels are properly parsed to strings both in the Python client and in the backend endpoint (Closes [#3495](https://github.com/argilla-io/argilla/issues/3495)).
-- Fix `PUT /api/v1/datasets/{dataset_id}/publish` to check whether at leat one field and question has `required=True` ([#3511](https://github.com/argilla-io/argilla/pull/3511)).
+- Fixed `PUT /api/v1/datasets/{dataset_id}/publish` to check whether at leat one field and question has `required=True` ([#3511](https://github.com/argilla-io/argilla/pull/3511)).
+- Fixed `FeedbackDataset.from_huggingface` as `suggestions` were being lost when there were no `responses` ([#3539](https://github.com/argilla-io/argilla/pull/3539)).
 
 ### Added
 
@@ -45,6 +46,7 @@ These are the section headers that we use:
 - Updated `POST /api/v1/me/datasets/{dataset_id}/records` endpoint to allow searching records matching one of the response statuses provided via query param.([#3359](https://github.com/argilla-io/argilla/pull/3359)).
 - Updated `SearchEngine.search` method to allow searching records matching one of the response statuses provided ([#3359](https://github.com/argilla-io/argilla/pull/3359)).
 - After calling `FeedbackDataset.push_to_argilla`, the methods `FeedbackDataset.add_records` and `FeedbackRecord.set_suggestions` will automatically call Argilla with no need of calling `push_to_argilla` explicitly ([#3465](https://github.com/argilla-io/argilla/pull/3465)).
+- Now calling `FeedbackDataset.push_to_huggingface` dumps the `responses` as a `List[Dict[str, Any]]` instead of `Sequence` to make it more readable via 🤗`datasets` ([#3539](https://github.com/argilla-io/argilla/pull/3539)).
 
 ### Deprecated
 

--- a/src/argilla/client/feedback/integrations/huggingface/dataset.py
+++ b/src/argilla/client/feedback/integrations/huggingface/dataset.py
@@ -327,72 +327,73 @@ class HuggingFaceDatasetMixin:
             suggestions = []
             user_without_id = False
             for question in config.questions:
-                if hfds[index][question.name] is None or len(hfds[index][question.name]) < 1:
-                    continue
-                # Here for backwards compatibility
-                if (
-                    len(
-                        [None for response in hfds[index][question.name] if response["user_id"] is None]
-                        if isinstance(hfds[index][question.name], list)
-                        else [None for user_id in hfds[index][question.name]["user_id"] if user_id is None]
-                    )
-                    > 1
-                ):
-                    warnings.warn(
-                        "Found more than one user without ID in the dataset, so just the"
-                        " responses for the first user without ID will be used, the rest"
-                        " will be discarded."
-                    )
-                user_without_id_response = False
-
-                # Here for backwards compatibility
-                original_responses = []
-                if isinstance(hfds[index][question.name], list):
-                    original_responses = hfds[index][question.name]
-                else:
-                    for user_id, value, status in zip(
-                        hfds[index][question.name]["user_id"],
-                        hfds[index][question.name]["value"],
-                        hfds[index][question.name]["status"],
+                if hfds[index][question.name] is not None and len(hfds[index][question.name]) > 0:
+                    if (
+                        len(
+                            [None for response in hfds[index][question.name] if response["user_id"] is None]
+                            if isinstance(hfds[index][question.name], list)
+                            else [None for user_id in hfds[index][question.name]["user_id"] if user_id is None]
+                        )
+                        > 1
                     ):
-                        original_responses.append({"user_id": user_id, "value": value, "status": status})
+                        warnings.warn(
+                            "Found more than one user without ID in the dataset, so just the"
+                            " responses for the first user without ID will be used, the rest"
+                            " will be discarded."
+                        )
+                    user_without_id_response = False
 
-                responses = {}
-                for response in original_responses:
-                    if user_without_id_response:
-                        continue
-                    user_id = response["user_id"]
-                    status = response["status"]
-                    if user_id is None:
-                        if not user_without_id:
-                            user_without_id = True
-                            responses["user_without_id"] = {
+                    # Here for backwards compatibility
+                    original_responses = []
+                    if isinstance(hfds[index][question.name], list):
+                        original_responses = hfds[index][question.name]
+                    else:
+                        for user_id, value, status in zip(
+                            hfds[index][question.name]["user_id"],
+                            hfds[index][question.name]["value"],
+                            hfds[index][question.name]["status"],
+                        ):
+                            original_responses.append({"user_id": user_id, "value": value, "status": status})
+
+                    responses = {}
+                    for response in original_responses:
+                        if user_without_id_response:
+                            continue
+                        user_id = response["user_id"]
+                        status = response["status"]
+                        if user_id is None:
+                            if not user_without_id:
+                                user_without_id = True
+                                responses["user_without_id"] = {
+                                    "user_id": user_id,
+                                    "status": status,
+                                    "values": {},
+                                }
+                                user_without_id_response = True
+                        if user_id is not None and user_id not in responses:
+                            responses[user_id] = {
                                 "user_id": user_id,
                                 "status": status,
                                 "values": {},
                             }
-                            user_without_id_response = True
-                    if user_id is not None and user_id not in responses:
-                        responses[user_id] = {
-                            "user_id": user_id,
-                            "status": status,
-                            "values": {},
-                        }
-                    value = response["value"]
-                    if value is not None:
-                        if question.settings["type"] == "ranking":
-                            value = [{"rank": r, "value": v} for r, v in zip(value["rank"], value["value"])]
-                        responses[user_id or "user_without_id"]["values"].update({question.name: {"value": value}})
+                        value = response["value"]
+                        if value is not None:
+                            if question.settings["type"] == "ranking":
+                                value = [{"rank": r, "value": v} for r, v in zip(value["rank"], value["value"])]
+                            responses[user_id or "user_without_id"]["values"].update({question.name: {"value": value}})
 
-            # First if-condition is here for backwards compatibility
-            if f"{question.name}-suggestion" in hfds[index] and hfds[index][f"{question.name}-suggestion"] is not None:
-                suggestion = {
-                    "question_name": question.name,
-                    "value": hfds[index][f"{question.name}-suggestion"],
-                }
-                if hfds[index][f"{question.name}-suggestion-metadata"] is not None:
-                    suggestion.update(hfds[index][f"{question.name}-suggestion-metadata"])
-                suggestions.append(suggestion)
+                # First if-condition is here for backwards compatibility
+                if (
+                    f"{question.name}-suggestion" in hfds[index]
+                    and hfds[index][f"{question.name}-suggestion"] is not None
+                ):
+                    suggestion = {
+                        "question_name": question.name,
+                        "value": hfds[index][f"{question.name}-suggestion"],
+                    }
+                    if hfds[index][f"{question.name}-suggestion-metadata"] is not None:
+                        suggestion.update(hfds[index][f"{question.name}-suggestion-metadata"])
+                    suggestions.append(suggestion)
 
             metadata = None
             if "metadata" in hfds[index] and hfds[index]["metadata"] is not None:

--- a/src/argilla/client/feedback/integrations/huggingface/dataset.py
+++ b/src/argilla/client/feedback/integrations/huggingface/dataset.py
@@ -227,7 +227,7 @@ class HuggingFaceDatasetMixin:
                 argilla_fields=self.fields,
                 argilla_questions=self.questions,
                 argilla_guidelines=self.guidelines,
-                argilla_record=json.loads(self.records[0].json()),
+                argilla_record=json.loads(self.records[0].json(exclude={"client", "id", "name2id"}, exclude_none=True)),
                 huggingface_record=hfds[0],
             )
             card.push_to_hub(repo_id, repo_type="dataset", token=kwargs.get("token"))

--- a/src/argilla/client/feedback/integrations/huggingface/dataset.py
+++ b/src/argilla/client/feedback/integrations/huggingface/dataset.py
@@ -83,14 +83,13 @@ class HuggingFaceDatasetMixin:
                     f" `{'`, `'.join([arg.__name__ for arg in AllowedQuestionTypes.__args__])}`."
                 )
 
-            hf_features[question.name] = Sequence(
+            hf_features[question.name] = [
                 {
-                    "user_id": Value(dtype="string"),
+                    "user_id": Value(dtype="string", id="question"),
                     "value": value,
-                    "status": Value(dtype="string"),
-                },
-                id="question",
-            )
+                    "status": Value(dtype="string", id="question"),
+                }
+            ]
             if question.name not in hf_dataset:
                 hf_dataset[question.name] = []
 
@@ -118,44 +117,35 @@ class HuggingFaceDatasetMixin:
                 hf_dataset[field.name].append(record.fields[field.name])
             for question in dataset.questions:
                 if not record.responses:
-                    hf_dataset[question.name].append(None)
+                    hf_dataset[question.name].append([])
                 else:
                     responses = []
                     for response in record.responses:
                         if question.name not in response.values:
-                            responses.append(None)
                             continue
+                        formatted_response = {"user_id": response.user_id, "value": None, "status": response.status}
                         if question.settings["type"] == "ranking":
-                            responses.append([r.dict() for r in response.values[question.name].value])
+                            value = [r.dict() for r in response.values[question.name].value]
                         else:
-                            responses.append(response.values[question.name].value)
-                    hf_dataset[question.name].append(
-                        {
-                            "user_id": [r.user_id for r in record.responses],
-                            "value": responses,
-                            "status": [r.status for r in record.responses],
-                        }
-                    )
+                            value = response.values[question.name].value
+                        formatted_response["value"] = value
+                        responses.append(formatted_response)
+                    hf_dataset[question.name].append(responses)
 
-                suggestion = next(filter(lambda s: s.question_name == question.name, record.suggestions), None)
-                if not record.suggestions or not suggestion:
-                    hf_dataset[f"{question.name}-suggestion"].append(None)
-                    hf_dataset[f"{question.name}-suggestion-metadata"].append(
-                        {
-                            "type": None,
-                            "score": None,
-                            "agent": None,
-                        }
-                    )
-                else:
-                    hf_dataset[f"{question.name}-suggestion"].append(suggestion.value)
-                    hf_dataset[f"{question.name}-suggestion-metadata"].append(
-                        {
+                suggestion_value, suggestion_metadata = None, {"type": None, "score": None, "agent": None}
+                if record.suggestions:
+                    for suggestion in record.suggestions:
+                        if question.name != suggestion.question_name:
+                            continue
+                        suggestion_value = suggestion.value
+                        suggestion_metadata = {
                             "type": suggestion.type,
                             "score": suggestion.score,
                             "agent": suggestion.agent,
                         }
-                    )
+                        break
+                hf_dataset[f"{question.name}-suggestion"].append(suggestion_value)
+                hf_dataset[f"{question.name}-suggestion-metadata"].append(suggestion_metadata)
 
             hf_dataset["metadata"].append(json.dumps(record.metadata) if record.metadata else {})
             hf_dataset["external_id"].append(record.external_id or None)

--- a/src/argilla/client/feedback/integrations/huggingface/dataset.py
+++ b/src/argilla/client/feedback/integrations/huggingface/dataset.py
@@ -312,7 +312,7 @@ class HuggingFaceDatasetMixin:
                 " the `DatasetConfig` as `argilla.yaml` to the HuggingFace Hub."
             ) from e
 
-        hfds = load_dataset(repo_id, use_auth_token=auth, *args, **kwargs)
+        hfds = load_dataset(repo_id, token=auth, *args, **kwargs)  # use_auth_token is deprecated
         if isinstance(hfds, DatasetDict) and "split" not in kwargs:
             if len(hfds.keys()) > 1:
                 raise ValueError(

--- a/src/argilla/client/feedback/integrations/huggingface/dataset.py
+++ b/src/argilla/client/feedback/integrations/huggingface/dataset.py
@@ -338,7 +338,6 @@ class HuggingFaceDatasetMixin:
                             " responses for the first user without ID will be used, the rest"
                             " will be discarded."
                         )
-                    user_without_id_response = False
 
                     # Here for backwards compatibility
                     original_responses = []
@@ -352,7 +351,7 @@ class HuggingFaceDatasetMixin:
                         ):
                             original_responses.append({"user_id": user_id, "value": value, "status": status})
 
-                    responses = {}
+                    user_without_id_response = False
                     for response in original_responses:
                         if user_without_id_response:
                             continue

--- a/src/argilla/client/feedback/integrations/huggingface/dataset.py
+++ b/src/argilla/client/feedback/integrations/huggingface/dataset.py
@@ -135,15 +135,14 @@ class HuggingFaceDatasetMixin:
                 suggestion_value, suggestion_metadata = None, {"type": None, "score": None, "agent": None}
                 if record.suggestions:
                     for suggestion in record.suggestions:
-                        if question.name != suggestion.question_name:
-                            continue
-                        suggestion_value = suggestion.value
-                        suggestion_metadata = {
-                            "type": suggestion.type,
-                            "score": suggestion.score,
-                            "agent": suggestion.agent,
-                        }
-                        break
+                        if question.name == suggestion.question_name:
+                            suggestion_value = suggestion.value
+                            suggestion_metadata = {
+                                "type": suggestion.type,
+                                "score": suggestion.score,
+                                "agent": suggestion.agent,
+                            }
+                            break
                 hf_dataset[f"{question.name}-suggestion"].append(suggestion_value)
                 hf_dataset[f"{question.name}-suggestion-metadata"].append(suggestion_metadata)
 

--- a/src/argilla/client/feedback/integrations/huggingface/dataset.py
+++ b/src/argilla/client/feedback/integrations/huggingface/dataset.py
@@ -150,10 +150,7 @@ class HuggingFaceDatasetMixin:
             hf_dataset["metadata"].append(json.dumps(record.metadata) if record.metadata else {})
             hf_dataset["external_id"].append(record.external_id or None)
 
-        return Dataset.from_dict(
-            hf_dataset,
-            features=Features(hf_features),
-        )
+        return Dataset.from_dict(hf_dataset, features=Features(hf_features))
 
     @requires_version("huggingface_hub")
     @requires_version("datasets")

--- a/src/argilla/client/feedback/integrations/huggingface/dataset.py
+++ b/src/argilla/client/feedback/integrations/huggingface/dataset.py
@@ -110,6 +110,7 @@ class HuggingFaceDatasetMixin:
         hf_features["external_id"] = Value(dtype="string", id="external_id")
         hf_dataset["external_id"] = []
 
+        hf_features["metadata"] = Value(dtype="string", id="metadata")
         hf_dataset["metadata"] = []
 
         for record in dataset.records:
@@ -156,11 +157,8 @@ class HuggingFaceDatasetMixin:
                         }
                     )
 
-            hf_dataset["metadata"].append(json.dumps(record.metadata) if record.metadata else None)
+            hf_dataset["metadata"].append(json.dumps(record.metadata) if record.metadata else {})
             hf_dataset["external_id"].append(record.external_id or None)
-
-        if hf_dataset.get("metadata", None) is not None:
-            hf_features["metadata"] = Value(dtype="string")
 
         return Dataset.from_dict(
             hf_dataset,

--- a/src/argilla/client/feedback/integrations/huggingface/dataset.py
+++ b/src/argilla/client/feedback/integrations/huggingface/dataset.py
@@ -69,13 +69,13 @@ class HuggingFaceDatasetMixin:
 
         for question in dataset.questions:
             if question.settings["type"] in ["text", "label_selection"]:
-                value = Value(dtype="string")
+                value = Value(dtype="string", id="question")
             elif question.settings["type"] == "rating":
-                value = Value(dtype="int32")
+                value = Value(dtype="int32", id="question")
             elif question.settings["type"] == "ranking":
-                value = Sequence({"rank": Value(dtype="uint8"), "value": Value(dtype="string")})
+                value = Sequence({"rank": Value(dtype="uint8"), "value": Value(dtype="string")}, id="question")
             elif question.settings["type"] in "multi_label_selection":
-                value = Sequence(Value(dtype="string"))
+                value = Sequence(Value(dtype="string"), id="question")
             else:
                 raise ValueError(
                     f"Question {question.name} is of type `{type(question).__name__}`,"

--- a/src/argilla/client/feedback/integrations/huggingface/dataset.py
+++ b/src/argilla/client/feedback/integrations/huggingface/dataset.py
@@ -329,7 +329,15 @@ class HuggingFaceDatasetMixin:
             for question in config.questions:
                 if hfds[index][question.name] is None or len(hfds[index][question.name]) < 1:
                     continue
-                if len([None for user_id in hfds[index][question.name]["user_id"] if user_id is None]) > 1:
+                # Here for backwards compatibility
+                if (
+                    len(
+                        [None for response in hfds[index][question.name] if response["user_id"] is None]
+                        if isinstance(hfds[index][question.name], list)
+                        else [None for user_id in hfds[index][question.name]["user_id"] if user_id is None]
+                    )
+                    > 1
+                ):
                     warnings.warn(
                         "Found more than one user without ID in the dataset, so just the"
                         " responses for the first user without ID will be used, the rest"
@@ -337,13 +345,24 @@ class HuggingFaceDatasetMixin:
                     )
                 user_without_id_response = False
 
-                for user_id, value, status in zip(
-                    hfds[index][question.name]["user_id"],
-                    hfds[index][question.name]["value"],
-                    hfds[index][question.name]["status"],
-                ):
+                # Here for backwards compatibility
+                original_responses = []
+                if isinstance(hfds[index][question.name], list):
+                    original_responses = hfds[index][question.name]
+                else:
+                    for user_id, value, status in zip(
+                        hfds[index][question.name]["user_id"],
+                        hfds[index][question.name]["value"],
+                        hfds[index][question.name]["status"],
+                    ):
+                        original_responses.append({"user_id": user_id, "value": value, "status": status})
+
+                responses = {}
+                for response in original_responses:
                     if user_without_id_response:
                         continue
+                    user_id = response["user_id"]
+                    status = response["status"]
                     if user_id is None:
                         if not user_without_id:
                             user_without_id = True
@@ -359,24 +378,21 @@ class HuggingFaceDatasetMixin:
                             "status": status,
                             "values": {},
                         }
+                    value = response["value"]
                     if value is not None:
                         if question.settings["type"] == "ranking":
                             value = [{"rank": r, "value": v} for r, v in zip(value["rank"], value["value"])]
-                        if value is not None:
-                            responses[user_id or "user_without_id"]["values"].update({question.name: {"value": value}})
+                        responses[user_id or "user_without_id"]["values"].update({question.name: {"value": value}})
 
-                # First if-condition is here for backwards compatibility
-                if (
-                    f"{question.name}-suggestion" in hfds[index]
-                    and hfds[index][f"{question.name}-suggestion"] is not None
-                ):
-                    suggestion = {
-                        "question_name": question.name,
-                        "value": hfds[index][f"{question.name}-suggestion"],
-                    }
-                    if hfds[index][f"{question.name}-suggestion-metadata"] is not None:
-                        suggestion.update(hfds[index][f"{question.name}-suggestion-metadata"])
-                    suggestions.append(suggestion)
+            # First if-condition is here for backwards compatibility
+            if f"{question.name}-suggestion" in hfds[index] and hfds[index][f"{question.name}-suggestion"] is not None:
+                suggestion = {
+                    "question_name": question.name,
+                    "value": hfds[index][f"{question.name}-suggestion"],
+                }
+                if hfds[index][f"{question.name}-suggestion-metadata"] is not None:
+                    suggestion.update(hfds[index][f"{question.name}-suggestion-metadata"])
+                suggestions.append(suggestion)
 
             metadata = None
             if "metadata" in hfds[index] and hfds[index]["metadata"] is not None:


### PR DESCRIPTION
# Description

This PR addresses the feature mentioned by @tomaarsen at https://github.com/argilla-io/argilla/pull/3467, to basically export the `responses` for the existing questions in the `FeedbackDataset` when calling `push_to_huggingface` in a row-based format instead of using the `Sequence` from 🤗`datasets`. This makes the dataset from the HuggingFace Hub more readable, and also easier to use with other frameworks and/or libraries.

```diff
- {"user_id": ["A", "B"], "value": [1, 2], "status": ["C", "D"]}
+ [{"user_id": "A", "value": 1, "status": "C"}, {"user_id": "B", "value": 2, "status": "D"}]
```

Additionally, this PR also ensure that the backwards compatibility is preserved with the previous versions, and assumes the new format as the default one when calling `format_as("datasets")`.

Finally, this PR also solves an issue reported by @nataliaelv recently that was affecting the `suggestions` when calling `FeedbackDataset.from_argilla`, as those were just kept when there were `responses`, otherwise, a `continue` statement was being called so the `suggestions` were completely ignored.

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [X] Ran the following script and tested different combinations as the connection to HuggingFace is mocked, but we should create a fake/testing user at some point to avoid overloading `argilla-io`

```python
import argilla as rg

dataset = rg.FeedbackDataset(
    fields=[
        rg.TextField(
            name="prompt",
            required=True,
        ),
    ],
    questions=[
        rg.TextQuestion(
            name="response-edit",
            title="Add or edit the response if necessary",
            required=True,
        ),
    ],
)
dataset.add_records(
    rg.FeedbackRecord(
        fields={
            "prompt": "This is the prompt!",
        },
        suggestions=[
            {
                "question_name": "response-edit",
                "value": "This is the suggestion!"
            }
        ],
    )
)
dataset.push_to_huggingface("<REPO_ID>")
dataset = rg.FeedbackDataset.from_huggingface("<REPO_ID>")
assert dataset.records[0].suggestions is not None
```

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [X] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)