### PR TITLE
feat: add `workspace_id` param to `GET /api/v1/me/datasets`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ These are the section headers that we use:
 - Added `created_at` and `updated_at` properties to `RemoteFeedbackDataset` and `FilteredRemoteFeedbackDataset` ([#3709](https://github.com/argilla-io/argilla/pull/3709)).
 - Added handling `PermissionError` when executing a command with a logged in user with not enough permissions ([#3717](https://github.com/argilla-io/argilla/pull/3717)).
 - Added `workspaces add-user` command to add a user to workspace ([#3712](https://github.com/argilla-io/argilla/pull/3712)).
+- Added `workspace_id` param to `GET /api/v1/me/datasets` endpoint ([#3727](https://github.com/argilla-io/argilla/pull/3727)).
+- Added `workspace_id` arg to `list_datasets` in the Python SDK ([#3727](https://github.com/argilla-io/argilla/pull/3727)).
 
 ### Changed
 

--- a/src/argilla/client/feedback/dataset/mixins.py
+++ b/src/argilla/client/feedback/dataset/mixins.py
@@ -316,12 +316,15 @@ class ArgillaMixin:
 
         try:
             datasets = datasets_api_v1.list_datasets(
-                client=httpx_client, workspace_id=workspace.id if workspace else None
+                client=httpx_client, workspace_id=workspace.id if workspace is not None else None
             ).parsed
         except Exception as e:
             raise RuntimeError(
                 f"Failed while listing the `FeedbackDataset` datasets in Argilla with exception: {e}"
             ) from e
+
+        if len(datasets) == 0:
+            return []
         return [
             RemoteFeedbackDataset(
                 client=httpx_client,

--- a/src/argilla/client/feedback/dataset/mixins.py
+++ b/src/argilla/client/feedback/dataset/mixins.py
@@ -314,10 +314,10 @@ class ArgillaMixin:
         if workspace is not None:
             workspace = Workspace.from_name(workspace)
 
-        # TODO(alvarobartt or gabrielmbmb): add `workspace_id` in `GET /api/v1/datasets`
-        # and in `GET /api/v1/me/datasets` to filter by workspace
         try:
-            datasets = datasets_api_v1.list_datasets(client=httpx_client).parsed
+            datasets = datasets_api_v1.list_datasets(
+                client=httpx_client, workspace_id=workspace.id if workspace else None
+            ).parsed
         except Exception as e:
             raise RuntimeError(
                 f"Failed while listing the `FeedbackDataset` datasets in Argilla with exception: {e}"
@@ -335,5 +335,4 @@ class ArgillaMixin:
                 guidelines=dataset.guidelines or None,
             )
             for dataset in datasets
-            if workspace is None or dataset.workspace_id == workspace.id
         ]

--- a/src/argilla/client/sdk/v1/datasets/api.py
+++ b/src/argilla/client/sdk/v1/datasets/api.py
@@ -157,7 +157,10 @@ def list_datasets(
 
     if response.status_code == 200:
         response_obj = Response.from_httpx_response(response)
-        response_obj.parsed = [FeedbackDatasetModel(**dataset) for dataset in response.json()["items"]]
+        if response.json()["items"] is None or len(response.json()["items"]) == 0:
+            response_obj.parsed = []
+        else:
+            response_obj.parsed = [FeedbackDatasetModel(**dataset) for dataset in response.json()["items"]]
         return response_obj
     return handle_response_error(response)
 

--- a/src/argilla/client/sdk/v1/datasets/api.py
+++ b/src/argilla/client/sdk/v1/datasets/api.py
@@ -132,19 +132,28 @@ def publish_dataset(
 
 def list_datasets(
     client: httpx.Client,
-) -> Response[Union[List[FeedbackDatasetModel], ErrorMessage, HTTPValidationError]]:
-    """Sends a GET request to `/api/v1/datasets` endpoint to retrieve a list of `FeedbackTask` datasets.
+    workspace_id: Optional[UUID] = None,
+) -> Response[Union[list, List[FeedbackDatasetModel], ErrorMessage, HTTPValidationError]]:
+    """Sends a GET request to `/api/v1/me/datasets` endpoint to retrieve a list of
+    `FeedbackTask` datasets filtered by `workspace_id` if applicable.
 
     Args:
         client: the authenticated Argilla client to be used to send the request to the API.
+        workspace_id: the id of the workspace to filter the datasets by. Note that the user
+            should either be owner or have access to the workspace. Defaults to None.
 
     Returns:
         A `Response` object containing a `parsed` attribute with the parsed response if the
-        request was successful, which is a list of `FeedbackDatasetModel`.
+        request was successful, which is a list of `FeedbackDatasetModel` if any, otherwise
+        it will contain an empty list.
     """
     url = "/api/v1/me/datasets"
 
-    response = client.get(url=url)
+    params = {}
+    if workspace_id is not None:
+        params["workspace_id"] = str(workspace_id)
+
+    response = client.get(url=url, params=params)
 
     if response.status_code == 200:
         response_obj = Response.from_httpx_response(response)

--- a/src/argilla/client/sdk/v1/datasets/api.py
+++ b/src/argilla/client/sdk/v1/datasets/api.py
@@ -157,10 +157,7 @@ def list_datasets(
 
     if response.status_code == 200:
         response_obj = Response.from_httpx_response(response)
-        if response.json()["items"] is None or len(response.json()["items"]) == 0:
-            response_obj.parsed = []
-        else:
-            response_obj.parsed = [FeedbackDatasetModel(**dataset) for dataset in response.json()["items"]]
+        response_obj.parsed = [FeedbackDatasetModel(**dataset) for dataset in response.json()["items"]]
         return response_obj
     return handle_response_error(response)
 

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -76,7 +76,7 @@ async def list_current_user_datasets(
 ):
     await authorize(current_user, DatasetPolicyV1.list(workspace_id))
 
-    if not workspace_id is not None:
+    if not workspace_id:
         if current_user.is_owner:
             dataset_list = await datasets.list_datasets(db)
         else:

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Optional
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import async_object_session
@@ -210,8 +210,10 @@ class DatasetPolicy:
 
 class DatasetPolicyV1:
     @classmethod
-    async def list(cls, actor: User) -> bool:
-        return True
+    async def list(cls, actor: User, workspace_id: Optional[UUID] = None) -> bool:
+        if actor.is_owner or workspace_id is None:
+            return True
+        return await _exists_workspace_user_by_user_and_workspace_id(actor, workspace_id)
 
     @classmethod
     def get(cls, dataset: Dataset) -> PolicyAction:

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -214,7 +214,7 @@ class DatasetPolicyV1:
         async def is_allowed(actor: User) -> bool:
             if actor.is_owner or workspace_id is None:
                 return True
-            await _exists_workspace_user_by_user_and_workspace_id(actor, workspace_id)
+            return await _exists_workspace_user_by_user_and_workspace_id(actor, workspace_id)
 
         return is_allowed
 

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -210,10 +210,13 @@ class DatasetPolicy:
 
 class DatasetPolicyV1:
     @classmethod
-    async def list(cls, actor: User, workspace_id: Optional[UUID] = None) -> bool:
-        if actor.is_owner or workspace_id is None:
-            return True
-        return await _exists_workspace_user_by_user_and_workspace_id(actor, workspace_id)
+    def list(cls, workspace_id: Optional[UUID] = None) -> PolicyAction:
+        async def is_allowed(actor: User) -> bool:
+            if actor.is_owner or workspace_id is None:
+                return True
+            await _exists_workspace_user_by_user_and_workspace_id(actor, workspace_id)
+
+        return is_allowed
 
     @classmethod
     def get(cls, dataset: Dataset) -> PolicyAction:

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -148,6 +148,31 @@ class TestSuiteDatasets:
         response_body = response.json()
         assert [dataset["name"] for dataset in response_body["items"]] == ["dataset-a", "dataset-b"]
 
+    @pytest.mark.parametrize("role", [UserRole.owner, UserRole.annotator, UserRole.admin])
+    async def test_list_current_user_datasets_by_workspace_id(
+        self, async_client: "AsyncClient", role: UserRole
+    ) -> None:
+        workspace = await WorkspaceFactory.create()
+        another_workspace = await WorkspaceFactory.create()
+
+        user = (
+            await UserFactory.create(role=role)
+            if role == UserRole.owner
+            else await UserFactory.create(workspaces=[workspace], role=role)
+        )
+
+        await DatasetFactory.create(name="dataset-a", workspace=workspace)
+        await DatasetFactory.create(name="dataset-b", workspace=another_workspace)
+
+        response = await async_client.get(
+            "/api/v1/me/datasets", params={"workspace_id": workspace.id}, headers={API_KEY_HEADER_NAME: user.api_key}
+        )
+
+        assert response.status_code == 200
+
+        response_body = response.json()
+        assert [dataset["name"] for dataset in response_body["items"]] == ["dataset-a"]
+
     async def test_list_dataset_fields(self, async_client: "AsyncClient", owner_auth_header: dict):
         dataset = await DatasetFactory.create()
         text_field_a = await TextFieldFactory.create(

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -85,7 +85,7 @@ if TYPE_CHECKING:
 
 @pytest.mark.asyncio
 class TestSuiteDatasets:
-    async def test_list_current_user_datasets(self, async_client: "AsyncClient", owner_auth_header: dict):
+    async def test_list_current_user_datasets(self, async_client: "AsyncClient", owner_auth_header: dict) -> None:
         dataset_a = await DatasetFactory.create(name="dataset-a")
         dataset_b = await DatasetFactory.create(name="dataset-b", guidelines="guidelines")
         dataset_c = await DatasetFactory.create(name="dataset-c", status=DatasetStatus.ready)
@@ -125,7 +125,7 @@ class TestSuiteDatasets:
             ]
         }
 
-    async def test_list_current_user_datasets_without_authentication(self, async_client: "AsyncClient"):
+    async def test_list_current_user_datasets_without_authentication(self, async_client: "AsyncClient") -> None:
         response = await async_client.get("/api/v1/me/datasets")
 
         assert response.status_code == 401
@@ -133,7 +133,7 @@ class TestSuiteDatasets:
     @pytest.mark.parametrize("role", [UserRole.annotator, UserRole.admin])
     async def test_list_current_user_datasets_as_restricted_user_role(
         self, async_client: "AsyncClient", role: UserRole
-    ):
+    ) -> None:
         workspace = await WorkspaceFactory.create()
         user = await UserFactory.create(workspaces=[workspace], role=role)
 


### PR DESCRIPTION
# Description

This PR adds the `workspace_id` param to `GET /api/v1/me/datasets` so that the workspace filtering when listing `FeedbackTask` datasets is applied in the API-side, as well as making sure that no local filters are applied e.g. `FeedbackDataset.list(workspace=...)`

Closes #3726

**Type of change**

- [X] New feature (non-breaking change which adds functionality)
- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

- [x] Add tests for `GET /api/v1/me/datasets` using the `workspace_id` param, including also the updated policies for non-owner users
- [x] Add tests for `list_datasets` in the Python SDK using the `workspace_id` arg
- [x] Add tests for `FeedbackDataset.list` in the Python client using the `workspace` arg

**Checklist**

- [X] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)