### PR TITLE
fix: default behaviour for `visible_labels` in `LabelQuestion` and `MultiLabelQuestion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ These are the section headers that we use:
 ### Fixed
 
 - Fixed `Pending queue` pagination problems when during data annotation ([#3677](https://github.com/argilla-io/argilla/pull/3677))
+- Fixed `visible_labels` default value to be 20 just when `visible_labels=None` and `len(labels) > 20`, otherwise it will either be `visible_labels=None` when `len(labels) < 20` or `len(labels)` when `visible_labels` is greater than it, for `LabelQuestion` and `MultiLabelQuestion` ([#3702](https://github.com/argilla-io/argilla/pull/3702)).
 
 ## [1.15.0](https://github.com/argilla-io/argilla/compare/v1.14.1...v1.15.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ These are the section headers that we use:
 ### Fixed
 
 - Fixed `Pending queue` pagination problems when during data annotation ([#3677](https://github.com/argilla-io/argilla/pull/3677))
-- Fixed `visible_labels` default value to be 20 just when `visible_labels=None` and `len(labels) > 20`, otherwise it will either be `visible_labels=None` when `len(labels) < 20` or `len(labels)` when `visible_labels` is greater than it, for `LabelQuestion` and `MultiLabelQuestion` ([#3702](https://github.com/argilla-io/argilla/pull/3702)).
+- Fixed `visible_labels` default value to be 20 just when `visible_labels=None` or `len(labels) > 20`, otherwise it will either be the provided `visible_labels` value or `None`, for `LabelQuestion` and `MultiLabelQuestion` ([#3702](https://github.com/argilla-io/argilla/pull/3702)).
 
 ## [1.15.0](https://github.com/argilla-io/argilla/compare/v1.14.1...v1.15.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ These are the section headers that we use:
 ### Fixed
 
 - Fixed `Pending queue` pagination problems when during data annotation ([#3677](https://github.com/argilla-io/argilla/pull/3677))
-- Fixed `visible_labels` default value to be 20 just when `visible_labels=None` or `len(labels) > 20`, otherwise it will either be the provided `visible_labels` value or `None`, for `LabelQuestion` and `MultiLabelQuestion` ([#3702](https://github.com/argilla-io/argilla/pull/3702)).
+- Fixed `visible_labels` default value to be 20 just when `visible_labels` not provided and `len(labels) > 20`, otherwise it will either be the provided `visible_labels` value or `None`, for `LabelQuestion` and `MultiLabelQuestion` ([#3702](https://github.com/argilla-io/argilla/pull/3702)).
 
 ## [1.15.0](https://github.com/argilla-io/argilla/compare/v1.14.1...v1.15.0)
 

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -167,7 +167,7 @@ class _LabelQuestion(QuestionSchema, LabelMappingMixin):
                 visible_options = total_options
             else:
                 warnings.warn(
-                    f"`labels={values.get('labels')} has less than 3 labels, so `visible_labels`"
+                    f"`labels={values.get('labels')}` has less than 3 labels, so `visible_labels`"
                     " will be set to `None`, which means that all the labels will be visible.",
                     UserWarning,
                     stacklevel=1,

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -170,16 +170,16 @@ class _LabelQuestion(QuestionSchema, LabelMappingMixin):
                 visible_labels = None
         else:
             visible_labels = values.get("visible_labels")
-            total_options = len(values.get("labels", []))
-            if visible_labels and visible_labels > total_options:
-                if total_options >= 3:
+            total_labels = len(values.get("labels", []))
+            if visible_labels and visible_labels > total_labels:
+                if total_labels >= 3:
                     warnings.warn(
                         f"`visible_labels={visible_labels}` is greater than the total number"
-                        f" of labels ({total_options}), so it will be set to `{total_options}`.",
+                        f" of labels ({total_labels}), so it will be set to `{total_labels}`.",
                         UserWarning,
                         stacklevel=1,
                     )
