### PR TITLE
chore: Remove  attribute for Dataset client model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ These are the section headers that we use:
 ### Removed
 
 - Remove `multi_task_text_token_classification` from `TaskType` as not used ([#3640](https://github.com/argilla-io/argilla/pull/3640)).
+- Remove unused `owner` attribute for client Dataset data model ([#3665](https://github.com/argilla-io/argilla/pull/3665))
 
 ## [1.14.1](https://github.com/argilla-io/argilla/compare/v1.14.0...v1.14.1)
 

--- a/src/argilla/client/sdk/datasets/models.py
+++ b/src/argilla/client/sdk/datasets/models.py
@@ -41,7 +41,6 @@ class BaseDatasetModel(BaseModel):
 class Dataset(BaseDatasetModel):
     id: str
     task: TaskType
-    owner: str = None
     workspace: str = None
     created_at: datetime = None
     last_updated: datetime = None


### PR DESCRIPTION
# Description

Since the release 1.15.0 includes the `rg.list_datasets` function to fetch datasets from Argilla. This PR removes the old `owner`  attribute in order to not propagate as part of `rg.list_datasets` results.
