### PR TITLE
refactor: reuse `UserModel` and remove duplicated `WorkspaceUserModel`

### DIFF
--- a/src/argilla/client/sdk/users/models.py
+++ b/src/argilla/client/sdk/users/models.py
@@ -46,7 +46,7 @@ class UserModel(BaseModel):
     full_name: Optional[str]
     username: str
     role: UserRole
-    workspaces: List[str]
+    workspaces: Optional[List[str]]
     api_key: str
     inserted_at: datetime
     updated_at: datetime

--- a/src/argilla/client/sdk/users/models.py
+++ b/src/argilla/client/sdk/users/models.py
@@ -34,10 +34,6 @@ class UserCreateModel(BaseModel):
     password: str = Field(min_length=8, max_length=100)
     workspaces: Optional[List[str]] = None
 
-    # TODO(alvarobartt): confirm with @frascuchon
-    # disabled: Optional[bool] = None
-    # api_key: Optional[str]  # backward compatibility
-
 
 class UserModel(BaseModel):
     id: UUID

--- a/src/argilla/client/sdk/workspaces/api.py
+++ b/src/argilla/client/sdk/workspaces/api.py
@@ -87,7 +87,7 @@ def list_workspace_users(
 
     if response.status_code == 200:
         response_obj = Response.from_httpx_response(response)
-        response_obj.parsed = [UserModel(**workspace) for workspace in response.json()]
+        response_obj.parsed = [UserModel(**user) for user in response.json()]
         return response_obj
     return handle_response_error(response)
 

--- a/src/argilla/client/sdk/workspaces/api.py
+++ b/src/argilla/client/sdk/workspaces/api.py
@@ -19,7 +19,8 @@ import httpx
 
 from argilla.client.sdk.commons.errors_handler import handle_response_error
 from argilla.client.sdk.commons.models import ErrorMessage, HTTPValidationError, Response
-from argilla.client.sdk.workspaces.models import WorkspaceModel, WorkspaceUserModel
+from argilla.client.sdk.users.models import UserModel
+from argilla.client.sdk.workspaces.models import WorkspaceModel
 
 
 def list_workspaces(client: httpx.Client) -> Response[Union[List[WorkspaceModel], ErrorMessage, HTTPValidationError]]:
@@ -69,7 +70,7 @@ def create_workspace(
 
 def list_workspace_users(
     client: httpx.Client, id: UUID
-) -> Response[Union[List[WorkspaceUserModel], ErrorMessage, HTTPValidationError]]:
+) -> Response[Union[List[UserModel], ErrorMessage, HTTPValidationError]]:
     """Sends a request to `GET /api/workspaces/{id}/users` to list all the users in the workspace.
 
     Args:
@@ -78,7 +79,7 @@ def list_workspace_users(
 
     Returns:
         A Response object with the parsed response, containing a `parsed` attribute with the
-        parsed response if the request was successful, which is a list of `WorkspaceUserModel` objects.
+        parsed response if the request was successful, which is a list of `UserModel` objects.
     """
     url = f"/api/workspaces/{id}/users"
 
@@ -86,14 +87,14 @@ def list_workspace_users(
 
     if response.status_code == 200:
         response_obj = Response.from_httpx_response(response)
-        response_obj.parsed = [WorkspaceUserModel(**workspace) for workspace in response.json()]
+        response_obj.parsed = [UserModel(**workspace) for workspace in response.json()]
         return response_obj
     return handle_response_error(response)
 
 
 def create_workspace_user(
     client: httpx.Client, id: UUID, user_id: UUID
-) -> Response[Union[WorkspaceUserModel, ErrorMessage, HTTPValidationError]]:
+) -> Response[Union[UserModel, ErrorMessage, HTTPValidationError]]:
     """Sends a request to `POST /api/workspaces/{id}/users/{user_id}` to add a new user to the workspace.
 
     Args:
@@ -103,7 +104,7 @@ def create_workspace_user(
 
     Returns:
         A Response object with the parsed response, containing a `parsed` attribute with the
-        parsed response if the request was successful, which is a `WorkspaceUserModel` object.
+        parsed response if the request was successful, which is a `UserModel` object.
     """
     url = f"/api/workspaces/{id}/users/{user_id}"
 
@@ -111,14 +112,14 @@ def create_workspace_user(
 
     if response.status_code == 200:
         response_obj = Response.from_httpx_response(response)
-        response_obj.parsed = WorkspaceUserModel(**response.json())
+        response_obj.parsed = UserModel(**response.json())
         return response_obj
     return handle_response_error(response)
 
 
 def delete_workspace_user(
     client: httpx.Client, id: UUID, user_id: UUID
-) -> Response[Union[WorkspaceUserModel, ErrorMessage, HTTPValidationError]]:
+) -> Response[Union[UserModel, ErrorMessage, HTTPValidationError]]:
     """Sends a request to `DELETE /api/workspaces/{id}/users/{user_id}` to remove a user from the workspace.
 
     Args:
@@ -128,7 +129,7 @@ def delete_workspace_user(
 
     Returns:
         A Response object with the parsed response, containing a `parsed` attribute with the
-        parsed response if the request was successful, which is a `WorkspaceUserModel` object.
+        parsed response if the request was successful, which is a `UserModel` object.
     """
     url = f"/api/workspaces/{id}/users/{user_id}"
 
@@ -136,6 +137,6 @@ def delete_workspace_user(
 
     if response.status_code == 200:
         response_obj = Response.from_httpx_response(response)
-        response_obj.parsed = WorkspaceUserModel(**response.json())
+        response_obj.parsed = UserModel(**response.json())
         return response_obj
     return handle_response_error(response)

--- a/src/argilla/client/sdk/workspaces/models.py
+++ b/src/argilla/client/sdk/workspaces/models.py
@@ -13,30 +13,13 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel
-
-from argilla.client.sdk.users.models import UserRole
 
 
 class WorkspaceModel(BaseModel):
     id: UUID
     name: str
-    inserted_at: datetime
-    updated_at: datetime
-
-
-# TODO(alvarobartt): replace with the `pydantic.BaseModel` created at https://github.com/argilla-io/argilla/pull/3169 once is merged
-class WorkspaceUserModel(BaseModel):
-    id: UUID
-    first_name: str
-    last_name: Optional[str]
-    full_name: Optional[str]
-    username: str
-    role: UserRole
-    workspaces: Optional[List[str]]
-    api_key: str
     inserted_at: datetime
     updated_at: datetime

--- a/src/argilla/client/workspaces.py
+++ b/src/argilla/client/workspaces.py
@@ -35,7 +35,7 @@ from argilla.client.utils import allowed_for_roles
 if TYPE_CHECKING:
     import httpx
 
-    from argilla.client.sdk.workspaces.models import WorkspaceUserModel
+    from argilla.client.sdk.users.models import UserModel
 
 
 class Workspace:
@@ -61,7 +61,7 @@ class Workspace:
         >>> workspace = rg.Workspace.from_name("my-workspace") # or `Workspace.from_id("...")`
         >>> workspace.add_user("my-user")
         >>> print(workspace.users)
-        [WorkspaceUserModel(id='...', first_name='Luke', last_name="Skywalker', full_name='Luke Skywalker', username='my-user', role='annotator', workspaces=['my-workspace'], api_key='...', inserted_at=datetime.datetime(2021, 8, 31, 10, 0, 0), updated_at=datetime.datetime(2021, 8, 31, 10, 0, 0))]
+        [UserModel(id='...', first_name='Luke', last_name="Skywalker', full_name='Luke Skywalker', username='my-user', role='annotator', workspaces=['my-workspace'], api_key='...', inserted_at=datetime.datetime(2021, 8, 31, 10, 0, 0), updated_at=datetime.datetime(2021, 8, 31, 10, 0, 0))]
         >>> workspace.delete_user("my-user")
         >>> print(workspace.users)
         []
@@ -70,7 +70,7 @@ class Workspace:
     _client: "httpx.Client"  # Required to be able to use `allowed_for_roles` decorator
     id: UUID
     name: str
-    users: Optional[List["WorkspaceUserModel"]] = None
+    users: Optional[List["UserModel"]] = None
     inserted_at: datetime
     updated_at: datetime
 
@@ -109,11 +109,11 @@ class Workspace:
 
     @property
     @allowed_for_roles(roles=[UserRole.owner, UserRole.admin])
-    def users(self) -> List["WorkspaceUserModel"]:
+    def users(self) -> List["UserModel"]:
         """Returns the list of users linked to the workspace.
 
         Returns:
-            A list of `WorkspaceUserModel` instances.
+            A list of `UserModel` instances.
         """
         # TODO(@alvarobartt): Maybe we should return a list of rg.User instead.
         return workspaces_api.list_workspace_users(self._client, self.id).parsed

--- a/tests/integration/client/sdk/api/test_workspaces.py
+++ b/tests/integration/client/sdk/api/test_workspaces.py
@@ -14,6 +14,7 @@
 
 import pytest
 from argilla.client.api import ArgillaSingleton
+from argilla.client.sdk.users.models import UserModel
 from argilla.client.sdk.workspaces.api import (
     create_workspace,
     create_workspace_user,
@@ -21,7 +22,7 @@ from argilla.client.sdk.workspaces.api import (
     list_workspace_users,
     list_workspaces,
 )
-from argilla.client.sdk.workspaces.models import WorkspaceModel, WorkspaceUserModel
+from argilla.client.sdk.workspaces.models import WorkspaceModel
 from argilla.server.models import User
 
 from tests.factories import WorkspaceFactory, WorkspaceUserFactory
@@ -58,7 +59,7 @@ async def test_list_workspace_users(owner: User) -> None:
     assert response.status_code == 200
     assert isinstance(response.parsed, list)
     assert len(response.parsed) > 0
-    assert isinstance(response.parsed[0], WorkspaceUserModel)
+    assert isinstance(response.parsed[0], UserModel)
 
 
 @pytest.mark.asyncio
@@ -68,7 +69,7 @@ async def test_create_workspace_user(owner: User) -> None:
 
     response = create_workspace_user(client=httpx_client, id=workspace.id, user_id=owner.id)
     assert response.status_code == 200
-    assert isinstance(response.parsed, WorkspaceUserModel)
+    assert isinstance(response.parsed, UserModel)
     assert response.parsed.id == owner.id
     assert response.parsed.workspaces[0] == workspace.name
 

--- a/tests/integration/client/test_workspaces.py
+++ b/tests/integration/client/test_workspaces.py
@@ -17,8 +17,7 @@ from uuid import UUID, uuid4
 
 import pytest
 from argilla.client.api import ArgillaSingleton
-from argilla.client.sdk.users.models import UserRole
-from argilla.client.sdk.workspaces.models import WorkspaceUserModel
+from argilla.client.sdk.users.models import UserModel, UserRole
 from argilla.client.workspaces import Workspace
 
 from tests.factories import (
@@ -30,7 +29,6 @@ from tests.factories import (
 
 if TYPE_CHECKING:
     from argilla.server.models import User as ServerUser
-    from sqlalchemy.ext.asyncio import AsyncSession
 
 
 def test_workspace_cls_init() -> None:
@@ -118,7 +116,7 @@ async def test_workspace_users(owner: "ServerUser") -> None:
     ArgillaSingleton.init(api_key=owner.api_key)
 
     workspace = Workspace.from_name(name=workspace.name)
-    assert all(isinstance(user, WorkspaceUserModel) for user in workspace.users)
+    assert all(isinstance(user, UserModel) for user in workspace.users)
 
 
 @pytest.mark.parametrize("role", [UserRole.annotator])


### PR DESCRIPTION
# Description

This PR addresses a pending TODO upon https://github.com/argilla-io/argilla/pull/3169 completion where the `UserModel` was included when wrapping the `/api/users` API endpoints. So on, in this PR we remove the `WorkspaceUserModel` schema in favour of `UserModel` to avoid duplicating the same schema to avoid potential incompatibilities.

**Type of change**

- [X] Refactor (change restructuring the codebase without changing functionality)
- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [X] Replace outdated references to `WorkspaceUserModel` with `UserModel` and re-run the existing unit/integration tests

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)