### PR TITLE
fix: display `UserWarning` in `add_user` and `delete_user` when ID is from an `owner`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ These are the section headers that we use:
 - Move `database` commands under `server` group of commands ([#3710](https://github.com/argilla-io/argilla/pull/3710))
 - `server` commands only included in the CLI app when `server` extra requirements are installed ([#3710](https://github.com/argilla-io/argilla/pull/3710)).
 - Updated `PUT /api/v1/responses/{response_id}` to replace `values` stored with received `values` in request ([#3711](https://github.com/argilla-io/argilla/pull/3711)).
+- Display a `UserWarning` when the `user_id` in `Workspace.add_user` and `Workspace.delete_user` is the ID of an user with the owner role as they don't require explicit permissions ([#3716](https://github.com/argilla-io/argilla/issues/3716)).
 
 ### Fixed
 

--- a/src/argilla/client/workspaces.py
+++ b/src/argilla/client/workspaces.py
@@ -156,7 +156,7 @@ class Workspace:
         except RuntimeError as e:
             raise RuntimeError(f"Error while retrieving user with id=`{user_id}` from Argilla.") from e
 
-        if user.role == UserRole.owner:
+        if user.is_owner:
             warnings.warn(
                 "The user you are trying to add to the workspace has the `owner` role, so it"
                 " will be excluded from the workspace. Note that users with `owner` role are"
@@ -205,7 +205,7 @@ class Workspace:
         except RuntimeError as e:
             raise RuntimeError(f"Error while retrieving user with id=`{user_id}` from Argilla.") from e
 
-        if user.role == UserRole.owner:
+        if user.is_owner:
             warnings.warn(
                 "The user you are trying to delete from the workspace has the `owner` role, so it"
                 " will be excluded from the workspace. Note that users with `owner` role are"

--- a/src/argilla/client/workspaces.py
+++ b/src/argilla/client/workspaces.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import warnings
 from datetime import datetime
 from typing import TYPE_CHECKING, Iterator, List, Optional, Union
 from uuid import UUID
@@ -28,6 +29,7 @@ from argilla.client.sdk.v1.workspaces import api as workspaces_api_v1
 from argilla.client.sdk.v1.workspaces.models import WorkspaceModel as WorkspaceModelV1
 from argilla.client.sdk.workspaces import api as workspaces_api
 from argilla.client.sdk.workspaces.models import WorkspaceModel as WorkspaceModelV0
+from argilla.client.users import User
 from argilla.client.utils import allowed_for_roles
 
 if TYPE_CHECKING:
@@ -126,12 +128,17 @@ class Workspace:
     def add_user(self, user_id: UUID) -> None:
         """Adds an existing user to the workspace in Argilla.
 
+        Note that users with `owner` role are excluded of the `add_user` method, as they
+        are superusers and they can access to all the workspaces and datasets in Argilla.
+
         Args:
             user_id: the ID of the user to be added to the workspace. The user must exist in Argilla.
 
         Raises:
-            ValueError: if the user with the provided ID already exists in the workspace.
-            RuntimeError: if there was an error while adding the user to the workspace.
+            ValueError: if the user with the provided ID either doesn't exist in Argilla or
+                already exists in the workspace.
+            RuntimeError: if there was an error while either fetching the user from Argilla or
+                adding the user to the workspace.
 
         Examples:
             >>> from argilla import rg
@@ -139,11 +146,28 @@ class Workspace:
             >>> workspace.add_user("my-user-id")
         """
         try:
-            workspaces_api.create_workspace_user(
-                client=self._client,
-                id=self.id,
-                user_id=user_id,
+            user = User.from_id(user_id)
+        except ValueError as e:
+            raise ValueError(
+                f"User with id=`{user_id}` doesn't exist in Argilla, so please"
+                " make sure that the ID you provided is a valid one. Otherwise,"
+                " you can create a new one via the `User.create` method."
+            ) from e
+        except RuntimeError as e:
+            raise RuntimeError(f"Error while retrieving user with id=`{user_id}` from Argilla.") from e
+
+        if user.role == UserRole.owner:
+            warnings.warn(
+                "The user you are trying to add to the workspace has the `owner` role, so it"
+                " will be excluded from the workspace. Note that users with `owner` role are"
+                " superusers and they can access to all the workspaces and datasets in Argilla.",
+                UserWarning,
+                stacklevel=2,
             )
+            return
+
+        try:
+            workspaces_api.create_workspace_user(client=self._client, id=self.id, user_id=user_id)
         except AlreadyExistsApiError as e:
             raise ValueError(f"User with id=`{user_id}` already exists in workspace with id=`{self.id}`.") from e
         except BaseClientError as e:
@@ -154,12 +178,16 @@ class Workspace:
         """Deletes an existing user from the workspace in Argilla. Note that the user
         will not be deleted from Argilla, but just from the workspace.
 
+        Note that users with `owner` role are excluded of the `delete_user` method, as they
+        are superusers and they can access to all the workspaces and datasets in Argilla.
+
         Args:
             user_id: the ID of the user to be deleted from the workspace. The user must exist in Argilla.
 
         Raises:
-            ValueError: if the user with the provided ID doesn't exist in the workspace.
-            RuntimeError: if there was an error while deleting the user from the workspace.
+            ValueError: if the user with the provided ID doesn't exist in either the workspace or Argilla.
+            RuntimeError: if there was an error while retrieving the user from Argilla or
+                while deleting it from the workspace.
 
         Examples:
             >>> from argilla import rg
@@ -167,11 +195,28 @@ class Workspace:
             >>> workspace.delete_user("my-user-id")
         """
         try:
-            workspaces_api.delete_workspace_user(
-                client=self._client,
-                id=self.id,
-                user_id=user_id,
+            user = User.from_id(user_id)
+        except ValueError as e:
+            raise ValueError(
+                f"User with id=`{user_id}` doesn't exist in Argilla, so please"
+                " make sure that the ID you provided is a valid one. Otherwise,"
+                " you can create a new one via the `User.create` method."
+            ) from e
+        except RuntimeError as e:
+            raise RuntimeError(f"Error while retrieving user with id=`{user_id}` from Argilla.") from e
+
+        if user.role == UserRole.owner:
+            warnings.warn(
+                "The user you are trying to delete from the workspace has the `owner` role, so it"
+                " will be excluded from the workspace. Note that users with `owner` role are"
+                " superusers and they can access to all the workspaces and datasets in Argilla.",
+                UserWarning,
+                stacklevel=2,
             )
+            return
+
+        try:
+            workspaces_api.delete_workspace_user(client=self._client, id=self.id, user_id=user_id)
         except NotFoundApiError as e:
             raise ValueError(
                 f"Either the user with id=`{user_id}` doesn't exist in Argilla, or it"

--- a/tests/integration/client/test_workspaces.py
+++ b/tests/integration/client/test_workspaces.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from typing import TYPE_CHECKING
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 from argilla.client.api import ArgillaSingleton
@@ -133,8 +133,9 @@ async def test_workspace_users_not_allowed_role(role: UserRole) -> None:
         workspace.users
 
 
+@pytest.mark.parametrize("role", [UserRole.admin, UserRole.annotator])
 @pytest.mark.asyncio
-async def test_workspace_add_user(owner: "ServerUser") -> None:
+async def test_workspace_add_user(owner: "ServerUser", role: UserRole) -> None:
     workspace = await WorkspaceFactory.create(name="test_workspace")
     ArgillaSingleton.init(api_key=owner.api_key)
 
@@ -142,15 +143,16 @@ async def test_workspace_add_user(owner: "ServerUser") -> None:
     assert workspace.name == "test_workspace"
     assert isinstance(workspace.id, UUID)
 
-    workspace.add_user(owner.id)
-    assert any(user.username == owner.username for user in workspace.users)
+    new_user = await UserFactory.create(role=role)
+    workspace.add_user(new_user.id)
+    assert any(user.username == new_user.username for user in workspace.users)
 
     with pytest.raises(ValueError, match="User with id="):
-        workspace.add_user(owner.id)
+        workspace.add_user(new_user.id)
 
     workspace = Workspace.from_name("test_workspace")
     assert isinstance(workspace.users, list)
-    assert any(user.username == owner.username for user in workspace.users)
+    assert any(user.username == new_user.username for user in workspace.users)
 
 
 @pytest.mark.parametrize("role", [UserRole.admin, UserRole.annotator])
@@ -166,19 +168,55 @@ async def test_workspace_add_user_not_allowed_role(role: UserRole) -> None:
 
 
 @pytest.mark.asyncio
-async def test_workspace_delete_user(owner: "ServerUser", db: "AsyncSession") -> None:
+async def test_workspace_add_user_warnings(owner: "ServerUser") -> None:
     workspace = await WorkspaceFactory.create(name="test_workspace")
-    await WorkspaceUserFactory.create(workspace_id=workspace.id, user_id=owner.id)
     ArgillaSingleton.init(api_key=owner.api_key)
 
     workspace = Workspace.from_name("test_workspace")
-    assert any(user.username == "owner" for user in workspace.users)
+    assert workspace.name == "test_workspace"
+    assert isinstance(workspace.id, UUID)
 
-    workspace.delete_user(owner.id)
-    assert not any(user.username == owner.username for user in workspace.users)
+    with pytest.warns(UserWarning, match="The user you are trying to add to the workspace has the `owner` role"):
+        workspace.add_user(owner.id)
+    assert workspace.users == []
+
+
+@pytest.mark.asyncio
+async def test_workspace_add_user_errors(owner: "ServerUser") -> None:
+    workspace = await WorkspaceFactory.create(name="test_workspace")
+    ArgillaSingleton.init(api_key=owner.api_key)
+
+    workspace = Workspace.from_name("test_workspace")
+    assert workspace.name == "test_workspace"
+    assert isinstance(workspace.id, UUID)
+
+    wrong_user_id = uuid4()
+    with pytest.raises(ValueError, match=f"User with id=\`{wrong_user_id}\` doesn't exist in Argilla"):
+        workspace.add_user(wrong_user_id)
+    assert workspace.users == []
+
+    valid_user = await UserFactory.create(role=UserRole.annotator)
+    workspace.add_user(valid_user.id)
+    with pytest.raises(ValueError, match=f"User with id=\`{valid_user.id}\` already exists in workspace"):
+        workspace.add_user(valid_user.id)
+
+
+@pytest.mark.parametrize("role", [UserRole.admin, UserRole.annotator])
+@pytest.mark.asyncio
+async def test_workspace_delete_user(owner: "ServerUser", role: UserRole) -> None:
+    workspace = await WorkspaceFactory.create(name="test_workspace")
+    new_user = await UserFactory.create(role=role)
+    await WorkspaceUserFactory.create(workspace_id=workspace.id, user_id=new_user.id)
+    ArgillaSingleton.init(api_key=owner.api_key)
+
+    workspace = Workspace.from_name("test_workspace")
+    assert any(user.username == new_user.username for user in workspace.users)
+
+    workspace.delete_user(new_user.id)
+    assert not any(user.username == new_user.username for user in workspace.users)
 
     with pytest.raises(ValueError, match="Either the user with id="):
-        workspace.delete_user(owner.id)
+        workspace.delete_user(new_user.id)
 
 
 @pytest.mark.parametrize("role", [UserRole.admin, UserRole.annotator])
@@ -191,6 +229,43 @@ async def test_workspace_delete_user_not_allowed_role(role: UserRole) -> None:
     workspace = Workspace.from_name(workspace.name)
     with pytest.raises(PermissionError, match=f"User with role={role} is not allowed to call `delete_user`"):
         workspace.delete_user(user.id)
+
+
+@pytest.mark.asyncio
+async def test_workspace_delete_user_warnings(owner: "ServerUser") -> None:
+    workspace = await WorkspaceFactory.create(name="test_workspace")
+    ArgillaSingleton.init(api_key=owner.api_key)
+
+    workspace = Workspace.from_name("test_workspace")
+    assert workspace.name == "test_workspace"
+    assert isinstance(workspace.id, UUID)
+
+    with pytest.warns(UserWarning, match="The user you are trying to delete from the workspace has the `owner` role"):
+        workspace.delete_user(owner.id)
+    assert workspace.users == []
+
+
+@pytest.mark.asyncio
+async def test_workspace_delete_user_errors(owner: "ServerUser") -> None:
+    workspace = await WorkspaceFactory.create(name="test_workspace")
+    new_user = await UserFactory.create(role=UserRole.annotator)
+    await WorkspaceUserFactory.create(workspace_id=workspace.id, user_id=new_user.id)
+    ArgillaSingleton.init(api_key=owner.api_key)
+
+    workspace = Workspace.from_name("test_workspace")
+    assert workspace.name == "test_workspace"
+    assert isinstance(workspace.id, UUID)
+
+    wrong_user_id = uuid4()
+    with pytest.raises(ValueError, match=f"User with id=\`{wrong_user_id}\` doesn't exist in Argilla"):
+        workspace.delete_user(wrong_user_id)
+
+    workspace.delete_user(new_user.id)
+    with pytest.raises(
+        ValueError,
+        match=f"Either the user with id=\`{new_user.id}\` doesn't exist in Argilla, or it doesn't belong to workspace with id=\`{workspace.id}\`",
+    ):
+        workspace.delete_user(new_user.id)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

This PR displays a `UserWarning` when trying to call `Workspace.add_user` or `Workspace.delete_user` with an `user_id` from an owner user in Argilla, as those are superusers and don't require explicit permissions.

Besides that, all the exceptions have been properly handled, and some more integration tests have been included.

Note that this PR is not an actual bug fix, as everything was working correctly, is more like an improvement on the current functionality, to avoid owner users to be explicitly granted permissions when there's no need to.

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [X] Add integration tests for `Workspace.add_user`, the new `UserWarning`, and the previously uncovered exceptions
- [X] Add integration tests for `Workspace.delete_user`, the new `UserWarning`, and the previously uncovered exceptions

**Checklist**

- [X] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [X] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)