### PR TITLE
:sparkles: FEAT: signal required questions instead optional

### DIFF
--- a/frontend/components/commons/forms/questions-form/fields/shared-components/question-header/QuestionHeader.component.vue
+++ b/frontend/components/commons/forms/questions-form/fields/shared-components/question-header/QuestionHeader.component.vue
@@ -3,7 +3,7 @@
     <span
       class="suggestion-info"
       v-text="title"
-      v-required-field="isRequired && { color: 'red' }"
+      v-required-field="{ show: isRequired, color: 'red' }"
       v-prefix-star="{
         show: hasSuggestion,
         tooltip: 'This question contains a suggestion',
@@ -24,7 +24,7 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import "assets/icons/info";
 export default {
   name: "QuestionHeader",
@@ -47,9 +47,8 @@ export default {
     },
   },
   computed: {
-    showIcon() {
-      // TODO - move this to the template to after reviewing the jest.config
-      return this.tooltipMessage?.length ? true : false;
+    showIcon(): boolean {
+      return !!this.tooltipMessage?.length;
     },
   },
 };

--- a/frontend/components/commons/forms/questions-form/fields/shared-components/question-header/QuestionHeader.component.vue
+++ b/frontend/components/commons/forms/questions-form/fields/shared-components/question-header/QuestionHeader.component.vue
@@ -3,7 +3,7 @@
     <span
       class="suggestion-info"
       v-text="title"
-      v-required-field="isRequired && { color: 'red'}"
+      v-required-field="isRequired && { color: 'red' }"
       v-prefix-star="{
         show: hasSuggestion,
         tooltip: 'This question contains a suggestion',

--- a/frontend/components/commons/forms/questions-form/fields/shared-components/question-header/QuestionHeader.component.vue
+++ b/frontend/components/commons/forms/questions-form/fields/shared-components/question-header/QuestionHeader.component.vue
@@ -3,7 +3,7 @@
     <span
       class="suggestion-info"
       v-text="title"
-      v-optional-field="!isRequired"
+      v-required-field="isRequired && { color: 'red'}"
       v-prefix-star="{
         show: hasSuggestion,
         tooltip: 'This question contains a suggestion',

--- a/frontend/components/commons/forms/questions-form/fields/shared-components/question-header/QuestionHeader.component.vue
+++ b/frontend/components/commons/forms/questions-form/fields/shared-components/question-header/QuestionHeader.component.vue
@@ -24,7 +24,7 @@
   </div>
 </template>
 
-<script lang="ts">
+<script>
 import "assets/icons/info";
 export default {
   name: "QuestionHeader",
@@ -47,7 +47,7 @@ export default {
     },
   },
   computed: {
-    showIcon(): boolean {
+    showIcon() {
       return !!this.tooltipMessage?.length;
     },
   },

--- a/frontend/components/commons/forms/questions-form/fields/shared-components/question-header/questionHeader.component.spec.js
+++ b/frontend/components/commons/forms/questions-form/fields/shared-components/question-header/questionHeader.component.spec.js
@@ -42,34 +42,6 @@ describe("QuestionHeaderComponent", () => {
       false
     );
   });
-  it.skip("render the optional-field directive if the question is not required", async () => {
-    await wrapper.setProps({ isRequired: true });
-    const getAllByText = (wrapper, text) => {
-      //  Get all elements with the given text.
-      return wrapper.findAll("*").filter((node) => node.text() === text);
-    };
-
-    const getByText = (wrapper, text) => {
-      // Get the first element that has the given text.
-
-      const results = getAllByText(wrapper, text);
-      if (results.length === 0) {
-        throw new Error(
-          `getByText() found no element with the text: "${text}".`
-        );
-      }
-      return results.at(0);
-    };
-
-    // FIXME - test that the question text have ' (optional)' at the end
-    // console.log(wrapper.find("span").element.innerHTML);
-
-    // expect(wrapper.find(" (optional)")" (optional)".exists()).toBe(true);
-    // expect(wrapper.vm.showAsOptional).toBe(false); // by default question is optional
-
-    expect(getByText(wrapper, "This is a question to ask").exists()).toBe(true);
-    // console.log(getByText(wrapper, " (optional)"));
-  });
   it("render the BaseIconWithBadge component if there is a tooltipMessage", async () => {
     await wrapper.setProps({ tooltipMessage: "The tooltip message to show" });
 

--- a/frontend/components/commons/forms/questions-form/fields/shared-components/question-header/questionHeader.component.spec.js
+++ b/frontend/components/commons/forms/questions-form/fields/shared-components/question-header/questionHeader.component.spec.js
@@ -5,8 +5,8 @@ let wrapper = null;
 const options = {
   stubs: ["BaseIconWithBadge"],
   directives: {
-    "optional-field"() {
-      // this directive is used to show '(optional)' at the end of a question optional
+    "required-field"() {
+      // this directive is used to show a red asterisk at the end of a required question
     },
     tooltip() {
       // this directive is used to show a tooltip

--- a/frontend/e2e/annotation-mode-page/annotation-mode.page.spec.ts
+++ b/frontend/e2e/annotation-mode-page/annotation-mode.page.spec.ts
@@ -97,11 +97,13 @@ test.describe("Annotate page", () => {
 
     await expect(page).toHaveScreenshot();
 
-    await page.getByText("Review Rating (optional)").scrollIntoViewIfNeeded();
+    await page
+      .getByText("Review Rating", { exact: true })
+      .scrollIntoViewIfNeeded();
 
     await expect(page).toHaveScreenshot();
 
-    await page.getByText("Ranking (optional)").scrollIntoViewIfNeeded();
+    await page.getByText("Ranking", { exact: true }).scrollIntoViewIfNeeded();
 
     await expect(page).toHaveScreenshot();
   });

--- a/frontend/plugins/directives/required-field.directive.js
+++ b/frontend/plugins/directives/required-field.directive.js
@@ -1,13 +1,15 @@
 import Vue from "vue";
 
 // NOTE - to use this directive, add to your html text element where to put a asterisk :
-//  v-required-field="{ color: 'blue'}"
+//  v-required-field="{ show: true, color: 'blue'}"
 //    => color (String) the color of the asterisk : black by default
 
 Vue.directive("required-field", {
   bind: (element, binding) => {
     if (binding?.value) {
-      const { color } = binding?.value ?? { color: "black" };
+      const { color, show } = binding?.value ?? { show: true, color: "black" };
+
+      if (!show) return;
 
       const text = document.createTextNode(" *");
       const textWrapper = document.createElement("span");


### PR DESCRIPTION
Show required question with a `red asterisk` instead of showing optional widget

See #3394 

**Type of change**

- New feature

**How Has This Been Tested**

Only feedback task => we should see a `red asterisk` at the end of the title from a required question instead of showing `(optional)` for optional question.

Note : 
All e2e images have to be regenerated since this affect all `feedback task` datasets
