### PR TITLE
fix: `{FieldSchema, QuestionSchema}.name` attribute didn't have regex validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,6 @@ These are the section headers that we use:
 
 ### Fixed
 
-- `TextClassificationSettings` and `TokenClassificationSettings` labels are properly parsed to strings both in the Python client and in the backend endpoint (Closes [#3495](https://github.com/argilla-io/argilla/issues/3495)).
-- Fixed `PUT /api/v1/datasets/{dataset_id}/publish` to check whether at leat one field and question has `required=True` ([#3511](https://github.com/argilla-io/argilla/pull/3511)).
-- Fixed `FeedbackDataset.from_huggingface` as `suggestions` were being lost when there were no `responses` ([#3539](https://github.com/argilla-io/argilla/pull/3539)).
-
 ### Added
 
 - Added `PATCH /api/v1/fields/{field_id}` endpoint to update the field title and markdown settings ([#3421](https://github.com/argilla-io/argilla/pull/3421)).
@@ -48,17 +44,21 @@ These are the section headers that we use:
 - After calling `FeedbackDataset.push_to_argilla`, the methods `FeedbackDataset.add_records` and `FeedbackRecord.set_suggestions` will automatically call Argilla with no need of calling `push_to_argilla` explicitly ([#3465](https://github.com/argilla-io/argilla/pull/3465)).
 - Now calling `FeedbackDataset.push_to_huggingface` dumps the `responses` as a `List[Dict[str, Any]]` instead of `Sequence` to make it more readable via 🤗`datasets` ([#3539](https://github.com/argilla-io/argilla/pull/3539)).
 
-### Deprecated
-
-- After calling `FeedbackDataset.push_to_argilla`, calling `push_to_argilla` again won't do anything since the dataset is already pushed to Argilla ([#3465](https://github.com/argilla-io/argilla/pull/3465)).
-- After calling `FeedbackDataset.push_to_argilla`, calling `fetch_records` won't do anything since the records are lazily fetched from Argilla ([#3465](https://github.com/argilla-io/argilla/pull/3465)).
-- After calling `FeedbackDataset.push_to_argilla`, the Argilla ID is no longer stored in the attribute/property `argilla_id` but in `id` instead ([#3465](https://github.com/argilla-io/argilla/pull/3465)).
-
 ### Fixed
 
 - Fixed issue with `bool` values and `default` from Jinja2 while generating the HuggingFace `DatasetCard` from `argilla_template.md` ([#3499](https://github.com/argilla-io/argilla/pull/3499)).
 - Fixed `DatasetConfig.from_yaml` which was failing when calling `FeedbackDataset.from_huggingface` as the UUIDs cannot be deserialized automatically by `PyYAML`, so UUIDs are neither dumped nor loaded anymore ([#3502](https://github.com/argilla-io/argilla/pull/3502)).
 - Fixed an issue that didn't allow the Argilla server to work behind a proxy ([#3543](https://github.com/argilla-io/argilla/pull/3543)).
+- `TextClassificationSettings` and `TokenClassificationSettings` labels are properly parsed to strings both in the Python client and in the backend endpoint (Closes [#3495](https://github.com/argilla-io/argilla/issues/3495)).
+- Fixed `PUT /api/v1/datasets/{dataset_id}/publish` to check whether at leat one field and question has `required=True` ([#3511](https://github.com/argilla-io/argilla/pull/3511)).
+- Fixed `FeedbackDataset.from_huggingface` as `suggestions` were being lost when there were no `responses` ([#3539](https://github.com/argilla-io/argilla/pull/3539)).
+- Fixed `QuestionSchema` and `FieldSchema` not validating `name` attribute ([#3550](https://github.com/argilla-io/argilla/pull/3550)).
+
+### Deprecated
+
+- After calling `FeedbackDataset.push_to_argilla`, calling `push_to_argilla` again won't do anything since the dataset is already pushed to Argilla ([#3465](https://github.com/argilla-io/argilla/pull/3465)).
+- After calling `FeedbackDataset.push_to_argilla`, calling `fetch_records` won't do anything since the records are lazily fetched from Argilla ([#3465](https://github.com/argilla-io/argilla/pull/3465)).
+- After calling `FeedbackDataset.push_to_argilla`, the Argilla ID is no longer stored in the attribute/property `argilla_id` but in `id` instead ([#3465](https://github.com/argilla-io/argilla/pull/3465)).
 
 ## [1.13.3](https://github.com/argilla-io/argilla/compare/v1.13.2...v1.13.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,6 @@ These are the section headers that we use:
 
 ## [Unreleased]
 
-### Fixed
-
 ### Added
 
 - Added `PATCH /api/v1/fields/{field_id}` endpoint to update the field title and markdown settings ([#3421](https://github.com/argilla-io/argilla/pull/3421)).

--- a/src/argilla/client/feedback/schemas/fields.py
+++ b/src/argilla/client/feedback/schemas/fields.py
@@ -17,6 +17,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, Extra, Field, root_validator, validator
 
+from argilla.client.feedback.schemas.validators import title_must_have_value
+
 FieldTypes = Literal["text"]
 
 
@@ -45,17 +47,13 @@ class FieldSchema(BaseModel):
     """
 
     id: Optional[UUID] = None
-    name: str
+    name: str = Field(..., regex=r"^(?=.*[a-z0-9])[a-z0-9_-]+$")
     title: Optional[str] = None
     required: bool = True
     type: Optional[FieldTypes] = None
     settings: Dict[str, Any] = Field(default_factory=dict, allow_mutation=False)
 
-    @validator("title", always=True)
-    def title_must_have_value(cls, v: Optional[str], values: Dict[str, Any]) -> str:
-        if not v:
-            return values.get("name").capitalize()
-        return v
+    _title_must_have_value = validator("title", always=True, allow_reuse=True)(title_must_have_value)
 
     class Config:
         validate_assignment = True

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -18,6 +18,7 @@ from uuid import UUID
 from pydantic import BaseModel, Extra, Field, conint, conlist, root_validator, validator
 
 from argilla.client.feedback.schemas.utils import LabelMappingMixin
+from argilla.client.feedback.schemas.validators import title_must_have_value
 
 QuestionTypes = Literal["text", "rating", "label_selection", "multi_label_selection", "ranking"]
 
@@ -50,18 +51,14 @@ class QuestionSchema(BaseModel):
     """
 
     id: Optional[UUID] = None
-    name: str
+    name: str = Field(..., regex=r"^(?=.*[a-z0-9])[a-z0-9_-]+$")
     title: Optional[str] = None
     description: Optional[str] = None
     required: bool = True
     type: Optional[QuestionTypes] = None
     settings: Dict[str, Any] = Field(default_factory=dict, allow_mutation=False)
 
-    @validator("title", always=True)
-    def title_must_have_value(cls, v: Optional[str], values: Dict[str, Any]) -> str:
-        if not v:
-            return values.get("name").capitalize()
-        return v
+    _title_must_have_value = validator("title", always=True, allow_reuse=True)(title_must_have_value)
 
     class Config:
         validate_assignment = True

--- a/src/argilla/client/feedback/schemas/validators.py
+++ b/src/argilla/client/feedback/schemas/validators.py
@@ -1,0 +1,24 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Any, Dict, Optional
+
+
+def title_must_have_value(cls, v: Optional[str], values: Dict[str, Any]) -> str:
+    if not v:
+        # If `name` doesn't pass the regex validation, then `values` won't have it
+        name = values.get("name")
+        if name:
+            return name.capitalize()
+    return v

--- a/tests/unit/client/feedback/schemas/test_fields.py
+++ b/tests/unit/client/feedback/schemas/test_fields.py
@@ -15,7 +15,22 @@
 from typing import Any, Dict
 
 import pytest
-from argilla.client.feedback.schemas.fields import TextField
+from argilla.client.feedback.schemas.fields import FieldSchema, TextField
+from pydantic import ValidationError
+
+
+def test_field_schema() -> None:
+    schema = FieldSchema(name="completion-a")
+    assert schema.id is None
+    assert schema.name == "completion-a"
+    assert schema.title == "Completion-a"
+    assert schema.type is None
+    assert schema.settings == {}
+
+
+def test_field_schema_name_validation_error() -> None:
+    with pytest.raises(ValidationError, match=r"name\n  string does not match regex"):
+        FieldSchema(name="Completion-A")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/client/feedback/schemas/test_questions.py
+++ b/tests/unit/client/feedback/schemas/test_questions.py
@@ -18,11 +18,17 @@ import pytest
 from argilla.client.feedback.schemas.questions import (
     LabelQuestion,
     MultiLabelQuestion,
+    QuestionSchema,
     RankingQuestion,
     RatingQuestion,
     TextQuestion,
 )
 from pydantic import ValidationError
+
+
+def test_question_schema_name_validation_error() -> None:
+    with pytest.raises(ValidationError, match=r"name\n  string does not match regex"):
+        QuestionSchema(name="Completion-A")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

This PR adds the regex validation to the `{FieldSchema, QuestionSchema}.name` attribute. This regex validation is already present in the server side, adding it to the client will allow to raise a `ValidationError` before calling the server.

Closes #3548

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

Added new unit tests covering the described issue above.

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
