### PR TITLE
:bug: FIX : Regex for query search highlight

### DIFF
--- a/frontend/plugins/plugins/highlight-search.js
+++ b/frontend/plugins/plugins/highlight-search.js
@@ -18,14 +18,13 @@
 export default (context, inject) => {
   const highlightKeywords = function (text, keywords) {
     const sortedKeywords = sortByLength([...keywords]);
-    const wordsEscaped = sortedKeywords.map((keyword) => escapeRegExp(keyword));
-    const regExp = findWordRegex(wordsEscaped.join("|"));
+    const regExp = createFindWordsRegex(sortedKeywords);
     return replaceText(regExp, text);
   };
 
   const keywordsSpans = function (text, keywords = []) {
     return keywords.flatMap((keyword) => {
-      const regex = findWordRegex(keyword);
+      const regex = createFindWordsPattern(keyword);
       return [...text.matchAll(regex)].map((match) => {
         return {
           start: match.index,
@@ -39,11 +38,19 @@ export default (context, inject) => {
     return keywords.sort((a, b) => b.length - a.length);
   };
 
+  function createFindWordsPattern(value) {
+    return new RegExp("\\" + value, "g");
+  }
+
   const escapeRegExp = function (text) {
     return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
   };
 
-  const findWordRegex = (words) => {
+  const createFindWordsRegex = (keyWords) => {
+    const wordsEscaped = keyWords.map((keyword) => escapeRegExp(keyword));
+
+    const words = wordsEscaped.join("|");
+
     return new RegExp("\\b" + words + "\\b", "gmi");
   };
 

--- a/frontend/plugins/plugins/highlight-search.js
+++ b/frontend/plugins/plugins/highlight-search.js
@@ -39,7 +39,7 @@ export default (context, inject) => {
   };
 
   function createFindWordsPattern(value) {
-    return new RegExp("\\" + value, "g");
+    return new RegExp(`\\${value}|[${value}]`, "g");
   }
 
   const escapeRegExp = function (text) {

--- a/frontend/plugins/plugins/highlight-search.js
+++ b/frontend/plugins/plugins/highlight-search.js
@@ -18,8 +18,8 @@
 export default (context, inject) => {
   const highlightKeywords = function (text, keywords) {
     const sortedKeywords = sortByLength([...keywords]);
-    const pattern = sortedKeywords.map((keyword) => createPattern(keyword));
-    const regExp = createRegExp(pattern.join("|"));
+    const wordsEscaped = sortedKeywords.map((keyword) => escapeRegExp(keyword));
+    const regExp = findWordRegex(wordsEscaped.join("|"));
     return replaceText(regExp, text);
   };
 
@@ -35,32 +35,35 @@ export default (context, inject) => {
     });
   };
 
-  function sortByLength(keywords) {
+  const sortByLength = (keywords) => {
     return (keywords || []).sort((a, b) => b.length - a.length);
-  }
+  };
 
-  function createPattern(value) {
-    const pattern = "[^A-Za-zÀ-ÿ\u00f1\u00d10-9_@./#&+-]";
-    return `(${pattern})${escapeRegExp(value)}(${pattern})`;
-  }
+  const createPattern = (value) => {
+    return `/\b(${value})\b/i`;
+  };
 
   const escapeRegExp = function (text) {
     return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
   };
 
-  function createRegExp(pattern) {
-    return new RegExp(pattern, "gmi");
-  }
+  const findWordRegex = (words) => {
+    return new RegExp("\\b" + words + "\\b");
+  };
 
-  function replaceText(regex, text) {
+  const createRegExp = (pattern) => {
+    return new RegExp(pattern, "gmi");
+  };
+
+  const replaceText = (regex, text) => {
     return htmlText(text).replace(regex, (matched) =>
       matched ? htmlHighlightText(matched) : matched
     );
-  }
+  };
 
-  function htmlHighlightText(text) {
+  const htmlHighlightText = (text) => {
     return `<span class="highlight-text">${htmlText(text)}</span>`;
-  }
+  };
 
   const htmlText = function (text) {
     return text

--- a/frontend/plugins/plugins/highlight-search.js
+++ b/frontend/plugins/plugins/highlight-search.js
@@ -52,7 +52,7 @@ export default (context, inject) => {
 
     const words = wordsEscaped.join("|");
 
-    return new RegExp(`\\b${words}`, "gmi");
+    return new RegExp(`${words}`, "gmi");
   };
 
   const replaceText = (regex, text) => {

--- a/frontend/plugins/plugins/highlight-search.js
+++ b/frontend/plugins/plugins/highlight-search.js
@@ -39,7 +39,8 @@ export default (context, inject) => {
   };
 
   function createFindWordsPattern(value) {
-    return new RegExp(`\\${value}|[${value}]`, "g");
+    const pattern = "[^A-Za-zÀ-ÿ\u00f1\u00d10-9_@./#&+-]";
+    return new RegExp(`(${pattern})${escapeRegExp(value)}(${pattern})`, "gmi");
   }
 
   const escapeRegExp = function (text) {
@@ -51,7 +52,7 @@ export default (context, inject) => {
 
     const words = wordsEscaped.join("|");
 
-    return new RegExp("\\b" + words + "\\b", "gmi");
+    return new RegExp(words, "gmi");
   };
 
   const replaceText = (regex, text) => {

--- a/frontend/plugins/plugins/highlight-search.js
+++ b/frontend/plugins/plugins/highlight-search.js
@@ -23,9 +23,9 @@ export default (context, inject) => {
     return replaceText(regExp, text);
   };
 
-  const keywordsSpans = function (text, keywords) {
-    return (keywords || []).flatMap((keyword) => {
-      const regex = createRegExp(createPattern(keyword));
+  const keywordsSpans = function (text, keywords = []) {
+    return keywords.flatMap((keyword) => {
+      const regex = findWordRegex(keyword);
       return [...text.matchAll(regex)].map((match) => {
         return {
           start: match.index,
@@ -36,11 +36,7 @@ export default (context, inject) => {
   };
 
   const sortByLength = (keywords) => {
-    return (keywords || []).sort((a, b) => b.length - a.length);
-  };
-
-  const createPattern = (value) => {
-    return `/\b(${value})\b/i`;
+    return keywords.sort((a, b) => b.length - a.length);
   };
 
   const escapeRegExp = function (text) {
@@ -48,11 +44,7 @@ export default (context, inject) => {
   };
 
   const findWordRegex = (words) => {
-    return new RegExp("\\b" + words + "\\b");
-  };
-
-  const createRegExp = (pattern) => {
-    return new RegExp(pattern, "gmi");
+    return new RegExp("\\b" + words + "\\b", "gmi");
   };
 
   const replaceText = (regex, text) => {

--- a/frontend/plugins/plugins/highlight-search.js
+++ b/frontend/plugins/plugins/highlight-search.js
@@ -52,7 +52,7 @@ export default (context, inject) => {
 
     const words = wordsEscaped.join("|");
 
-    return new RegExp(words, "gmi");
+    return new RegExp(`\\b${words}`, "gmi");
   };
 
   const replaceText = (regex, text) => {


### PR DESCRIPTION
Fix regex used to highlight records text from query search

Closes #3525 

**Type of change**

- Bug fix

**How Has This Been Tested**

The modification is applyed in highlighting common functions for : 
- `Text2Text`
- `TextClassification`


`TokenClassification` is not concerned by this modification
