### PR TITLE
refactor: move `Enum`s to `enums`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ These are the section headers that we use:
 ### Changed
 
 - Move `users` CLI app under `database` CLI app ([#3593](https://github.com/argilla-io/argilla/pull/3593)).
+- Move server `Enum` classes to `argilla.server.enums` module ([#3620](https://github.com/argilla-io/argilla/pull/3620)).
 
 ## [1.14.1](https://github.com/argilla-io/argilla/compare/v1.14.0...v1.14.1)
 

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -20,7 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from argilla.server.contexts import accounts, datasets
 from argilla.server.database import get_async_db
-from argilla.server.enums import ResponseStatusFilter
+from argilla.server.enums import RecordInclude, ResponseStatusFilter
 from argilla.server.models import Dataset as DatasetModel
 from argilla.server.models import ResponseStatus, User
 from argilla.server.policies import DatasetPolicyV1, authorize
@@ -37,7 +37,6 @@ from argilla.server.schemas.v1.datasets import (
     QuestionCreate,
     Questions,
     Record,
-    RecordInclude,
     Records,
     RecordsCreate,
     SearchRecord,

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -20,7 +20,7 @@ from sqlalchemy import and_, delete, func, or_, select
 from sqlalchemy.orm import contains_eager, joinedload, selectinload
 
 from argilla.server.contexts import accounts
-from argilla.server.enums import ResponseStatusFilter
+from argilla.server.enums import RecordInclude, ResponseStatusFilter
 from argilla.server.models import (
     Dataset,
     DatasetStatus,
@@ -33,7 +33,7 @@ from argilla.server.models import (
     Suggestion,
 )
 from argilla.server.models.suggestions import SuggestionCreateWithRecordId
-from argilla.server.schemas.v1.datasets import DatasetCreate, FieldCreate, QuestionCreate, RecordInclude, RecordsCreate
+from argilla.server.schemas.v1.datasets import DatasetCreate, FieldCreate, QuestionCreate, RecordsCreate
 from argilla.server.schemas.v1.records import ResponseCreate
 from argilla.server.schemas.v1.responses import ResponseUpdate
 from argilla.server.search_engine import SearchEngine

--- a/src/argilla/server/enums.py
+++ b/src/argilla/server/enums.py
@@ -15,8 +15,47 @@
 from enum import Enum
 
 
+class FieldType(str, Enum):
+    text = "text"
+
+
+class ResponseStatus(str, Enum):
+    draft = "draft"
+    submitted = "submitted"
+    discarded = "discarded"
+
+
 class ResponseStatusFilter(str, Enum):
     draft = "draft"
     missing = "missing"
     submitted = "submitted"
     discarded = "discarded"
+
+
+class SuggestionType(str, Enum):
+    model = "model"
+    human = "human"
+
+
+class DatasetStatus(str, Enum):
+    draft = "draft"
+    ready = "ready"
+
+
+class UserRole(str, Enum):
+    owner = "owner"
+    admin = "admin"
+    annotator = "annotator"
+
+
+class RecordInclude(str, Enum):
+    responses = "responses"
+    suggestions = "suggestions"
+
+
+class QuestionType(str, Enum):
+    text = "text"
+    rating = "rating"
+    label_selection = "label_selection"
+    multi_label_selection = "multi_label_selection"
+    ranking = "ranking"

--- a/src/argilla/server/models/models.py
+++ b/src/argilla/server/models/models.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 import secrets
-from enum import Enum
 from typing import Any, List, Optional
 from uuid import UUID
 
@@ -23,36 +22,11 @@ from sqlalchemy import Enum as SAEnum
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from argilla.server.enums import DatasetStatus, ResponseStatus, SuggestionType, UserRole
 from argilla.server.models.base import DatabaseModel
 from argilla.server.models.questions import QuestionSettings
 
 _USER_API_KEY_BYTES_LENGTH = 80
-
-
-class FieldType(str, Enum):
-    text = "text"
-
-
-class ResponseStatus(str, Enum):
-    draft = "draft"
-    submitted = "submitted"
-    discarded = "discarded"
-
-
-class SuggestionType(str, Enum):
-    model = "model"
-    human = "human"
-
-
-class DatasetStatus(str, Enum):
-    draft = "draft"
-    ready = "ready"
-
-
-class UserRole(str, Enum):
-    owner = "owner"
-    admin = "admin"
-    annotator = "annotator"
 
 
 class Field(DatabaseModel):

--- a/src/argilla/server/models/questions.py
+++ b/src/argilla/server/models/questions.py
@@ -12,23 +12,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from enum import Enum
 from typing import Any, Generic, List, Literal, Optional, Protocol, TypeVar, Union
 
 from pydantic import BaseModel, Field
+
+from argilla.server.enums import QuestionType
 
 try:
     from typing import Annotated
 except ImportError:
     from typing_extensions import Annotated
-
-
-class QuestionType(str, Enum):
-    text = "text"
-    rating = "rating"
-    label_selection = "label_selection"
-    multi_label_selection = "multi_label_selection"
-    ranking = "ranking"
 
 
 class ResponseValue(Protocol):

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -13,13 +13,11 @@
 #  limitations under the License.
 
 from datetime import datetime
-from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
 
 from pydantic import (
     BaseModel,
-    Field,
     PositiveInt,
     conlist,
     constr,
@@ -38,7 +36,8 @@ try:
 except ImportError:
     from typing_extensions import Annotated
 
-from argilla.server.models import DatasetStatus, FieldType, QuestionSettings, QuestionType, ResponseStatus
+from argilla.server.enums import FieldType
+from argilla.server.models import DatasetStatus, QuestionSettings, QuestionType, ResponseStatus
 
 DATASET_NAME_REGEX = r"^(?!-|_)[a-zA-Z0-9-_ ]+$"
 DATASET_NAME_MIN_LENGTH = 1
@@ -335,11 +334,6 @@ class Response(BaseModel):
 
     class Config:
         orm_mode = True
-
-
-class RecordInclude(str, Enum):
-    responses = "responses"
-    suggestions = "suggestions"
 
 
 class RecordGetterDict(GetterDict):

--- a/src/argilla/server/schemas/v1/fields.py
+++ b/src/argilla/server/schemas/v1/fields.py
@@ -18,7 +18,7 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
-from argilla.server.models import FieldType
+from argilla.server.enums import FieldType
 from argilla.server.schemas.base import UpdateSchema
 from argilla.server.schemas.v1.datasets import FieldTitle
 

--- a/src/argilla/server/search_engine.py
+++ b/src/argilla/server/search_engine.py
@@ -20,11 +20,10 @@ from opensearchpy import AsyncOpenSearch, helpers
 from pydantic import BaseModel
 from pydantic.utils import GetterDict
 
-from argilla.server.enums import ResponseStatusFilter
+from argilla.server.enums import FieldType, ResponseStatusFilter
 from argilla.server.models import (
     Dataset,
     Field,
-    FieldType,
     Question,
     QuestionType,
     Record,

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -15,10 +15,10 @@
 import inspect
 
 import factory
+from argilla.server.enums import FieldType
 from argilla.server.models import (
     Dataset,
     Field,
-    FieldType,
     Question,
     QuestionType,
     Record,

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -20,7 +20,7 @@ from uuid import UUID, uuid4
 import pytest
 from argilla._constants import API_KEY_HEADER_NAME
 from argilla.server.apis.v1.handlers.datasets import LIST_DATASET_RECORDS_LIMIT_DEFAULT
-from argilla.server.enums import ResponseStatusFilter
+from argilla.server.enums import RecordInclude, ResponseStatusFilter
 from argilla.server.models import (
     Dataset,
     DatasetStatus,
@@ -49,7 +49,6 @@ from argilla.server.schemas.v1.datasets import (
     VALUE_TEXT_OPTION_DESCRIPTION_MAX_LENGTH,
     VALUE_TEXT_OPTION_TEXT_MAX_LENGTH,
     VALUE_TEXT_OPTION_VALUE_MAX_LENGTH,
-    RecordInclude,
 )
 from argilla.server.search_engine import (
     Query,


### PR DESCRIPTION
# Description

This PR moves all the `Enum` classes of the Argilla server to the `argilla.server.enums` module in order to avoid circular imports, and to have one single file in which find all the enums (they are used across all the server codebase).

**Type of change**

- [x] Refactor (change restructuring the codebase without changing functionality)

**How Has This Been Tested**



**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
