### PR TITLE
feat: add `whoami` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ These are the section headers that we use:
 - Added `workspaces list` command to list Argilla workspaces ([#3594](https://github.com/argilla-io/argilla/pull/3594)).
 - Added `datasets list` command to list Argilla datasets ([#3658](https://github.com/argilla-io/argilla/pull/3658)).
 - Added `users create` command to create users ([#3667](https://github.com/argilla-io/argilla/pull/3667)).
+- Added `whoami` command to get current user ([#3673](https://github.com/argilla-io/argilla/pull/3673)).
 
 ### Changed
 

--- a/src/argilla/__main__.py
+++ b/src/argilla/__main__.py
@@ -23,6 +23,7 @@ from argilla.tasks import (
     server_app,
     training_app,
     users_app,
+    whoami_app,
     workspaces_app,
 )
 from argilla.tasks.async_typer import AsyncTyper
@@ -38,6 +39,7 @@ app.add_typer(logout_app, name="logout")
 app.add_typer(server_app, name="server")
 app.add_typer(training_app, name="train")
 app.add_typer(users_app, name="users")
+app.add_typer(whoami_app, name="whoami")
 app.add_typer(workspaces_app, name="workspaces")
 
 if __name__ == "__main__":

--- a/src/argilla/tasks/callback.py
+++ b/src/argilla/tasks/callback.py
@@ -23,4 +23,10 @@ def init_callback() -> None:
         typer.echo("You are not logged in. Please run `argilla login` to login to an Argilla server.")
         raise typer.Exit(code=1)
 
-    init()
+    try:
+        init()
+    except Exception as e:
+        typer.echo(
+            "The Argilla Server you are logged in is not available or not responding. Please make sure it's running and try again."
+        )
+        raise typer.Exit(code=1) from e

--- a/src/argilla/tasks/database/migrate.py
+++ b/src/argilla/tasks/database/migrate.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
 from typing import Optional
 
 import alembic

--- a/src/argilla/tasks/database/revisions.py
+++ b/src/argilla/tasks/database/revisions.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
 import alembic.config
 import typer
 

--- a/src/argilla/tasks/datasets/__main__.py
+++ b/src/argilla/tasks/datasets/__main__.py
@@ -21,7 +21,6 @@ app = typer.Typer(
     help="Holds CLI commands for datasets management", invoke_without_command=True, callback=init_callback
 )
 
-
 app.command(name="list", help="List datasets linked to user's workspaces")(list_datasets)
 
 

--- a/src/argilla/tasks/logout/__main__.py
+++ b/src/argilla/tasks/logout/__main__.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 import typer
 
 app = typer.Typer(invoke_without_command=True)

--- a/src/argilla/tasks/server/__main__.py
+++ b/src/argilla/tasks/server/__main__.py
@@ -12,7 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 import typer
 import uvicorn
 

--- a/src/argilla/tasks/users/__main__.py
+++ b/src/argilla/tasks/users/__main__.py
@@ -19,4 +19,5 @@ from argilla.tasks.callback import init_callback
 from .create import create_user
 
 app = typer.Typer(help="Holds CLI commands for user management.", no_args_is_help=True, callback=init_callback)
+
 app.command(name="create", help="Creates a new user.")(create_user)

--- a/src/argilla/tasks/whoami/__init__.py
+++ b/src/argilla/tasks/whoami/__init__.py
@@ -12,12 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from .database import app as database_app
-from .datasets import app as datasets_app
-from .login import app as login_app
-from .logout import app as logout_app
-from .server import app as server_app
-from .training import app as training_app
-from .users import app as users_app
-from .whoami import app as whoami_app
-from .workspaces import app as workspaces_app
+from .__main__ import app
+
+if __name__ == "__main__":
+    app()

--- a/src/argilla/tasks/whoami/__main__.py
+++ b/src/argilla/tasks/whoami/__main__.py
@@ -26,13 +26,9 @@ def whoami() -> None:
     from argilla.tasks.callback import init_callback
     from argilla.tasks.rich import get_argilla_themed_panel
 
-    try:
-        init_callback()
-    except RuntimeError as e:
-        typer.echo("An unexpected error occurred when trying to get the current user")
-        raise typer.Exit(code=1) from e
-
+    init_callback()
     user = active_client()._user
+
     panel = get_argilla_themed_panel(
         Markdown(
             f"- **Username**: {user.username}\n"

--- a/src/argilla/tasks/whoami/__main__.py
+++ b/src/argilla/tasks/whoami/__main__.py
@@ -23,7 +23,14 @@ def whoami() -> None:
     from rich.markdown import Markdown
 
     from argilla.client.api import active_client
+    from argilla.tasks.callback import init_callback
     from argilla.tasks.rich import get_argilla_themed_panel
+
+    try:
+        init_callback()
+    except RuntimeError as e:
+        typer.echo("An unexpected error occurred when trying to get the current user")
+        raise typer.Exit(code=1) from e
 
     user = active_client()._user
     panel = get_argilla_themed_panel(

--- a/src/argilla/tasks/whoami/__main__.py
+++ b/src/argilla/tasks/whoami/__main__.py
@@ -1,0 +1,45 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import typer
+
+app = typer.Typer(invoke_without_command=True)
+
+
+@app.callback(help="Check the current user on the Argilla Server")
+def whoami() -> None:
+    from rich.console import Console
+    from rich.markdown import Markdown
+
+    from argilla.client.api import active_client
+    from argilla.tasks.rich import get_argilla_themed_panel
+
+    user = active_client()._user
+    panel = get_argilla_themed_panel(
+        Markdown(
+            f"- **Username**: {user.username}\n"
+            f"- **First name**: {user.first_name}\n"
+            f"- **Last name**: {user.last_name}\n"
+            f"- **API Key**: {user.api_key}\n"
+            f"- **Workspaces**: {user.workspaces}"
+        ),
+        title="Current User",
+        title_align="left",
+    )
+
+    Console().print(panel)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/argilla/tasks/workspaces/__main__.py
+++ b/src/argilla/tasks/workspaces/__main__.py
@@ -13,7 +13,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-
 from argilla.tasks.async_typer import AsyncTyper
 from argilla.tasks.callback import init_callback
 

--- a/tests/unit/tasks/conftest.py
+++ b/tests/unit/tasks/conftest.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import json
+
 from typing import TYPE_CHECKING, Generator
 
 import pytest
@@ -23,7 +23,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from typer.testing import CliRunner
 
 from tests.database import SyncTestSession
-from tests.factories import UserSyncFactory
 
 if TYPE_CHECKING:
     from argilla.tasks.async_typer import AsyncTyper

--- a/tests/unit/tasks/whoami/__init__.py
+++ b/tests/unit/tasks/whoami/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/unit/tasks/whoami/test_whoami.py
+++ b/tests/unit/tasks/whoami/test_whoami.py
@@ -1,0 +1,37 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from click.testing import CliRunner
+    from typer import Typer
+
+
+@pytest.mark.usefixtures("login_mock")
+def test_cli_whoami(cli_runner: "CliRunner", cli: "Typer") -> None:
+    result = cli_runner.invoke(cli, "whoami")
+
+    assert result.exit_code == 0
+    assert "Current User" in result.stdout
+
+
+@pytest.mark.usefixtures("not_logged_mock")
+def test_cli_whoami_needs_login(cli_runner: "CliRunner", cli: "Typer") -> None:
+    result = cli_runner.invoke(cli, "whoami")
+
+    assert "You are not logged in. Please run `argilla login` to login to an Argilla server." in result.stdout
+    assert result.exit_code == 1


### PR DESCRIPTION
# Description

This PR adds the `whoami` command to the Argilla CLI, to show the information of the current active user.

Closes #3669 

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [X] Add unit tests for the `whoami` command

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)