### PR TITLE
Return `str` for `TrainingTaskMappingForTextClassification.__repr__`

### DIFF
--- a/src/argilla/client/feedback/training/schemas.py
+++ b/src/argilla/client/feedback/training/schemas.py
@@ -243,11 +243,11 @@ class TrainingTaskMappingForTextClassification(BaseModel, TrainingData):
 
     def __repr__(self) -> str:
         return (
-            "TrainingTaskMappingForTextClassification",
-            f"\n\t text={self.text.name}",
-            f"\n\t label={self.label.question.name}",
-            f"\n\t multi_label={self.__multi_label__}",
-            f"\n\t all_labels={self.__all_labels__}",
+            "TrainingTaskMappingForTextClassification"
+            f"\n\t text={self.text.name}"
+            f"\n\t label={self.label.question.name}"
+            f"\n\t multi_label={self.__multi_label__}"
+            f"\n\t all_labels={self.__all_labels__}"
         )
 
     @requires_version("datasets>1.17.0")

--- a/tests/unit/client/feedback/training/test_schemas.py
+++ b/tests/unit/client/feedback/training/test_schemas.py
@@ -347,3 +347,10 @@ def test_task_mapping_for_text_classification(
             assert isinstance(d, e)
     else:
         assert isinstance(data, expected)
+
+
+def test_training_task_repr(label_question_payload):
+    field = TextField(name="text")
+    label = LabelQuestion(**label_question_payload)
+    task_mapping = TrainingTaskMapping.for_text_classification(text=field, label=label)
+    assert isinstance(repr(task_mapping), str)


### PR DESCRIPTION

# Description

This PR returns `str` for `TrainingTaskMappingForTextClassification.__repr__`. I assumed the expected return was what the method already contained without the commas.

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Closes #3573

**Type of change**
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

Basic test under `test/unit/client/feedback/training/test_schema.py` to check the return from the `__repr__` method is a `str`.

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
