### PR TITLE
fix: Argilla not working behind proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ These are the section headers that we use:
 
 - Fixed issue with `bool` values and `default` from Jinja2 while generating the HuggingFace `DatasetCard` from `argilla_template.md` ([#3499](https://github.com/argilla-io/argilla/pull/3499)).
 - Fixed `DatasetConfig.from_yaml` which was failing when calling `FeedbackDataset.from_huggingface` as the UUIDs cannot be deserialized automatically by `PyYAML`, so UUIDs are neither dumped nor loaded anymore ([#3502](https://github.com/argilla-io/argilla/pull/3502)).
+- Fixed an issue that didn't allow the Argilla server to work behind a proxy ([#3543](https://github.com/argilla-io/argilla/pull/3543)).
 
 ## [1.13.3](https://github.com/argilla-io/argilla/compare/v1.13.2...v1.13.3)
 

--- a/docker/scripts/start_argilla_server.sh
+++ b/docker/scripts/start_argilla_server.sh
@@ -6,7 +6,7 @@ python -m argilla database migrate
 
 # Create default user
 if [ "$DEFAULT_USER_ENABLED" = "true" ]; then
-  python -m argilla users create_default --password $DEFAULT_USER_PASSWORD --api-key $DEFAULT_USER_API_KEY
+	python -m argilla users create_default --password $DEFAULT_USER_PASSWORD --api-key $DEFAULT_USER_API_KEY
 fi
 
 # Run argilla-server (See https://www.uvicorn.org/settings/#settings)
@@ -16,4 +16,10 @@ fi
 #   with the prefix UVICORN_. For example, in case you want to
 #   run the app on port 5000, just set the environment variable
 #   UVICORN_PORT to 5000.
-uvicorn argilla:app --host "0.0.0.0"
+
+# Check for ARGILLA_BASE_URL and add --root-path if present
+if [ -n "$ARGILLA_BASE_URL" ]; then
+	uvicorn argilla:app --host "0.0.0.0" --root-path "$ARGILLA_BASE_URL"
+else
+	uvicorn argilla:app --host "0.0.0.0"
+fi

--- a/docker/scripts/start_quickstart_argilla.sh
+++ b/docker/scripts/start_quickstart_argilla.sh
@@ -13,33 +13,37 @@ python -m argilla database migrate
 
 echo "Creating owner user"
 python -m argilla users create \
-  --first-name "Owner" \
-  --username "$OWNER_USERNAME" \
-  --password "$OWNER_PASSWORD" \
-  --api-key "$OWNER_API_KEY" \
-  --role owner \
-  --workspace "$ARGILLA_WORKSPACE"
+	--first-name "Owner" \
+	--username "$OWNER_USERNAME" \
+	--password "$OWNER_PASSWORD" \
+	--api-key "$OWNER_API_KEY" \
+	--role owner \
+	--workspace "$ARGILLA_WORKSPACE"
 
 echo "Creating admin user"
 python -m argilla users create \
-  --first-name "Admin" \
-  --username "$ADMIN_USERNAME" \
-  --password "$ADMIN_PASSWORD" \
-  --api-key "$ADMIN_API_KEY" \
-  --role admin \
-  --workspace "$ARGILLA_WORKSPACE"
+	--first-name "Admin" \
+	--username "$ADMIN_USERNAME" \
+	--password "$ADMIN_PASSWORD" \
+	--api-key "$ADMIN_API_KEY" \
+	--role admin \
+	--workspace "$ARGILLA_WORKSPACE"
 
 echo "Creating annotator user"
 python -m argilla users create \
-  --first-name "Annotator" \
-  --username "$ANNOTATOR_USERNAME" \
-  --password "$ANNOTATOR_PASSWORD" \
-  --role annotator \
-  --workspace "$ARGILLA_WORKSPACE"
+	--first-name "Annotator" \
+	--username "$ANNOTATOR_USERNAME" \
+	--password "$ANNOTATOR_PASSWORD" \
+	--role annotator \
+	--workspace "$ARGILLA_WORKSPACE"
 
 # Load data
 python /load_data.py "$OWNER_API_KEY" "$LOAD_DATASETS" &
 
 # Start Argilla
 echo "Starting Argilla"
-uvicorn argilla:app --host "0.0.0.0"
+if [ -n "$ARGILLA_BASE_URL" ]; then
+	uvicorn argilla:app --host "0.0.0.0" --root-path "$ARGILLA_BASE_URL"
+else
+	uvicorn argilla:app --host "0.0.0.0"
+fi

--- a/src/argilla/server/server.py
+++ b/src/argilla/server/server.py
@@ -263,7 +263,7 @@ async def redirect_api():
 
 
 app = FastAPI(docs_url=None)
-app.mount(settings.base_url, argilla_app)
+app.mount("/", argilla_app)
 
 configure_app_logging(app)
 configure_database(app)


### PR DESCRIPTION
# Description

This PR updates the URL in which the Argilla App is mounted to be `"/"`, as it's not required to change the URL of the server because the proxy will know what rewrite has to be done.

In addition, the entrypoint scripts of both images have been updated to add the `--root-path $ARGILLA_BASE_URL` option to the `uvicorn` command if `ARGILLA_BASE_URL` env variable has been set. More info: [FastAPI - Behind a proxy](https://fastapi.tiangolo.com/advanced/behind-a-proxy/#behind-a-proxy).

Closes #3542

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

- [x] `localhost/argilla` load in a web browser and can connect using `rg.init` with an NGINX local setup:
  <details>
    <summary>Local Nginx</summary>
  
  `docker-compose.yaml`:
  
    ```yaml
  version: '3.8'
  
  services:
    argilla:
      image: argilla/argilla-quickstart:pr-3543
      environment:
        ARGILLA_BASE_URL: /argilla
        LOAD_DATASETS: none
      ports:
        - 6900:6900
  
    nginx:
      image: nginx:latest
      ports:
        - 80:80
      volumes:
        - ./nginx.conf:/etc/nginx/nginx.conf
    ```
    `nginx.conf`:
    ```
  events {}
  
  http {
    server {
        listen 80;
  
        server_name your_server_name_or_ip;
  
        location /argilla/ {
            proxy_pass http://argilla:6900/;
            proxy_set_header Host $host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto $scheme;
        }
    }
  }
    ```
  </details>

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
