### PR TITLE
refactor: move `AllowedFieldTypes` and `AllowedQuestionTypes` to `argilla/client/feedback/schemas/types.py`

### DIFF
--- a/src/argilla/client/feedback/config.py
+++ b/src/argilla/client/feedback/config.py
@@ -31,7 +31,7 @@ except ImportError:
         " so you can run `pip install pyyaml`."
     )
 
-from argilla.client.feedback.types import AllowedFieldTypes, AllowedQuestionTypes
+from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQuestionTypes
 
 
 class DatasetConfig(BaseModel):

--- a/src/argilla/client/feedback/dataset/base.py
+++ b/src/argilla/client/feedback/dataset/base.py
@@ -28,8 +28,8 @@ from argilla.client.feedback.schemas import (
     RankingQuestion,
     RatingQuestion,
 )
+from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQuestionTypes
 from argilla.client.feedback.training.schemas import TrainingTaskMappingForTextClassification
-from argilla.client.feedback.types import AllowedFieldTypes, AllowedQuestionTypes
 from argilla.client.feedback.unification import (
     LabelQuestionStrategy,
     MultiLabelQuestionStrategy,

--- a/src/argilla/client/feedback/dataset/local.py
+++ b/src/argilla/client/feedback/dataset/local.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
 from argilla.client.feedback.constants import FETCHING_BATCH_SIZE
 from argilla.client.feedback.dataset.base import FeedbackDatasetBase
 from argilla.client.feedback.dataset.mixins import ArgillaToFromMixin
-from argilla.client.feedback.types import AllowedFieldTypes, AllowedQuestionTypes
+from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQuestionTypes
 
 if TYPE_CHECKING:
     from argilla.client.feedback.schemas import FeedbackRecord

--- a/src/argilla/client/feedback/dataset/mixins.py
+++ b/src/argilla/client/feedback/dataset/mixins.py
@@ -29,7 +29,7 @@ from argilla.client.feedback.schemas import (
     TextField,
     TextQuestion,
 )
-from argilla.client.feedback.types import AllowedQuestionTypes
+from argilla.client.feedback.schemas.types import AllowedQuestionTypes
 from argilla.client.feedback.utils import feedback_dataset_in_argilla
 from argilla.client.sdk.v1.datasets import api as datasets_api_v1
 from argilla.client.workspaces import Workspace
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 
     from argilla.client.client import Argilla as ArgillaClient
     from argilla.client.feedback.dataset.local import FeedbackDataset
-    from argilla.client.feedback.types import AllowedFieldTypes
+    from argilla.client.feedback.schemas.types import AllowedFieldTypes
     from argilla.client.sdk.v1.datasets.models import FeedbackDatasetModel
 
 warnings.simplefilter("always", DeprecationWarning)

--- a/src/argilla/client/feedback/dataset/remote.py
+++ b/src/argilla/client/feedback/dataset/remote.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     import httpx
 
     from argilla.client.feedback.dataset.local import FeedbackDataset
-    from argilla.client.feedback.types import AllowedFieldTypes, AllowedQuestionTypes
+    from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQuestionTypes
     from argilla.client.sdk.v1.datasets.models import FeedbackItemModel
     from argilla.client.workspaces import Workspace
 

--- a/src/argilla/client/feedback/integrations/huggingface/dataset.py
+++ b/src/argilla/client/feedback/integrations/huggingface/dataset.py
@@ -22,7 +22,7 @@ from packaging.version import parse as parse_version
 
 from argilla.client.feedback.constants import FIELD_TYPE_TO_PYTHON_TYPE
 from argilla.client.feedback.schemas import FeedbackRecord
-from argilla.client.feedback.types import AllowedQuestionTypes
+from argilla.client.feedback.schemas.types import AllowedQuestionTypes
 from argilla.utils.dependency import requires_version
 
 if TYPE_CHECKING:

--- a/src/argilla/client/feedback/schemas/types.py
+++ b/src/argilla/client/feedback/schemas/types.py
@@ -14,12 +14,12 @@
 
 from typing import Union
 
-from argilla.client.feedback.schemas import (
+from argilla.client.feedback.schemas.fields import TextField
+from argilla.client.feedback.schemas.questions import (
     LabelQuestion,
     MultiLabelQuestion,
     RankingQuestion,
     RatingQuestion,
-    TextField,
     TextQuestion,
 )
 

--- a/tests/integration/client/conftest.py
+++ b/tests/integration/client/conftest.py
@@ -29,7 +29,7 @@ from argilla.server.models import User
 from datasets import Dataset
 
 if TYPE_CHECKING:
-    from argilla.client.feedback.types import AllowedFieldTypes, AllowedQuestionTypes
+    from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQuestionTypes
 
 from argilla.client.feedback.schemas import (
     FeedbackRecord,

--- a/tests/integration/client/feedback/test_card.py
+++ b/tests/integration/client/feedback/test_card.py
@@ -23,7 +23,7 @@ from huggingface_hub import DatasetCardData
 
 if TYPE_CHECKING:
     from argilla.client.feedback.schemas import FeedbackRecord
-    from argilla.client.feedback.types import AllowedFieldTypes, AllowedQuestionTypes
+    from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQuestionTypes
     from datasets import Dataset
 
 

--- a/tests/integration/client/feedback/test_dataset.py
+++ b/tests/integration/client/feedback/test_dataset.py
@@ -31,7 +31,7 @@ from argilla.client.feedback.training.schemas import TrainingTaskMapping
 from argilla.client.models import Framework
 
 if TYPE_CHECKING:
-    from argilla.client.feedback.types import AllowedFieldTypes, AllowedQuestionTypes
+    from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQuestionTypes
     from argilla.server.models import User as ServerUser
     from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/tests/integration/client/feedback/training/test_trainer.py
+++ b/tests/integration/client/feedback/training/test_trainer.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, List, Union
 import pytest
 
 if TYPE_CHECKING:
-    from argilla.client.feedback.types import AllowedFieldTypes, AllowedQuestionTypes
+    from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQuestionTypes
 
 import shutil
 import sys

--- a/tests/unit/client/feedback/conftest.py
+++ b/tests/unit/client/feedback/conftest.py
@@ -17,7 +17,7 @@ from typing import List
 import pytest
 from argilla.client.feedback.schemas.fields import TextField
 from argilla.client.feedback.schemas.questions import TextQuestion
-from argilla.client.feedback.types import AllowedFieldTypes, AllowedQuestionTypes
+from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQuestionTypes
 
 
 @pytest.fixture

--- a/tests/unit/client/feedback/dataset/test_base.py
+++ b/tests/unit/client/feedback/dataset/test_base.py
@@ -23,7 +23,7 @@ from argilla.client.feedback.schemas import (
 )
 
 if TYPE_CHECKING:
-    from argilla.client.feedback.types import AllowedFieldTypes, AllowedQuestionTypes
+    from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQuestionTypes
 
 
 class FeedbackDataset(FeedbackDatasetBase):


### PR DESCRIPTION
# Description

This is a small PR that moves both `AllowedFieldTypes` and `AllowedQuestionTypes` from `argilla/client/feedback/types.py` to `argilla/client/feedback/schemas/types.py`, as it makes more sense to define those under `schemas` rather than under `feedback`.

**Type of change**

- [X] Refactor (change restructuring the codebase without changing functionality)

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)