### PR TITLE
feat: add delete suggestions endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ These are the section headers that we use:
 
 - Added `login` function in `argilla.client.login` to login into an Argilla server and store the credentials locally ([#3582](https://github.com/argilla-io/argilla/pull/3582)).
 - Added `login` command to login into an Argilla server ([#3600](https://github.com/argilla-io/argilla/pull/3600)).
+- Added `DELETE /api/v1/suggestions/{suggestion_id}` endpoint to delete a suggestion given its ID ([#3617](https://github.com/argilla-io/argilla/pull/3617)).
+- Added `DELETE /api/v1/records/{record_id}/suggestions` endpoint to delete several suggestions linked to the same record given their IDs ([#3617](https://github.com/argilla-io/argilla/pull/3617)).
 
 ### Changed
 

--- a/src/argilla/server/apis/v1/handlers/records.py
+++ b/src/argilla/server/apis/v1/handlers/records.py
@@ -139,7 +139,7 @@ async def delete_record_suggestions(
     db: AsyncSession = Depends(get_async_db),
     record_id: UUID,
     current_user: User = Security(auth.get_current_user),
-    ids: str = Query(..., description="A comma separated list with the IDs of the records to be removed"),
+    ids: str = Query(..., description="A comma separated list with the IDs of the suggestions to be removed"),
 ):
     record = await _get_record(db, record_id)
 

--- a/src/argilla/server/apis/v1/handlers/suggestions.py
+++ b/src/argilla/server/apis/v1/handlers/suggestions.py
@@ -1,0 +1,54 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Security, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from argilla.server.contexts import datasets
+from argilla.server.database import get_async_db
+from argilla.server.models import Suggestion, User
+from argilla.server.policies import SuggestionPolicyV1, authorize
+from argilla.server.schemas.v1.suggestions import Suggestion as SuggestionSchema
+from argilla.server.security import auth
+
+router = APIRouter(tags=["suggestions"])
+
+
+async def _get_suggestion(db: "AsyncSession", suggestion_id: UUID) -> Suggestion:
+    suggestion = await datasets.get_suggestion_by_id(db, suggestion_id)
+    if not suggestion:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Suggestion with id `{suggestion_id}` not found",
+        )
+    return suggestion
+
+
+@router.delete("/suggestions/{suggestion_id}", response_model=SuggestionSchema)
+async def delete_suggestion(
+    *,
+    db: AsyncSession = Depends(get_async_db),
+    suggestion_id: UUID,
+    current_user: User = Security(auth.get_current_user),
+):
+    suggestion = await _get_suggestion(db, suggestion_id)
+
+    await authorize(current_user, SuggestionPolicyV1.delete(suggestion))
+
+    try:
+        return await datasets.delete_suggestion(db, suggestion)
+    except ValueError as err:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(err))

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -530,3 +530,8 @@ async def upsert_suggestion(
         schema=SuggestionCreateWithRecordId(record_id=record.id, **suggestion_create.dict()),
         constraints=[Suggestion.record_id, Suggestion.question_id],
     )
+
+
+async def delete_suggestions(db: "AsyncSession", record: Record, suggestions_ids: List[UUID]) -> None:
+    params = [Suggestion.id.in_(suggestions_ids), Suggestion.record_id == record.id]
+    await Suggestion.delete_many(db=db, params=params)

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -20,7 +20,18 @@ from sqlalchemy.ext.asyncio import async_object_session
 from argilla.server.contexts import accounts
 from argilla.server.daos.models.datasets import DatasetDB
 from argilla.server.errors import ForbiddenOperationError
-from argilla.server.models import Dataset, Field, Question, Record, Response, User, UserRole, Workspace, WorkspaceUser
+from argilla.server.models import (
+    Dataset,
+    Field,
+    Question,
+    Record,
+    Response,
+    Suggestion,
+    User,
+    UserRole,
+    Workspace,
+    WorkspaceUser,
+)
 
 PolicyAction = Callable[[User], Awaitable[bool]]
 
@@ -421,6 +432,18 @@ class ResponsePolicyV1:
                         actor, response.record.dataset.workspace_id
                     )
                 )
+            )
+
+        return is_allowed
+
+
+class SuggestionPolicyV1:
+    @classmethod
+    def delete(cls, suggestion: Suggestion) -> PolicyAction:
+        async def is_allowed(actor: User) -> bool:
+            return actor.is_owner or (
+                actor.is_admin
+                and await _exists_workspace_user_by_user_and_workspace_id(actor, suggestion.record.dataset.workspace_id)
             )
 
         return is_allowed

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -381,6 +381,16 @@ class RecordPolicyV1:
 
         return is_allowed
 
+    @classmethod
+    def delete_suggestions(cls, record: Record) -> PolicyAction:
+        async def is_allowed(actor: User) -> bool:
+            return actor.is_owner or (
+                actor.is_admin
+                and await _exists_workspace_user_by_user_and_workspace_id(actor, record.dataset.workspace_id)
+            )
+
+        return is_allowed
+
 
 class ResponsePolicyV1:
     @classmethod

--- a/src/argilla/server/routes.py
+++ b/src/argilla/server/routes.py
@@ -38,6 +38,7 @@ from argilla.server.apis.v1.handlers import fields as fields_v1
 from argilla.server.apis.v1.handlers import questions as questions_v1
 from argilla.server.apis.v1.handlers import records as records_v1
 from argilla.server.apis.v1.handlers import responses as responses_v1
+from argilla.server.apis.v1.handlers import suggestions as suggestions_v1
 from argilla.server.apis.v1.handlers import users as users_v1
 from argilla.server.apis.v1.handlers import workspaces as workspaces_v1
 from argilla.server.errors.base_errors import __ALL__
@@ -70,3 +71,4 @@ api_router.include_router(records_v1.router, prefix="/v1")
 api_router.include_router(responses_v1.router, prefix="/v1")
 api_router.include_router(users_v1.router, prefix="/v1")
 api_router.include_router(workspaces_v1.router, prefix="/v1")
+api_router.include_router(suggestions_v1.router, prefix="/v1")

--- a/tests/unit/server/api/v1/test_records.py
+++ b/tests/unit/server/api/v1/test_records.py
@@ -71,932 +71,901 @@ async def create_ranking_question(dataset: "Dataset") -> None:
     await RankingQuestionFactory.create(name="ranking_question_2", dataset=dataset)
 
 
-@pytest.mark.parametrize("response_status", ["submitted", "discarded", "draft"])
-@pytest.mark.parametrize(
-    "create_questions_func, responses",
-    [
-        (
-            create_text_questions,
-            {
-                "values": {
-                    "input_ok": {"value": "yes"},
-                    "output_ok": {"value": "yes"},
-                },
-            },
-        ),
-        (
-            create_rating_questions,
-            {
-                "values": {
-                    "rating_question_1": {"value": 5},
-                },
-            },
-        ),
-        (
-            create_label_selection_questions,
-            {
-                "values": {
-                    "label_selection_question_1": {"value": "option1"},
-                },
-            },
-        ),
-        (
-            create_multi_label_selection_questions,
-            {
-                "values": {
-                    "multi_label_selection_question_1": {"value": ["option1"]},
-                },
-            },
-        ),
-        (
-            create_multi_label_selection_questions,
-            {
-                "values": {
-                    "multi_label_selection_question_1": {"value": ["option1", "option2"]},
-                },
-            },
-        ),
-        (
-            create_text_questions,
-            {
-                "values": {
-                    "input_ok": {"value": "yes"},
-                },
-            },
-        ),
-        (
-            create_ranking_question,
-            {
-                "values": {
-                    "ranking_question_1": {
-                        "value": [
-                            {"value": "completion-b", "rank": 1},
-                            {"value": "completion-c", "rank": 2},
-                            {"value": "completion-a", "rank": 3},
-                        ]
+@pytest.mark.asyncio
+class TestSuiteRecords:
+    @pytest.mark.parametrize("response_status", ["submitted", "discarded", "draft"])
+    @pytest.mark.parametrize(
+        "create_questions_func, responses",
+        [
+            (
+                create_text_questions,
+                {
+                    "values": {
+                        "input_ok": {"value": "yes"},
+                        "output_ok": {"value": "yes"},
                     },
-                }
-            },
-        ),
-    ],
-)
-@pytest.mark.asyncio
-async def test_create_record_response_with_required_questions(
-    async_client: "AsyncClient",
-    db: "AsyncSession",
-    mock_search_engine: SearchEngine,
-    owner: User,
-    owner_auth_header: dict,
-    create_questions_func: Callable[["Dataset"], Awaitable[None]],
-    response_status: str,
-    responses: dict,
-):
-    dataset = await DatasetFactory.create()
-    await create_questions_func(dataset)
-    record = await RecordFactory.create(dataset=dataset)
-
-    response_json = {**responses, "status": response_status}
-    response = await async_client.post(
-        f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
-    )
-
-    response_body = response.json()
-    assert response.status_code == 201
-    assert (await db.execute(select(func.count(Response.id)))).scalar() == 1
-    assert await db.get(Response, UUID(response_body["id"]))
-    assert response_body == {
-        "id": str(UUID(response_body["id"])),
-        "values": responses["values"],
-        "status": response_status,
-        "user_id": str(owner.id),
-        "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
-        "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
-    }
-
-    response = (await db.execute(select(Response).where(Response.record_id == record.id))).scalar_one()
-    mock_search_engine.update_record_response.assert_called_once_with(response)
-
-
-@pytest.mark.asyncio
-async def test_create_submitted_record_response_with_missing_required_questions(
-    async_client: "AsyncClient", owner_auth_header: dict
-):
-    dataset = await DatasetFactory.create()
-    await create_text_questions(dataset)
-
-    record = await RecordFactory.create(dataset=dataset)
-    response_json = {
-        "values": {"output_ok": {"value": "yes"}},
-        "status": "submitted",
-    }
-
-    response = await async_client.post(
-        f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
-    )
-    assert response.status_code == 422
-    assert response.json() == {"detail": "Missing required question: 'input_ok'"}
-
-
-@pytest.mark.parametrize("response_status", ["discarded", "draft"])
-@pytest.mark.parametrize(
-    "create_questions_func, responses",
-    [
-        (
-            create_text_questions,
-            {
-                "values": {
-                    "output_ok": {"value": "yes"},
                 },
-            },
-        ),
-        (
-            create_rating_questions,
-            {
-                "values": {
-                    "rating_question_2": {"value": 5},
-                },
-            },
-        ),
-        (
-            create_label_selection_questions,
-            {
-                "values": {
-                    "label_selection_question_2": {"value": "option1"},
-                },
-            },
-        ),
-        (
-            create_multi_label_selection_questions,
-            {
-                "values": {
-                    "multi_label_selection_question_2": {"value": ["option1"]},
-                },
-            },
-        ),
-        (
-            create_multi_label_selection_questions,
-            {
-                "values": {
-                    "multi_label_selection_question_2": {"value": ["option1", "option2"]},
-                },
-            },
-        ),
-        (
-            create_ranking_question,
-            {
-                "values": {
-                    "ranking_question_2": {
-                        "value": [
-                            {"value": "completion-b", "rank": 1},
-                            {"value": "completion-c", "rank": 2},
-                            {"value": "completion-a", "rank": 3},
-                        ]
+            ),
+            (
+                create_rating_questions,
+                {
+                    "values": {
+                        "rating_question_1": {"value": 5},
                     },
-                }
-            },
-        ),
-        (
-            create_ranking_question,
-            {
-                "values": {
-                    "ranking_question_2": {
-                        "value": [
-                            {"value": "completion-b", "rank": 1},
-                            {"value": "completion-c", "rank": 1},
-                            {"value": "completion-a", "rank": 3},
-                        ]
+                },
+            ),
+            (
+                create_label_selection_questions,
+                {
+                    "values": {
+                        "label_selection_question_1": {"value": "option1"},
                     },
-                }
-            },
-        ),
-        (
-            create_ranking_question,
-            {
-                "values": {
-                    "ranking_question_2": {
-                        "value": [
-                            {"value": "completion-b", "rank": 1},
-                            {"value": "completion-c", "rank": 3},
-                            {"value": "completion-a", "rank": 3},
-                        ]
+                },
+            ),
+            (
+                create_multi_label_selection_questions,
+                {
+                    "values": {
+                        "multi_label_selection_question_1": {"value": ["option1"]},
                     },
-                }
-            },
-        ),
-        (
-            create_ranking_question,
-            {
-                "values": {
-                    "ranking_question_2": {
-                        "value": [
-                            {"value": "completion-b", "rank": 1},
-                            {"value": "completion-c", "rank": 1},
-                            {"value": "completion-a", "rank": 1},
-                        ]
+                },
+            ),
+            (
+                create_multi_label_selection_questions,
+                {
+                    "values": {
+                        "multi_label_selection_question_1": {"value": ["option1", "option2"]},
                     },
-                }
-            },
-        ),
-    ],
-)
-@pytest.mark.asyncio
-async def test_create_record_response_with_missing_required_questions(
-    async_client: "AsyncClient",
-    db: "AsyncSession",
-    mock_search_engine: SearchEngine,
-    owner: User,
-    owner_auth_header: dict,
-    create_questions_func: Callable[["Dataset"], Awaitable[None]],
-    response_status: str,
-    responses: dict,
-):
-    dataset = await DatasetFactory.create()
-    await create_questions_func(dataset)
-    record = await RecordFactory.create(dataset=dataset)
-
-    response_json = {**responses, "status": response_status}
-    response = await async_client.post(
-        f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
-    )
-
-    response_body = response.json()
-    assert response.status_code == 201
-    assert (await db.execute(select(func.count(Response.id)))).scalar() == 1
-    assert await db.get(Response, UUID(response_body["id"]))
-    assert response_body == {
-        "id": str(UUID(response_body["id"])),
-        "values": responses["values"],
-        "status": response_status,
-        "user_id": str(owner.id),
-        "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
-        "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
-    }
-
-    response = (await db.execute(select(Response).where(Response.record_id == record.id))).scalar_one()
-    mock_search_engine.update_record_response.assert_called_once_with(response)
-
-
-@pytest.mark.asyncio
-async def test_create_record_response_with_extra_question_responses(
-    async_client: "AsyncClient", owner_auth_header: dict
-):
-    dataset = await DatasetFactory.create()
-    await create_text_questions(dataset)
-    record = await RecordFactory.create(dataset=dataset)
-
-    response_json = {
-        "values": {
-            "input_ok": {"value": "yes"},
-            "unknown_question": {"value": "Test"},
-        },
-        "status": "submitted",
-    }
-    response = await async_client.post(
-        f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
-    )
-
-    assert response.status_code == 422
-    assert response.json() == {"detail": "Error: found responses for non configured questions: ['unknown_question']"}
-
-
-@pytest.mark.parametrize(
-    "create_questions_func, responses, expected_error_msg",
-    [
-        (
-            create_text_questions,
-            {
-                "values": {
-                    "input_ok": {"value": True},
-                    "output_ok": {"value": False},
                 },
-            },
-            "Expected text value, found <class 'bool'>",
-        ),
-        (
-            create_rating_questions,
-            {
-                "values": {
-                    "rating_question_1": {"value": "wrong-rating-value"},
+            ),
+            (
+                create_text_questions,
+                {
+                    "values": {
+                        "input_ok": {"value": "yes"},
+                    },
                 },
-            },
-            "'wrong-rating-value' is not a valid option.\nValid options are: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",
-        ),
-        (
-            create_label_selection_questions,
-            {
-                "values": {
-                    "label_selection_question_1": {"value": False},
+            ),
+            (
+                create_ranking_question,
+                {
+                    "values": {
+                        "ranking_question_1": {
+                            "value": [
+                                {"value": "completion-b", "rank": 1},
+                                {"value": "completion-c", "rank": 2},
+                                {"value": "completion-a", "rank": 3},
+                            ]
+                        },
+                    }
                 },
-            },
-            "False is not a valid option.\nValid options are: ['option1', 'option2', 'option3']",
-        ),
-        (
-            create_multi_label_selection_questions,
-            {
-                "values": {
-                    "multi_label_selection_question_1": {"value": "wrong-type"},
-                },
-            },
-            "This MultiLabelSelection question expects a list of values, found <class 'str'>",
-        ),
-        (
-            create_multi_label_selection_questions,
-            {
-                "values": {
-                    "multi_label_selection_question_1": {"value": ["option4", "option5"]},
-                },
-            },
-            "['option4', 'option5'] are not valid options for this MultiLabelSelection question.\nValid options are: ['option1', 'option2', 'option3']",
-        ),
-        (
-            create_multi_label_selection_questions,
-            {"values": {"multi_label_selection_question_1": {"value": []}}},
-            "This MultiLabelSelection question expects a list of values, found empty list",
-        ),
-        (
-            create_ranking_question,
-            {"values": {"ranking_question_1": {"value": "wrong-type"}}},
-            "This Ranking question expects a list of values, found <class 'str'>",
-        ),
-        (
-            create_ranking_question,
-            {"values": {"ranking_question_1": {"value": []}}},
-            "This Ranking question expects a list containing 3 values, found a list of 0 values",
-        ),
-        (
-            create_ranking_question,
-            {
-                "values": {
-                    "ranking_question_1": {
-                        "value": [
-                            {"value": "completion-b", "rank": 1},
-                        ]
-                    }
-                }
-            },
-            "This Ranking question expects a list containing 3 values, found a list of 1 values",
-        ),
-        (
-            create_ranking_question,
-            {
-                "values": {
-                    "ranking_question_1": {
-                        "value": [
-                            {"value": "completion-b", "rank": 1},
-                            {"value": "completion-c", "rank": 2},
-                            {"value": "completion-a", "rank": 3},
-                            {"value": "completion-z", "rank": 4},
-                        ],
-                    }
-                }
-            },
-            "This Ranking question expects a list containing 3 values, found a list of 4 values",
-        ),
-        (
-            create_ranking_question,
-            {
-                "values": {
-                    "ranking_question_1": {
-                        "value": [
-                            {"value": "completion-b", "rank": 1},
-                            {"value": "completion-c", "rank": 2},
-                            {"value": "completion-a", "rank": 4},
-                        ]
-                    }
-                }
-            },
-            "[4] are not valid ranks for this Ranking question.\nValid ranks are: [1, 2, 3]",
-        ),
-        (
-            create_ranking_question,
-            {
-                "values": {
-                    "ranking_question_1": {
-                        "value": [
-                            {"value": "completion-b"},
-                            {"value": "completion-c"},
-                            {"value": "completion-a"},
-                        ]
-                    }
-                }
-            },
-            "[None] are not valid ranks for this Ranking question.\nValid ranks are: [1, 2, 3]",
-        ),
-        (
-            create_ranking_question,
-            {
-                "values": {
-                    "ranking_question_1": {
-                        "value": [
-                            {"value": "completion-z", "rank": 1},
-                            {"value": "completion-c", "rank": 2},
-                            {"value": "completion-a", "rank": 3},
-                        ]
-                    }
-                }
-            },
-            "['completion-z'] are not valid options for this Ranking question.\nValid options are: ['completion-a', 'completion-b', 'completion-c']",
-        ),
-        (
-            create_ranking_question,
-            {
-                "values": {
-                    "ranking_question_1": {
-                        "value": [
-                            {"value": "completion-a", "rank": 1},
-                            {"value": "completion-c", "rank": 2},
-                            {"value": "completion-a", "rank": 3},
-                        ]
-                    }
-                }
-            },
-            "This Ranking question expects a list of unique values, but duplicates were found",
-        ),
-    ],
-)
-@pytest.mark.asyncio
-async def test_create_record_response_with_wrong_response_value(
-    async_client: "AsyncClient",
-    owner_auth_header: dict,
-    create_questions_func: Callable[["Dataset"], None],
-    responses: dict,
-    expected_error_msg: str,
-):
-    dataset = await DatasetFactory.create()
-    await create_questions_func(dataset)
-    record = await RecordFactory.create(dataset=dataset)
-
-    response_json = {**responses, "status": "submitted"}
-    response = await async_client.post(
-        f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
+            ),
+        ],
     )
+    async def test_create_record_response_with_required_questions(
+        self,
+        async_client: "AsyncClient",
+        db: "AsyncSession",
+        mock_search_engine: SearchEngine,
+        owner: User,
+        owner_auth_header: dict,
+        create_questions_func: Callable[["Dataset"], Awaitable[None]],
+        response_status: str,
+        responses: dict,
+    ):
+        dataset = await DatasetFactory.create()
+        await create_questions_func(dataset)
+        record = await RecordFactory.create(dataset=dataset)
 
-    assert response.status_code == 422
-    assert response.json() == {"detail": expected_error_msg}
+        response_json = {**responses, "status": response_status}
+        response = await async_client.post(
+            f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
+        )
 
-
-@pytest.mark.asyncio
-async def test_create_record_response_without_authentication(async_client: "AsyncClient", db: "AsyncSession"):
-    record = await RecordFactory.create()
-    response_json = {
-        "values": {
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "yes"},
-        },
-        "status": "submitted",
-    }
-
-    response = await async_client.post(f"/api/v1/records/{record.id}/responses", json=response_json)
-
-    assert response.status_code == 401
-    assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
-
-
-@pytest.mark.parametrize("status", ["submitted", "discarded", "draft"])
-@pytest.mark.asyncio
-async def test_create_record_response(
-    async_client: "AsyncClient", db: "AsyncSession", owner: User, owner_auth_header: dict, status: str
-):
-    dataset = await DatasetFactory.create()
-    await TextQuestionFactory.create(name="input_ok", dataset=dataset)
-    await TextQuestionFactory.create(name="output_ok", dataset=dataset)
-
-    record = await RecordFactory.create(dataset=dataset)
-    response_json = {
-        "values": {
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "yes"},
-        },
-        "status": status,
-    }
-
-    response = await async_client.post(
-        f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
-    )
-
-    assert response.status_code == 201
-    assert (await db.execute(select(func.count(Response.id)))).scalar() == 1
-
-    response_body = response.json()
-    assert await db.get(Response, UUID(response_body["id"]))
-    assert response_body == {
-        "id": str(UUID(response_body["id"])),
-        "values": {
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "yes"},
-        },
-        "status": status,
-        "user_id": str(owner.id),
-        "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
-        "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
-    }
-
-
-@pytest.mark.parametrize(
-    "status, expected_status_code, expected_response_count",
-    [("submitted", 422, 0), ("discarded", 201, 1), ("draft", 422, 0)],
-)
-@pytest.mark.asyncio
-async def test_create_record_response_without_values(
-    async_client: "AsyncClient",
-    db: "AsyncSession",
-    owner: User,
-    owner_auth_header: dict,
-    status: str,
-    expected_status_code: int,
-    expected_response_count: int,
-):
-    record = await RecordFactory.create()
-    response_json = {"status": status}
-
-    response = await async_client.post(
-        f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
-    )
-
-    assert response.status_code == expected_status_code
-    assert (await db.execute(select(func.count(Response.id)))).scalar() == expected_response_count
-
-    if expected_status_code == 201:
         response_body = response.json()
+        assert response.status_code == 201
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 1
         assert await db.get(Response, UUID(response_body["id"]))
         assert response_body == {
             "id": str(UUID(response_body["id"])),
-            "values": None,
-            "status": "discarded",
+            "values": responses["values"],
+            "status": response_status,
             "user_id": str(owner.id),
             "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
             "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
         }
 
+        response = (await db.execute(select(Response).where(Response.record_id == record.id))).scalar_one()
+        mock_search_engine.update_record_response.assert_called_once_with(response)
 
-@pytest.mark.parametrize("status", ["submitted", "discarded", "draft"])
-@pytest.mark.asyncio
-async def test_create_record_submitted_response_with_wrong_values(
-    async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict, status: str
-):
-    record = await RecordFactory.create()
-    response_json = {"status": status, "values": {"wrong_question": {"value": "wrong value"}}}
+    async def test_create_submitted_record_response_with_missing_required_questions(
+        self, async_client: "AsyncClient", owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+        await create_text_questions(dataset)
 
-    response = await async_client.post(
-        f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
+        record = await RecordFactory.create(dataset=dataset)
+        response_json = {
+            "values": {"output_ok": {"value": "yes"}},
+            "status": "submitted",
+        }
+
+        response = await async_client.post(
+            f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
+        )
+        assert response.status_code == 422
+        assert response.json() == {"detail": "Missing required question: 'input_ok'"}
+
+    @pytest.mark.parametrize("response_status", ["discarded", "draft"])
+    @pytest.mark.parametrize(
+        "create_questions_func, responses",
+        [
+            (
+                create_text_questions,
+                {
+                    "values": {
+                        "output_ok": {"value": "yes"},
+                    },
+                },
+            ),
+            (
+                create_rating_questions,
+                {
+                    "values": {
+                        "rating_question_2": {"value": 5},
+                    },
+                },
+            ),
+            (
+                create_label_selection_questions,
+                {
+                    "values": {
+                        "label_selection_question_2": {"value": "option1"},
+                    },
+                },
+            ),
+            (
+                create_multi_label_selection_questions,
+                {
+                    "values": {
+                        "multi_label_selection_question_2": {"value": ["option1"]},
+                    },
+                },
+            ),
+            (
+                create_multi_label_selection_questions,
+                {
+                    "values": {
+                        "multi_label_selection_question_2": {"value": ["option1", "option2"]},
+                    },
+                },
+            ),
+            (
+                create_ranking_question,
+                {
+                    "values": {
+                        "ranking_question_2": {
+                            "value": [
+                                {"value": "completion-b", "rank": 1},
+                                {"value": "completion-c", "rank": 2},
+                                {"value": "completion-a", "rank": 3},
+                            ]
+                        },
+                    }
+                },
+            ),
+            (
+                create_ranking_question,
+                {
+                    "values": {
+                        "ranking_question_2": {
+                            "value": [
+                                {"value": "completion-b", "rank": 1},
+                                {"value": "completion-c", "rank": 1},
+                                {"value": "completion-a", "rank": 3},
+                            ]
+                        },
+                    }
+                },
+            ),
+            (
+                create_ranking_question,
+                {
+                    "values": {
+                        "ranking_question_2": {
+                            "value": [
+                                {"value": "completion-b", "rank": 1},
+                                {"value": "completion-c", "rank": 3},
+                                {"value": "completion-a", "rank": 3},
+                            ]
+                        },
+                    }
+                },
+            ),
+            (
+                create_ranking_question,
+                {
+                    "values": {
+                        "ranking_question_2": {
+                            "value": [
+                                {"value": "completion-b", "rank": 1},
+                                {"value": "completion-c", "rank": 1},
+                                {"value": "completion-a", "rank": 1},
+                            ]
+                        },
+                    }
+                },
+            ),
+        ],
     )
+    async def test_create_record_response_with_missing_required_questions(
+        self,
+        async_client: "AsyncClient",
+        db: "AsyncSession",
+        mock_search_engine: SearchEngine,
+        owner: User,
+        owner_auth_header: dict,
+        create_questions_func: Callable[["Dataset"], Awaitable[None]],
+        response_status: str,
+        responses: dict,
+    ):
+        dataset = await DatasetFactory.create()
+        await create_questions_func(dataset)
+        record = await RecordFactory.create(dataset=dataset)
 
-    assert response.status_code == 422
-    assert response.json() == {"detail": "Error: found responses for non configured questions: ['wrong_question']"}
-    assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
+        response_json = {**responses, "status": response_status}
+        response = await async_client.post(
+            f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
+        )
 
+        response_body = response.json()
+        assert response.status_code == 201
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 1
+        assert await db.get(Response, UUID(response_body["id"]))
+        assert response_body == {
+            "id": str(UUID(response_body["id"])),
+            "values": responses["values"],
+            "status": response_status,
+            "user_id": str(owner.id),
+            "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
+            "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
+        }
 
-@pytest.mark.parametrize("role", [UserRole.owner, UserRole.admin, UserRole.annotator])
-@pytest.mark.asyncio
-async def test_create_record_response_for_user_role(async_client: "AsyncClient", db: Session, role: UserRole):
-    dataset = await DatasetFactory.create()
-    await TextQuestionFactory.create(name="input_ok", dataset=dataset)
-    await TextQuestionFactory.create(name="output_ok", dataset=dataset)
+        response = (await db.execute(select(Response).where(Response.record_id == record.id))).scalar_one()
+        mock_search_engine.update_record_response.assert_called_once_with(response)
 
-    record = await RecordFactory.create(dataset=dataset)
-    user = await UserFactory.create(workspaces=[record.dataset.workspace], role=role)
-    response_json = {
-        "values": {
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "yes"},
-        },
-        "status": "submitted",
-    }
+    async def test_create_record_response_with_extra_question_responses(
+        self, async_client: "AsyncClient", owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+        await create_text_questions(dataset)
+        record = await RecordFactory.create(dataset=dataset)
 
-    response = await async_client.post(
-        f"/api/v1/records/{record.id}/responses", headers={API_KEY_HEADER_NAME: user.api_key}, json=response_json
+        response_json = {
+            "values": {
+                "input_ok": {"value": "yes"},
+                "unknown_question": {"value": "Test"},
+            },
+            "status": "submitted",
+        }
+        response = await async_client.post(
+            f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
+        )
+
+        assert response.status_code == 422
+        assert response.json() == {
+            "detail": "Error: found responses for non configured questions: ['unknown_question']"
+        }
+
+    @pytest.mark.parametrize(
+        "create_questions_func, responses, expected_error_msg",
+        [
+            (
+                create_text_questions,
+                {
+                    "values": {
+                        "input_ok": {"value": True},
+                        "output_ok": {"value": False},
+                    },
+                },
+                "Expected text value, found <class 'bool'>",
+            ),
+            (
+                create_rating_questions,
+                {
+                    "values": {
+                        "rating_question_1": {"value": "wrong-rating-value"},
+                    },
+                },
+                "'wrong-rating-value' is not a valid option.\nValid options are: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",
+            ),
+            (
+                create_label_selection_questions,
+                {
+                    "values": {
+                        "label_selection_question_1": {"value": False},
+                    },
+                },
+                "False is not a valid option.\nValid options are: ['option1', 'option2', 'option3']",
+            ),
+            (
+                create_multi_label_selection_questions,
+                {
+                    "values": {
+                        "multi_label_selection_question_1": {"value": "wrong-type"},
+                    },
+                },
+                "This MultiLabelSelection question expects a list of values, found <class 'str'>",
+            ),
+            (
+                create_multi_label_selection_questions,
+                {
+                    "values": {
+                        "multi_label_selection_question_1": {"value": ["option4", "option5"]},
+                    },
+                },
+                "['option4', 'option5'] are not valid options for this MultiLabelSelection question.\nValid options are: ['option1', 'option2', 'option3']",
+            ),
+            (
+                create_multi_label_selection_questions,
+                {"values": {"multi_label_selection_question_1": {"value": []}}},
+                "This MultiLabelSelection question expects a list of values, found empty list",
+            ),
+            (
+                create_ranking_question,
+                {"values": {"ranking_question_1": {"value": "wrong-type"}}},
+                "This Ranking question expects a list of values, found <class 'str'>",
+            ),
+            (
+                create_ranking_question,
+                {"values": {"ranking_question_1": {"value": []}}},
+                "This Ranking question expects a list containing 3 values, found a list of 0 values",
+            ),
+            (
+                create_ranking_question,
+                {
+                    "values": {
+                        "ranking_question_1": {
+                            "value": [
+                                {"value": "completion-b", "rank": 1},
+                            ]
+                        }
+                    }
+                },
+                "This Ranking question expects a list containing 3 values, found a list of 1 values",
+            ),
+            (
+                create_ranking_question,
+                {
+                    "values": {
+                        "ranking_question_1": {
+                            "value": [
+                                {"value": "completion-b", "rank": 1},
+                                {"value": "completion-c", "rank": 2},
+                                {"value": "completion-a", "rank": 3},
+                                {"value": "completion-z", "rank": 4},
+                            ],
+                        }
+                    }
+                },
+                "This Ranking question expects a list containing 3 values, found a list of 4 values",
+            ),
+            (
+                create_ranking_question,
+                {
+                    "values": {
+                        "ranking_question_1": {
+                            "value": [
+                                {"value": "completion-b", "rank": 1},
+                                {"value": "completion-c", "rank": 2},
+                                {"value": "completion-a", "rank": 4},
+                            ]
+                        }
+                    }
+                },
+                "[4] are not valid ranks for this Ranking question.\nValid ranks are: [1, 2, 3]",
+            ),
+            (
+                create_ranking_question,
+                {
+                    "values": {
+                        "ranking_question_1": {
+                            "value": [
+                                {"value": "completion-b"},
+                                {"value": "completion-c"},
+                                {"value": "completion-a"},
+                            ]
+                        }
+                    }
+                },
+                "[None] are not valid ranks for this Ranking question.\nValid ranks are: [1, 2, 3]",
+            ),
+            (
+                create_ranking_question,
+                {
+                    "values": {
+                        "ranking_question_1": {
+                            "value": [
+                                {"value": "completion-z", "rank": 1},
+                                {"value": "completion-c", "rank": 2},
+                                {"value": "completion-a", "rank": 3},
+                            ]
+                        }
+                    }
+                },
+                "['completion-z'] are not valid options for this Ranking question.\nValid options are: ['completion-a', 'completion-b', 'completion-c']",
+            ),
+            (
+                create_ranking_question,
+                {
+                    "values": {
+                        "ranking_question_1": {
+                            "value": [
+                                {"value": "completion-a", "rank": 1},
+                                {"value": "completion-c", "rank": 2},
+                                {"value": "completion-a", "rank": 3},
+                            ]
+                        }
+                    }
+                },
+                "This Ranking question expects a list of unique values, but duplicates were found",
+            ),
+        ],
     )
+    async def test_create_record_response_with_wrong_response_value(
+        self,
+        async_client: "AsyncClient",
+        owner_auth_header: dict,
+        create_questions_func: Callable[["Dataset"], None],
+        responses: dict,
+        expected_error_msg: str,
+    ):
+        dataset = await DatasetFactory.create()
+        await create_questions_func(dataset)
+        record = await RecordFactory.create(dataset=dataset)
 
-    assert response.status_code == 201
-    assert (await db.execute(select(func.count(Response.id)))).scalar() == 1
+        response_json = {**responses, "status": "submitted"}
+        response = await async_client.post(
+            f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
+        )
 
-    response_body = response.json()
-    assert response_body == {
-        "id": str(UUID(response_body["id"])),
-        "values": {
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "yes"},
-        },
-        "status": "submitted",
-        "user_id": str(user.id),
-        "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
-        "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
-    }
+        assert response.status_code == 422
+        assert response.json() == {"detail": expected_error_msg}
 
+    async def test_create_record_response_without_authentication(self, async_client: "AsyncClient", db: "AsyncSession"):
+        record = await RecordFactory.create()
+        response_json = {
+            "values": {
+                "input_ok": {"value": "yes"},
+                "output_ok": {"value": "yes"},
+            },
+            "status": "submitted",
+        }
 
-@pytest.mark.parametrize("role", [UserRole.admin, UserRole.annotator])
-@pytest.mark.asyncio
-async def test_create_record_response_as_restricted_user_from_different_workspace(
-    async_client: "AsyncClient", db: Session, role: UserRole
-):
-    record = await RecordFactory.create()
-    workspace = await WorkspaceFactory.create()
-    user = await UserFactory.create(workspaces=[workspace], role=role)
-    response_json = {
-        "values": {
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "yes"},
-        },
-        "status": "submitted",
-    }
+        response = await async_client.post(f"/api/v1/records/{record.id}/responses", json=response_json)
 
-    response = await async_client.post(
-        f"/api/v1/records/{record.id}/responses", headers={API_KEY_HEADER_NAME: user.api_key}, json=response_json
+        assert response.status_code == 401
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
+
+    @pytest.mark.parametrize("status", ["submitted", "discarded", "draft"])
+    async def test_create_record_response(
+        self, async_client: "AsyncClient", db: "AsyncSession", owner: User, owner_auth_header: dict, status: str
+    ):
+        dataset = await DatasetFactory.create()
+        await TextQuestionFactory.create(name="input_ok", dataset=dataset)
+        await TextQuestionFactory.create(name="output_ok", dataset=dataset)
+
+        record = await RecordFactory.create(dataset=dataset)
+        response_json = {
+            "values": {
+                "input_ok": {"value": "yes"},
+                "output_ok": {"value": "yes"},
+            },
+            "status": status,
+        }
+
+        response = await async_client.post(
+            f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
+        )
+
+        assert response.status_code == 201
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 1
+
+        response_body = response.json()
+        assert await db.get(Response, UUID(response_body["id"]))
+        assert response_body == {
+            "id": str(UUID(response_body["id"])),
+            "values": {
+                "input_ok": {"value": "yes"},
+                "output_ok": {"value": "yes"},
+            },
+            "status": status,
+            "user_id": str(owner.id),
+            "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
+            "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
+        }
+
+    @pytest.mark.parametrize(
+        "status, expected_status_code, expected_response_count",
+        [("submitted", 422, 0), ("discarded", 201, 1), ("draft", 422, 0)],
     )
+    async def test_create_record_response_without_values(
+        self,
+        async_client: "AsyncClient",
+        db: "AsyncSession",
+        owner: User,
+        owner_auth_header: dict,
+        status: str,
+        expected_status_code: int,
+        expected_response_count: int,
+    ):
+        record = await RecordFactory.create()
+        response_json = {"status": status}
 
-    assert response.status_code == 403
-    assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
+        response = await async_client.post(
+            f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
+        )
 
+        assert response.status_code == expected_status_code
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == expected_response_count
 
-@pytest.mark.asyncio
-async def test_create_record_response_already_created(
-    async_client: "AsyncClient", db: "AsyncSession", owner: User, owner_auth_header: dict
-):
-    record = await RecordFactory.create()
-    await ResponseFactory.create(record=record, user=owner)
-    response_json = {
-        "values": {
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "yes"},
-        },
-        "status": "submitted",
-    }
+        if expected_status_code == 201:
+            response_body = response.json()
+            assert await db.get(Response, UUID(response_body["id"]))
+            assert response_body == {
+                "id": str(UUID(response_body["id"])),
+                "values": None,
+                "status": "discarded",
+                "user_id": str(owner.id),
+                "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
+                "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
+            }
 
-    response = await async_client.post(
-        f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
-    )
+    @pytest.mark.parametrize("status", ["submitted", "discarded", "draft"])
+    async def test_create_record_submitted_response_with_wrong_values(
+        self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict, status: str
+    ):
+        record = await RecordFactory.create()
+        response_json = {"status": status, "values": {"wrong_question": {"value": "wrong value"}}}
 
-    assert response.status_code == 409
-    assert (await db.execute(select(func.count(Response.id)))).scalar() == 1
+        response = await async_client.post(
+            f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
+        )
 
+        assert response.status_code == 422
+        assert response.json() == {"detail": "Error: found responses for non configured questions: ['wrong_question']"}
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
 
-@pytest.mark.asyncio
-async def test_create_record_response_with_invalid_values(
-    async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
-):
-    record = await RecordFactory.create()
-    response_json = {
-        "values": "invalid",
-        "status": "submitted",
-    }
+    @pytest.mark.parametrize("role", [UserRole.owner, UserRole.admin, UserRole.annotator])
+    async def test_create_record_response_for_user_role(self, async_client: "AsyncClient", db: Session, role: UserRole):
+        dataset = await DatasetFactory.create()
+        await TextQuestionFactory.create(name="input_ok", dataset=dataset)
+        await TextQuestionFactory.create(name="output_ok", dataset=dataset)
 
-    response = await async_client.post(
-        f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
-    )
+        record = await RecordFactory.create(dataset=dataset)
+        user = await UserFactory.create(workspaces=[record.dataset.workspace], role=role)
+        response_json = {
+            "values": {
+                "input_ok": {"value": "yes"},
+                "output_ok": {"value": "yes"},
+            },
+            "status": "submitted",
+        }
 
-    assert response.status_code == 422
-    assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
+        response = await async_client.post(
+            f"/api/v1/records/{record.id}/responses", headers={API_KEY_HEADER_NAME: user.api_key}, json=response_json
+        )
 
+        assert response.status_code == 201
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 1
 
-@pytest.mark.asyncio
-async def test_create_record_response_with_invalid_status(
-    async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
-):
-    record = await RecordFactory.create()
-    response_json = {
-        "values": {
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "yes"},
-        },
-        "status": "invalid",
-    }
+        response_body = response.json()
+        assert response_body == {
+            "id": str(UUID(response_body["id"])),
+            "values": {
+                "input_ok": {"value": "yes"},
+                "output_ok": {"value": "yes"},
+            },
+            "status": "submitted",
+            "user_id": str(user.id),
+            "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
+            "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
+        }
 
-    response = await async_client.post(
-        f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
-    )
+    @pytest.mark.parametrize("role", [UserRole.admin, UserRole.annotator])
+    async def test_create_record_response_as_restricted_user_from_different_workspace(
+        self, async_client: "AsyncClient", db: Session, role: UserRole
+    ):
+        record = await RecordFactory.create()
+        workspace = await WorkspaceFactory.create()
+        user = await UserFactory.create(workspaces=[workspace], role=role)
+        response_json = {
+            "values": {
+                "input_ok": {"value": "yes"},
+                "output_ok": {"value": "yes"},
+            },
+            "status": "submitted",
+        }
 
-    assert response.status_code == 422
-    assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
+        response = await async_client.post(
+            f"/api/v1/records/{record.id}/responses", headers={API_KEY_HEADER_NAME: user.api_key}, json=response_json
+        )
 
+        assert response.status_code == 403
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
 
-@pytest.mark.asyncio
-async def test_create_record_response_with_nonexistent_record_id(
-    async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
-):
-    await RecordFactory.create()
-    response_json = {
-        "values": {
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "yes"},
-        },
-        "status": "submitted",
-    }
+    async def test_create_record_response_already_created(
+        self, async_client: "AsyncClient", db: "AsyncSession", owner: User, owner_auth_header: dict
+    ):
+        record = await RecordFactory.create()
+        await ResponseFactory.create(record=record, user=owner)
+        response_json = {
+            "values": {
+                "input_ok": {"value": "yes"},
+                "output_ok": {"value": "yes"},
+            },
+            "status": "submitted",
+        }
 
-    response = await async_client.post(
-        f"/api/v1/records/{uuid4()}/responses", headers=owner_auth_header, json=response_json
-    )
+        response = await async_client.post(
+            f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
+        )
 
-    assert response.status_code == 404
-    assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
+        assert response.status_code == 409
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 1
 
+    async def test_create_record_response_with_invalid_values(
+        self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
+    ):
+        record = await RecordFactory.create()
+        response_json = {
+            "values": "invalid",
+            "status": "submitted",
+        }
 
-@pytest.mark.parametrize("role", [UserRole.annotator, UserRole.admin, UserRole.owner])
-@pytest.mark.asyncio
-async def test_get_record_suggestions(async_client: "AsyncClient", role: UserRole):
-    dataset = await DatasetFactory.create()
-    user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
-    record = await RecordFactory.create(dataset=dataset)
-    question_a = await TextQuestionFactory.create(dataset=dataset)
-    question_b = await TextQuestionFactory.create(dataset=dataset)
-    suggestion_a = await SuggestionFactory.create(
-        question=question_a, record=record, value="This is a unit test suggestion"
-    )
-    suggestion_b = await SuggestionFactory.create(
-        question=question_b, record=record, value="This is a another unit test suggestion"
-    )
+        response = await async_client.post(
+            f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
+        )
 
-    response = await async_client.get(
-        f"/api/v1/records/{record.id}/suggestions", headers={API_KEY_HEADER_NAME: user.api_key}
-    )
+        assert response.status_code == 422
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
 
-    assert response.status_code == 200
-    assert response.json() == {
-        "items": [
+    async def test_create_record_response_with_invalid_status(
+        self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
+    ):
+        record = await RecordFactory.create()
+        response_json = {
+            "values": {
+                "input_ok": {"value": "yes"},
+                "output_ok": {"value": "yes"},
+            },
+            "status": "invalid",
+        }
+
+        response = await async_client.post(
+            f"/api/v1/records/{record.id}/responses", headers=owner_auth_header, json=response_json
+        )
+
+        assert response.status_code == 422
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
+
+    async def test_create_record_response_with_nonexistent_record_id(
+        self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
+    ):
+        await RecordFactory.create()
+        response_json = {
+            "values": {
+                "input_ok": {"value": "yes"},
+                "output_ok": {"value": "yes"},
+            },
+            "status": "submitted",
+        }
+
+        response = await async_client.post(
+            f"/api/v1/records/{uuid4()}/responses", headers=owner_auth_header, json=response_json
+        )
+
+        assert response.status_code == 404
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
+
+    @pytest.mark.parametrize("role", [UserRole.annotator, UserRole.admin, UserRole.owner])
+    async def test_get_record_suggestions(self, async_client: "AsyncClient", role: UserRole):
+        dataset = await DatasetFactory.create()
+        user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
+        record = await RecordFactory.create(dataset=dataset)
+        question_a = await TextQuestionFactory.create(dataset=dataset)
+        question_b = await TextQuestionFactory.create(dataset=dataset)
+        suggestion_a = await SuggestionFactory.create(
+            question=question_a, record=record, value="This is a unit test suggestion"
+        )
+        suggestion_b = await SuggestionFactory.create(
+            question=question_b, record=record, value="This is a another unit test suggestion"
+        )
+
+        response = await async_client.get(
+            f"/api/v1/records/{record.id}/suggestions", headers={API_KEY_HEADER_NAME: user.api_key}
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "items": [
+                {
+                    "id": str(suggestion_a.id),
+                    "question_id": str(question_a.id),
+                    "type": None,
+                    "score": None,
+                    "value": "This is a unit test suggestion",
+                    "agent": None,
+                },
+                {
+                    "id": str(suggestion_b.id),
+                    "question_id": str(question_b.id),
+                    "type": None,
+                    "score": None,
+                    "value": "This is a another unit test suggestion",
+                    "agent": None,
+                },
+            ]
+        }
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
             {
-                "id": str(suggestion_a.id),
-                "question_id": str(question_a.id),
+                "type": "model",
+                "score": 1,
+                "value": "This is a unit test suggestion",
+                "agent": "unit-test-agent",
+            },
+            {
                 "type": None,
                 "score": None,
                 "value": "This is a unit test suggestion",
                 "agent": None,
             },
-            {
-                "id": str(suggestion_b.id),
-                "question_id": str(question_b.id),
-                "type": None,
-                "score": None,
-                "value": "This is a another unit test suggestion",
-                "agent": None,
-            },
-        ]
-    }
+        ],
+    )
+    @pytest.mark.parametrize("role", [UserRole.admin, UserRole.owner])
+    async def test_create_record_suggestion(
+        self, async_client: "AsyncClient", db: "AsyncSession", role: UserRole, payload: dict
+    ):
+        dataset = await DatasetFactory.create()
+        question = await TextQuestionFactory.create(dataset=dataset)
+        user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
+        record = await RecordFactory.create(dataset=dataset)
 
+        response = await async_client.put(
+            f"/api/v1/records/{record.id}/suggestions",
+            headers={API_KEY_HEADER_NAME: user.api_key},
+            json={"question_id": str(question.id), **payload},
+        )
 
-@pytest.mark.parametrize(
-    "payload",
-    [
-        {
-            "type": "model",
-            "score": 1,
-            "value": "This is a unit test suggestion",
-            "agent": "unit-test-agent",
-        },
-        {
+        response_body = response.json()
+        assert response.status_code == 201
+        assert response_body == {"id": response_body["id"], "question_id": str(question.id), **payload}
+        assert (await db.execute(select(func.count(Suggestion.id)))).scalar() == 1
+
+    async def test_create_record_suggestion_update(
+        self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+        question = await TextQuestionFactory.create(dataset=dataset)
+        record = await RecordFactory.create(dataset=dataset)
+        suggestion = await SuggestionFactory.create(question=question, record=record)
+
+        response = await async_client.put(
+            f"/api/v1/records/{record.id}/suggestions",
+            headers=owner_auth_header,
+            json={"question_id": str(question.id), "value": "Testing updating a suggestion"},
+        )
+
+        response_body = response.json()
+        assert response.status_code == 200
+        assert response_body == {
+            "id": str(suggestion.id),
+            "question_id": str(question.id),
             "type": None,
             "score": None,
-            "value": "This is a unit test suggestion",
+            "value": "Testing updating a suggestion",
             "agent": None,
-        },
-    ],
-)
-@pytest.mark.parametrize("role", [UserRole.admin, UserRole.owner])
-@pytest.mark.asyncio
-async def test_create_record_suggestion(async_client: "AsyncClient", db: "AsyncSession", role: UserRole, payload: dict):
-    dataset = await DatasetFactory.create()
-    question = await TextQuestionFactory.create(dataset=dataset)
-    user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
-    record = await RecordFactory.create(dataset=dataset)
+        }
+        assert (await db.execute(select(func.count(Suggestion.id)))).scalar() == 1
 
-    response = await async_client.put(
-        f"/api/v1/records/{record.id}/suggestions",
-        headers={API_KEY_HEADER_NAME: user.api_key},
-        json={"question_id": str(question.id), **payload},
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {},  # missing value
+            {
+                "value": {"this": "is not valid response for a TextQuestion"},
+            },
+        ],
     )
+    async def test_create_record_suggestion_not_valid(
+        self, async_client: "AsyncClient", owner_auth_header: dict, payload: dict
+    ):
+        dataset = await DatasetFactory.create()
+        question = await TextQuestionFactory.create(dataset=dataset)
+        record = await RecordFactory.create(dataset=dataset)
 
-    response_body = response.json()
-    assert response.status_code == 201
-    assert response_body == {"id": response_body["id"], "question_id": str(question.id), **payload}
-    assert (await db.execute(select(func.count(Suggestion.id)))).scalar() == 1
+        response = await async_client.put(
+            f"/api/v1/records/{record.id}/suggestions",
+            headers=owner_auth_header,
+            json={"question_id": str(question.id), **payload},
+        )
 
+        assert response.status_code == 422
 
-@pytest.mark.asyncio
-async def test_create_record_suggestion_update(
-    async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
-):
-    dataset = await DatasetFactory.create()
-    question = await TextQuestionFactory.create(dataset=dataset)
-    record = await RecordFactory.create(dataset=dataset)
-    suggestion = await SuggestionFactory.create(question=question, record=record)
+    async def test_create_record_suggestion_for_non_existent_question(
+        self, async_client: "AsyncClient", owner_auth_header: dict
+    ):
+        record = await RecordFactory.create()
 
-    response = await async_client.put(
-        f"/api/v1/records/{record.id}/suggestions",
-        headers=owner_auth_header,
-        json={"question_id": str(question.id), "value": "Testing updating a suggestion"},
-    )
+        response = await async_client.put(
+            f"/api/v1/records/{record.id}/suggestions",
+            headers=owner_auth_header,
+            json={"question_id": str(uuid4()), "value": "This is a unit test suggestion"},
+        )
 
-    response_body = response.json()
-    assert response.status_code == 200
-    assert response_body == {
-        "id": str(suggestion.id),
-        "question_id": str(question.id),
-        "type": None,
-        "score": None,
-        "value": "Testing updating a suggestion",
-        "agent": None,
-    }
-    assert (await db.execute(select(func.count(Suggestion.id)))).scalar() == 1
+        assert response.status_code == 422
 
+    async def test_create_record_suggestion_as_annotator(self, async_client: "AsyncClient"):
+        annotator = await UserFactory.create(role=UserRole.annotator)
+        record = await RecordFactory.create()
 
-@pytest.mark.parametrize(
-    "payload",
-    [
-        {},  # missing value
-        {
-            "value": {"this": "is not valid response for a TextQuestion"},
-        },
-    ],
-)
-@pytest.mark.asyncio
-async def test_create_record_suggestion_not_valid(async_client: "AsyncClient", owner_auth_header: dict, payload: dict):
-    dataset = await DatasetFactory.create()
-    question = await TextQuestionFactory.create(dataset=dataset)
-    record = await RecordFactory.create(dataset=dataset)
+        response = await async_client.put(
+            f"/api/v1/records/{record.id}/suggestions",
+            headers={API_KEY_HEADER_NAME: annotator.api_key},
+            json={"question_id": str(uuid4()), "value": "This is a unit test suggestion"},
+        )
 
-    response = await async_client.put(
-        f"/api/v1/records/{record.id}/suggestions",
-        headers=owner_auth_header,
-        json={"question_id": str(question.id), **payload},
-    )
+        assert response.status_code == 403
 
-    assert response.status_code == 422
+    @pytest.mark.parametrize("role", [UserRole.owner, UserRole.admin])
+    async def test_delete_record(
+        self, async_client: "AsyncClient", db: "AsyncSession", mock_search_engine: "SearchEngine", role: UserRole
+    ):
+        dataset = await DatasetFactory.create()
+        record = await RecordFactory.create(dataset=dataset)
+        user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
 
+        response = await async_client.delete(
+            f"/api/v1/records/{record.id}", headers={API_KEY_HEADER_NAME: user.api_key}
+        )
 
-@pytest.mark.asyncio
-async def test_create_record_suggestion_for_non_existent_question(async_client: "AsyncClient", owner_auth_header: dict):
-    record = await RecordFactory.create()
+        assert response.status_code == 200
+        assert response.json() == {
+            "id": str(record.id),
+            "fields": record.fields,
+            "metadata": None,
+            "external_id": record.external_id,
+            "inserted_at": record.inserted_at.isoformat(),
+            "updated_at": record.updated_at.isoformat(),
+        }
+        assert (await db.execute(select(func.count(Record.id)))).scalar() == 0
+        mock_search_engine.delete_records.assert_called_once_with(dataset=dataset, records=[record])
 
-    response = await async_client.put(
-        f"/api/v1/records/{record.id}/suggestions",
-        headers=owner_auth_header,
-        json={"question_id": str(uuid4()), "value": "This is a unit test suggestion"},
-    )
+    async def test_delete_record_as_admin_from_another_workspace(self, async_client: "AsyncClient", db: "AsyncSession"):
+        dataset = await DatasetFactory.create()
+        record = await RecordFactory.create(dataset=dataset)
+        user = await UserFactory.create(role=UserRole.admin)
 
-    assert response.status_code == 422
+        response = await async_client.delete(
+            f"/api/v1/records/{record.id}", headers={API_KEY_HEADER_NAME: user.api_key}
+        )
 
+        assert response.status_code == 403
+        assert (await db.execute(select(func.count(Record.id)))).scalar() == 1
 
-@pytest.mark.asyncio
-async def test_create_record_suggestion_as_annotator(async_client: "AsyncClient"):
-    annotator = await UserFactory.create(role=UserRole.annotator)
-    record = await RecordFactory.create()
+    async def test_delete_record_as_annotator(self, async_client: "AsyncClient"):
+        annotator = await UserFactory.create(role=UserRole.annotator)
+        record = await RecordFactory.create()
 
-    response = await async_client.put(
-        f"/api/v1/records/{record.id}/suggestions",
-        headers={API_KEY_HEADER_NAME: annotator.api_key},
-        json={"question_id": str(uuid4()), "value": "This is a unit test suggestion"},
-    )
+        response = await async_client.delete(
+            f"/api/v1/records/{record.id}", headers={API_KEY_HEADER_NAME: annotator.api_key}
+        )
 
-    assert response.status_code == 403
+        assert response.status_code == 403
 
-
-@pytest.mark.parametrize("role", [UserRole.owner, UserRole.admin])
-@pytest.mark.asyncio
-async def test_delete_record(
-    async_client: "AsyncClient", db: "AsyncSession", mock_search_engine: "SearchEngine", role: UserRole
-):
-    dataset = await DatasetFactory.create()
-    record = await RecordFactory.create(dataset=dataset)
-    user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
-
-    response = await async_client.delete(f"/api/v1/records/{record.id}", headers={API_KEY_HEADER_NAME: user.api_key})
-
-    assert response.status_code == 200
-    assert response.json() == {
-        "id": str(record.id),
-        "fields": record.fields,
-        "metadata": None,
-        "external_id": record.external_id,
-        "inserted_at": record.inserted_at.isoformat(),
-        "updated_at": record.updated_at.isoformat(),
-    }
-    assert (await db.execute(select(func.count(Record.id)))).scalar() == 0
-    mock_search_engine.delete_records.assert_called_once_with(dataset=dataset, records=[record])
-
-
-@pytest.mark.asyncio
-async def test_delete_record_as_admin_from_another_workspace(async_client: "AsyncClient", db: "AsyncSession"):
-    dataset = await DatasetFactory.create()
-    record = await RecordFactory.create(dataset=dataset)
-    user = await UserFactory.create(role=UserRole.admin)
-
-    response = await async_client.delete(f"/api/v1/records/{record.id}", headers={API_KEY_HEADER_NAME: user.api_key})
-
-    assert response.status_code == 403
-    assert (await db.execute(select(func.count(Record.id)))).scalar() == 1
-
-
-@pytest.mark.asyncio
-async def test_delete_record_as_annotator(async_client: "AsyncClient"):
-    annotator = await UserFactory.create(role=UserRole.annotator)
-    record = await RecordFactory.create()
-
-    response = await async_client.delete(
-        f"/api/v1/records/{record.id}", headers={API_KEY_HEADER_NAME: annotator.api_key}
-    )
-
-    assert response.status_code == 403
-
-
-@pytest.mark.asyncio
-async def test_delete_record_non_existent(async_client: "AsyncClient", owner_auth_header: dict):
-    response = await async_client.delete(f"/api/v1/records/{uuid4()}", headers=owner_auth_header)
-    assert response.status_code == 404
+    async def test_delete_record_non_existent(self, async_client: "AsyncClient", owner_auth_header: dict):
+        response = await async_client.delete(f"/api/v1/records/{uuid4()}", headers=owner_auth_header)
+        assert response.status_code == 404

--- a/tests/unit/server/api/v1/test_suggestions.py
+++ b/tests/unit/server/api/v1/test_suggestions.py
@@ -1,0 +1,76 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import pytest
+from argilla._constants import API_KEY_HEADER_NAME
+from argilla.server.models import Suggestion, UserRole
+from sqlalchemy import func, select
+
+from tests.factories import SuggestionFactory, UserFactory
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.mark.asyncio
+class TestSuiteSuggestions:
+    @pytest.mark.parametrize("role", [UserRole.admin, UserRole.owner])
+    async def test_delete_suggestion(self, async_client: "AsyncClient", db: "AsyncSession", role: UserRole) -> None:
+        suggestion = await SuggestionFactory.create()
+        user = await UserFactory.create(role=role, workspaces=[suggestion.record.dataset.workspace])
+
+        response = await async_client.delete(
+            f"/api/v1/suggestions/{suggestion.id}",
+            headers={API_KEY_HEADER_NAME: user.api_key},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "id": f"{suggestion.id}",
+            "question_id": f"{suggestion.question_id}",
+            "type": None,
+            "score": None,
+            "value": "negative",
+            "agent": None,
+        }
+        assert (await db.execute(select(func.count(Suggestion.id)))).scalar() == 0
+
+    async def test_delete_suggestion_non_existent(self, async_client: "AsyncClient", owner_auth_header: dict) -> None:
+        response = await async_client.delete(f"/api/v1/suggestions/{uuid4()}", headers=owner_auth_header)
+
+        assert response.status_code == 404
+
+    async def test_delete_suggestion_as_admin_from_another_workspace(self, async_client: "AsyncClient") -> None:
+        suggestion = await SuggestionFactory.create()
+        user = await UserFactory.create(role=UserRole.admin)
+
+        response = await async_client.delete(
+            f"/api/v1/suggestions/{suggestion.id}", headers={API_KEY_HEADER_NAME: user.api_key}
+        )
+
+        assert response.status_code == 403
+
+    async def test_delete_suggestion_as_annotator(self, async_client: "AsyncClient") -> None:
+        suggestion = await SuggestionFactory.create()
+        user = await UserFactory.create(role=UserRole.annotator, workspaces=[suggestion.record.dataset.workspace])
+
+        response = await async_client.delete(
+            f"/api/v1/suggestions/{suggestion.id}", headers={API_KEY_HEADER_NAME: user.api_key}
+        )
+
+        assert response.status_code == 403

--- a/tests/unit/server/api/v1/test_suggestions.py
+++ b/tests/unit/server/api/v1/test_suggestions.py
@@ -41,8 +41,8 @@ class TestSuiteSuggestions:
 
         assert response.status_code == 200
         assert response.json() == {
-            "id": f"{suggestion.id}",
-            "question_id": f"{suggestion.question_id}",
+            "id": str(suggestion.id),
+            "question_id": str(suggestion.question_id),
             "type": None,
             "score": None,
             "value": "negative",


### PR DESCRIPTION
# Description

This PR adds two new endpoints:

- `DELETE /api/v1/suggestions/{suggestion_id}`: allows to remove a specific suggestion
- `DELETE /api/v1/records/{record_id}/suggestions`: allows to remove several suggestions linked to one record passing their IDs in a comma-separated list using the `ids` query parameter (up to 100 IDs per request).

In addition, I moved the unit tests of the record endpoints to a class `TestSuiteRecords`.

Closes #3618 

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

In a local development environment:

- [x] Specific suggestion is removed when calling `DELETE /api/v1/suggestions/{suggestion_id}`
- [x] Several suggestions are removed when calling `DELETE /api/v1/records/{record_id}/suggestions`

Additionally, I've added unit tests to cover the additions.

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
