### PR TITLE
build: skip CI trigger when PR is draft

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,7 +5,13 @@
 # Source repository: https://github.com/actions/dependency-review-action
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
 name: "Dependency Review"
-on: [pull_request]
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 permissions:
   contents: read
@@ -13,6 +19,7 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: "Checkout Repository"
         uses: actions/checkout@v3

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -6,17 +6,14 @@ concurrency:
 
 on:
   workflow_dispatch:
-
   release:
     types:
       - "published"
-
   push:
     branches:
       - "main"
       - "develop"
       - "releases/**"
-
   pull_request:
     branches:
       - "main"
@@ -25,10 +22,16 @@ on:
       - "feature/**"
       - "feat/**"
       - "fix/**"
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
   check_repo_files:
     name: Check source changes
+    if: ${{ !github.event.pull_request.draft }}
     uses: ./.github/workflows/check-repo-files.yml
 
   deployable_check:


### PR DESCRIPTION
# Description

This PR skips the CI trigger from `package.yml` when the PR is still a draft, but keeps the trigger for opened, reopened, synchronize, and ready_for_review. The same filtering is applied for the `dependency_review.yml` file.

Closes #3466 

**Type of change**

- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

- [X] Created this PR as a draft to see that the CI is skipped