### PR TITLE
feat: add `info` command

### DIFF
--- a/.github/ISSUE_TEMPLATE/🐞-bug-ui-ux.md
+++ b/.github/ISSUE_TEMPLATE/🐞-bug-ui-ux.md
@@ -25,6 +25,7 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
+<!-- Since version 1.16.0 you can use `python -m argilla info` command to easily get the used versions -->
 **Environment (please complete the following information):**
  - OS [e.g. iOS]:
  - Browser [e.g. chrome, safari]:

--- a/.github/ISSUE_TEMPLATE/🔗-💥-integration-issues.md
+++ b/.github/ISSUE_TEMPLATE/🔗-💥-integration-issues.md
@@ -15,6 +15,7 @@ A clear and concise description of what the bug is.
 **Expected behaviour**
 A clear and concise description of what you expected to happen.
 
+<!-- Since version 1.16.0 you can use `python -m argilla info` command to easily get the used versions -->
 **Environment:**
  - Argilla Version [e.g. 1.0.0]:
 

--- a/.github/ISSUE_TEMPLATE/🪲-bug-python-deployment.md
+++ b/.github/ISSUE_TEMPLATE/🪲-bug-python-deployment.md
@@ -23,6 +23,7 @@ my_bash_code
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
+<!-- Since version 1.16.0 you can use `python -m argilla info` command to easily get the used versions -->
 **Environment:**
  - Argilla Version [e.g. 1.0.0]:
  - ElasticSearch Version [e.g. 7.10.2]:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ These are the section headers that we use:
 - Added `users delete` command to delete users ([#3671](https://github.com/argilla-io/argilla/pull/3671)).
 - Added `workspaces create` command to create an Argilla workspace ([#3676](https://github.com/argilla-io/argilla/pull/3676)).
 - Added `datasets push-to-hub` command to push a `FeedbackDataset` from Argilla into the HuggingFace Hub ([#3685](https://github.com/argilla-io/argilla/pull/3685)).
+- Added `info` command to get info about the used Argilla client and server ([#3707](https://github.com/argilla-io/argilla/pull/3707)).
 
 ### Fixed
 

--- a/src/argilla/__main__.py
+++ b/src/argilla/__main__.py
@@ -18,6 +18,7 @@ import warnings
 from argilla.tasks import (
     database_app,
     datasets_app,
+    info_app,
     login_app,
     logout_app,
     server_app,
@@ -34,6 +35,7 @@ app = AsyncTyper(rich_help_panel=True, help="Argilla CLI", no_args_is_help=True)
 
 app.add_typer(database_app, name="database")
 app.add_typer(datasets_app, name="datasets")
+app.add_typer(info_app, name="info")
 app.add_typer(login_app, name="login")
 app.add_typer(logout_app, name="logout")
 app.add_typer(server_app, name="server")

--- a/src/argilla/tasks/info/__init__.py
+++ b/src/argilla/tasks/info/__init__.py
@@ -12,13 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from .database import app as database_app
-from .datasets import app as datasets_app
-from .info import app as info_app
-from .login import app as login_app
-from .logout import app as logout_app
-from .server import app as server_app
-from .training import app as training_app
-from .users import app as users_app
-from .whoami import app as whoami_app
-from .workspaces import app as workspaces_app
+from .__main__ import app
+
+if __name__ == "__main__":
+    app()

--- a/src/argilla/tasks/info/__main__.py
+++ b/src/argilla/tasks/info/__main__.py
@@ -1,0 +1,56 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import typer
+
+from argilla.tasks.callback import init_callback
+
+app = typer.Typer(invoke_without_command=True)
+
+
+@app.callback(help="Displays information about the Argilla client and server")
+def info() -> None:
+    from rich.console import Console
+    from rich.markdown import Markdown
+
+    from argilla._version import version
+    from argilla.client.api import active_client
+    from argilla.client.apis.status import Status
+    from argilla.tasks.rich import get_argilla_themed_panel
+
+    init_callback()
+
+    server_info = Status(active_client().client).get_status()
+
+    elasticsearch_version = (
+        f"{server_info.elasticsearch.version.number} ({server_info.elasticsearch.version.distribution})"
+        if server_info.elasticsearch.version.distribution
+        else server_info.elasticsearch.version.number
+    )
+
+    panel = get_argilla_themed_panel(
+        Markdown(
+            f"- **Client version:** {version}\n"
+            f"- **Server version:** {server_info.version}\n"
+            f"- **ElasticSearch version:** {elasticsearch_version}\n"
+        ),
+        title="Argilla Info",
+        title_align="left",
+    )
+
+    Console().print(panel)
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/unit/tasks/info/__init__.py
+++ b/tests/unit/tasks/info/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/unit/tasks/info/test_info.py
+++ b/tests/unit/tasks/info/test_info.py
@@ -1,0 +1,69 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import TYPE_CHECKING
+
+import pytest
+from argilla._version import version
+from argilla.client.apis.status import ApiStatus
+
+if TYPE_CHECKING:
+    from click.testing import CliRunner
+    from pytest_mock import MockerFixture
+    from typer import Typer
+
+
+@pytest.mark.usefixtures("login_mock")
+def test_info_command(cli_runner: "CliRunner", cli: "Typer", mocker: "MockerFixture") -> None:
+    status_get_status_mock = mocker.patch(
+        "argilla.client.apis.status.Status.get_status",
+        return_value=ApiStatus(
+            **{
+                "version": "1.2.3",
+                "elasticsearch": {
+                    "name": "elasticsearch",
+                    "cluster_name": "es-argilla-local",
+                    "cluster_uuid": "p7gBcG5OTlG7e-RHg28-Qg",
+                    "version": {
+                        "number": "1.2.3",
+                        "build_flavor": "default",
+                        "build_type": "docker",
+                        "build_hash": "4ed5ee9afac63de92ec98f404ccbed7d3ba9584e",
+                        "build_date": "2022-12-05T18:22:22.226119656Z",
+                        "build_snapshot": False,
+                        "lucene_version": "9.4.2",
+                        "minimum_wire_compatibility_version": "7.17.0",
+                        "minimum_index_compatibility_version": "7.0.0",
+                    },
+                    "tagline": "You Know, for Search",
+                },
+                "mem_info": {"rss": "210M", "vms": "391G", "pfaults": "18K", "pageins": "26B"},
+            }
+        ),
+    )
+
+    result = cli_runner.invoke(cli, "info")
+
+    assert result.exit_code == 0
+    assert f"Client version: {version}" in result.stdout
+    assert "Server version: 1.2.3" in result.stdout
+    assert "ElasticSearch version: 1.2.3" in result.stdout
+
+
+@pytest.mark.usefixtures("not_logged_mock")
+def test_info_needs_login(cli_runner: "CliRunner", cli: "Typer") -> None:
+    result = cli_runner.invoke(cli, "info")
+
+    assert result.exit_code == 1
+    assert "You are not logged in. Please run `argilla login` to login to an Argilla server." in result.stdout


### PR DESCRIPTION
# Description

This PR adds a new command `python -m argilla info` that prints basic information about the Argilla client and connected server.

In addition, this PR adds a new method to `argilla.client.apis.status.Status` class to call the `GET /api/_status` endpoint of the server to get info about the server version and the elasticsearch instance used.

Closes #3704

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
