### PR TITLE
fix: `.`s were replaced by `-` in Dockerimage tag

### DIFF
--- a/.github/actions/docker-image-tag-from-ref/app/main.py
+++ b/.github/actions/docker-image-tag-from-ref/app/main.py
@@ -42,7 +42,7 @@ def get_tag_name() -> Union[str, None]:
 
 
 def clean_branch_name(branch_name: str) -> str:
-    return re.sub(r"[^A-Za-z0-9]", "-", branch_name)
+    return re.sub(r"[^A-Za-z0-9\.]", "-", branch_name)
 
 
 def get_docker_image_tag_from_reg() -> str:


### PR DESCRIPTION
# Description

Fix replacing `.` by `-` when generating a tag for the Dockerimage using the branch name from `GITHUB_REF` environment variable.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**


**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
