### PR TITLE
feat: add `rg.list_datasets` for API v0 datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ These are the section headers that we use:
 - Added `DELETE /api/v1/records/{record_id}/suggestions` endpoint to delete several suggestions linked to the same record given their IDs ([#3617](https://github.com/argilla-io/argilla/pull/3617)).
 - Added `response_status` param to `GET /api/v1/datasets/{dataset_id}/records` to be able to filter by `response_status` as previously included for `GET /api/v1/me/datasets/{dataset_id}/records` ([#3613](https://github.com/argilla-io/argilla/pull/3613)).
 - Added `list` classmethod to `ArgillaMixin` to be used as `FeedbackDataset.list()`, also including the `workspace` to list from as arg ([#3619](https://github.com/argilla-io/argilla/pull/3619)).
+- Added `list_datasets` function (to be used as `rg.list_datasets`) to list the `TextClassification`, `TokenClassification`, and `Text2Text` datasets in Argilla ([#3638](https://github.com/argilla-io/argilla/pull/3638)).
 
 ### Changed
 

--- a/src/argilla/__init__.py
+++ b/src/argilla/__init__.py
@@ -44,6 +44,7 @@ if _TYPE_CHECKING:
         delete_records,
         get_workspace,
         init,
+        list_datasets,
         load,
         log,
         log_async,
@@ -118,6 +119,7 @@ _import_structure = {
         "log_async",
         "set_workspace",
         "active_client",
+        "list_datasets",
     ],
     "client.models": [
         "Text2TextRecord",

--- a/src/argilla/client/api.py
+++ b/src/argilla/client/api.py
@@ -12,8 +12,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
 import asyncio
-import logging
 import warnings
 from asyncio import Future
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
@@ -22,6 +22,7 @@ from argilla.client.client import Argilla
 from argilla.client.datasets import Dataset
 from argilla.client.models import BulkResponse, Record  # TODO Remove TextGenerationRecord
 from argilla.client.sdk.commons import errors
+from argilla.client.sdk.datasets.models import Dataset as DatasetModel
 from argilla.client.sdk.v1.datasets.api import list_datasets as list_datasets_api_v1
 from argilla.client.sdk.workspaces.api import list_workspaces as list_workspaces_api_v0
 
@@ -434,6 +435,22 @@ def get_workspace() -> str:
         The name of the active workspace as a string.
     """
     return ArgillaSingleton.get().get_workspace()
+
+
+def list_datasets(workspace: Optional[str] = None) -> List[DatasetModel]:
+    """Lists all the available datasets for the current user in Argilla.
+
+    Args:
+        workspace: If provided, list datasets from that workspace only. Note that
+            the workspace must exist in advance, otherwise a HTTP 400 error will be
+            raised.
+
+    Returns:
+        A list of `DatasetModel` objects, containing the dataset
+        attributes: tags, metadata, name, id, task, owner, workspace, created_at,
+        and last_updated.
+    """
+    return ArgillaSingleton.get().list_datasets(workspace=workspace)
 
 
 def active_client() -> Argilla:

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 import logging
 import os
 import re
@@ -56,6 +55,7 @@ from argilla.client.sdk.commons.api import bulk
 from argilla.client.sdk.commons.errors import AlreadyExistsApiError, InputValueError, NotFoundApiError
 from argilla.client.sdk.datasets import api as datasets_api
 from argilla.client.sdk.datasets.models import CopyDatasetRequest, TaskType
+from argilla.client.sdk.datasets.models import Dataset as DatasetModel
 from argilla.client.sdk.metrics import api as metrics_api
 from argilla.client.sdk.metrics.models import MetricInfo
 from argilla.client.sdk.text2text.models import CreationText2TextRecord, Text2TextBulkData
@@ -262,6 +262,21 @@ class Argilla:
         user_workspaces = users_api.whoami(self.http_client).workspaces
         all_workspaces = workspaces_api.list_workspaces(client=self.http_client.httpx).parsed
         return [workspace for workspace in all_workspaces if workspace.name in user_workspaces]
+
+    def list_datasets(self, workspace: Optional[str] = None) -> List[DatasetModel]:
+        """Lists all the available datasets for the current user in Argilla.
+
+        Args:
+            workspace: If provided, list datasets from that workspace only. Note that
+                the workspace must exist in advance, otherwise a HTTP 400 error will be
+                raised.
+
+        Returns:
+            A list of `DatasetModel` objects, containing the dataset
+            attributes: tags, metadata, name, id, task, owner, workspace, created_at,
+            and last_updated.
+        """
+        return datasets_api.list_datasets(client=self.http_client, workspace=workspace).parsed
 
     def copy(self, dataset: str, name_of_copy: str, workspace: str = None):
         """Creates a copy of a dataset including its tags and metadata

--- a/src/argilla/client/sdk/datasets/api.py
+++ b/src/argilla/client/sdk/datasets/api.py
@@ -25,7 +25,7 @@ from argilla.client.sdk.datasets.models import CopyDatasetRequest, Dataset
 
 
 @lru_cache(maxsize=None)
-def get_dataset(client: AuthenticatedClient, name: str) -> Response[Dataset]:
+def get_dataset(client: AuthenticatedClient, name: str) -> Response[Union[Dataset, ErrorMessage, HTTPValidationError]]:
     url = f"{client.base_url}/api/datasets/{name}"
 
     response = httpx.get(
@@ -42,7 +42,9 @@ def get_dataset(client: AuthenticatedClient, name: str) -> Response[Dataset]:
     return handle_response_error(response)
 
 
-def list_datasets(client: AuthenticatedClient, workspace: Optional[str] = None) -> Response[List[Dataset]]:
+def list_datasets(
+    client: AuthenticatedClient, workspace: Optional[str] = None
+) -> Response[Union[List[Dataset], ErrorMessage, HTTPValidationError]]:
     url = f"{client.base_url}/api/datasets"
 
     response = httpx.get(
@@ -60,7 +62,9 @@ def list_datasets(client: AuthenticatedClient, workspace: Optional[str] = None) 
     return handle_response_error(response)
 
 
-def copy_dataset(client: AuthenticatedClient, name: str, json_body: CopyDatasetRequest) -> Response[Dataset]:
+def copy_dataset(
+    client: AuthenticatedClient, name: str, json_body: CopyDatasetRequest
+) -> Response[Union[Dataset, ErrorMessage, HTTPValidationError]]:
     url = f"{client.base_url}/api/datasets/{name}:copy"
 
     response = httpx.put(
@@ -78,8 +82,8 @@ def copy_dataset(client: AuthenticatedClient, name: str, json_body: CopyDatasetR
     return handle_response_error(response)
 
 
-def delete_dataset(client: AuthenticatedClient, name: str) -> httpx.Response:
-    url = "{}/api/datasets/{name}".format(client.base_url, name=name)
+def delete_dataset(client: AuthenticatedClient, name: str) -> Response[Union[ErrorMessage, HTTPValidationError]]:
+    url = f"{client.base_url}/api/datasets/{name}"
 
     response = httpx.delete(
         url=url,

--- a/src/argilla/client/sdk/datasets/api.py
+++ b/src/argilla/client/sdk/datasets/api.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 
 from functools import lru_cache
-from typing import Union
+from typing import List, Optional, Union
 
 import httpx
 
@@ -36,6 +36,28 @@ def get_dataset(client: AuthenticatedClient, name: str) -> Response[Dataset]:
     )
 
     return _build_response(response=response, name=name)
+
+
+def list_datasets(client: AuthenticatedClient, workspace: Optional[str] = None) -> Response[List[Dataset]]:
+    url = "{}/api/datasets".format(client.base_url)
+
+    response = httpx.get(
+        url=url,
+        params={"workspace": workspace} if workspace else None,
+        headers=client.get_headers(),
+        cookies=client.get_cookies(),
+        timeout=client.get_timeout(),
+    )
+
+    if response.status_code == 200:
+        parsed_response = [Dataset(**dataset) for dataset in response.json()]
+        return Response(
+            status_code=response.status_code,
+            content=response.content,
+            headers=response.headers,
+            parsed=parsed_response,
+        )
+    return handle_response_error(response)
 
 
 def copy_dataset(client: AuthenticatedClient, name: str, json_body: CopyDatasetRequest) -> Response[Dataset]:

--- a/src/argilla/client/sdk/datasets/api.py
+++ b/src/argilla/client/sdk/datasets/api.py
@@ -18,6 +18,7 @@ from typing import List, Optional, Union
 
 import httpx
 
+from argilla._constants import WORKSPACE_HEADER_NAME
 from argilla.client.sdk.client import AuthenticatedClient
 from argilla.client.sdk.commons.errors_handler import handle_response_error
 from argilla.client.sdk.commons.models import ErrorMessage, HTTPValidationError, Response
@@ -47,10 +48,13 @@ def list_datasets(
 ) -> Response[Union[List[Dataset], ErrorMessage, HTTPValidationError]]:
     url = f"{client.base_url}/api/datasets"
 
+    headers = client.get_headers().copy()
+    headers.pop(WORKSPACE_HEADER_NAME, None)
+
     response = httpx.get(
         url=url,
         params={"workspace": workspace} if workspace else None,
-        headers=client.get_headers(),
+        headers=headers,
         cookies=client.get_cookies(),
         timeout=client.get_timeout(),
     )

--- a/src/argilla/client/sdk/datasets/api.py
+++ b/src/argilla/client/sdk/datasets/api.py
@@ -21,12 +21,12 @@ import httpx
 from argilla._constants import WORKSPACE_HEADER_NAME
 from argilla.client.sdk.client import AuthenticatedClient
 from argilla.client.sdk.commons.errors_handler import handle_response_error
-from argilla.client.sdk.commons.models import ErrorMessage, HTTPValidationError, Response
+from argilla.client.sdk.commons.models import Response
 from argilla.client.sdk.datasets.models import CopyDatasetRequest, Dataset
 
 
 @lru_cache(maxsize=None)
-def get_dataset(client: AuthenticatedClient, name: str) -> Response[Union[Dataset, ErrorMessage, HTTPValidationError]]:
+def get_dataset(client: AuthenticatedClient, name: str) -> Response[Dataset]:
     url = f"{client.base_url}/api/datasets/{name}"
 
     response = httpx.get(
@@ -40,12 +40,10 @@ def get_dataset(client: AuthenticatedClient, name: str) -> Response[Union[Datase
         response_obj = Response.from_httpx_response(response)
         response_obj.parsed = Dataset(**response.json())
         return response_obj
-    return handle_response_error(response)
+    handle_response_error(response)
 
 
-def list_datasets(
-    client: AuthenticatedClient, workspace: Optional[str] = None
-) -> Response[Union[List[Dataset], ErrorMessage, HTTPValidationError]]:
+def list_datasets(client: AuthenticatedClient, workspace: Optional[str] = None) -> Response[List[Dataset]]:
     url = f"{client.base_url}/api/datasets"
 
     headers = client.get_headers().copy()
@@ -63,12 +61,10 @@ def list_datasets(
         response_obj = Response.from_httpx_response(response)
         response_obj.parsed = [Dataset(**dataset) for dataset in response.json()]
         return response_obj
-    return handle_response_error(response)
+    handle_response_error(response)
 
 
-def copy_dataset(
-    client: AuthenticatedClient, name: str, json_body: CopyDatasetRequest
-) -> Response[Union[Dataset, ErrorMessage, HTTPValidationError]]:
+def copy_dataset(client: AuthenticatedClient, name: str, json_body: CopyDatasetRequest) -> Response[Dataset]:
     url = f"{client.base_url}/api/datasets/{name}:copy"
 
     response = httpx.put(
@@ -83,10 +79,10 @@ def copy_dataset(
         response_obj = Response.from_httpx_response(response)
         response_obj.parsed = Dataset(**response.json())
         return response_obj
-    return handle_response_error(response)
+    handle_response_error(response)
 
 
-def delete_dataset(client: AuthenticatedClient, name: str) -> Response[Union[ErrorMessage, HTTPValidationError]]:
+def delete_dataset(client: AuthenticatedClient, name: str) -> Response:
     url = f"{client.base_url}/api/datasets/{name}"
 
     response = httpx.delete(
@@ -104,4 +100,4 @@ def delete_dataset(client: AuthenticatedClient, name: str) -> Response[Union[Err
             headers=response.headers,
             parsed=response.json(),
         )
-    return handle_response_error(response, dataset=name)
+    handle_response_error(response, dataset=name)

--- a/tests/database.py
+++ b/tests/database.py
@@ -16,7 +16,7 @@ import asyncio
 from typing import Union
 
 from sqlalchemy import orm
-from sqlalchemy.ext.asyncio import AsyncSession, async_scoped_session, async_sessionmaker
+from sqlalchemy.ext.asyncio import async_scoped_session, async_sessionmaker
 
 task: Union[asyncio.Task, None] = None
 


### PR DESCRIPTION
# Description

This PR adds the `list_datasets` method via `import argilla as rg; rg.list_datasets` to list the `TextClassification`, `TokenClassification`, and `Text2Text` datasets via calling the endpoint `GET /api/datasets` in the API v0.

Closes #3250 

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [X] Add integration tests for `list_datasets` in the Python SDK

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [X] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)