### PR TITLE
fix: response with `draft` status was returning `422`

### DIFF
--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -477,7 +477,7 @@ def validate_response_values(dataset: Dataset, values: Dict[str, ResponseValue],
 
         question_response = values_copy.pop(question.name, None)
         if question_response:
-            question.parsed_settings.check_response(question_response)
+            question.parsed_settings.check_response(question_response, status)
 
     if values_copy:
         raise ValueError(f"Error: found responses for non configured questions: {list(values_copy.keys())!r}")

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -462,7 +462,7 @@ async def delete_response(db: "AsyncSession", search_engine: SearchEngine, respo
 
 def validate_response_values(dataset: Dataset, values: Dict[str, ResponseValue], status: ResponseStatus):
     if not values:
-        if status == ResponseStatus.submitted:
+        if status != ResponseStatus.discarded:
             raise ValueError("Missing response values")
         return
 

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -462,7 +462,7 @@ async def delete_response(db: "AsyncSession", search_engine: SearchEngine, respo
 
 def validate_response_values(dataset: Dataset, values: Dict[str, ResponseValue], status: ResponseStatus):
     if not values:
-        if status != ResponseStatus.discarded:
+        if status == ResponseStatus.submitted:
             raise ValueError("Missing response values")
         return
 

--- a/src/argilla/server/models/questions.py
+++ b/src/argilla/server/models/questions.py
@@ -16,7 +16,7 @@ from typing import Any, Generic, List, Literal, Optional, Protocol, TypeVar, Uni
 
 from pydantic import BaseModel, Field
 
-from argilla.server.enums import QuestionType
+from argilla.server.enums import QuestionType, ResponseStatus
 
 try:
     from typing import Annotated
@@ -29,7 +29,7 @@ class ResponseValue(Protocol):
 
 
 class BaseQuestionSettings(BaseModel):
-    def check_response(self, response: ResponseValue):
+    def check_response(self, response: ResponseValue, status: Optional[ResponseStatus] = None):
         pass
 
 
@@ -37,7 +37,7 @@ class TextQuestionSettings(BaseQuestionSettings):
     type: Literal[QuestionType.text]
     use_markdown: bool = False
 
-    def check_response(self, response: ResponseValue):
+    def check_response(self, response: ResponseValue, status: Optional[ResponseStatus] = None):
         if not isinstance(response.value, str):
             raise ValueError(f"Expected text value, found {type(response.value)}")
 
@@ -54,7 +54,7 @@ class ValidOptionCheckerMixin(BaseQuestionSettings, Generic[T]):
     def option_values(self) -> List[T]:
         return [option.value for option in self.options]
 
-    def check_response(self, response: ResponseValue):
+    def check_response(self, response: ResponseValue, status: Optional[ResponseStatus] = None):
         if response.value not in self.option_values:
             raise ValueError(f"{response.value!r} is not a valid option.\nValid options are: {self.option_values!r}")
 
@@ -83,7 +83,7 @@ def _are_all_elements_in_list(elements: List[T], list_: List[T]) -> List[T]:
 class MultiLabelSelectionQuestionSettings(LabelSelectionQuestionSettings):
     type: Literal[QuestionType.multi_label_selection]
 
-    def check_response(self, response: ResponseValue):
+    def check_response(self, response: ResponseValue, status: Optional[ResponseStatus] = None):
         if not isinstance(response.value, list):
             raise ValueError(
                 f"This MultiLabelSelection question expects a list of values, found {type(response.value)}"
@@ -114,11 +114,12 @@ class RankingQuestionSettings(ValidOptionCheckerMixin[str]):
     def rank_values(self) -> List[int]:
         return list(range(1, len(self.option_values) + 1))
 
-    def check_response(self, response: ResponseValue):
+    def check_response(self, response: ResponseValue, status: Optional[ResponseStatus] = None):
         if not isinstance(response.value, list):
             raise ValueError(f"This Ranking question expects a list of values, found {type(response.value)}")
 
-        if len(response.value) != len(self.option_values):
+        # Only if the response is submitted check that all the possible options have been ranked
+        if status == ResponseStatus.submitted and len(response.value) != len(self.option_values):
             raise ValueError(
                 f"This Ranking question expects a list containing {len(self.option_values)} values, found a list of"
                 f" {len(response.value)} values"

--- a/src/argilla/server/schemas/v1/responses.py
+++ b/src/argilla/server/schemas/v1/responses.py
@@ -57,4 +57,11 @@ class DiscardedResponseUpdate(BaseModel):
     status: Literal[ResponseStatus.discarded]
 
 
-ResponseUpdate = Annotated[Union[SubmittedResponseUpdate, DiscardedResponseUpdate], Field(discriminator="status")]
+class DraftResponseUpdate(BaseModel):
+    values: Optional[Dict[str, ResponseValueUpdate]]
+    status: Literal[ResponseStatus.draft]
+
+
+ResponseUpdate = Annotated[
+    Union[SubmittedResponseUpdate, DiscardedResponseUpdate, DraftResponseUpdate], Field(discriminator="status")
+]

--- a/tests/unit/server/api/v1/test_records.py
+++ b/tests/unit/server/api/v1/test_records.py
@@ -18,6 +18,7 @@ from uuid import UUID, uuid4
 
 import pytest
 from argilla._constants import API_KEY_HEADER_NAME
+from argilla.server.enums import ResponseStatus
 from argilla.server.models import Record, Response, Suggestion, User, UserRole
 from argilla.server.search_engine import SearchEngine
 from sqlalchemy import func, select
@@ -72,7 +73,9 @@ async def create_ranking_question(dataset: "Dataset") -> None:
 
 @pytest.mark.asyncio
 class TestSuiteRecords:
-    @pytest.mark.parametrize("response_status", ["submitted", "discarded", "draft"])
+    @pytest.mark.parametrize(
+        "response_status", [ResponseStatus.submitted, ResponseStatus.discarded, ResponseStatus.draft]
+    )
     @pytest.mark.parametrize(
         "create_questions_func, responses",
         [
@@ -149,7 +152,7 @@ class TestSuiteRecords:
         owner: User,
         owner_auth_header: dict,
         create_questions_func: Callable[["Dataset"], Awaitable[None]],
-        response_status: str,
+        response_status: ResponseStatus,
         responses: dict,
     ):
         dataset = await DatasetFactory.create()
@@ -195,7 +198,7 @@ class TestSuiteRecords:
         assert response.status_code == 422
         assert response.json() == {"detail": "Missing required question: 'input_ok'"}
 
-    @pytest.mark.parametrize("response_status", ["discarded", "draft"])
+    @pytest.mark.parametrize("response_status", [ResponseStatus.discarded, ResponseStatus.draft])
     @pytest.mark.parametrize(
         "create_questions_func, responses",
         [
@@ -305,7 +308,7 @@ class TestSuiteRecords:
         owner: User,
         owner_auth_header: dict,
         create_questions_func: Callable[["Dataset"], Awaitable[None]],
-        response_status: str,
+        response_status: ResponseStatus,
         responses: dict,
     ):
         dataset = await DatasetFactory.create()
@@ -620,9 +623,9 @@ class TestSuiteRecords:
                 "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
             }
 
-    @pytest.mark.parametrize("status", ["submitted", "discarded", "draft"])
-    async def test_create_record_submitted_response_with_wrong_values(
-        self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict, status: str
+    @pytest.mark.parametrize("status", [ResponseStatus.submitted, ResponseStatus.discarded, ResponseStatus.draft])
+    async def test_create_record_response_with_wrong_values(
+        self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict, status: ResponseStatus
     ):
         record = await RecordFactory.create()
         response_json = {"status": status, "values": {"wrong_question": {"value": "wrong value"}}}

--- a/tests/unit/server/api/v1/test_responses.py
+++ b/tests/unit/server/api/v1/test_responses.py
@@ -39,385 +39,367 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.asyncio
-async def test_update_response(
-    async_client: "AsyncClient", db: "AsyncSession", mock_search_engine: SearchEngine, owner_auth_header: dict
-):
-    dataset = await DatasetFactory.create(status=DatasetStatus.ready)
-    await TextQuestionFactory.create(name="input_ok", dataset=dataset)
-    await TextQuestionFactory.create(name="output_ok", dataset=dataset)
-    record = await RecordFactory.create(dataset=dataset)
+class TestSuiteResponses:
+    async def test_update_response(
+        self, async_client: "AsyncClient", db: "AsyncSession", mock_search_engine: SearchEngine, owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create(status=DatasetStatus.ready)
+        await TextQuestionFactory.create(name="input_ok", dataset=dataset)
+        await TextQuestionFactory.create(name="output_ok", dataset=dataset)
+        record = await RecordFactory.create(dataset=dataset)
 
-    response = await ResponseFactory.create(
-        record=record,
-        values={"input_ok": {"value": "no"}, "output_ok": {"value": "no"}},
-        status=ResponseStatus.submitted,
-    )
-    response_json = {
-        "values": {"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}},
-        "status": "submitted",
-    }
+        response = await ResponseFactory.create(
+            record=record,
+            values={"input_ok": {"value": "no"}, "output_ok": {"value": "no"}},
+            status=ResponseStatus.submitted,
+        )
+        response_json = {
+            "values": {"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}},
+            "status": "submitted",
+        }
 
-    resp = await async_client.put(f"/api/v1/responses/{response.id}", headers=owner_auth_header, json=response_json)
+        resp = await async_client.put(f"/api/v1/responses/{response.id}", headers=owner_auth_header, json=response_json)
 
-    assert resp.status_code == 200
-    assert (await db.get(Response, response.id)).values == {"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}}
+        assert resp.status_code == 200
+        assert (await db.get(Response, response.id)).values == {
+            "input_ok": {"value": "yes"},
+            "output_ok": {"value": "yes"},
+        }
 
-    resp_body = resp.json()
-    assert resp_body == {
-        "id": str(response.id),
-        "values": {"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}},
-        "status": "submitted",
-        "record_id": str(response.record_id),
-        "user_id": str(response.user_id),
-        "inserted_at": response.inserted_at.isoformat(),
-        "updated_at": datetime.fromisoformat(resp_body["updated_at"]).isoformat(),
-    }
+        resp_body = resp.json()
+        assert resp_body == {
+            "id": str(response.id),
+            "values": {"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}},
+            "status": "submitted",
+            "record_id": str(response.record_id),
+            "user_id": str(response.user_id),
+            "inserted_at": response.inserted_at.isoformat(),
+            "updated_at": datetime.fromisoformat(resp_body["updated_at"]).isoformat(),
+        }
 
-    mock_search_engine.update_record_response.assert_called_once_with(response)
+        mock_search_engine.update_record_response.assert_called_once_with(response)
 
+    async def test_update_response_without_authentication(self, async_client: "AsyncClient", db: "AsyncSession"):
+        response = await ResponseFactory.create(
+            values={
+                "input_ok": {"value": "no"},
+                "output_ok": {"value": "no"},
+            },
+            status="submitted",
+        )
+        response_json = {
+            "values": {
+                "input_ok": {"value": "yes"},
+                "output_ok": {"value": "yes"},
+            },
+            "status": "submitted",
+        }
 
-@pytest.mark.asyncio
-async def test_update_response_without_authentication(async_client: "AsyncClient", db: "AsyncSession"):
-    response = await ResponseFactory.create(
-        values={
+        resp = await async_client.put(f"/api/v1/responses/{response.id}", json=response_json)
+
+        assert resp.status_code == 401
+        assert (await db.get(Response, response.id)).values == {
             "input_ok": {"value": "no"},
             "output_ok": {"value": "no"},
-        },
-        status="submitted",
-    )
-    response_json = {
-        "values": {
+        }
+
+    async def test_update_response_from_submitted_to_discarded(
+        self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create(status=DatasetStatus.ready)
+        await TextQuestionFactory.create(name="input_ok", dataset=dataset)
+        await TextQuestionFactory.create(name="output_ok", dataset=dataset)
+        record = await RecordFactory.create(dataset=dataset)
+
+        response = await ResponseFactory.create(
+            record=record,
+            values={
+                "input_ok": {"value": "no"},
+                "output_ok": {"value": "no"},
+            },
+            status="submitted",
+        )
+        response_json = {
+            "values": {
+                "input_ok": {"value": "yes"},
+                "output_ok": {"value": "yes"},
+            },
+            "status": "discarded",
+        }
+
+        resp = await async_client.put(f"/api/v1/responses/{response.id}", headers=owner_auth_header, json=response_json)
+
+        assert resp.status_code == 200
+
+        response = await db.get(Response, response.id)
+        assert response.values == {
             "input_ok": {"value": "yes"},
             "output_ok": {"value": "yes"},
-        },
-        "status": "submitted",
-    }
+        }
+        assert response.status == ResponseStatus.discarded
 
-    resp = await async_client.put(f"/api/v1/responses/{response.id}", json=response_json)
+        resp_body = resp.json()
+        assert resp_body == {
+            "id": str(response.id),
+            "values": {
+                "input_ok": {"value": "yes"},
+                "output_ok": {"value": "yes"},
+            },
+            "status": "discarded",
+            "record_id": str(response.record_id),
+            "user_id": str(response.user_id),
+            "inserted_at": response.inserted_at.isoformat(),
+            "updated_at": datetime.fromisoformat(resp_body["updated_at"]).isoformat(),
+        }
 
-    assert resp.status_code == 401
-    assert (await db.get(Response, response.id)).values == {
-        "input_ok": {"value": "no"},
-        "output_ok": {"value": "no"},
-    }
+    async def test_update_response_from_submitted_to_discarded_without_values(
+        self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
+    ):
+        response = await ResponseFactory.create(
+            values={
+                "input_ok": {"value": "no"},
+                "output_ok": {"value": "no"},
+            },
+            status="submitted",
+        )
+        response_json = {
+            "status": "discarded",
+        }
 
+        resp = await async_client.put(f"/api/v1/responses/{response.id}", headers=owner_auth_header, json=response_json)
 
-@pytest.mark.asyncio
-async def test_update_response_from_submitted_to_discarded(
-    async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
-):
-    dataset = await DatasetFactory.create(status=DatasetStatus.ready)
-    await TextQuestionFactory.create(name="input_ok", dataset=dataset)
-    await TextQuestionFactory.create(name="output_ok", dataset=dataset)
-    record = await RecordFactory.create(dataset=dataset)
+        assert resp.status_code == 200
 
-    response = await ResponseFactory.create(
-        record=record,
-        values={
+        response = await db.get(Response, response.id)
+        assert response.values is None
+        assert response.status == ResponseStatus.discarded
+
+        resp_body = resp.json()
+        assert resp_body == {
+            "id": str(response.id),
+            "values": None,
+            "status": "discarded",
+            "record_id": str(response.record_id),
+            "user_id": str(response.user_id),
+            "inserted_at": response.inserted_at.isoformat(),
+            "updated_at": datetime.fromisoformat(resp_body["updated_at"]).isoformat(),
+        }
+
+    async def test_update_response_from_discarded_to_submitted(
+        self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
+    ):
+        response = await ResponseFactory.create(status="discarded")
+        response_json = {
+            "status": "submitted",
+        }
+
+        resp = await async_client.put(f"/api/v1/responses/{response.id}", headers=owner_auth_header, json=response_json)
+
+        assert resp.status_code == 422
+
+    async def test_update_response_from_discarded_to_submitted_without_values(
+        self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
+    ):
+        response = await ResponseFactory.create(status="discarded")
+        response_json = {
+            "status": "submitted",
+        }
+
+        resp = await async_client.put(f"/api/v1/responses/{response.id}", headers=owner_auth_header, json=response_json)
+
+        assert resp.status_code == 422
+
+        response = await db.get(Response, response.id)
+        assert response.values is None
+        assert response.status == ResponseStatus.discarded
+
+    async def test_update_response_with_wrong_values(
+        self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
+    ):
+        response = await ResponseFactory.create(status="discarded")
+        response_json = {"status": "submitted", "values": {"wrong_question": {"value": "wrong value"}}}
+
+        resp = await async_client.put(f"/api/v1/responses/{response.id}", headers=owner_auth_header, json=response_json)
+
+        assert resp.status_code == 422
+        assert resp.json() == {"detail": "Error: found responses for non configured questions: ['wrong_question']"}
+
+        response = await db.get(Response, response.id)
+        assert response.values is None
+        assert response.status == ResponseStatus.discarded
+
+    async def test_update_response_as_annotator(self, async_client: "AsyncClient", db: "AsyncSession"):
+        dataset = await DatasetFactory.create(status=DatasetStatus.ready)
+        await TextQuestionFactory.create(name="input_ok", dataset=dataset)
+        await TextQuestionFactory.create(name="output_ok", dataset=dataset)
+        record = await RecordFactory.create(dataset=dataset)
+        annotator = await AnnotatorFactory.create()
+
+        response = await ResponseFactory.create(
+            record=record,
+            values={
+                "input_ok": {"value": "no"},
+                "output_ok": {"value": "no"},
+            },
+            status="submitted",
+            user=annotator,
+        )
+        response_json = {
+            "values": {
+                "input_ok": {"value": "yes"},
+                "output_ok": {"value": "yes"},
+            },
+            "status": "submitted",
+        }
+
+        resp = await async_client.put(
+            f"/api/v1/responses/{response.id}", headers={API_KEY_HEADER_NAME: annotator.api_key}, json=response_json
+        )
+
+        assert resp.status_code == 200
+        assert (await db.get(Response, response.id)).values == {
+            "input_ok": {"value": "yes"},
+            "output_ok": {"value": "yes"},
+        }
+
+        resp_body = resp.json()
+        assert resp_body == {
+            "id": str(response.id),
+            "values": {
+                "input_ok": {"value": "yes"},
+                "output_ok": {"value": "yes"},
+            },
+            "status": "submitted",
+            "record_id": str(response.record_id),
+            "user_id": str(response.user_id),
+            "inserted_at": response.inserted_at.isoformat(),
+            "updated_at": datetime.fromisoformat(resp_body["updated_at"]).isoformat(),
+        }
+
+    async def test_update_response_as_annotator_for_different_user_response(
+        self, async_client: "AsyncClient", db: "AsyncSession"
+    ):
+        annotator = await AnnotatorFactory.create()
+        response = await ResponseFactory.create(
+            values={
+                "input_ok": {"value": "no"},
+                "output_ok": {"value": "no"},
+            },
+            status="submitted",
+        )
+        response_json = {
+            "values": {
+                "input_ok": {"value": "yes"},
+                "output_ok": {"value": "yes"},
+            },
+            "status": "submitted",
+        }
+
+        resp = await async_client.put(
+            f"/api/v1/responses/{response.id}", headers={API_KEY_HEADER_NAME: annotator.api_key}, json=response_json
+        )
+
+        assert resp.status_code == 403
+        assert (await db.get(Response, response.id)).values == {
             "input_ok": {"value": "no"},
             "output_ok": {"value": "no"},
-        },
-        status="submitted",
-    )
-    response_json = {
-        "values": {
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "yes"},
-        },
-        "status": "discarded",
-    }
+        }
 
-    resp = await async_client.put(f"/api/v1/responses/{response.id}", headers=owner_auth_header, json=response_json)
+    async def test_update_response_with_nonexistent_response_id(
+        self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
+    ):
+        response = await ResponseFactory.create(
+            values={
+                "input_ok": {"value": "no"},
+                "output_ok": {"value": "no"},
+            },
+            status="submitted",
+        )
+        response_json = {
+            "values": {
+                "input_ok": {"value": "yes"},
+                "output_ok": {"value": "yes"},
+            },
+            "status": "submitted",
+        }
 
-    assert resp.status_code == 200
+        resp = await async_client.put(f"/api/v1/responses/{uuid4()}", headers=owner_auth_header, json=response_json)
 
-    response = await db.get(Response, response.id)
-    assert response.values == {
-        "input_ok": {"value": "yes"},
-        "output_ok": {"value": "yes"},
-    }
-    assert response.status == ResponseStatus.discarded
-
-    resp_body = resp.json()
-    assert resp_body == {
-        "id": str(response.id),
-        "values": {
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "yes"},
-        },
-        "status": "discarded",
-        "record_id": str(response.record_id),
-        "user_id": str(response.user_id),
-        "inserted_at": response.inserted_at.isoformat(),
-        "updated_at": datetime.fromisoformat(resp_body["updated_at"]).isoformat(),
-    }
-
-
-@pytest.mark.asyncio
-async def test_update_response_from_submitted_to_discarded_without_values(
-    async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
-):
-    response = await ResponseFactory.create(
-        values={
+        assert resp.status_code == 404
+        assert (await db.get(Response, response.id)).values == {
             "input_ok": {"value": "no"},
             "output_ok": {"value": "no"},
-        },
-        status="submitted",
-    )
-    response_json = {
-        "status": "discarded",
-    }
+        }
 
-    resp = await async_client.put(f"/api/v1/responses/{response.id}", headers=owner_auth_header, json=response_json)
+    async def test_delete_response(
+        self, async_client: "AsyncClient", mock_search_engine: SearchEngine, db: "AsyncSession", owner_auth_header: dict
+    ):
+        response = await ResponseFactory.create()
 
-    assert resp.status_code == 200
+        resp = await async_client.delete(f"/api/v1/responses/{response.id}", headers=owner_auth_header)
 
-    response = await db.get(Response, response.id)
-    assert response.values is None
-    assert response.status == ResponseStatus.discarded
+        assert resp.status_code == 200
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
 
-    resp_body = resp.json()
-    assert resp_body == {
-        "id": str(response.id),
-        "values": None,
-        "status": "discarded",
-        "record_id": str(response.record_id),
-        "user_id": str(response.user_id),
-        "inserted_at": response.inserted_at.isoformat(),
-        "updated_at": datetime.fromisoformat(resp_body["updated_at"]).isoformat(),
-    }
+        mock_search_engine.delete_record_response.assert_called_once_with(response)
 
+    async def test_delete_response_without_authentication(self, async_client: "AsyncClient", db: "AsyncSession"):
+        response = await ResponseFactory.create()
 
-@pytest.mark.asyncio
-async def test_update_response_from_discarded_to_submitted(
-    async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
-):
-    response = await ResponseFactory.create(status="discarded")
-    response_json = {
-        "status": "submitted",
-    }
+        resp = await async_client.delete(f"/api/v1/responses/{response.id}")
 
-    resp = await async_client.put(f"/api/v1/responses/{response.id}", headers=owner_auth_header, json=response_json)
+        assert resp.status_code == 401
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 1
 
-    assert resp.status_code == 422
+    @pytest.mark.parametrize("role", [UserRole.admin, UserRole.annotator])
+    async def test_delete_response_as_restricted_user(
+        self, async_client: "AsyncClient", db: "AsyncSession", role: UserRole
+    ):
+        user = await UserFactory.create(role=role)
+        response = await ResponseFactory.create(user=user)
 
+        resp = await async_client.delete(
+            f"/api/v1/responses/{response.id}", headers={API_KEY_HEADER_NAME: user.api_key}
+        )
 
-@pytest.mark.asyncio
-async def test_update_response_from_discarded_to_submitted_without_values(
-    async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
-):
-    response = await ResponseFactory.create(status="discarded")
-    response_json = {
-        "status": "submitted",
-    }
+        assert resp.status_code == 200
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
 
-    resp = await async_client.put(f"/api/v1/responses/{response.id}", headers=owner_auth_header, json=response_json)
+    async def test_delete_response_as_admin_for_different_user_response(
+        self, async_client: "AsyncClient", db: "AsyncSession"
+    ):
+        workspace = await WorkspaceFactory.create()
+        admin = await AdminFactory.create(workspaces=[workspace])
+        dataset = await DatasetFactory.create(workspace=workspace)
+        record = await RecordFactory.create(dataset=dataset)
+        response = await ResponseFactory.create(record=record)
 
-    assert resp.status_code == 422
+        resp = await async_client.delete(
+            f"/api/v1/responses/{response.id}", headers={API_KEY_HEADER_NAME: admin.api_key}
+        )
 
-    response = await db.get(Response, response.id)
-    assert response.values is None
-    assert response.status == ResponseStatus.discarded
+        assert resp.status_code == 200
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
 
+    async def test_delete_response_as_annotator_for_different_user_response(
+        self, async_client: "AsyncClient", db: "AsyncSession"
+    ):
+        annotator = await AnnotatorFactory.create()
+        response = await ResponseFactory.create()
 
-@pytest.mark.asyncio
-async def test_update_response_with_wrong_values(
-    async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
-):
-    response = await ResponseFactory.create(status="discarded")
-    response_json = {"status": "submitted", "values": {"wrong_question": {"value": "wrong value"}}}
+        resp = await async_client.delete(
+            f"/api/v1/responses/{response.id}", headers={API_KEY_HEADER_NAME: annotator.api_key}
+        )
 
-    resp = await async_client.put(f"/api/v1/responses/{response.id}", headers=owner_auth_header, json=response_json)
+        assert resp.status_code == 403
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 1
 
-    assert resp.status_code == 422
-    assert resp.json() == {"detail": "Error: found responses for non configured questions: ['wrong_question']"}
+    async def test_delete_response_with_nonexistent_response_id(
+        self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
+    ):
+        await ResponseFactory.create()
 
-    response = await db.get(Response, response.id)
-    assert response.values is None
-    assert response.status == ResponseStatus.discarded
+        resp = await async_client.delete(f"/api/v1/responses/{uuid4()}", headers=owner_auth_header)
 
-
-@pytest.mark.asyncio
-async def test_update_response_as_annotator(async_client: "AsyncClient", db: "AsyncSession"):
-    dataset = await DatasetFactory.create(status=DatasetStatus.ready)
-    await TextQuestionFactory.create(name="input_ok", dataset=dataset)
-    await TextQuestionFactory.create(name="output_ok", dataset=dataset)
-    record = await RecordFactory.create(dataset=dataset)
-    annotator = await AnnotatorFactory.create()
-
-    response = await ResponseFactory.create(
-        record=record,
-        values={
-            "input_ok": {"value": "no"},
-            "output_ok": {"value": "no"},
-        },
-        status="submitted",
-        user=annotator,
-    )
-    response_json = {
-        "values": {
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "yes"},
-        },
-        "status": "submitted",
-    }
-
-    resp = await async_client.put(
-        f"/api/v1/responses/{response.id}", headers={API_KEY_HEADER_NAME: annotator.api_key}, json=response_json
-    )
-
-    assert resp.status_code == 200
-    assert (await db.get(Response, response.id)).values == {
-        "input_ok": {"value": "yes"},
-        "output_ok": {"value": "yes"},
-    }
-
-    resp_body = resp.json()
-    assert resp_body == {
-        "id": str(response.id),
-        "values": {
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "yes"},
-        },
-        "status": "submitted",
-        "record_id": str(response.record_id),
-        "user_id": str(response.user_id),
-        "inserted_at": response.inserted_at.isoformat(),
-        "updated_at": datetime.fromisoformat(resp_body["updated_at"]).isoformat(),
-    }
-
-
-@pytest.mark.asyncio
-async def test_update_response_as_annotator_for_different_user_response(
-    async_client: "AsyncClient", db: "AsyncSession"
-):
-    annotator = await AnnotatorFactory.create()
-    response = await ResponseFactory.create(
-        values={
-            "input_ok": {"value": "no"},
-            "output_ok": {"value": "no"},
-        },
-        status="submitted",
-    )
-    response_json = {
-        "values": {
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "yes"},
-        },
-        "status": "submitted",
-    }
-
-    resp = await async_client.put(
-        f"/api/v1/responses/{response.id}", headers={API_KEY_HEADER_NAME: annotator.api_key}, json=response_json
-    )
-
-    assert resp.status_code == 403
-    assert (await db.get(Response, response.id)).values == {
-        "input_ok": {"value": "no"},
-        "output_ok": {"value": "no"},
-    }
-
-
-@pytest.mark.asyncio
-async def test_update_response_with_nonexistent_response_id(
-    async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
-):
-    response = await ResponseFactory.create(
-        values={
-            "input_ok": {"value": "no"},
-            "output_ok": {"value": "no"},
-        },
-        status="submitted",
-    )
-    response_json = {
-        "values": {
-            "input_ok": {"value": "yes"},
-            "output_ok": {"value": "yes"},
-        },
-        "status": "submitted",
-    }
-
-    resp = await async_client.put(f"/api/v1/responses/{uuid4()}", headers=owner_auth_header, json=response_json)
-
-    assert resp.status_code == 404
-    assert (await db.get(Response, response.id)).values == {
-        "input_ok": {"value": "no"},
-        "output_ok": {"value": "no"},
-    }
-
-
-@pytest.mark.asyncio
-async def test_delete_response(
-    async_client: "AsyncClient", mock_search_engine: SearchEngine, db: "AsyncSession", owner_auth_header: dict
-):
-    response = await ResponseFactory.create()
-
-    resp = await async_client.delete(f"/api/v1/responses/{response.id}", headers=owner_auth_header)
-
-    assert resp.status_code == 200
-    assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
-
-    mock_search_engine.delete_record_response.assert_called_once_with(response)
-
-
-@pytest.mark.asyncio
-async def test_delete_response_without_authentication(async_client: "AsyncClient", db: "AsyncSession"):
-    response = await ResponseFactory.create()
-
-    resp = await async_client.delete(f"/api/v1/responses/{response.id}")
-
-    assert resp.status_code == 401
-    assert (await db.execute(select(func.count(Response.id)))).scalar() == 1
-
-
-@pytest.mark.parametrize("role", [UserRole.admin, UserRole.annotator])
-@pytest.mark.asyncio
-async def test_delete_response_as_restricted_user(async_client: "AsyncClient", db: "AsyncSession", role: UserRole):
-    user = await UserFactory.create(role=role)
-    response = await ResponseFactory.create(user=user)
-
-    resp = await async_client.delete(f"/api/v1/responses/{response.id}", headers={API_KEY_HEADER_NAME: user.api_key})
-
-    assert resp.status_code == 200
-    assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
-
-
-@pytest.mark.asyncio
-async def test_delete_response_as_admin_for_different_user_response(async_client: "AsyncClient", db: "AsyncSession"):
-    workspace = await WorkspaceFactory.create()
-    admin = await AdminFactory.create(workspaces=[workspace])
-    dataset = await DatasetFactory.create(workspace=workspace)
-    record = await RecordFactory.create(dataset=dataset)
-    response = await ResponseFactory.create(record=record)
-
-    resp = await async_client.delete(f"/api/v1/responses/{response.id}", headers={API_KEY_HEADER_NAME: admin.api_key})
-
-    assert resp.status_code == 200
-    assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
-
-
-@pytest.mark.asyncio
-async def test_delete_response_as_annotator_for_different_user_response(
-    async_client: "AsyncClient", db: "AsyncSession"
-):
-    annotator = await AnnotatorFactory.create()
-    response = await ResponseFactory.create()
-
-    resp = await async_client.delete(
-        f"/api/v1/responses/{response.id}", headers={API_KEY_HEADER_NAME: annotator.api_key}
-    )
-
-    assert resp.status_code == 403
-    assert (await db.execute(select(func.count(Response.id)))).scalar() == 1
-
-
-@pytest.mark.asyncio
-async def test_delete_response_with_nonexistent_response_id(
-    async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
-):
-    await ResponseFactory.create()
-
-    resp = await async_client.delete(f"/api/v1/responses/{uuid4()}", headers=owner_auth_header)
-
-    assert resp.status_code == 404
-    assert (await db.execute(select(func.count(Response.id)))).scalar() == 1
+        assert resp.status_code == 404
+        assert (await db.execute(select(func.count(Response.id)))).scalar() == 1


### PR DESCRIPTION
# Description

This PR fix an issue in which the server returned a `422` when trying to update the response of a record with `draft` status.

In addition, this PR updates `check_response` method used to validate the responses received for a question to also received the `status` of the response. This allows to execute partial validations of the responses depending on the received status. For example, for the `RankingQuestion` we only want to validate that all the possible options have been ranked if the status is `submitted`, otherwise, we just want to validate that the options that have been ranked are valid:

Closes #3612

**Type of change**

- [x] New feature
- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

In a local development environment:

- [x] Record response can be updated with `draft` status

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
