### PR TITLE
tests: Mock init properly

### DIFF
--- a/tests/integration/client/test_api.py
+++ b/tests/integration/client/test_api.py
@@ -66,7 +66,7 @@ from argilla.client.sdk.commons.errors import (
 from argilla.client.sdk.datasets.models import TaskType
 from argilla.client.sdk.users import api as users_api
 from argilla.client.sdk.users.models import UserModel
-from argilla.client.sdk.workspaces import api as workspaces_api
+from argilla.client.sdk.v1.workspaces import api as workspaces_api_v1
 from argilla.client.sdk.workspaces.models import WorkspaceModel
 from argilla.server.apis.v0.models.text_classification import (
     TextClassificationBulkRequest,
@@ -175,7 +175,7 @@ def mock_init_ok(monkeypatch):
 
     monkeypatch.setattr(Status, "get_info", mock_get_info)
     monkeypatch.setattr(users_api, "whoami", mock_whoami)
-    monkeypatch.setattr(workspaces_api, "list_workspaces", mock_list_workspaces)
+    monkeypatch.setattr(workspaces_api_v1, "list_workspaces_me", mock_list_workspaces)
 
 
 @pytest.fixture


### PR DESCRIPTION
# Argilla Community Growers

Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged.

# Pull Request Templates

Please go the the `Preview` tab and select the appropriate sub-template:

* [🐞-bug](?expand=1&template=bug.md)
* [📚-documentation](?expand=1&template=docs.md)
* [🆕-features](?expand=1&template=features.md)
* [🔗-💥-integration](?expand=1&template=integration.md)

# Generic Pull Request Template

Since changes introduced in https://github.com/argilla-io/argilla/commit/347dd9c216cd6f586f5566374bf79d6cb15f8326, some tests using a mocked version for the `rg.init` function are outdated. This PR updates them and fixes the pipeline execution. 


