### PR TITLE
fix: PR number couldn't get extracted from `GITHUB_REF` when PR merged

### DIFF
--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -28,13 +28,9 @@ jobs:
         with:
           version: '>= 435.0.0'
 
-      - name: Get Docker image tag from GITHUB_REF
-        id: docker-image-tag-from-ref
-        uses: ./.github/actions/docker-image-tag-from-ref
-
       - name: Remove PR environment if exists
         run: |
-          service_name="argilla-quickstart-${{ steps.docker-image-tag-from-ref.outputs.docker-image-tag }}"
+          service_name="argilla-quickstart-pr-${{ github.event.pull_request.number }}"
           services=$(gcloud run services list --project=argilla-ci --format="value(metadata.name)")
           if echo "$services" | grep -q "$service_name"; then
             echo "Service '$service_name' exists. Removing it..."


### PR DESCRIPTION
# Description

This PR fixes the close pull request workflow that was failing because the value of the environment variable `GITHUB_REF` that it's supposed to have the following format `refs/pull/:prNumber/merge` (as documented [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request)) has the name of the target branch instead. Apparently, it's a GitHub bug that remains unfixed: https://github.com/actions/runner/issues/256

Instead of trying to get the PR number from the `GITHUB_REF`, this PR uses the `github.event.pull_request.number` variable.

Closes #3647

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

Opening a new dummy PR: https://github.com/argilla-io/argilla/pull/3650

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
