### PR TITLE
fix: `RatingQuestion.values` validation when values out of range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,6 @@ These are the section headers that we use:
 - Updated `RemoteFeedbackDataset.delete_records` to use batch delete records endpoint ([#3580](https://github.com/argilla-io/argilla/pull/3580)).
 - Included `allowed_for_roles` for some `RemoteFeedbackDataset`, `RemoteFeedbackRecords`, and `RemoteFeedbackRecord` methods that are only allowed for users with roles `owner` and `admin` ([#3601](https://github.com/argilla-io/argilla/pull/3601)).
 - Renamed `ArgillaToFromMixin` to `ArgillaMixin` ([#3619](https://github.com/argilla-io/argilla/pull/3619)).
-
-### Changed
-
 - Move `users` CLI app under `database` CLI app ([#3593](https://github.com/argilla-io/argilla/pull/3593)).
 - Move server `Enum` classes to `argilla.server.enums` module ([#3620](https://github.com/argilla-io/argilla/pull/3620)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ These are the section headers that we use:
 - Move `users` CLI app under `database` CLI app ([#3593](https://github.com/argilla-io/argilla/pull/3593)).
 - Move server `Enum` classes to `argilla.server.enums` module ([#3620](https://github.com/argilla-io/argilla/pull/3620)).
 
+### Fixed
+
+- Fixed `RatingQuestion.values` validation to raise a `ValidationError` when values are out of range i.e. [1, 10] ([#3626](https://github.com/argilla-io/argilla/pull/3626)).
+
 ## [1.14.1](https://github.com/argilla-io/argilla/compare/v1.14.0...v1.14.1)
 
 ### Fixed

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -109,26 +109,7 @@ class RatingQuestion(QuestionSchema, LabelMappingMixin):
     """
 
     type: Literal["rating"] = Field("rating", allow_mutation=False)
-    values: List[int] = Field(unique_items=True, min_items=2)
-
-    @validator("values")
-    def check_values(cls, values: List[int]):
-        if len(values) > 10:
-            warnings.warn(
-                "`values` list contains more than 10 elements, which is not supported from Argilla 1.14.0 onwards. "
-                "Please, make sure `values` is a list with more than 1 element and less or equal than 10 "
-                "before pushing the dataset into Argilla. Otherwise, the `push_to_argilla` method will fail",
-            )
-        for value in values:
-            if not 1 <= value <= 10:
-                warnings.warn(
-                    "At least one `value` in `values` is out of range [1, 10], "
-                    "which is not supported from Argilla 1.14.0 onwards. "
-                    "Please, make sure `values` is a list with unique values within the range [1, 10] "
-                    "before pushing the dataset into Argilla. Otherwise, the `push_to_argilla` method will fail. ",
-                )
-                break
-        return values
+    values: List[int] = Field(..., unique_items=True, ge=1, le=10, min_items=2)
 
     @root_validator(skip_on_failure=True)
     def update_settings(cls, values: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/unit/client/feedback/schemas/test_questions.py
+++ b/tests/unit/client/feedback/schemas/test_questions.py
@@ -232,6 +232,16 @@ def test_text_question(schema_kwargs: Dict[str, Any], expected_settings: Dict[st
             ValidationError,
             "ensure this value has at least 2 items",
         ),
+        (
+            {"name": "a", "description": "a", "required": True, "values": [0, 1]},
+            ValidationError,
+            "ensure this value is greater than or equal to 1",
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "values": [1, 11]},
+            ValidationError,
+            "ensure this value is less than or equal to 10",
+        ),
     ],
 )
 def test_rating_question_errors(

--- a/tests/unit/client/feedback/schemas/test_questions.py
+++ b/tests/unit/client/feedback/schemas/test_questions.py
@@ -252,30 +252,6 @@ def test_rating_question_errors(
 
 
 @pytest.mark.parametrize(
-    ("schema_kwargs", "expected_warning_message"),
-    [
-        (
-            {"name": "a", "description": "a", "required": True, "values": list(range(1, 12))},
-            r"\`values\` list contains more than 10 elements, which is not supported from Argilla 1.14.0 onwards",
-        ),
-        (
-            {"name": "a", "description": "a", "required": True, "values": [0, 1, 2]},
-            r"At least one \`value\` in \`values\` is out of range \[1, 10\], "
-            r"which is not supported from Argilla 1.14.0 onwards",
-        ),
-        (
-            {"name": "a", "description": "a", "required": True, "values": [10, 11]},
-            r"At least one \`value\` in \`values\` is out of range \[1, 10\], "
-            r"which is not supported from Argilla 1.14.0 onwards",
-        ),
-    ],
-)
-def test_rating_question_warnings(schema_kwargs: Dict[str, Any], expected_warning_message: str) -> None:
-    with pytest.warns(UserWarning, match=expected_warning_message):
-        RatingQuestion(**schema_kwargs)
-
-
-@pytest.mark.parametrize(
     "schema_kwargs, expected_settings",
     [
         (


### PR DESCRIPTION
# Description

This PR fixes a bug identified by @dvsrepo, introduced at https://github.com/argilla-io/argilla/pull/3452, since we were just showing a `warnings.warn` message announcing the `DeprecationWarning`, but no version was scoped and the `RatingQuestion` was not valid on the Argilla Server side either, so the `warnings.warn` should have been a `ValidationError` instead.

So on, this PR fixes that and replaces the custom `validator` with `Field` to rely on `pydantic`'s validation for it.

Closes #3624 

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

- [X] Add unit tests for `RatingQuestion` out of range values

**Checklist**

- [X] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [X] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)