### PR TITLE
fix: `users create` command was not printing workspace names

### DIFF
--- a/src/argilla/tasks/users/create.py
+++ b/src/argilla/tasks/users/create.py
@@ -58,6 +58,8 @@ def create_user(
         typer.echo("An unexpected error occurred when trying to create the user")
         raise typer.Exit(code=1) from e
 
+    workspaces_str = ", ".join(workspace.name for workspace in user.workspaces)
+
     panel = get_argilla_themed_panel(
         Markdown(
             f"- **Username**: {user.username}\n"
@@ -65,7 +67,7 @@ def create_user(
             f"- **First name**: {user.first_name}\n"
             f"- **Last name**: {user.last_name}\n"
             f"- **API Key**: {user.api_key}\n"
-            f"- **Workspaces**: {user.workspaces}"
+            f"- **Workspaces**: {workspaces_str}"
         ),
         title="User created",
         title_align="left",

--- a/tests/unit/tasks/users/test_create.py
+++ b/tests/unit/tasks/users/test_create.py
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
 class TestSuiteCreateUserCommand:
     def test_create_user(self, cli_runner: "CliRunner", cli: "Typer", mocker: "MockerFixture", user: "User") -> None:
         user_create_mock = mocker.patch("argilla.client.users.User.create", return_value=user)
-        mocker.patch("argilla.client.users.User.workspaces", return_value=["ws1", "ws2"])
 
         result = cli_runner.invoke(
             cli,
@@ -37,6 +36,11 @@ class TestSuiteCreateUserCommand:
 
         assert result.exit_code == 0
         assert "User created" in result.stdout
+        assert "Username: unit-test" in result.stdout
+        assert "Role: admin" in result.stdout
+        assert "First name: unit-test" in result.stdout
+        assert "Last name: unit-test" in result.stdout
+        assert "Workspaces: unit-test" in result.stdout
         user_create_mock.assert_called_once_with(
             username="unit-test",
             password="unit-test",


### PR DESCRIPTION
# Description

In #3667 a new command to create users was added. This command prints a summary of the created user which includes a list of workspaces to which the users belongs. Instead of the name of the workspaces, workspaces classes were being printed. This PR fixes this.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

In a local development environment:

- [x] `python -m argilla users create --username gabriel --role annotator --workspace ws1 --workspace ws2`: prints `Workspaces: ws1, ws2`

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
