### PR TITLE
feat: add `confirmation_prompt` and `hide_input` to protected CLI prompts

### DIFF
--- a/src/argilla/tasks/database/users/create.py
+++ b/src/argilla/tasks/database/users/create.py
@@ -73,6 +73,8 @@ async def create(
     password: str = typer.Option(
         default=None,
         prompt=True,
+        confirmation_prompt=True,
+        hide_input=True,
         callback=password_callback,
         help=f"Password as a string with a minimum length of {USER_PASSWORD_MIN_LENGTH} characters.",
     ),

--- a/src/argilla/tasks/login/__main__.py
+++ b/src/argilla/tasks/login/__main__.py
@@ -22,7 +22,9 @@ app = typer.Typer(invoke_without_command=True)
 @app.callback(help="Login to an Argilla Server")
 def login(
     api_url: str = typer.Option(..., help="The URL of the Argilla Server to login in to"),
-    api_key: str = typer.Option(..., help="The API key for logging into the Argilla Server", prompt="API Key"),
+    api_key: str = typer.Option(
+        ..., prompt="API Key", hide_input=True, help="The API key for logging into the Argilla Server"
+    ),
     workspace: Optional[str] = typer.Option(
         None, help="The default workspace over which the operations will be performed"
     ),

--- a/src/argilla/tasks/users/create.py
+++ b/src/argilla/tasks/users/create.py
@@ -21,7 +21,9 @@ from argilla.client.sdk.users.models import UserRole
 
 def create_user(
     username: str = typer.Option(..., prompt=True, help="The username of the user to be created"),
-    password: str = typer.Option(..., prompt=True, help="The password of the user to be created"),
+    password: str = typer.Option(
+        ..., prompt=True, confirmation_prompt=True, hide_input=True, help="The password of the user to be created"
+    ),
     first_name: Optional[str] = typer.Option(None, help="The first name of the user to be created"),
     last_name: Optional[str] = typer.Option(None, help="The last name of the user to be created"),
     role: UserRole = typer.Option(UserRole.annotator, help="The role of the user to be created"),


### PR DESCRIPTION
# Description

This PR adds both the `hide_input` and `confirmation_prompt` for the CLI arguments/options `password` and `api_key` to make sure those are somehow protected, as it's a nice practice to hide those fields.

Note that the `confirmation_prompt` is just set for the `password`, as the API Key tends to be longer and can be easily retrieved, while the password needs to be remembered and cannot be checked at any point since the creation.

Closes #3679

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)