### PR TITLE
fix: execute build docker only if build python

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -127,6 +127,7 @@ jobs:
       - run_unit_tests
     if: |
       !cancelled() &&
+      needs.build_python_package.result == 'success' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     with:


### PR DESCRIPTION
# Description

This PR updates the `package.yaml` workflow to **only** execute the `build_server_docker_image` job if the `build_python_package` has been executed and it's execution has succeeded (as the first job needs the python package artifact generated by the second one)

Closes #3544

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

N/A

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)