### PR TITLE
chore: deprecation lifecycle before 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,11 @@ These are the section headers that we use:
 
 ### Removed
 
-- Remove `multi_task_text_token_classification` from `TaskType` as not used ([#3640](https://github.com/argilla-io/argilla/pull/3640)).
+- Removed `multi_task_text_token_classification` from `TaskType` as not used ([#3640](https://github.com/argilla-io/argilla/pull/3640)).
+- Removed `argilla_id` in favor of `id` from `RemoteFeedbackDataset` ([#3663](https://github.com/argilla-io/argilla/pull/3663)).
+- Removed `fetch_records` from `RemoteFeedbackDataset` as now the records are lazily fetched from Argilla ([#3663](https://github.com/argilla-io/argilla/pull/3663)).
+- Removed `push_to_argilla` from `RemoteFeedbackDataset`, as it just works when calling it through a `FeedbackDataset` locally, as now the updates of the remote datasets are automatically pushed to Argilla ([#3663](https://github.com/argilla-io/argilla/pull/3663)).
+- Removed `set_suggestions` in favor of `update(suggestions=...)` for both `FeedbackRecord` and `RemoteFeedbackRecord`, as all the updates of any "updateable" attribute of a record will go through `update` instead ([#3663](https://github.com/argilla-io/argilla/pull/3663)).
 
 ## [1.14.1](https://github.com/argilla-io/argilla/compare/v1.14.0...v1.14.1)
 

--- a/src/argilla/client/feedback/dataset/base.py
+++ b/src/argilla/client/feedback/dataset/base.py
@@ -318,8 +318,7 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin):
         test_size: Optional[float] = None,
         seed: Optional[int] = None,
         lang: Optional[str] = None,
-        fetch_records: Optional[bool] = None,
-    ):
+    ) -> Any:
         """
         Prepares the dataset for training for a specific training framework and NLP task by splitting the dataset into train and test sets.
 
@@ -332,18 +331,7 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin):
             test_size: the size of the test set. If `None`, the whole dataset will be used for testing.
             seed: the seed to use for splitting the dataset into train and test sets.
             lang: the spaCy language to use for training. If `None`, the language of the dataset will be used.
-            fetch_records: whether to fetch the records from Argilla or use the local records instead. If `None`, use local.
         """
-        if fetch_records is not None:
-            warnings.warn(
-                "`fetch_records` is deprecated and will be removed in a future version."
-                " `records` will be fetched automatically from Argilla, if the dataset"
-                " is not in Argilla, then the local records will be used instead.\n`fetch_records`"
-                " will be deprecated in Argilla v1.15.0.",
-                DeprecationWarning,
-                stacklevel=1,
-            )
-
         if isinstance(framework, str):
             framework = Framework(framework)
 

--- a/src/argilla/client/feedback/dataset/local.py
+++ b/src/argilla/client/feedback/dataset/local.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import warnings
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
 
 from argilla.client.feedback.constants import FETCHING_BATCH_SIZE
@@ -22,9 +21,6 @@ from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQues
 
 if TYPE_CHECKING:
     from argilla.client.feedback.schemas import FeedbackRecord
-
-
-warnings.simplefilter("always", DeprecationWarning)
 
 
 class FeedbackDataset(FeedbackDatasetBase, ArgillaMixin):
@@ -129,31 +125,6 @@ class FeedbackDataset(FeedbackDatasetBase, ArgillaMixin):
         """
         for i in range(0, len(self._records), batch_size):
             yield self._records[i : i + batch_size]
-
-    def fetch_records(self) -> None:
-        warnings.warn(
-            "As the current `FeedbackDataset` is stored locally and not pushed to Argilla,"
-            " the method `fetch_records` won't do anything. If you want to fetch the records"
-            " from Argilla, make sure you're using an `RemoteFeedbackDataset`, either by"
-            " calling `FeedbackDataset.from_argilla` or by keeping the returned value from"
-            " `FeedbackDataset.push_to_argilla`.\n`fetch_records` will be deprecated in"
-            " Argilla v1.15.0.",
-            DeprecationWarning,
-            stacklevel=1,
-        )
-
-    @property
-    def argilla_id(self) -> None:
-        warnings.warn(
-            "As the current `FeedbackDataset` is stored locally, `argilla_id` won't"
-            " return anything as it's not pushed to Argilla. If you want to get the id"
-            " of a dataset in Argilla, make sure you're using an `RemoteFeedbackDataset`,"
-            " either by calling `FeedbackDataset.from_argilla` or by keeping the returned"
-            " value from `FeedbackDataset.push_to_argilla`.\n`argilla_id` will be deprecated in"
-            " Argilla v1.15.0.",
-            DeprecationWarning,
-            stacklevel=1,
-        )
 
     def add_records(
         self,

--- a/src/argilla/client/feedback/dataset/mixins.py
+++ b/src/argilla/client/feedback/dataset/mixins.py
@@ -124,7 +124,7 @@ class ArgillaMixin:
         name: str,
         workspace: Optional[Union[str, Workspace]] = None,
         show_progress: bool = False,
-    ) -> Optional[RemoteFeedbackDataset]:
+    ) -> RemoteFeedbackDataset:
         """Pushes the `FeedbackDataset` to Argilla.
 
         Note that you may need to `rg.init(...)` with your Argilla credentials before calling this function, otherwise

--- a/src/argilla/client/feedback/dataset/mixins.py
+++ b/src/argilla/client/feedback/dataset/mixins.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import warnings
 from typing import TYPE_CHECKING, Dict, List, Optional, Type, Union
 from uuid import UUID
 
@@ -41,8 +40,6 @@ if TYPE_CHECKING:
     from argilla.client.feedback.dataset.local import FeedbackDataset
     from argilla.client.feedback.schemas.types import AllowedFieldTypes
     from argilla.client.sdk.v1.datasets.models import FeedbackDatasetModel
-
-warnings.simplefilter("always", DeprecationWarning)
 
 
 class ArgillaMixin:
@@ -124,7 +121,7 @@ class ArgillaMixin:
 
     def push_to_argilla(
         self: "FeedbackDataset",
-        name: Optional[str] = None,
+        name: str,
         workspace: Optional[Union[str, Workspace]] = None,
         show_progress: bool = False,
     ) -> Optional[RemoteFeedbackDataset]:
@@ -143,22 +140,6 @@ class ArgillaMixin:
         """
         client: "ArgillaClient" = ArgillaSingleton.get()
         httpx_client: "httpx.Client" = client.http_client.httpx
-
-        if name is None:
-            warnings.warn(
-                "`push_to_argilla` will no longer be used to push changes to an existing"
-                " `FeedbackDataset` in Argilla, but to create a new one instead. So on,"
-                " please use `push_to_argilla` with the `name` argument and the `workspace`"
-                " if applicable. If you want to update an existing `FeedbackDataset` in"
-                " Argilla, you will need to either keep the returned dataset from the"
-                " `push_to_argilla` call and the functions will automatically call Argilla"
-                " or just call this function and then `from_argilla` to retrieve the"
-                " `FeedbackDataset` from Argilla.\n`push_to_argilla` with no arguments will"
-                " be deprecated in Argilla v1.15.0.",
-                DeprecationWarning,
-                stacklevel=1,
-            )
-            return
 
         if workspace is None:
             workspace = Workspace.from_name(client.get_workspace())
@@ -190,18 +171,6 @@ class ArgillaMixin:
 
         self.__push_records(
             client=httpx_client, id=argilla_id, show_progress=show_progress, question_mapping=question_name2id
-        )
-
-        warnings.warn(
-            "Calling `push_to_argilla` no longer implies that the `FeedbackDataset` can"
-            " be updated in Argilla. If you want to push a `FeedbackDataset` and then"
-            " update it in Argilla, you need to catch the returned object and use it"
-            " instead: `remote_ds = ds.push_to_argilla(...)`. Otherwise, you can just"
-            " call `push_to_argilla` and then `from_argilla` to retrieve the"
-            " `FeedbackDataset` from Argilla, so the current `FeedbackDataset` can be"
-            f" retrieved as `FeedbackDataset.from_argilla(id='{argilla_id}')`.",
-            DeprecationWarning,
-            stacklevel=1,
         )
 
         return RemoteFeedbackDataset(
@@ -269,7 +238,6 @@ class ArgillaMixin:
         *,
         workspace: Optional[str] = None,
         id: Optional[str] = None,
-        with_records: Optional[bool] = None,  # TODO(alvarobartt): deprecate `with_records`
     ) -> RemoteFeedbackDataset:
         """Retrieves an existing `FeedbackDataset` from Argilla (must have been pushed in advance).
 
@@ -281,8 +249,6 @@ class ArgillaMixin:
             workspace: the workspace of the `FeedbackDataset` to retrieve from Argilla.
                 If not provided, the active workspace will be used.
             id: the ID of the `FeedbackDataset` to retrieve from Argilla. Defaults to `None`.
-            with_records: whether to retrieve the records of the `FeedbackDataset` from
-                Argilla. Defaults to `None`.
 
         Returns:
             The `RemoteFeedbackDataset` retrieved from Argilla.
@@ -295,17 +261,6 @@ class ArgillaMixin:
             >>> rg.init(...)
             >>> dataset = rg.FeedbackDataset.from_argilla(name="my_dataset")
         """
-        if with_records is not None:
-            warnings.warn(
-                "`with_records` will no longer be used to retrieve the records of a"
-                " `FeedbackDataset` from Argilla, as by default no records will be"
-                " fetched from Argilla. To retrieve the records you will need to explicitly"
-                " fetch those via `fetch_records` from the returned `RemoteFeedbackDataset`.",
-                "\n`with_records` will be deprecated in Argilla v1.15.0.",
-                DeprecationWarning,
-                stacklevel=1,
-            )
-
         httpx_client: "httpx.Client" = ArgillaSingleton.get().http_client.httpx
 
         existing_dataset = feedback_dataset_in_argilla(name=name, workspace=workspace, id=id)

--- a/src/argilla/client/feedback/dataset/remote/base.py
+++ b/src/argilla/client/feedback/dataset/remote/base.py
@@ -34,8 +34,6 @@ if TYPE_CHECKING:
     from argilla.client.workspaces import Workspace
 
 
-warnings.simplefilter("always", DeprecationWarning)
-
 T = TypeVar("T", bound="RemoteFeedbackRecordsBase")
 
 
@@ -175,17 +173,6 @@ class RemoteFeedbackDatasetBase(Generic[T], FeedbackDatasetBase):
         return self._records
 
     @property
-    def argilla_id(self) -> "UUID":
-        warnings.warn(
-            "`argilla_id` is deprected in favor of `id` and will be removed in a future"
-            " release. Please use `id` instead.\n`argilla_id` will be deprecated in"
-            " Argilla v1.15.0.",
-            DeprecationWarning,
-            stacklevel=1,
-        )
-        return self.id
-
-    @property
     def id(self) -> "UUID":
         """Returns the ID of the dataset in Argilla."""
         return self._id
@@ -265,25 +252,6 @@ class RemoteFeedbackDatasetBase(Generic[T], FeedbackDatasetBase):
             RuntimeError: If the deletion of the records from Argilla fails.
         """
         self._records.delete(records=[records] if not isinstance(records, list) else records)
-
-    def fetch_records(self) -> None:
-        warnings.warn(
-            "`fetch_records` method is deprecated, as the records are fetched automatically"
-            " when iterating over a `FeedbackDataset` pushed to Argilla.\n`fetch_records`"
-            " will be deprecated in Argilla v1.15.0.",
-            DeprecationWarning,
-            stacklevel=1,
-        )
-
-    def push_to_argilla(self, *args, **kwargs) -> None:
-        warnings.warn(
-            "`push_to_argilla` is no longer working for a `FeedbackDataset` pushed to Argilla,"
-            " as the additions, deletions and/or updates over a `FeedbackDataset` in Argilla"
-            " are being tracked automatically, so there's no need to explicitly push them."
-            "\n`push_to_argilla` will be deprecated in Argilla v1.15.0.",
-            DeprecationWarning,
-            stacklevel=1,
-        )
 
     def pull(self) -> "FeedbackDataset":
         """Pulls the dataset from Argilla and returns a local instance of it.

--- a/src/argilla/client/feedback/dataset/remote/dataset.py
+++ b/src/argilla/client/feedback/dataset/remote/dataset.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from tqdm import trange
@@ -34,9 +33,6 @@ if TYPE_CHECKING:
     from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQuestionTypes
     from argilla.client.sdk.v1.datasets.models import FeedbackRecordsModel
     from argilla.client.workspaces import Workspace
-
-
-warnings.simplefilter("always", DeprecationWarning)
 
 
 class RemoteFeedbackRecords(RemoteFeedbackRecordsBase):

--- a/src/argilla/client/feedback/schemas/records.py
+++ b/src/argilla/client/feedback/schemas/records.py
@@ -235,18 +235,6 @@ class FeedbackRecord(BaseModel):
 
         self.__dict__["suggestions"] = tuple(suggestions_dict.values())
 
-    def set_suggestions(
-        self, suggestions: Union[SuggestionSchema, List[SuggestionSchema], Dict[str, Any], List[Dict[str, Any]]]
-    ) -> None:
-        warnings.warn(
-            "`set_suggestions` is deprected in favor of `update` and will be removed in a future"
-            " release.\n`set_suggestions` will be deprecated in Argilla v1.15.0, please"
-            " use `update` instead.",
-            DeprecationWarning,
-            stacklevel=1,
-        )
-        self.update(suggestions=suggestions)
-
     class Config:
         extra = Extra.forbid
         validate_assignment = True
@@ -405,19 +393,6 @@ class RemoteFeedbackRecord(FeedbackRecord):
             PermissionError: if the user does not have either `owner` or `admin` role.
         """
         self.__update_suggestions(suggestions=suggestions)
-
-    def set_suggestions(
-        self, suggestions: Union[SuggestionSchema, List[SuggestionSchema], Dict[str, Any], List[Dict[str, Any]]]
-    ) -> None:
-        """Deprecated, use `update` instead."""
-        warnings.warn(
-            "`set_suggestions` is deprected in favor of `update` and will be removed in a future"
-            " release.\n`set_suggestions` will be deprecated in Argilla v1.15.0, please"
-            " use `update` instead.",
-            DeprecationWarning,
-            stacklevel=1,
-        )
-        self.update(suggestions=suggestions)
 
     @allowed_for_roles(roles=[UserRole.owner, UserRole.admin])
     def delete_suggestions(self, suggestions: Union[RemoteSuggestionSchema, List[RemoteSuggestionSchema]]) -> None:

--- a/tests/integration/client/feedback/test_dataset.py
+++ b/tests/integration/client/feedback/test_dataset.py
@@ -157,9 +157,6 @@ def test_create_dataset_with_suggestions(argilla_user: "ServerUser") -> None:
 
     remote_dataset = ds.push_to_argilla(name="new_dataset")
 
-    with pytest.warns(DeprecationWarning):
-        remote_dataset.fetch_records()
-
     assert len(remote_dataset.records) == 1
     assert remote_dataset.records[0].id is not None
     assert isinstance(remote_dataset.records[0].suggestions[0], RemoteSuggestionSchema)
@@ -405,13 +402,8 @@ async def test_push_to_argilla_and_from_argilla(
         ]
     )
 
-    with pytest.warns(
-        DeprecationWarning, match="Calling `push_to_argilla` no longer implies that the `FeedbackDataset`"
-    ):
-        remote_dataset = dataset.push_to_argilla(name="my-dataset")
-
     with pytest.warns(UserWarning, match="Multiple responses without `user_id`"):
-        dataset.push_to_argilla(name="test-dataset")
+        remote_dataset = dataset.push_to_argilla(name="my-dataset")
 
     dataset_from_argilla = FeedbackDataset.from_argilla(id=remote_dataset.id)
 
@@ -448,16 +440,16 @@ async def test_copy_dataset_in_argilla(
     same_dataset = FeedbackDataset.from_argilla("test-dataset")
     same_dataset_local = same_dataset.pull()
     same_dataset_local.push_to_argilla("copy-dataset")
-    assert same_dataset.argilla_id is not None
+    assert same_dataset.id is not None
 
     await db.refresh(argilla_user, attribute_names=["datasets"])
 
-    same_dataset = FeedbackDataset.from_argilla("copy-dataset")
-    assert same_dataset.argilla_id != dataset.argilla_id
-    assert [field.dict(exclude={"id"}) for field in same_dataset.fields] == [
+    same_dataset_copy = FeedbackDataset.from_argilla("copy-dataset")
+    assert same_dataset_copy.id != same_dataset.id
+    assert [field.dict(exclude={"id"}) for field in same_dataset_copy.fields] == [
         field.dict(exclude={"id"}) for field in dataset.fields
     ]
-    assert [question.dict(exclude={"id"}) for question in same_dataset.questions] == [
+    assert [question.dict(exclude={"id"}) for question in same_dataset_copy.questions] == [
         question.dict(exclude={"id"}) for question in dataset.questions
     ]
 

--- a/tests/unit/client/feedback/schemas/test_records.py
+++ b/tests/unit/client/feedback/schemas/test_records.py
@@ -116,7 +116,7 @@ def test_feedback_record(schema_kwargs: Dict[str, Any]) -> None:
         ),
     ],
 )
-def test_feedback_record_set_suggestions(
+def test_feedback_record_update(
     schema_kwargs: Dict[str, Any],
     suggestions: Union[SuggestionSchema, List[SuggestionSchema], Dict[str, Any], List[Dict[str, Any]]],
     expected_warning: Optional[Warning],
@@ -124,7 +124,7 @@ def test_feedback_record_set_suggestions(
 ) -> None:
     record = FeedbackRecord(**schema_kwargs)
     with pytest.warns(expected_warning, match=warning_match):
-        record.set_suggestions(suggestions)
+        record.update(suggestions)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

This PR removes the stuff stated to be deprecated before v1.15.0 release, as well as all the tests covering the `DeprecationWarning`s raised when trying to call to-be-deprecated methods, functions, and properties.