### PR TITLE
feat: add `list` classmethod to `FeedbackDataset` via `ArgillaMixin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,13 @@ These are the section headers that we use:
 - Added `login` function in `argilla.client.login` to login into an Argilla server and store the credentials locally ([#3582](https://github.com/argilla-io/argilla/pull/3582)).
 - Added `login` command to login into an Argilla server ([#3600](https://github.com/argilla-io/argilla/pull/3600)).
 - Added `response_status` param to `GET /api/v1/datasets/{dataset_id}/records` to be able to filter by `response_status` as previously included for `GET /api/v1/me/datasets/{dataset_id}/records` ([#3613](https://github.com/argilla-io/argilla/pull/3613)).
+- Added `list` classmethod to `ArgillaMixin` to be used as `FeedbackDataset.list()`, also including the `workspace` to list from as arg ([#3619](https://github.com/argilla-io/argilla/pull/3619)).
 
 ### Changed
 
 - Updated `RemoteFeedbackDataset.delete_records` to use batch delete records endpoint ([#3580](https://github.com/argilla-io/argilla/pull/3580)).
 - Included `allowed_for_roles` for some `RemoteFeedbackDataset`, `RemoteFeedbackRecords`, and `RemoteFeedbackRecord` methods that are only allowed for users with roles `owner` and `admin` ([#3601](https://github.com/argilla-io/argilla/pull/3601)).
+- Renamed `ArgillaToFromMixin` to `ArgillaMixin` ([#3619](https://github.com/argilla-io/argilla/pull/3619)).
 
 ### Changed
 

--- a/src/argilla/client/feedback/dataset/local.py
+++ b/src/argilla/client/feedback/dataset/local.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
 
 from argilla.client.feedback.constants import FETCHING_BATCH_SIZE
 from argilla.client.feedback.dataset.base import FeedbackDatasetBase
-from argilla.client.feedback.dataset.mixins import ArgillaToFromMixin
+from argilla.client.feedback.dataset.mixins import ArgillaMixin
 from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQuestionTypes
 
 if TYPE_CHECKING:
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 warnings.simplefilter("always", DeprecationWarning)
 
 
-class FeedbackDataset(FeedbackDatasetBase, ArgillaToFromMixin):
+class FeedbackDataset(FeedbackDatasetBase, ArgillaMixin):
     def __init__(
         self,
         *,

--- a/src/argilla/client/feedback/dataset/mixins.py
+++ b/src/argilla/client/feedback/dataset/mixins.py
@@ -333,7 +333,8 @@ class ArgillaMixin:
             guidelines=existing_dataset.guidelines or None,
         )
 
-    def list(self: "FeedbackDataset", workspace: Optional[str] = None) -> List[RemoteFeedbackDataset]:
+    @classmethod
+    def list(cls: Type["FeedbackDataset"], workspace: Optional[str] = None) -> List[RemoteFeedbackDataset]:
         """Lists the `FeedbackDataset`s pushed to Argilla.
 
         Note that you may need to `rg.init(...)` with your Argilla credentials before
@@ -368,8 +369,8 @@ class ArgillaMixin:
                 id=dataset.id,
                 name=dataset.name,
                 workspace=workspace if workspace is not None else Workspace.from_id(dataset.workspace_id),
-                fields=self.__get_fields(client=httpx_client, id=dataset.id),
-                questions=self.__get_questions(client=httpx_client, id=dataset.id),
+                fields=cls.__get_fields(client=httpx_client, id=dataset.id),
+                questions=cls.__get_questions(client=httpx_client, id=dataset.id),
                 guidelines=dataset.guidelines or None,
             )
             for dataset in datasets

--- a/src/argilla/client/feedback/dataset/mixins.py
+++ b/src/argilla/client/feedback/dataset/mixins.py
@@ -373,5 +373,6 @@ class ArgillaMixin:
                 questions=cls.__get_questions(client=httpx_client, id=dataset.id),
                 guidelines=dataset.guidelines or None,
             )
-            for dataset in datasets if workspace is None or dataset.workspace_id == workspace.id
+            for dataset in datasets
+            if workspace is None or dataset.workspace_id == workspace.id
         ]

--- a/src/argilla/client/feedback/dataset/mixins.py
+++ b/src/argilla/client/feedback/dataset/mixins.py
@@ -332,3 +332,45 @@ class ArgillaToFromMixin:
             questions=questions,
             guidelines=existing_dataset.guidelines or None,
         )
+
+    def list(self: "FeedbackDataset", workspace: Optional[str] = None) -> List[RemoteFeedbackDataset]:
+        """Lists the `FeedbackDataset`s pushed to Argilla.
+
+        Note that you may need to `rg.init(...)` with your Argilla credentials before
+        calling this function, otherwise, the default http://localhost:6900 will be used,
+        which will fail if Argilla is not deployed locally.
+
+        Args:
+            workspace: the workspace where to list the datasets from. Defaults to `None`
+                which means that no workspace filtering will be applied.
+
+        Returns:
+            A list of `RemoteFeedbackDataset` datasets, which are `FeedbackDataset`
+            datasets previously pushed to Argilla via `push_to_argilla`.
+        """
+        client: "ArgillaClient" = ArgillaSingleton.get()
+        httpx_client: "httpx.Client" = client.http_client.httpx
+
+        if workspace is not None:
+            workspace = Workspace.from_name(workspace)
+
+        # TODO(alvarobartt or gabrielmbmb): add `workspace_id` in `GET /api/v1/datasets`
+        # and in `GET /api/v1/me/datasets` to filter by workspace
+        try:
+            datasets = datasets_api_v1.list_datasets(client=httpx_client).parsed
+        except Exception as e:
+            raise Exception(
+                "Failed while listing the `FeedbackDataset` datasets in Argilla with" f" exception: {e}"
+            ) from e
+        return [
+            RemoteFeedbackDataset(
+                client=httpx_client,
+                id=dataset.id,
+                name=dataset.name,
+                workspace=workspace if workspace is not None else Workspace.from_id(dataset.workspace_id),
+                fields=self.__get_fields(client=httpx_client, id=dataset.id),
+                questions=self.__get_questions(client=httpx_client, id=dataset.id),
+                guidelines=dataset.guidelines or None,
+            )
+            for dataset in datasets
+        ]

--- a/src/argilla/client/feedback/dataset/mixins.py
+++ b/src/argilla/client/feedback/dataset/mixins.py
@@ -342,8 +342,8 @@ class ArgillaMixin:
         which will fail if Argilla is not deployed locally.
 
         Args:
-            workspace: the workspace where to list the datasets from. Defaults to `None`
-                which means that no workspace filtering will be applied.
+            workspace: the workspace where to list the datasets from. If not provided,
+                then the workspace filtering won't be applied. Defaults to `None`.
 
         Returns:
             A list of `RemoteFeedbackDataset` datasets, which are `FeedbackDataset`
@@ -360,8 +360,8 @@ class ArgillaMixin:
         try:
             datasets = datasets_api_v1.list_datasets(client=httpx_client).parsed
         except Exception as e:
-            raise Exception(
-                "Failed while listing the `FeedbackDataset` datasets in Argilla with" f" exception: {e}"
+            raise RuntimeError(
+                f"Failed while listing the `FeedbackDataset` datasets in Argilla with exception: {e}"
             ) from e
         return [
             RemoteFeedbackDataset(
@@ -373,5 +373,5 @@ class ArgillaMixin:
                 questions=cls.__get_questions(client=httpx_client, id=dataset.id),
                 guidelines=dataset.guidelines or None,
             )
-            for dataset in datasets
+            for dataset in datasets if workspace is None or dataset.workspace_id == workspace.id
         ]

--- a/src/argilla/client/feedback/dataset/mixins.py
+++ b/src/argilla/client/feedback/dataset/mixins.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 warnings.simplefilter("always", DeprecationWarning)
 
 
-class ArgillaToFromMixin:
+class ArgillaMixin:
     # TODO(alvarobartt): remove when `delete` is implemented
     def __delete_dataset(self: "FeedbackDataset", client: "httpx.Client", id: UUID) -> None:
         try:

--- a/tests/integration/client/feedback/dataset/test_remote.py
+++ b/tests/integration/client/feedback/dataset/test_remote.py
@@ -24,10 +24,10 @@ from tests.factories import DatasetFactory, RecordFactory, TextFieldFactory, Tex
 @pytest.mark.asyncio
 async def test_delete_records(role: UserRole) -> None:
     text_field = await TextFieldFactory.create(required=True)
-    rating_question = await TextQuestionFactory.create(required=True)
+    text_question = await TextQuestionFactory.create(required=True)
     dataset = await DatasetFactory.create(
         fields=[text_field],
-        questions=[rating_question],
+        questions=[text_question],
         records=await RecordFactory.create_batch(size=100),
     )
     user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
@@ -48,8 +48,8 @@ async def test_delete_records(role: UserRole) -> None:
 @pytest.mark.asyncio
 async def test_delete(role: UserRole) -> None:
     text_field = await TextFieldFactory.create(required=True)
-    rating_question = await TextQuestionFactory.create(required=True)
-    dataset = await DatasetFactory.create(fields=[text_field], questions=[rating_question])
+    text_question = await TextQuestionFactory.create(required=True)
+    dataset = await DatasetFactory.create(fields=[text_field], questions=[text_question])
     user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
 
     api.init(api_key=user.api_key)
@@ -64,8 +64,8 @@ async def test_delete(role: UserRole) -> None:
 @pytest.mark.asyncio
 async def test_delete_not_allowed_role(role: UserRole) -> None:
     text_field = await TextFieldFactory.create(required=True)
-    rating_question = await TextQuestionFactory.create(required=True)
-    dataset = await DatasetFactory.create(fields=[text_field], questions=[rating_question])
+    text_question = await TextQuestionFactory.create(required=True)
+    dataset = await DatasetFactory.create(fields=[text_field], questions=[text_question])
     user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
 
     api.init(api_key=user.api_key)

--- a/tests/integration/client/feedback/dataset/test_remote.py
+++ b/tests/integration/client/feedback/dataset/test_remote.py
@@ -75,7 +75,7 @@ async def test_delete_not_allowed_role(role: UserRole) -> None:
         remote_dataset.delete()
 
 
-@pytest.mark.parametrize("role", [UserRole.owner])
+@pytest.mark.parametrize("role", [UserRole.owner, UserRole.admin, UserRole.annotator])
 @pytest.mark.asyncio
 async def test_list(role: UserRole) -> None:
     dataset = await DatasetFactory.create()

--- a/tests/integration/client/feedback/dataset/test_remote.py
+++ b/tests/integration/client/feedback/dataset/test_remote.py
@@ -89,3 +89,19 @@ async def test_list(role: UserRole) -> None:
     assert len(remote_datasets) == 1
     assert all(isinstance(remote_dataset, RemoteFeedbackDataset) for remote_dataset in remote_datasets)
     assert all(remote_dataset.workspace.id == dataset.workspace.id for remote_dataset in remote_datasets)
+
+
+@pytest.mark.parametrize("role", [UserRole.owner, UserRole.admin, UserRole.annotator])
+@pytest.mark.asyncio
+async def test_list_with_workspace_name(role: UserRole) -> None:
+    dataset = await DatasetFactory.create()
+    await TextFieldFactory.create(dataset=dataset, required=True)
+    await TextQuestionFactory.create(dataset=dataset, required=True)
+    await RecordFactory.create_batch(dataset=dataset, size=10)
+    user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
+
+    api.init(api_key=user.api_key)
+    remote_datasets = FeedbackDataset.list(workspace=dataset.workspace.name)
+    assert len(remote_datasets) == 1
+    assert all(isinstance(remote_dataset, RemoteFeedbackDataset) for remote_dataset in remote_datasets)
+    assert all(remote_dataset.workspace.id == dataset.workspace.id for remote_dataset in remote_datasets)

--- a/tests/integration/client/feedback/dataset/test_remote.py
+++ b/tests/integration/client/feedback/dataset/test_remote.py
@@ -24,13 +24,10 @@ from tests.factories import DatasetFactory, RecordFactory, TextFieldFactory, Tex
 @pytest.mark.parametrize("role", [UserRole.owner, UserRole.admin])
 @pytest.mark.asyncio
 async def test_delete_records(role: UserRole) -> None:
-    text_field = await TextFieldFactory.create(required=True)
-    text_question = await TextQuestionFactory.create(required=True)
-    dataset = await DatasetFactory.create(
-        fields=[text_field],
-        questions=[text_question],
-        records=await RecordFactory.create_batch(size=100),
-    )
+    dataset = await DatasetFactory.create()
+    await TextFieldFactory.create(dataset=dataset, required=True)
+    await TextQuestionFactory.create(dataset=dataset, required=True)
+    await RecordFactory.create_batch(dataset=dataset, size=10)
     user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
 
     api.init(api_key=user.api_key)
@@ -48,9 +45,10 @@ async def test_delete_records(role: UserRole) -> None:
 @pytest.mark.parametrize("role", [UserRole.owner, UserRole.admin])
 @pytest.mark.asyncio
 async def test_delete(role: UserRole) -> None:
-    text_field = await TextFieldFactory.create(required=True)
-    text_question = await TextQuestionFactory.create(required=True)
-    dataset = await DatasetFactory.create(fields=[text_field], questions=[text_question])
+    dataset = await DatasetFactory.create()
+    await TextFieldFactory.create(dataset=dataset, required=True)
+    await TextQuestionFactory.create(dataset=dataset, required=True)
+    await RecordFactory.create_batch(dataset=dataset, size=10)
     user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
 
     api.init(api_key=user.api_key)
@@ -64,9 +62,10 @@ async def test_delete(role: UserRole) -> None:
 @pytest.mark.parametrize("role", [UserRole.annotator])
 @pytest.mark.asyncio
 async def test_delete_not_allowed_role(role: UserRole) -> None:
-    text_field = await TextFieldFactory.create(required=True)
-    text_question = await TextQuestionFactory.create(required=True)
-    dataset = await DatasetFactory.create(fields=[text_field], questions=[text_question])
+    dataset = await DatasetFactory.create()
+    await TextFieldFactory.create(dataset=dataset, required=True)
+    await TextQuestionFactory.create(dataset=dataset, required=True)
+    await RecordFactory.create_batch(dataset=dataset, size=10)
     user = await UserFactory.create(role=role, workspaces=[dataset.workspace])
 
     api.init(api_key=user.api_key)


### PR DESCRIPTION
# Description

This PR adds the class method `list` in `ArgillaMixin`, also renamed from `ArgillaToFromMixin`. This way, users can call `FeedbackDataset.list()` to list all the `FeedbackDataset` datasets in Argilla.

Additionally, `list` includes the arg `workspace` so that users can also specify the `workspace` that they want to list from, in case those are assigned to more than one workspace.

Closes #3413
Mentioned #3521 #3591

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [X] Add integration tests for `FeedbackDataset.list` (producing a list of `RemoteFeedbackDataset`)

**Checklist**

- [X] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)