### PR TITLE
feat: add `users create` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ These are the section headers that we use:
 - Added `list_datasets` function (to be used as `rg.list_datasets`) to list the `TextClassification`, `TokenClassification`, and `Text2Text` datasets in Argilla ([#3638](https://github.com/argilla-io/argilla/pull/3638)).
 - Added `workspaces list` command to list Argilla workspaces ([#3594](https://github.com/argilla-io/argilla/pull/3594)).
 - Added `datasets list` command to list Argilla datasets ([#3658](https://github.com/argilla-io/argilla/pull/3658)).
+- Added `users create` command to create users ([#3667](https://github.com/argilla-io/argilla/pull/3667)).
 
 ### Changed
 

--- a/src/argilla/__main__.py
+++ b/src/argilla/__main__.py
@@ -14,8 +14,12 @@
 #  limitations under the License.
 
 
-from argilla.tasks import database_app, login_app, logout_app, server_app, training_app, workspaces_app
+import warnings
+
+from argilla.tasks import database_app, login_app, logout_app, server_app, training_app, users_app, workspaces_app
 from argilla.tasks.async_typer import AsyncTyper
+
+warnings.simplefilter("ignore", UserWarning)
 
 app = AsyncTyper(rich_help_panel=True, help="Argilla CLI", no_args_is_help=True)
 
@@ -24,6 +28,7 @@ app.add_typer(login_app, name="login")
 app.add_typer(logout_app, name="logout")
 app.add_typer(server_app, name="server")
 app.add_typer(training_app, name="train")
+app.add_typer(users_app, name="users")
 app.add_typer(workspaces_app, name="workspaces")
 
 if __name__ == "__main__":

--- a/src/argilla/__main__.py
+++ b/src/argilla/__main__.py
@@ -13,7 +13,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 import warnings
 
 from argilla.tasks import (

--- a/src/argilla/client/users.py
+++ b/src/argilla/client/users.py
@@ -197,7 +197,8 @@ class User:
             A new `User` instance.
 
         Raises:
-            ValueError: if the user already exists in Argilla.
+            KeyError: if the user already exists in Argilla.
+            ValueError: if the provided parameters are not valid.
             RuntimeError: if the user cannot be created in Argilla.
 
         Examples:
@@ -226,7 +227,7 @@ class User:
             ).parsed
             return cls.__new_instance(client, user)
         except AlreadyExistsApiError as e:
-            raise ValueError(
+            raise KeyError(
                 f"User with username=`{username}` already exists in Argilla, so please"
                 " make sure that the name you provided is a unique one."
             ) from e

--- a/src/argilla/tasks/rich.py
+++ b/src/argilla/tasks/rich.py
@@ -12,11 +12,21 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+from rich.panel import Panel
 from rich.table import Table
+
+if TYPE_CHECKING:
+    from rich.console import RenderableType
+
+# TODO: update colors after consulting it with UI expert
+_ARGILLA_BORDER_STYLE = "red"
 
 
 def get_argilla_themed_table(title: str, **kwargs: Any) -> Table:
-    # TODO: update colors after consulting it with UI expert
-    return Table(title=title, border_style="red", **kwargs)
+    return Table(title=title, border_style=_ARGILLA_BORDER_STYLE, **kwargs)
+
+
+def get_argilla_themed_panel(renderable: "RenderableType", **kwargs: Any) -> Panel:
+    return Panel(renderable=renderable, border_style=_ARGILLA_BORDER_STYLE, **kwargs)

--- a/src/argilla/tasks/users/__init__.py
+++ b/src/argilla/tasks/users/__init__.py
@@ -12,10 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from .database import app as database_app
-from .login import app as login_app
-from .logout import app as logout_app
-from .server import app as server_app
-from .training import app as training_app
-from .users import app as users_app
-from .workspaces import app as workspaces_app
+from .__main__ import app
+
+if __name__ == "__main__":
+    app()

--- a/src/argilla/tasks/users/__main__.py
+++ b/src/argilla/tasks/users/__main__.py
@@ -12,10 +12,11 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from .database import app as database_app
-from .login import app as login_app
-from .logout import app as logout_app
-from .server import app as server_app
-from .training import app as training_app
-from .users import app as users_app
-from .workspaces import app as workspaces_app
+import typer
+
+from argilla.tasks.callback import init_callback
+
+from .create import create_user
+
+app = typer.Typer(help="Holds CLI commands for user management.", no_args_is_help=True, callback=init_callback)
+app.command(name="create", help="Creates a new user.")(create_user)

--- a/src/argilla/tasks/users/create.py
+++ b/src/argilla/tasks/users/create.py
@@ -53,7 +53,7 @@ def create_user(
         typer.echo(f"Provided parameters are not valid:\n\n{e}")
         raise typer.Exit(code=1) from e
     except RuntimeError as e:
-        typer.echo("An error ocurred when trying to create the user")
+        typer.echo("An unexpected error occurred when trying to create the user")
         raise typer.Exit(code=1) from e
 
     panel = get_argilla_themed_panel(

--- a/src/argilla/tasks/users/create.py
+++ b/src/argilla/tasks/users/create.py
@@ -36,6 +36,7 @@ def create_user(
     from rich.panel import Panel
 
     from argilla.client.users import User
+    from argilla.tasks.rich import get_argilla_themed_panel
 
     try:
         user = User.create(
@@ -56,7 +57,7 @@ def create_user(
         typer.echo("An error ocurred when trying to create the user")
         raise typer.Exit(code=1) from e
 
-    panel = Panel(
+    panel = get_argilla_themed_panel(
         Markdown(
             "User successfully created:\n"
             f"- **Username**: {user.username}\n"

--- a/src/argilla/tasks/users/create.py
+++ b/src/argilla/tasks/users/create.py
@@ -33,7 +33,6 @@ def create_user(
 ) -> None:
     from rich.console import Console
     from rich.markdown import Markdown
-    from rich.panel import Panel
 
     from argilla.client.users import User
     from argilla.tasks.rich import get_argilla_themed_panel

--- a/src/argilla/tasks/users/create.py
+++ b/src/argilla/tasks/users/create.py
@@ -1,0 +1,72 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import List, Optional
+
+import typer
+
+from argilla.client.sdk.users.models import UserRole
+
+
+def create_user(
+    username: str = typer.Option(..., help="The username of the user to be created"),
+    password: str = typer.Option(..., prompt=True, help="The password of the user to be created"),
+    first_name: Optional[str] = typer.Option(None, help="The first name of the user to be created"),
+    last_name: Optional[str] = typer.Option(None, help="The last name of the user to be created"),
+    role: UserRole = typer.Option(UserRole.annotator, help="The role of the user to be created"),
+    workspaces: Optional[List[str]] = typer.Option(
+        None,
+        "--workspace",
+        help="A workspace name to which the user will be linked to. This option can be provided several times.",
+    ),
+) -> None:
+    from textwrap import dedent
+
+    from rich.console import Console
+    from rich.markdown import Markdown
+    from rich.panel import Panel
+
+    from argilla.client.users import User
+
+    try:
+        user = User.create(
+            username=username,
+            password=password,
+            first_name=first_name,
+            last_name=last_name,
+            role=role,
+            workspaces=workspaces,
+        )
+    except KeyError as e:
+        typer.echo(f"User with '{username}' already exists!")
+        raise typer.Exit(code=1) from e
+    except ValueError as e:
+        typer.echo(f"Provided parameters are not valid:\n\n{e}")
+        raise typer.Exit(code=1) from e
+    except RuntimeError as e:
+        typer.echo("An error ocurred when trying to create the user.")
+        raise typer.Exit(code=1) from e
+
+    panel = Panel(
+        Markdown(
+            "User successfully created:\n"
+            f"- **Username**: {user.username}\n"
+            f"- **First name**: {user.first_name}\n"
+            f"- **Last name**: {user.last_name}\n"
+            f"- **API Key**: {user.api_key}\n"
+            f"- **Workspaces**: {user.workspaces}"
+        )
+    )
+
+    Console().print(panel)

--- a/src/argilla/tasks/users/create.py
+++ b/src/argilla/tasks/users/create.py
@@ -20,7 +20,7 @@ from argilla.client.sdk.users.models import UserRole
 
 
 def create_user(
-    username: str = typer.Option(..., help="The username of the user to be created"),
+    username: str = typer.Option(..., prompt=True, help="The username of the user to be created"),
     password: str = typer.Option(..., prompt=True, help="The password of the user to be created"),
     first_name: Optional[str] = typer.Option(None, help="The first name of the user to be created"),
     last_name: Optional[str] = typer.Option(None, help="The last name of the user to be created"),
@@ -58,13 +58,14 @@ def create_user(
 
     panel = get_argilla_themed_panel(
         Markdown(
-            "User successfully created:\n"
             f"- **Username**: {user.username}\n"
             f"- **First name**: {user.first_name}\n"
             f"- **Last name**: {user.last_name}\n"
             f"- **API Key**: {user.api_key}\n"
             f"- **Workspaces**: {user.workspaces}"
-        )
+        ),
+        title="User created",
+        title_align="left",
     )
 
     Console().print(panel)

--- a/src/argilla/tasks/users/create.py
+++ b/src/argilla/tasks/users/create.py
@@ -31,8 +31,6 @@ def create_user(
         help="A workspace name to which the user will be linked to. This option can be provided several times.",
     ),
 ) -> None:
-    from textwrap import dedent
-
     from rich.console import Console
     from rich.markdown import Markdown
     from rich.panel import Panel
@@ -55,7 +53,7 @@ def create_user(
         typer.echo(f"Provided parameters are not valid:\n\n{e}")
         raise typer.Exit(code=1) from e
     except RuntimeError as e:
-        typer.echo("An error ocurred when trying to create the user.")
+        typer.echo("An error ocurred when trying to create the user")
         raise typer.Exit(code=1) from e
 
     panel = Panel(

--- a/tests/integration/client/test_users.py
+++ b/tests/integration/client/test_users.py
@@ -117,7 +117,7 @@ async def test_user_create(owner: "ServerUser") -> None:
             )
         ]
 
-    with pytest.raises(ValueError, match="already exists in Argilla"):
+    with pytest.raises(KeyError, match="already exists in Argilla"):
         User.create("test_user", password="test_password")
 
 

--- a/tests/unit/tasks/users/__init__.py
+++ b/tests/unit/tasks/users/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/unit/tasks/users/test_create.py
+++ b/tests/unit/tasks/users/test_create.py
@@ -73,7 +73,7 @@ class TestSuiteCreateUserCommand:
         [
             (KeyError, "User with 'unit-test' already exists!"),
             (ValueError, "Provided parameters are not valid"),
-            (RuntimeError, "An error ocurred when trying to create the user"),
+            (RuntimeError, "An unexpected error occurred when trying to create the user"),
         ],
     )
     def test_create_user_errors(

--- a/tests/unit/tasks/users/test_create.py
+++ b/tests/unit/tasks/users/test_create.py
@@ -58,7 +58,7 @@ class TestSuiteCreateUserCommand:
         )
 
         assert result.exit_code == 0
-        assert "User successfully created" in result.stdout
+        assert "User created" in result.stdout
         user_create_mock.assert_called_once_with(
             username="unit-test",
             password="unit-test",

--- a/tests/unit/tasks/users/test_create.py
+++ b/tests/unit/tasks/users/test_create.py
@@ -58,6 +58,7 @@ class TestSuiteCreateUserCommand:
         )
 
         assert result.exit_code == 0
+        assert "User successfully created" in result.stdout
         user_create_mock.assert_called_once_with(
             username="unit-test",
             password="unit-test",

--- a/tests/unit/tasks/users/test_create.py
+++ b/tests/unit/tasks/users/test_create.py
@@ -1,0 +1,102 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Type
+from uuid import uuid4
+
+import httpx
+import pytest
+from argilla.client.sdk.users.models import UserRole
+from argilla.client.users import User
+
+if TYPE_CHECKING:
+    from click.testing import CliRunner
+    from pytest_mock import MockerFixture
+    from typer import Typer
+
+
+@pytest.fixture
+def user() -> User:
+    user = User.__new__(User)
+    user.__dict__.update(
+        {
+            "_client": httpx.Client(),
+            "id": uuid4(),
+            "username": "unit-test",
+            "last_name": "unit-test",
+            "first_name": "unit-test",
+            "role": UserRole.owner,
+            "api_key": "apikey.unit-test",
+            "inserted_at": datetime.now(),
+            "updated_at": datetime.now(),
+        }
+    )
+    return user
+
+
+@pytest.mark.usefixtures("login_mock")
+class TestSuiteCreateUserCommand:
+    def test_create_user(self, cli_runner: "CliRunner", cli: "Typer", mocker: "MockerFixture", user: User) -> None:
+        user_create_mock = mocker.patch("argilla.client.users.User.create", return_value=user)
+        mocker.patch("argilla.client.users.User.workspaces", return_value=["ws1", "ws2"])
+
+        result = cli_runner.invoke(
+            cli,
+            "users create --username unit-test --password unit-test --first-name unit-test --last-name unit-test --role owner --workspace ws1 --workspace ws2",
+        )
+
+        assert result.exit_code == 0
+        user_create_mock.assert_called_once_with(
+            username="unit-test",
+            password="unit-test",
+            first_name="unit-test",
+            last_name="unit-test",
+            role=UserRole.owner,
+            workspaces=["ws1", "ws2"],
+        )
+
+    @pytest.mark.parametrize(
+        "ExceptionType, expected_msg",
+        [
+            (KeyError, "User with 'unit-test' already exists!"),
+            (ValueError, "Provided parameters are not valid"),
+            (RuntimeError, "An error ocurred when trying to create the user"),
+        ],
+    )
+    def test_create_user_errors(
+        self,
+        cli_runner: "CliRunner",
+        cli: "Typer",
+        mocker: "MockerFixture",
+        ExceptionType: Type[Exception],
+        expected_msg: str,
+    ) -> None:
+        user_create_mock = mocker.patch("argilla.client.users.User.create", side_effect=ExceptionType)
+
+        result = cli_runner.invoke(
+            cli,
+            "users create --username unit-test --password unit-test --first-name unit-test --last-name unit-test --role owner --workspace ws1 --workspace ws2",
+        )
+
+        assert result.exit_code == 1
+        assert expected_msg in result.stdout
+        user_create_mock.assert_called_once_with(
+            username="unit-test",
+            password="unit-test",
+            first_name="unit-test",
+            last_name="unit-test",
+            role=UserRole.owner,
+            workspaces=["ws1", "ws2"],
+        )


### PR DESCRIPTION
# Description

This PR adds `users create` command that allows to create an user calling the API and the logged user.

Closes #3588

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

I've added unit tests that covers the additions.

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
