### PR TITLE
fix: remove `TaskType.multi_task_text_token_classification`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ These are the section headers that we use:
 
 - Fixed `RatingQuestion.values` validation to raise a `ValidationError` when values are out of range i.e. [1, 10] ([#3626](https://github.com/argilla-io/argilla/pull/3626)).
 
+### Removed
+
+- Remove `multi_task_text_token_classification` from `TaskType` as not used ([#3640](https://github.com/argilla-io/argilla/pull/3640)).
+
 ## [1.14.1](https://github.com/argilla-io/argilla/compare/v1.14.0...v1.14.1)
 
 ### Fixed

--- a/src/argilla/client/sdk/datasets/models.py
+++ b/src/argilla/client/sdk/datasets/models.py
@@ -24,7 +24,6 @@ class TaskType(str, Enum):
     text_classification = "TextClassification"
     token_classification = "TokenClassification"
     text2text = "Text2Text"
-    multi_task_text_token_classification = "MultitaskTextTokenClassification"
 
     @classmethod
     def _missing_(cls, value):

--- a/src/argilla/server/commons/models.py
+++ b/src/argilla/server/commons/models.py
@@ -26,7 +26,6 @@ class TaskType(str, Enum):
     text_classification = "TextClassification"
     token_classification = "TokenClassification"
     text2text = "Text2Text"
-    multi_task_text_token_classification = "MultitaskTextTokenClassification"
 
 
 class PredictionStatus(str, Enum):


### PR DESCRIPTION
# Description

This PR removes the `multi_task_text_token_classification` from the `TaskType` enum from both the client and the server, as it's unused, and can lead to confusion.

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

- [X] No need to, as `TaskType.multi_task_text_token_classification` was not being covered by tests

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)