### PR TITLE
fix: exclude `id` and `client` from `suggestions` in `DatasetCard`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ These are the section headers that we use:
 
 - Fixed `Pending queue` pagination problems when during data annotation ([#3677](https://github.com/argilla-io/argilla/pull/3677))
 - Fixed `visible_labels` default value to be 20 just when `visible_labels` not provided and `len(labels) > 20`, otherwise it will either be the provided `visible_labels` value or `None`, for `LabelQuestion` and `MultiLabelQuestion` ([#3702](https://github.com/argilla-io/argilla/pull/3702)).
+- Fixed `DatasetCard` generation when `RemoteFeedbackDataset` contains suggestions ([#3718](https://github.com/argilla-io/argilla/pull/3718)).
 
 ## [1.15.0](https://github.com/argilla-io/argilla/compare/v1.14.1...v1.15.0)
 

--- a/src/argilla/client/feedback/integrations/huggingface/dataset.py
+++ b/src/argilla/client/feedback/integrations/huggingface/dataset.py
@@ -223,7 +223,17 @@ class HuggingFaceDatasetMixin:
                 argilla_fields=self.fields,
                 argilla_questions=self.questions,
                 argilla_guidelines=self.guidelines,
-                argilla_record=json.loads(self.records[0].json(exclude={"client", "id", "name2id"}, exclude_none=True)),
+                argilla_record=json.loads(
+                    self.records[0].json(
+                        exclude={
+                            "client": ...,
+                            "id": ...,
+                            "name2id": ...,
+                            "suggestions": {"__all__": {"id", "client"}},
+                        },
+                        exclude_none=True,
+                    )
+                ),
                 huggingface_record=hfds[0],
             )
             card.push_to_hub(repo_id, repo_type="dataset", token=kwargs.get("token"))


### PR DESCRIPTION
# Description

This PR addressed a bug internally reported by @gabrielmbmb, that was happening when calling `argilla datasets push-to-huggingface` on a `FeedbackDataset` from Argilla with suggestions, since recently we included the `id` and `client` fields in the `RemoteSuggestionSchema` so those were not properly serialised when generating a random dataset entry for the `DatasetCard` to be uploaded to HuggingFace. This is already patched, and the `DatasetCard` is properly generated.

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [X] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)