### PR TITLE
fix: `SearchEngine` had num index == num replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ These are the section headers that we use:
 
 ## [Unreleased]()
 
+## 1.15.1
+
+### Fixed
+
+- Fixed `SearchEngine` was creating the same number of primary shards and replica shards for each `FeedbackDataset` ([#3736](https://github.com/argilla-io/argilla/pull/3736)).
+
 ## [1.15.0](https://github.com/argilla-io/argilla/compare/v1.14.1...v1.15.0)
 
 ### Added

--- a/src/argilla/server/search_engine.py
+++ b/src/argilla/server/search_engine.py
@@ -318,7 +318,7 @@ async def get_search_engine() -> AsyncGenerator[SearchEngine, None]:
     search_engine = SearchEngine(
         config,
         es_number_of_shards=settings.es_records_index_shards,
-        es_number_of_replicas=settings.es_records_index_shards,
+        es_number_of_replicas=settings.es_records_index_replicas,
     )
     try:
         yield search_engine


### PR DESCRIPTION
# Description

When the instance of `SearchEngine` was created we were passing the value of the attribute `settings.es_records_index_shards` to both `es_number_of_shards` and `es_number_of_replicas` arguments. This PR fix that and now value of attribute `settings.es_records_index_shards` is passed to `es_number_of_replicas` argument.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

In a local development environment:

- [x] Run the Argilla server without the fix and create a FeedbackDataset. When calling `GET localhost:9200/_cat/shards?v`, two shards are listed for the dataset (one primary started and one replica unassigned)
- [x] Run the Argilla with the fix and create a FeedbackDataset.  When calling `GET localhost:9200/_cat/shards?v`, only one primary shard is listed for the dataset

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
