### PR TITLE
feat: add `argilla` script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ These are the section headers that we use:
 - Added `workspaces add-user` command to add a user to workspace ([#3712](https://github.com/argilla-io/argilla/pull/3712)).
 - Added `workspace_id` param to `GET /api/v1/me/datasets` endpoint ([#3727](https://github.com/argilla-io/argilla/pull/3727)).
 - Added `workspace_id` arg to `list_datasets` in the Python SDK ([#3727](https://github.com/argilla-io/argilla/pull/3727)).
+- Added `argilla` script that allows to execute Argilla CLI using the `argilla` command ([#3730](https://github.com/argilla-io/argilla/pull/3730)).
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ postgresql = [
     # If we're on macOS, then install `psycopg2-binary` instead
     "psycopg2-binary ~= 2.9.5; sys_platform == 'darwin'",
     # Async PostgreSQL
-    "asyncpg >=0.27.0"
+    "asyncpg >=0.27.0",
 ]
 listeners = ["schedule ~= 1.1.0", "prodict ~= 0.8.0"]
 integrations = [
@@ -93,7 +93,8 @@ integrations = [
     # TODO: some backward comp. problems introduced in 0.5.0. 0.13 does not match with setfit
     "huggingface_hub >= 0.5.0,< 0.13",
     # Version 0.12 fixes a known installation issue related to `sentencepiece` and `tokenizers`, more at https://github.com/flairNLP/flair/issues/3129
-    "flair >= 0.12.2",  # Version 0.12.2 relaxes the `huggingface_hub` dependency
+    # Version 0.12.2 relaxes the `huggingface_hub` dependency
+    "flair >= 0.12.2",
     "faiss-cpu",
     "flyingsquid",
     "pgmpy",
@@ -108,7 +109,7 @@ integrations = [
     "span_marker",
     "openai>=0.27.10",
     "peft",
-    "trl>=0.5.0"
+    "trl>=0.5.0",
 ]
 tests = [
     "pytest",
@@ -122,6 +123,9 @@ tests = [
 homepage = "https://www.argilla.io"
 documentation = "https://docs.argilla.io"
 repository = "https://github.com/argilla-io/argilla"
+
+[project.scripts]
+argilla = "argilla.cli.app:app"
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
# Description

This PR adds an script called `argilla` to the package that allows to execute the Argilla CLI without the need of `python -m argilla` (`argilla --help`).

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [x] `pip install -e.` (to reinstall the package)
- [x] `argilla --help` worked

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