-                    visible_labels = total_options
+                    visible_labels = total_labels
                 else:
                     warnings.warn(
                         f"`labels={values.get('labels')}` has less than 3 labels, so `visible_labels`"

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -135,7 +135,7 @@ class _LabelQuestion(QuestionSchema, LabelMappingMixin):
     """
 
     labels: Union[conlist(str, unique_items=True, min_items=2), Dict[str, str]]
-    visible_labels: Optional[conint(ge=3)] = 20
+    visible_labels: Optional[conint(ge=3)] = None
 
     @validator("labels", always=True)
     def labels_dict_must_be_valid(cls, v: Union[List[str], Dict[str, str]]) -> Union[List[str], Dict[str, str]]:

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -160,13 +160,17 @@ class _LabelQuestion(QuestionSchema, LabelMappingMixin):
             if total_options >= 3:
                 warnings.warn(
                     f"`visible_labels={visible_options}` is greater than the total number"
-                    f" of labels ({total_options}), so it will be set to `{total_options}`."
+                    f" of labels ({total_options}), so it will be set to `{total_options}`.",
+                    UserWarning,
+                    stacklevel=1,
                 )
                 visible_options = total_options
             else:
                 warnings.warn(
                     f"`labels={values.get('labels')} has less than 3 labels, so `visible_labels`"
-                    " will be set to `None`, which means that all the labels will be visible."
+                    " will be set to `None`, which means that all the labels will be visible.",
+                    UserWarning,
+                    stacklevel=1,
                 )
                 visible_options = None
         if not visible_options and total_options > 20:

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -173,6 +173,14 @@ class _LabelQuestion(QuestionSchema, LabelMappingMixin):
                     stacklevel=1,
                 )
                 visible_options = None
+        if not visible_options and total_options > 20:
+            warnings.warn(
+                "Since `visible_labels` has not been provided or is `None`, and the total number"
+                " of labels is greater than 20, `visible_labels` will be set to `20`.",
+                UserWarning,
+                stacklevel=1,
+            )
+            visible_options = 20
         values["settings"]["visible_options"] = visible_options
         return values
 

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -11,6 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
 import warnings
 from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
@@ -153,9 +154,17 @@ class _LabelQuestion(QuestionSchema, LabelMappingMixin):
             ]
         if isinstance(values.get("labels"), list):
             values["settings"]["options"] = [{"value": label, "text": label} for label in values.get("labels")]
-        values["settings"]["visible_options"] = values.get(
-            "visible_labels"
-        )  # `None` is a possible value, which means all labels are visible
+        visible_options = values.get("visible_labels")
+        total_options = len(values["settings"]["options"])
+        if visible_options and visible_options > total_options:
+            warnings.warn(
+                f"`visible_labels={visible_options}` is greater than the total number"
+                f" of labels ({total_options}), so it will be set to `{total_options}`."
+            )
+            visible_options = total_options
+        if not visible_options and total_options > 20:
+            visible_options = 20
+        values["settings"]["visible_options"] = visible_options
         return values
 
 

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -192,8 +192,8 @@ class _LabelQuestion(QuestionSchema, LabelMappingMixin):
                         stacklevel=1,
                     )
                     visible_labels = None
+        values["visible_labels"] = visible_labels
         values["settings"]["visible_options"] = visible_labels
-
         return values
 
 

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -173,8 +173,6 @@ class _LabelQuestion(QuestionSchema, LabelMappingMixin):
                     stacklevel=1,
                 )
                 visible_options = None
-        if not visible_options and total_options > 20:
-            visible_options = 20
         values["settings"]["visible_options"] = visible_options
         return values
 

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -119,6 +119,10 @@ class RatingQuestion(QuestionSchema, LabelMappingMixin):
         return values
 
 
+UndefinedType = Literal["undefined"]
+UNDEFINED = "undefined"
+
+
 class _LabelQuestion(QuestionSchema, LabelMappingMixin):
     """Protected schema for the `FeedbackDataset` label questions, which are the ones that
     will require a label response from the user. This class should not be used directly,
@@ -137,7 +141,7 @@ class _LabelQuestion(QuestionSchema, LabelMappingMixin):
     """
 
     labels: Union[conlist(str, unique_items=True, min_items=2), Dict[str, str]]
-    visible_labels: Union[Literal["undefined"], conint(ge=3), None] = "undefined"
+    visible_labels: Union[UndefinedType, conint(ge=3), None] = UNDEFINED
 
     @validator("labels", pre=True, always=True)
     def labels_dict_must_be_valid(cls, v: Union[List[str], Dict[str, str]]) -> Union[List[str], Dict[str, str]]:
@@ -157,7 +161,7 @@ class _LabelQuestion(QuestionSchema, LabelMappingMixin):
         elif isinstance(values.get("labels"), list):
             values["settings"]["options"] = [{"value": label, "text": label} for label in values.get("labels")]
 
-        if values.get("visible_labels") == "undefined":
+        if values.get("visible_labels") == UNDEFINED:
             if len(values.get("labels", [])) > 20:
                 warnings.warn(
                     "Since `visible_labels` has not been provided and the total number"

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -157,11 +157,18 @@ class _LabelQuestion(QuestionSchema, LabelMappingMixin):
         visible_options = values.get("visible_labels")
         total_options = len(values["settings"]["options"])
         if visible_options and visible_options > total_options:
-            warnings.warn(
-                f"`visible_labels={visible_options}` is greater than the total number"
-                f" of labels ({total_options}), so it will be set to `{total_options}`."
-            )
-            visible_options = total_options
+            if total_options >= 3:
+                warnings.warn(
+                    f"`visible_labels={visible_options}` is greater than the total number"
+                    f" of labels ({total_options}), so it will be set to `{total_options}`."
+                )
+                visible_options = total_options
+            else:
+                warnings.warn(
+                    f"`labels={values.get('labels')} has less than 3 labels, so `visible_labels`"
+                    " will be set to `None`, which means that all the labels will be visible."
+                )
+                visible_options = None
         if not visible_options and total_options > 20:
             visible_options = 20
         values["settings"]["visible_options"] = visible_options

--- a/tests/unit/client/feedback/schemas/test_questions.py
+++ b/tests/unit/client/feedback/schemas/test_questions.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import string
 from typing import Any, Dict, Type, Union
 
 import pytest
@@ -81,7 +82,7 @@ def test_label_question_errors(
             {
                 "type": "label_selection",
                 "options": [{"value": "a", "text": "a"}, {"value": "b", "text": "b"}],
-                "visible_options": 20,
+                "visible_options": None,
             },
         ),
         (
@@ -89,15 +90,15 @@ def test_label_question_errors(
             {
                 "type": "label_selection",
                 "options": [{"value": "a", "text": "A"}, {"value": "b", "text": "B"}],
-                "visible_options": 20,
+                "visible_options": None,
             },
         ),
         (
-            {"name": "a", "description": "a", "required": True, "labels": ["a", "b"], "visible_labels": 5},
+            {"name": "a", "description": "a", "required": True, "labels": ["a", "b"], "visible_labels": 3},
             {
                 "type": "label_selection",
                 "options": [{"value": "a", "text": "a"}, {"value": "b", "text": "b"}],
-                "visible_options": 5,
+                "visible_options": None,
             },
         ),
         (
@@ -106,6 +107,28 @@ def test_label_question_errors(
                 "type": "label_selection",
                 "options": [{"value": "a", "text": "a"}, {"value": "b", "text": "b"}],
                 "visible_options": None,
+            },
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": list(string.ascii_lowercase)},
+            {
+                "type": "label_selection",
+                "options": [{"value": a, "text": a} for a in string.ascii_lowercase],
+                "visible_options": 20,
+            },
+        ),
+        (
+            {
+                "name": "a",
+                "description": "a",
+                "required": True,
+                "labels": list(string.ascii_lowercase),
+                "visible_labels": len(string.ascii_lowercase) * 2,
+            },
+            {
+                "type": "label_selection",
+                "options": [{"value": a, "text": a} for a in string.ascii_lowercase],
+                "visible_options": len(string.ascii_lowercase),
             },
         ),
     ],
@@ -164,7 +187,7 @@ def test_multi_label_question_errors(
             {
                 "type": "multi_label_selection",
                 "options": [{"value": "a", "text": "a"}, {"value": "b", "text": "b"}],
-                "visible_options": 20,
+                "visible_options": None,
             },
         ),
         (
@@ -172,7 +195,7 @@ def test_multi_label_question_errors(
             {
                 "type": "multi_label_selection",
                 "options": [{"value": "a", "text": "A"}, {"value": "b", "text": "B"}],
-                "visible_options": 20,
+                "visible_options": None,
             },
         ),
         (
@@ -180,7 +203,7 @@ def test_multi_label_question_errors(
             {
                 "type": "multi_label_selection",
                 "options": [{"value": "a", "text": "a"}, {"value": "b", "text": "b"}],
-                "visible_options": 5,
+                "visible_options": None,
             },
         ),
         (
@@ -189,6 +212,28 @@ def test_multi_label_question_errors(
                 "type": "multi_label_selection",
                 "options": [{"value": "a", "text": "a"}, {"value": "b", "text": "b"}],
                 "visible_options": None,
+            },
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": list(string.ascii_lowercase)},
+            {
+                "type": "multi_label_selection",
+                "options": [{"value": a, "text": a} for a in string.ascii_lowercase],
+                "visible_options": 20,
+            },
+        ),
+        (
+            {
+                "name": "a",
+                "description": "a",
+                "required": True,
+                "labels": list(string.ascii_lowercase),
+                "visible_labels": len(string.ascii_lowercase) * 2,
+            },
+            {
+                "type": "multi_label_selection",
+                "options": [{"value": a, "text": a} for a in string.ascii_lowercase],
+                "visible_options": len(string.ascii_lowercase),
             },
         ),
     ],

--- a/tests/unit/client/feedback/schemas/test_questions.py
+++ b/tests/unit/client/feedback/schemas/test_questions.py
@@ -85,6 +85,11 @@ def test__label_question_errors(
             UserWarning,
             "\`labels=\['a', 'b'\]\` has less than 3 labels, so \`visible_labels\` will be set to \`None\`, which means that all the labels will be visible.",
         ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": list(range(100))},
+            UserWarning,
+            "Since \`visible_labels\` has not been provided and the total number of labels is greater than 20, \`visible_labels\` will be set to \`20\`.",
+        ),
     ],
 )
 def test__label_question_warnings(

--- a/tests/unit/client/feedback/schemas/test_questions.py
+++ b/tests/unit/client/feedback/schemas/test_questions.py
@@ -80,12 +80,12 @@ def test_label_question_errors(
         (
             {"name": "a", "description": "a", "required": True, "labels": ["a", "b", "c"], "visible_labels": 4},
             UserWarning,
-            "`visible_labels=4` is greater than the total number of labels (3), so it will be set to `3`.",
+            "\`visible_labels=4\` is greater than the total number of labels \(3\), so it will be set to \`3\`.",
         ),
         (
             {"name": "a", "description": "a", "required": True, "labels": ["a", "b"], "visible_labels": 3},
             UserWarning,
-            "`labels=['a', 'b']` has less than 3 labels, so `visible_labels` will be set to `None`, which means that all the labels will be visible.",
+            "\`labels=\['a', 'b'\]\` has less than 3 labels, so \`visible_labels\` will be set to \`None\`, which means that all the labels will be visible.",
         ),
     ],
 )
@@ -209,12 +209,12 @@ def test_multi_label_question_errors(
         (
             {"name": "a", "description": "a", "required": True, "labels": ["a", "b", "c"], "visible_labels": 4},
             UserWarning,
-            "`visible_labels=4` is greater than the total number of labels (3), so it will be set to `3`.",
+            "\`visible_labels=4\` is greater than the total number of labels \(3\), so it will be set to \`3\`.",
         ),
         (
             {"name": "a", "description": "a", "required": True, "labels": ["a", "b"], "visible_labels": 3},
             UserWarning,
-            "`labels=['a', 'b']` has less than 3 labels, so `visible_labels` will be set to `None`, which means that all the labels will be visible.",
+            "\`labels=\['a', 'b'\]\` has less than 3 labels, so \`visible_labels\` will be set to \`None\`, which means that all the labels will be visible.",
         ),
     ],
 )

--- a/tests/unit/client/feedback/schemas/test_questions.py
+++ b/tests/unit/client/feedback/schemas/test_questions.py
@@ -75,6 +75,30 @@ def test_label_question_errors(
 
 
 @pytest.mark.parametrize(
+    "schema_kwargs, expected_warning, expected_warning_message",
+    [
+        (
+            {"name": "a", "description": "a", "required": True, "labels": ["a", "b", "c"], "visible_labels": 4},
+            UserWarning,
+            "`visible_labels=4` is greater than the total number of labels (3), so it will be set to `3`.",
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": ["a", "b"], "visible_labels": 3},
+            UserWarning,
+            "`labels=['a', 'b']` has less than 3 labels, so `visible_labels` will be set to `None`, which means that all the labels will be visible.",
+        ),
+    ],
+)
+def test_label_question_warnings(
+    schema_kwargs: Dict[str, Any],
+    expected_warning: Warning,
+    expected_warning_message: str,
+) -> None:
+    with pytest.warns(expected_warning, match=expected_warning_message):
+        LabelQuestion(**schema_kwargs)
+
+
+@pytest.mark.parametrize(
     "schema_kwargs, expected_settings",
     [
         (
@@ -176,6 +200,30 @@ def test_multi_label_question_errors(
     schema_kwargs: Dict[str, Any], expected_exception: Exception, expected_exception_message: Union[str, None]
 ) -> None:
     with pytest.raises(expected_exception, match=expected_exception_message):
+        MultiLabelQuestion(**schema_kwargs)
+
+
+@pytest.mark.parametrize(
+    "schema_kwargs, expected_warning, expected_warning_message",
+    [
+        (
+            {"name": "a", "description": "a", "required": True, "labels": ["a", "b", "c"], "visible_labels": 4},
+            UserWarning,
+            "`visible_labels=4` is greater than the total number of labels (3), so it will be set to `3`.",
+        ),
+        (
+            {"name": "a", "description": "a", "required": True, "labels": ["a", "b"], "visible_labels": 3},
+            UserWarning,
+            "`labels=['a', 'b']` has less than 3 labels, so `visible_labels` will be set to `None`, which means that all the labels will be visible.",
+        ),
+    ],
+)
+def test_multi_label_question_warnings(
+    schema_kwargs: Dict[str, Any],
+    expected_warning: Warning,
+    expected_warning_message: str,
+) -> None:
+    with pytest.warns(expected_warning, match=expected_warning_message):
         MultiLabelQuestion(**schema_kwargs)
 
 

--- a/tests/unit/client/feedback/schemas/test_questions.py
+++ b/tests/unit/client/feedback/schemas/test_questions.py
@@ -138,7 +138,7 @@ def test_label_question_warnings(
             {
                 "type": "label_selection",
                 "options": [{"value": a, "text": a} for a in string.ascii_lowercase],
-                "visible_options": 20,
+                "visible_options": None,
             },
         ),
         (
@@ -267,7 +267,7 @@ def test_multi_label_question_warnings(
             {
                 "type": "multi_label_selection",
                 "options": [{"value": a, "text": a} for a in string.ascii_lowercase],
-                "visible_options": 20,
+                "visible_options": None,
             },
         ),
         (


### PR DESCRIPTION
# Description

This PR fixes the default behaviour for the `visible_labels` field of the `_LabelQuestion` schema parsing, so that instead of setting the default to 20, now it's set to the correct value which is 20 just if not provided (`visible_labels=None`) and `len(labels) > 20`.

So on, the behaviour is explained based on the following scenarios:

* `len(labels) > 20`, and `visible_labels = undefined` -> `warnings.warn` and `visible_options=20`
* `len(labels) < 21`, and `visible_labels = undefined` -> `visible_options=None`
* `len(labels) < 21`, and `visible_labels > 20` -> `warnings.warn` and `visible_options=None`
* `len(labels) > 20`, and `visible_labels < 21` -> `visible_options = visible_labels`
* `len(labels) < 3`, and `visible_labels > 3` -> `warnings.warn` and `visible_options = None`
* `len(labels) >= visible_labels` -> `visible_options = visible_labels`

Closes #3693

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

- [X] Add unit tests to check that the scenarios mentioned above are successfully matched for different combinations of `labels` and `visible_labels`
- [X] Add unit tests to check that the expected `warnings.warn` messages are being shown

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [X] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)