### PR TITLE
fix: change drop_duplicates to work on columns contaning lists

### DIFF
--- a/src/argilla/client/feedback/training/schemas.py
+++ b/src/argilla/client/feedback/training/schemas.py
@@ -61,7 +61,14 @@ class TrainingData(ABC):
             formatted_data.append(data)
         df = pd.DataFrame(formatted_data)
         df = df.explode(list(explode_columns))
-        df = df.drop_duplicates()
+
+        # In cases of MultiLabel datasets the label column contains a list,
+        # which is unhashable, so for those cases we transform the rows in the
+        # dataframe to tuples to drop duplicates and reconstruct the original
+        # dataframe format.
+        if df.applymap(lambda x: isinstance(x, list)).all().any():
+            df = pd.DataFrame(df.apply(tuple, 1).drop_duplicates().to_list(), columns=df.columns)
+
         df = df.dropna(how="any")
         return df.to_dict(orient="records")
 

--- a/src/argilla/client/feedback/training/schemas.py
+++ b/src/argilla/client/feedback/training/schemas.py
@@ -61,12 +61,11 @@ class TrainingData(ABC):
             formatted_data.append(data)
         df = pd.DataFrame(formatted_data)
         df = df.explode(list(explode_columns))
-
         # In cases of MultiLabel datasets the label column contains a list,
         # which is unhashable, so for those cases we transform the rows in the
         # dataframe to tuples to drop duplicates and reconstruct the original
         # dataframe format.
-        if df.applymap(lambda x: isinstance(x, list)).all().any():
+        if df.applymap(lambda x: isinstance(x, list)).any().any():
             df = pd.DataFrame(df.apply(tuple, 1).drop_duplicates().to_list(), columns=df.columns)
         else:
             df = df.drop_duplicates()

--- a/src/argilla/client/feedback/training/schemas.py
+++ b/src/argilla/client/feedback/training/schemas.py
@@ -68,6 +68,8 @@ class TrainingData(ABC):
         # dataframe format.
         if df.applymap(lambda x: isinstance(x, list)).all().any():
             df = pd.DataFrame(df.apply(tuple, 1).drop_duplicates().to_list(), columns=df.columns)
+        else:
+            df = df.drop_duplicates()
 
         df = df.dropna(how="any")
         return df.to_dict(orient="records")

--- a/tests/integration/client/feedback/test_dataset.py
+++ b/tests/integration/client/feedback/test_dataset.py
@@ -665,6 +665,13 @@ def test_push_to_huggingface_and_from_huggingface(
         Framework("spacy-transformers"),
     ],
 )
+@pytest.mark.parametrize(
+    "question",
+    [
+        "question-3",
+        "question-4"
+    ],
+)
 @pytest.mark.usefixtures(
     "feedback_dataset_guidelines",
     "feedback_dataset_fields",
@@ -673,6 +680,7 @@ def test_push_to_huggingface_and_from_huggingface(
 )
 def test_prepare_for_training_text_classification(
     framework: Union[Framework, str],
+    question: str,
     feedback_dataset_guidelines: str,
     feedback_dataset_fields: List["AllowedFieldTypes"],
     feedback_dataset_questions: List["AllowedQuestionTypes"],
@@ -684,7 +692,7 @@ def test_prepare_for_training_text_classification(
         questions=feedback_dataset_questions,
     )
     dataset.add_records(feedback_dataset_records)
-    label = dataset.question_by_name("question-3")
+    label = dataset.question_by_name(question)
     task_mapping = TrainingTaskMapping.for_text_classification(text=dataset.fields[0], label=label)
 
     dataset.prepare_for_training(framework=framework, task_mapping=task_mapping, fetch_records=False)

--- a/tests/integration/client/feedback/test_dataset.py
+++ b/tests/integration/client/feedback/test_dataset.py
@@ -667,10 +667,7 @@ def test_push_to_huggingface_and_from_huggingface(
 )
 @pytest.mark.parametrize(
     "question",
-    [
-        "question-3",
-        "question-4"
-    ],
+    ["question-3", "question-4"],
 )
 @pytest.mark.usefixtures(
     "feedback_dataset_guidelines",


### PR DESCRIPTION
# Description

This PR updates the `TrainingData` class to work with `FeedbackDataset` containing `MultiLabelQuestion`. 

Contrary to the approach taken in this [issue comment](https://github.com/argilla-io/argilla/pull/3592#issuecomment-1685043451), the rows with duplicated elements are now dropped even though they contain a list of values.

*Note*: There is another bug in the same function but already taken into account in [this PR](https://github.com/argilla-io/argilla/pull/3467), it's just waiting for that PR to be approved so nothing was done here.

Closes #3596

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

The integration tests for the new `ArgillaTrainer` at `tests/integration/client/feedback/training/test_trainer.py` still pass after this update.

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
