### PR TITLE
:rotating_light: fix console warning due to missing props

### DIFF
--- a/frontend/components/features/datasets/datasets-settings/LeftDatasetSettings.content.vue
+++ b/frontend/components/features/datasets/datasets-settings/LeftDatasetSettings.content.vue
@@ -17,7 +17,7 @@
     </div>
     <div class="dataset-description-component left-content-item">
       <DatasetDescriptionReadOnlyComponent
-        :datasetDescription="settingsDescription"
+        :guidelines="settingsDescription"
       />
     </div>
     <div

--- a/frontend/components/features/datasets/datasets-settings/LeftDatasetSettings.content.vue
+++ b/frontend/components/features/datasets/datasets-settings/LeftDatasetSettings.content.vue
@@ -16,9 +16,7 @@
       </base-action-tooltip>
     </div>
     <div class="dataset-description-component left-content-item">
-      <DatasetDescriptionReadOnlyComponent
-        :guidelines="settingsDescription"
-      />
+      <DatasetDescriptionReadOnlyComponent :guidelines="settingsDescription" />
     </div>
     <div
       class="labels-edition-component left-content-item"


### PR DESCRIPTION
Since the guidelines of a dataset could be empty, when going on the settings page of a dataset there is some `missing props` warning in the console of the browser.

![image](https://github.com/argilla-io/argilla/assets/88380932/dde1f908-54c7-4abf-bd71-bcb0a13ba269)

**Type of change**

- Bug fix

**How Has This Been Tested**

- settings page of all dataset (feedback task and old tasks)
