### PR TITLE
docs: replace `ELASTICSEARCH` with `ARGILLA_ELASTICSEARCH`

### DIFF
--- a/docs/_source/community/migration-rubrix.md
+++ b/docs/_source/community/migration-rubrix.md
@@ -31,7 +31,7 @@ python -m rubrix
 All the environment variables have changed from using the prefix `RUBRIX_` to using the prefix `ARGILLA_`.
 
 .. warning::
-  From version `1.13.0`, the support for non-prefixed environment variables was removed. All environment variables must be prefixed with `ARGILLA_`.
+  From version `1.13.0`, the support for non-prefixed environment variables has been removed. All environment variables must be prefixed with `ARGILLA_`.
 
 The best to configure a new Argilla Server from Rubrix is just to duplicate all ENV variables for
 both, Rubrix and Argilla instances. This will simplify a version rollback if needed.

--- a/docs/_source/community/migration-rubrix.md
+++ b/docs/_source/community/migration-rubrix.md
@@ -29,8 +29,9 @@ python -m rubrix
 ## Environment variables
 
 All the environment variables have changed from using the prefix `RUBRIX_` to using the prefix `ARGILLA_`.
-The `ELASTICSEARCH` and other non-prefixed variables are still available, but they will be removed in the future.
-You should use `ARGILLA_` version instead.
+
+.. warning::
+  From version `1.13.0`, the support for non-prefixed environment variables was removed. All environment variables must be prefixed with `ARGILLA_`.
 
 The best to configure a new Argilla Server from Rubrix is just to duplicate all ENV variables for
 both, Rubrix and Argilla instances. This will simplify a version rollback if needed.

--- a/docs/_source/conf.py
+++ b/docs/_source/conf.py
@@ -93,7 +93,7 @@ services:
    ports:
      - "80:80"
    environment:
-     ELASTICSEARCH: <elasticsearch-host_and_port>
+     ARGILLA_ELASTICSEARCH: <elasticsearch-host_and_port>
    restart: unless-stopped
 ```""".format(
     myst_substitutions["dockertag"]
@@ -108,7 +108,7 @@ services:
     ports:
       - "6900:80"
     environment:
-      ELASTICSEARCH: http://elasticsearch:9200
+      ARGILLA_ELASTICSEARCH: http://elasticsearch:9200
       ARGILLA_LOCAL_AUTH_USERS_DB_FILE: /config/.users.yaml
 
     volumes:

--- a/docs/_source/getting_started/installation/configurations/elasticsearch.md
+++ b/docs/_source/getting_started/installation/configurations/elasticsearch.md
@@ -15,7 +15,7 @@ All you need to take into account is:
 
 * Argilla creates an index template for these indices, so you may provide related template privileges to this ES role.
 
-Argilla uses the `ELASTICSEARCH` environment variable to set the ES connection.
+Argilla uses the `ARGILLA_ELASTICSEARCH` environment variable to set the ES connection.
 
 :::{note}
 Argilla supports ElasticSearch versions 8.8, 8.5, 8.0, and 7.17.

--- a/docs/_source/getting_started/installation/deployments/docker.md
+++ b/docs/_source/getting_started/installation/deployments/docker.md
@@ -59,12 +59,12 @@ docker pull argilla/argilla-server
 Then simply run it.
 Keep in mind that you need a running Elasticsearch instance for Argilla to work.
 By default, the Argilla server will look for your Elasticsearch endpoint at `http://localhost:9200`.
-But you can customize this by setting the `ELASTICSEARCH` environment variable.
+But you can customize this by setting the `ARGILLA_ELASTICSEARCH` environment variable.
 
 
 
 ```bash
-docker run --network argilla-net -p 6900:6900 -e "ELASTICSEARCH=http://elasticsearch-for-argilla:9200" --name argilla argilla/argilla-server
+docker run --network argilla-net -p 6900:6900 -e "ARGILLA_ELASTICSEARCH=http://elasticsearch-for-argilla:9200" --name argilla argilla/argilla-server
 ```
 :::{note}
 By default, telemetry is enabled. This helps us to improve our product. For more info about the metrics and disabling them check [telemetry](../../../reference/telemetry.md).

--- a/docs/_source/getting_started/installation/deployments/python.md
+++ b/docs/_source/getting_started/installation/deployments/python.md
@@ -48,5 +48,5 @@ If you want to run the web app of the `develop` branch **without** docker, we re
 If you want to use vanilla docker (and have your own Elasticsearch instance running), you can just use our `develop` image:
 
 ```bash
-docker run -p 6900:6900 -e "ELASTICSEARCH=<your-elasticsearch-endpoint>" --network argilla-net --name argilla argilla/argilla-server:develop
+docker run -p 6900:6900 -e "ARGILLA_ELASTICSEARCH=<your-elasticsearch-endpoint>" --network argilla-net --name argilla argilla/argilla-server:develop
 ```


### PR DESCRIPTION
# Description

This PR updates the docs to replace the reference to environment variables with the `ARGILLA_` prefix missing.

**Type of change**

- [x] Documentation update

**How Has This Been Tested**

- [x] `sphinx-autobuild` (read [Developer Documentation](https://docs.argilla.io/en/latest/community/developer_docs.html#building-the-documentation) for more details)

**Checklist**

- [x] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
