### PR TITLE
fix: add missing database `commit`s after `begin_nested`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ These are the section headers that we use:
 
 ## [Unreleased]()
 
+## [1.14.1](https://github.com/argilla-io/argilla/compare/v1.14.0...v1.14.1)
+
+### Fixed
+
+- Fixed PostgreSQL database not being updated after `begin_nested` because of missing `commit` ([#3567](https://github.com/argilla-io/argilla/pull/3567)).
+
 ## [1.14.0](https://github.com/argilla-io/argilla/compare/v1.13.3...v1.14.0)
 
 ### Added

--- a/src/argilla/server/contexts/accounts.py
+++ b/src/argilla/server/contexts/accounts.py
@@ -132,6 +132,8 @@ async def create_user(db: "AsyncSession", user_create: UserCreate) -> User:
                     autocommit=False,
                 )
 
+    await db.commit()
+
     return user
 
 

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -117,6 +117,8 @@ async def publish_dataset(db: "AsyncSession", search_engine: SearchEngine, datas
         dataset = await dataset.update(db, status=DatasetStatus.ready, autocommit=False)
         await search_engine.create_index(dataset)
 
+    await db.commit()
+
     return dataset
 
 
@@ -124,6 +126,9 @@ async def delete_dataset(db: "AsyncSession", search_engine: SearchEngine, datase
     async with db.begin_nested():
         dataset = await dataset.delete(db, autocommit=False)
         await search_engine.delete_index(dataset)
+
+    await db.commit()
+
     return dataset
 
 
@@ -221,6 +226,9 @@ async def delete_record(db: "AsyncSession", search_engine: "SearchEngine", recor
     async with db.begin_nested():
         record = await record.delete(db=db, autocommit=False)
         await search_engine.delete_records(dataset=record.dataset, records=[record])
+
+    await db.commit()
+
     return record
 
 
@@ -374,6 +382,8 @@ async def create_records(
             await record.awaitable_attrs.responses
         await search_engine.add_records(dataset, records)
 
+    await db.commit()
+
 
 async def get_response_by_id(db: "AsyncSession", response_id: UUID) -> Union[Response, None]:
     result = await db.execute(
@@ -423,6 +433,8 @@ async def create_response(
         await db.flush([response])
         await search_engine.update_record_response(response)
 
+    await db.commit()
+
     return response
 
 
@@ -437,6 +449,8 @@ async def update_response(
         )
         await search_engine.update_record_response(response)
 
+    await db.commit()
+
     return response
 
 
@@ -444,6 +458,9 @@ async def delete_response(db: "AsyncSession", search_engine: SearchEngine, respo
     async with db.begin_nested():
         response = await response.delete(db, autocommit=False)
         await search_engine.delete_record_response(response)
+
+    await db.commit()
+
     return response
 
 


### PR DESCRIPTION
# Description

When using PostgreSQL, the changes made after a `begin_nested` where not being written to the database because missing `commit`. This didn't happen when using SQLite3, which was writing the data even without executing a `commit`.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

I've tested in a local development environment with PostgreSQL all the endpoints that were using `begin_nested`:

- [x] Publish dataset
- [x] Delete dataset
- [x] Delete record
- [x] Create records
- [x] Create response
- [x] Update response
- [x] Delete response

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
