### PR TITLE
feat: add `sentence-similarity` support to the `ArgillaTrainer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ These are the section headers that we use:
 
 ### Added
 
+- Added `ArgillaTrainer` integration with sentence-transformers, allowing fine tuning for sentence similarity ([#3739](https://github.com/argilla-io/argilla/pull/3739))
 - Added `Auto save record` to save automatically the current record that you are working on ([#3541](https://github.com/argilla-io/argilla/pull/3541))
 - Added `ArgillaTrainer` integration with OpenAI, allowing fine tuning for chat completion ([#3615](https://github.com/argilla-io/argilla/pull/3615))
 - Added `workspaces list` command to list Argilla workspaces ([#3594](https://github.com/argilla-io/argilla/pull/3594)).

--- a/docs/_source/_common/tabs/train_update_config.md
+++ b/docs/_source/_common/tabs/train_update_config.md
@@ -326,7 +326,7 @@ trainer.update_config(
 # can be set externally.
 trainer.update_config(
     batch_size=8,  # It will be passed to the DataLoader to generate batches during training.
-    loss_cls=losses.BatchAllTripletLoss    
+    loss_cls=losses.BatchAllTripletLoss
 )
 ```
 :::

--- a/docs/_source/_common/tabs/train_update_config.md
+++ b/docs/_source/_common/tabs/train_update_config.md
@@ -272,4 +272,63 @@ trainer.update_config(
 ```
 :::
 
+:::{tab-item} sentence-transformers
+
+```python
+# parameters related to the model initialization from `sentence_transformers.SentenceTransformer`
+trainer.update_config(
+    model="sentence-transformers/all-MiniLM-L6-v2",
+    modules = False,
+    device="cuda",
+    cache_folder="dir/folder",
+    use_auth_token=True
+)
+# and from `sentence_transformers.CrossEncoder`
+trainer.update_config(
+    model="cross-encoder/ms-marco-MiniLM-L-6-v2",
+    num_labels=2,
+    max_length=128,
+    device="cpu",
+    tokenizer_args={},
+    automodel_args={},
+    default_activation_function=None
+)
+# Related to the training procedure from `sentence_transformers.SentenceTransformer`
+trainer.update_config(
+    steps_per_epoch = 2,
+    checkpoint_path: str = None,
+    checkpoint_save_steps: int = 500,
+    checkpoint_save_total_limit: int = 0
+)
+# and from `sentence_transformers.CrossEncoder`
+trainer.update_config(
+    loss_fct = None
+    activation_fct = nn.Identity(),
+)
+# the remaining arguments are common for both procedures
+trainer.update_config(
+    evaluator: SentenceEvaluator = evaluation.EmbeddingSimilarityEvaluator,
+    epochs: int = 1,
+    scheduler: str = 'WarmupLinear',
+    warmup_steps: int = 10000,
+    optimizer_class: Type[Optimizer] = torch.optim.AdamW,
+    optimizer_params : Dict[str, object]= {'lr': 2e-5},
+    weight_decay: float = 0.01,
+    evaluation_steps: int = 0,
+    output_path: str = None,
+    save_best_model: bool = True,
+    max_grad_norm: float = 1,
+    use_amp: bool = False,
+    callback: Callable[[float, int, int], None] = None,
+    show_progress_bar: bool = True,
+)
+# Other parameters that don't correspond to the initialization or the trainer, but
+# can be set externally.
+trainer.update_config(
+    batch_size=8,  # It will be passed to the DataLoader to generate batches during training.
+    loss_cls=losses.BatchAllTripletLoss    
+)
+```
+:::
+
 ::::

--- a/docs/_source/guides/llms/practical_guides/fine_tune.md
+++ b/docs/_source/guides/llms/practical_guides/fine_tune.md
@@ -76,7 +76,7 @@ A `TrainingTask` is used to define how the data should be processed and formatte
 | for_proximal_policy_optimization   | `text`                       | `Union[str, Iterator[str]]]`                                            | ✗      |
 | for_direct_preference_optimization | `prompt-chosen-rejected`     | `Union[Tuple[str, str, str], Iterator[Tuple[str, str, str]]]`          | ✗      |
 | for_chat_completion                | `chat-turn-role-content`     | `Union[Tuple[str, str, str, str], Iterator[Tuple[str, str, str, str]]]`| ✗      |
-| for_sentence_similarity            | `sentence-1-sentence-2-(sentence-3)-(label)` | `Union[Dict[str, Union[float, int]], Dict[str, str], List[Dict[str, Union[float, int]]], List[Dict[str, str]]]`| ✗      |
+| for_sentence_similarity            | `sentence-1-sentence-2-(sentence-3)-(label)` | `Union[Dict[str, Union[float, int]], Dict[str, str], List[Dict[str, Union[float, int]]], List[Dict[str, str]]]`| ✔️      |
 
 
 ## Tasks

--- a/docs/_source/guides/llms/practical_guides/fine_tune.md
+++ b/docs/_source/guides/llms/practical_guides/fine_tune.md
@@ -39,14 +39,15 @@ trainer.predict("This is awesome!")
 
 We plan on adding more support for other tasks and frameworks so feel free to reach out on our Slack or GitHub to help us prioritize each task.
 
-| Task/Framework                  | TRL  | OpenAI | SetFit | spaCy | Transformers | PEFT |
-|:--------------------------------|:-----|:-------|:-------|:------|:-------------|:-----|
-| Text Classification             |      |        |  ✔️     | ✔️     | ✔️            | ✔️    |
-| Supervised Fine-tuning          | ✔️    |        |        |       |              |      |
-| Reward Modeling                 | ✔️    |        |        |       |              |      |
-| Proximal Policy Optimization    | ✔️    |        |        |       |              |      |
-| Direct Preference Optimization  | ✔️    |        |        |       |              |      |
-| Chat Completion                 |      | ✔️      |        |       |              |      |
+| Task/Framework                  | TRL  | OpenAI | SetFit | spaCy | Transformers | PEFT | SentenceTransformers |
+|:--------------------------------|:-----|:-------|:-------|:------|:-------------|:-----|:---------------------|
+| Text Classification             |      |        |  ✔️     | ✔️     | ✔️            | ✔️    |                      |
+| Supervised Fine-tuning          | ✔️    |        |        |       |              |      |                      |
+| Reward Modeling                 | ✔️    |        |        |       |              |      |                      |
+| Proximal Policy Optimization    | ✔️    |        |        |       |              |      |                      |
+| Direct Preference Optimization  | ✔️    |        |        |       |              |      |                      |
+| Chat Completion                 |      | ✔️      |        |       |              |      |                      |
+| Sentence Similarity             |      |        |        |       |              |      | ✔️                    |
 
 ```{note}
 We also offer support for Token Classification using our `TokenClassifcationDataset` but this is shown in [a section](/guides/train_a_model) about our older dataset-types.
@@ -74,7 +75,8 @@ A `TrainingTask` is used to define how the data should be processed and formatte
 | for_reward_modeling                | `chosen-rejected`            | `Union[Tuple[str, str], Iterator[Tuple[str, str]]]`                    | ✗      |
 | for_proximal_policy_optimization   | `text`                       | `Union[str, Iterator[str]]]`                                            | ✗      |
 | for_direct_preference_optimization | `prompt-chosen-rejected`     | `Union[Tuple[str, str, str], Iterator[Tuple[str, str, str]]]`          | ✗      |
-| for_chat_completion                | `chat-turn-role-content` | `Union[Tuple[str, str, str, str], Iterator[Tuple[str, str, str, str]]]`| ✗      |
+| for_chat_completion                | `chat-turn-role-content`     | `Union[Tuple[str, str, str, str], Iterator[Tuple[str, str, str, str]]]`| ✗      |
+| for_sentence_similarity            | `sentence-1-sentence-2-(sentence-3)-(label)` | `Union[Dict[str, Union[float, int]], Dict[str, str], List[Dict[str, Union[float, int]]], List[Dict[str, str]]]`| ✗      |
 
 
 ## Tasks
@@ -953,3 +955,142 @@ completion = openai.ChatCompletion.create(
   ]
 )
 ```
+
+### Sentence Similarity
+
+#### Background
+
+Sentence Similarity is the task of determining how similar two texts are. By transforming the text into embeddings (vectors representing the semantic information) we can compute the similarity between these texts , computing the distance between their vectors. The [Sentence-Transformers](https://www.sbert.net/) library makes easy to compute these sentence embeddings, and use them for information retrieval and clustering.
+
+In this [blog article](https://huggingface.co/blog/how-to-train-sentence-transformers) from hugging face you can see the different types of datasets that can be used for training `sentence-transformers` models (keep in mind the `Cross Encoder` based models don't allow training with sentence triplets).
+
+#### Training
+
+Let's use a small version of [snli](https://huggingface.co/datasets/snli) dataset for this example, ready to work with argilla [snli-small](https://huggingface.co/datasets/plaguss/snli-small).
+
+**Data Preparation**
+
+```python
+import argilla as rg
+
+dataset = rg.FeedbackDataset.from_huggingface("plaguss/snli-small")
+```
+
+::::{tab-set}
+
+:::{tab-item} sentence-1-sentence-2-label
+We offer the option to use default unification strategies and formatting based on a `sentence`-pairs and `sentence-` triplets, with or without `label`. Here we infer formatting information based on tw `TextField` and a `LabelQuestion`. This is the easiest way to define a `TrainingTask` for sentence similarity but if you need a custom workflow, you can use `formatting_func`.
+
+```{note}
+An overview of the unifcation measures can be found [here](/guides/llms/practical_guides/collect_responses). For this type of task, only `LabelQuestion` applies.
+```
+
+```python
+from argilla.feedback import TrainingTask
+
+task = TrainingTask.for_sentence_similarity(
+    texts=[dataset.field_by_name("premise"), dataset.field_by_name("hypothesis")],
+    label=dataset.question_by_name("label")
+)
+```
+
+:::
+
+:::{tab-item} formatting_func
+We offer the option to provide a `formatting_func` to the `TrainingTask.for_sentence_similarity`. This function is applied to each sample in the dataset and can be used for more advanced preprocessing and data formatting. The function can return a dict with `sentence-1`, `sentence-2` and optionally `sentence-3` and the corresponding sentences, and it can also include a `label`, which can be either an `int` (to represent the class) or a `float`, as well as lists of these elements.
+
+```python
+def formatting_func(sample):
+    record = {"sentence-1": sample["premise"], "sentence-2": sample["hypothesis"]}
+
+    # Choose the most common label
+    values = [resp["value"] for resp in sample["label"]]
+    counter = Counter(values)
+    if counter:
+        most_common = counter.most_common()
+        max_frequency = most_common[0][1]
+        most_common_elements = [
+            element for element, frequency in most_common if frequency == max_frequency
+        ]
+        label = random.choice(most_common_elements)
+        record["label"] = label
+        return record
+    else:
+        return None
+
+task = TrainingTask.for_sentence_similarity(formatting_func=formatting_func)
+```
+
+:::
+
+::::
+
+**ArgillaTrainer**
+
+We’ll use the task directly with our `FeedbackDataset` in the `ArgillaTrainer`. For this case we are using the default `SentenceTransformer` model, to fine-tune a `Cross Encoder` based, pass `framework_kwargs={"cross_encoder": True}`.
+
+```python
+from argilla.feedback import ArgillaTrainer
+
+trainer = ArgillaTrainer(
+    dataset=dataset,
+    task=task,
+    framework="sentence-transformers",
+    framework_kwargs={"cross_encoder": False}
+)
+trainer.train(output_dir="my_sentence_transformer_model")
+```
+
+**Inference**
+
+These models can be loaded using `sentence-transformers` (or `transformers`), the reader can take a look to each type of model at the following links:
+
+- [Bi-Encoder](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2)
+- [Cross-Encoder](https://huggingface.co/cross-encoder/ms-marco-MiniLM-L-6-v2)
+
+But the `ArgillaTrainer` offers the possibility to predict the sentence similarity from its API. Lets check how they work using the same sample sentences from [sentence similarity task](https://huggingface.co/tasks/sentence-similarity) in Hugging Face:
+
+```python
+from argilla.feedback import ArgillaTrainer, FeedbackDataset, TrainingTask
+
+trainer.predict(
+    [
+        "Machine learning is so easy.",
+        ["Deep learning is so straightforward.", "This is so difficult, like rocket science.", "I can't believe how much I struggled with this."]
+    ]
+)
+# [0.77857256, 0.4587626, 0.29062212]
+```
+
+Just to see the other format that can be passed to get the sentence similarity (a list with pairs of sentences), let's see the following example (the pairs don't need to share the first sentence, it's a example to check the same values are returned with both options).
+
+```python
+
+trainer.predict(
+    [
+        ["Machine learning is so easy.", "Deep learning is so straightforward."],
+        ["Machine learning is so easy.", "This is so difficult, like rocket science."],
+        ["Machine learning is so easy.", "I can't believe how much I struggled with this."]
+    ]
+)
+# [0.77857256, 0.4587626, 0.29062212]
+```
+
+The previous result were obtained assuming the model trained was a `SentenceTransformer`. If instead of using a `SentenceTransformer` model (a `Bi-Encoder` based model) we would have chosen a `Cross-Encoder` we would obtain a different result, but with the same interpretation.
+
+```python
+trainer = ArgillaTrainer(
+    dataset=dataset,
+    task=task,
+    framework="sentence-transformers",
+    framework_kwargs={"cross_encoder": False}
+)
+trainer.predict(
+    [
+        "Machine learning is so easy.",
+        ["Deep learning is so straightforward.", "This is so difficult, like rocket science.", "I can't believe how much I struggled with this."]
+    ]
+)
+# [2.2006402, -6.2634926, -10.251489]
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ integrations = [
     "transformers[torch] >= 4.30.0",
     "evaluate",
     "seqeval",
+    "sentence-transformers",
     "setfit",
     "span_marker",
     "openai>=0.27.10",

--- a/src/argilla/client/feedback/dataset/base.py
+++ b/src/argilla/client/feedback/dataset/base.py
@@ -34,10 +34,10 @@ from argilla.client.feedback.training.schemas import (
     TrainingTaskForDPO,
     TrainingTaskForPPO,
     TrainingTaskForRM,
+    TrainingTaskForSentenceSimilarity,
     TrainingTaskForSFT,
     TrainingTaskForTextClassification,
     TrainingTaskTypes,
-    TrainingTaskForSentenceSimilarity
 )
 from argilla.client.feedback.unification import (
     LabelQuestionStrategy,

--- a/src/argilla/client/feedback/dataset/base.py
+++ b/src/argilla/client/feedback/dataset/base.py
@@ -37,6 +37,7 @@ from argilla.client.feedback.training.schemas import (
     TrainingTaskForSFT,
     TrainingTaskForTextClassification,
     TrainingTaskTypes,
+    TrainingTaskForSentenceSimilarity
 )
 from argilla.client.feedback.unification import (
     LabelQuestionStrategy,
@@ -325,9 +326,9 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin):
 
         Args:
             framework: the framework to use for training. Currently supported frameworks are: `transformers`, `peft`,
-                `setfit`, `spacy`, `spacy-transformers`, `span_marker`, `spark-nlp`, `openai`, `trl`.
+                `setfit`, `spacy`, `spacy-transformers`, `span_marker`, `spark-nlp`, `openai`, `trl`, `sentence-transformers`.
             task: the NLP task to use for training. Currently supported tasks are: `TrainingTaskForTextClassification`,
-                `TrainingTaskForSFT`, `TrainingTaskForRM`, `TrainingTaskForPPO`, `TrainingTaskForDPO`.
+                `TrainingTaskForSFT`, `TrainingTaskForRM`, `TrainingTaskForPPO`, `TrainingTaskForDPO`, `TrainingTaskForSentenceSimilarity`.
             train_size: the size of the train set. If `None`, the whole dataset will be used for training.
             test_size: the size of the test set. If `None`, the whole dataset will be used for testing.
             seed: the seed to use for splitting the dataset into train and test sets.
@@ -369,6 +370,7 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin):
                 TrainingTaskForPPO,
                 TrainingTaskForDPO,
                 TrainingTaskForChatCompletion,
+                TrainingTaskForSentenceSimilarity
             ),
         ):
             raise ValueError(f"Training data {type(task)} is not supported yet")
@@ -404,6 +406,8 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin):
             return task._prepare_for_training_with_trl(data=data, train_size=train_size, seed=seed)
         elif framework is Framework.TRLX:
             return task._prepare_for_training_with_trlx(data=data, train_size=train_size, seed=seed)
+        elif framework is Framework.SENTENCE_TRANSFORMERS:
+            return task._prepare_for_training_with_sentence_similarity(data=data, train_size=train_size, seed=seed)
         else:
             raise NotImplementedError(
                 f"Framework {framework} is not supported. Choose from: {[e.value for e in Framework]}"

--- a/src/argilla/client/feedback/dataset/base.py
+++ b/src/argilla/client/feedback/dataset/base.py
@@ -359,9 +359,11 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin):
                 " dataset via the `FeedbackDataset.add_records` method first."
             )
 
-        if isinstance(task, TrainingTaskForTextClassification):
+        if isinstance(task, (TrainingTaskForTextClassification, TrainingTaskForSentenceSimilarity)):
             if task.formatting_func is None:
-                self.unify_responses(question=task.label.question, strategy=task.label.strategy)
+                # in sentence-transformer models we can train without labels
+                if task.label:
+                    self.unify_responses(question=task.label.question, strategy=task.label.strategy)
         elif not isinstance(
             task,
             (
@@ -370,7 +372,6 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin):
                 TrainingTaskForPPO,
                 TrainingTaskForDPO,
                 TrainingTaskForChatCompletion,
-                TrainingTaskForSentenceSimilarity
             ),
         ):
             raise ValueError(f"Training data {type(task)} is not supported yet")
@@ -407,7 +408,7 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin):
         elif framework is Framework.TRLX:
             return task._prepare_for_training_with_trlx(data=data, train_size=train_size, seed=seed)
         elif framework is Framework.SENTENCE_TRANSFORMERS:
-            return task._prepare_for_training_with_sentence_similarity(data=data, train_size=train_size, seed=seed)
+            return task._prepare_for_training_with_sentence_transformers(data=data, train_size=train_size, seed=seed)
         else:
             raise NotImplementedError(
                 f"Framework {framework} is not supported. Choose from: {[e.value for e in Framework]}"

--- a/src/argilla/client/feedback/training/base.py
+++ b/src/argilla/client/feedback/training/base.py
@@ -168,7 +168,9 @@ class ArgillaTrainer(ArgillaTrainerV1):
                 model=self._model,
             )
         elif framework is Framework.SENTENCE_TRANSFORMERS:
-            from argilla.client.feedback.training.frameworks.sentence_transformers import ArgillaSentenceTransformersTrainer
+            from argilla.client.feedback.training.frameworks.sentence_transformers import (
+                ArgillaSentenceTransformersTrainer,
+            )
 
             self._trainer = ArgillaSentenceTransformersTrainer(
                 dataset=self._dataset,
@@ -176,7 +178,7 @@ class ArgillaTrainer(ArgillaTrainerV1):
                 prepared_data=self._prepared_data,
                 seed=self._seed,
                 model=self._model,
-                **framework_kwargs  # cross_encoder
+                **framework_kwargs,  # cross_encoder
             )
         else:
             raise NotImplementedError(f"{framework} is not a valid framework.")

--- a/src/argilla/client/feedback/training/base.py
+++ b/src/argilla/client/feedback/training/base.py
@@ -50,7 +50,7 @@ class ArgillaTrainer(ArgillaTrainerV1):
             dataset: the dataset to be used for training.
             task: the training data to be used for training.
             framework: the framework to use for training. Currently, "transformers", "setfit", "spacy", "peft",
-                "openai", "span_marker" and "trl" are supported.
+                "openai", "span_marker", "trl" and "sentence-transformers" are supported.
             lang: the spaCy language model to use for training, just required when `framework="spacy"`.
                 Defaults to None, but it will be set to `spacy.blank("en")` if not specified.
             model: name or path to the baseline model to be used. If not specified will set to a good default

--- a/src/argilla/client/feedback/training/base.py
+++ b/src/argilla/client/feedback/training/base.py
@@ -167,6 +167,17 @@ class ArgillaTrainer(ArgillaTrainerV1):
                 seed=self._seed,
                 model=self._model,
             )
+        elif framework is Framework.SENTENCE_TRANSFORMERS:
+            from argilla.client.feedback.training.frameworks.sentence_transformers import ArgillaSentenceTransformersTrainer
+
+            self._trainer = ArgillaSentenceTransformersTrainer(
+                dataset=self._dataset,
+                task=self._task,
+                prepared_data=self._prepared_data,
+                seed=self._seed,
+                model=self._model,
+                **framework_kwargs  # cross_encoder
+            )
         else:
             raise NotImplementedError(f"{framework} is not a valid framework.")
 

--- a/src/argilla/client/feedback/training/frameworks/sentence_transformers.py
+++ b/src/argilla/client/feedback/training/frameworks/sentence_transformers.py
@@ -54,7 +54,7 @@ class ArgillaSentenceTransformersTrainer(ArgillaTrainerSkeleton):
             else:
                 self._model = "cross-encoder/ms-marco-MiniLM-L-6-v2"
 
-            self._logger.warning(f"No model was selected, using pre-defined `{'Cross-Encoder' if self._cross_encoder else 'Bi-Encoder'}` with `{self._model}`.")
+            self._logger.info(f"No model was selected, using pre-defined `{'Cross-Encoder' if self._cross_encoder else 'Bi-Encoder'}` with `{self._model}`.")
 
         else:
             self._model = model
@@ -104,7 +104,7 @@ class ArgillaSentenceTransformersTrainer(ArgillaTrainerSkeleton):
         self._logger.warning(f"`loss_cls` parameter set as default `{self._loss_cls}`.")
 
         if self._eval_dataset:
-            self._set_evaluator(sample.label, len(sample.texts))
+            self._set_evaluator(label=sample.label, number_of_sentences=len(sample.texts))
             self._logger.warning(f"`evaluator` parameter set to `{self.trainer_kwargs['evaluator']}` by default.")
 
     def _set_loss_cls(self, label: Optional[Union[int, float]], number_of_sentences: int) -> None:
@@ -167,17 +167,20 @@ class ArgillaSentenceTransformersTrainer(ArgillaTrainerSkeleton):
                     # a subset of the evaluators defined in sentence-transformers, inform
                     # the user the one selected is not allowed.
                     self.trainer_kwargs["evaluator"] = None
-                    self._logger.warning(f"Currently only developed evaluators that implement `cls.from_input_examples`.")
+                    self._logger.warning(f"Currently only developed evaluators that implement `cls.from_input_examples` can be set.")
         else:
             if label:
                 if number_of_sentences == 2:
                     if isinstance(label, int):
-                        if self._cross_encoder:
-                            from sentence_transformers.cross_encoder.evaluation import CEBinaryClassificationEvaluator
-                            self.trainer_kwargs["evaluator"] = CEBinaryClassificationEvaluator.from_input_examples(self._eval_dataset)
-                        else:
-                            from sentence_transformers.evaluation import BinaryClassificationEvaluator
-                            self.trainer_kwargs["evaluator"] = BinaryClassificationEvaluator.from_input_examples(self._eval_dataset)
+                        # This should work, but for some reason in the tests with default values
+                        # the classes cannot be instantiated, need some time to review.
+                        # if self._cross_encoder:
+                        #     from sentence_transformers.cross_encoder.evaluation import CEBinaryClassificationEvaluator
+                        #     self.trainer_kwargs["evaluator"] = CEBinaryClassificationEvaluator.from_input_examples(self._eval_dataset)
+                        # else:
+                        #     from sentence_transformers.evaluation import BinaryClassificationEvaluator
+                        #     self.trainer_kwargs["evaluator"] = BinaryClassificationEvaluator.from_input_examples(self._eval_dataset)
+                        self.trainer_kwargs["evaluator"] = None
 
                     else:
                         if self._cross_encoder:

--- a/src/argilla/client/feedback/training/frameworks/sentence_transformers.py
+++ b/src/argilla/client/feedback/training/frameworks/sentence_transformers.py
@@ -29,9 +29,6 @@ class ArgillaSentenceTransformersTrainer(ArgillaTrainerSkeleton):
     _logger = logging.getLogger("ArgillaSentenceTransformersTrainer")
     _logger.setLevel(logging.INFO)
 
-    # TODO: Update with https://github.com/argilla-io/argilla/pull/3555
-    require_version("sentence-transformers")
-
     def __init__(
         self,
         dataset: "FeedbackDataset",
@@ -42,6 +39,9 @@ class ArgillaSentenceTransformersTrainer(ArgillaTrainerSkeleton):
         train_size: Optional[float] = 1,
         cross_encoder: bool = False
     ) -> None:
+        # TODO: Update with https://github.com/argilla-io/argilla/pull/3555
+        require_version("sentence-transformers")
+
         super().__init__(dataset=dataset, task=task, prepared_data=prepared_data, model=model, train_size=train_size, seed=seed)
 
         # The prepared_data is lost in the TrainerSkeleton, is this intended?

--- a/src/argilla/client/feedback/training/frameworks/sentence_transformers.py
+++ b/src/argilla/client/feedback/training/frameworks/sentence_transformers.py
@@ -53,6 +53,8 @@ class ArgillaSentenceTransformersTrainer(ArgillaTrainerSkeleton):
                 self._model = "sentence-transformers/all-MiniLM-L6-v2"
             else:
                 self._model = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+        else:
+            self._model = model
  
         if isinstance(self._prepared_data, tuple):
             self._train_dataset = self._prepared_data[0]

--- a/src/argilla/client/feedback/training/frameworks/sentence_transformers.py
+++ b/src/argilla/client/feedback/training/frameworks/sentence_transformers.py
@@ -1,0 +1,198 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+from typing import List, Union, Optional, TYPE_CHECKING
+
+from argilla.training.utils import get_default_args, filter_allowed_args
+from argilla.utils.dependency import require_version
+
+from argilla.client.feedback.training.base import ArgillaTrainerSkeleton
+from argilla.client.feedback.training.schemas import TrainingTaskForSentenceSimilarity
+
+if TYPE_CHECKING:
+    from argilla.client.feedback.dataset import FeedbackDataset
+
+
+class ArgillaSentenceTransformersTrainer(ArgillaTrainerSkeleton):
+    _logger = logging.getLogger("ArgillaSentenceTransformersTrainer")
+    _logger.setLevel(logging.INFO)
+
+    # TODO: Update with https://github.com/argilla-io/argilla/pull/3555
+    require_version("sentence-transformers")
+
+    def __init__(
+        self,
+        dataset: "FeedbackDataset",
+        task: TrainingTaskForSentenceSimilarity,
+        prepared_data = None,
+        model: str = None,
+        seed: int = None,
+        train_size: Optional[float] = 1,
+        cross_encoder: bool = False
+    ) -> None:
+        super().__init__(dataset=dataset, task=task, prepared_data=prepared_data, model=model, train_size=train_size, seed=seed)
+
+        # The prepared_data is lost in the TrainerSkeleton, is this intended?
+        self._prepared_data = prepared_data
+        self._cross_encoder = cross_encoder
+
+        if model is None:
+            if not self._cross_encoder:
+                self._model = "sentence-transformers/all-MiniLM-L6-v2"
+            else:
+                self._model = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+ 
+        if isinstance(self._prepared_data, tuple):
+            self._train_dataset = self._prepared_data[0]
+            self._eval_dataset = self._prepared_data[1]
+        else:
+            self._train_dataset = self._prepared_data
+            self._eval_dataset = None
+
+        self._loss_cls = None
+        self.init_training_args()
+
+    def init_training_args(self) -> None:
+        """
+        Initializes the training arguments.
+        """
+        self.model_kwargs = {}
+
+        # Use a sample of the dataset to do some checking
+        sample = self._train_dataset[0]
+
+        if self._cross_encoder:
+            # Cross encoders don't support training with triplets
+            if (n := len(sample.texts)) > 2:
+                raise ValueError(f"Cross-encoders don't support training with triplets, the dataset has `{n}` sentences per sample.")
+
+            from sentence_transformers import CrossEncoder
+            self._trainer_cls = CrossEncoder
+        else:
+            from sentence_transformers import SentenceTransformer
+            self._trainer_cls = SentenceTransformer
+
+        self.model_kwargs = get_default_args(self._trainer_cls.__init__)
+        self.trainer_kwargs = get_default_args(self._trainer_cls.fit)
+        self.dataloader_kwargs = {}
+        self.dataloader_kwargs["batch_size"] = 1
+        self._dataset_type = None
+
+        # For a guide on the selection of the loss function:
+        # https://huggingface.co/blog/how-to-train-sentence-transformers#loss-functions-for-training-a-sentence-transformers-model
+        if not self._loss_cls:
+            if sample.label:
+                if len(sample.texts) == 2:
+                    if isinstance(sample.label, int):
+                        from sentence_transformers.losses import ContrastiveLoss
+                        self._loss_cls = ContrastiveLoss
+                    else:
+                        from sentence_transformers.losses import CosineSimilarityLoss
+                        self._loss_cls = CosineSimilarityLoss
+                else:
+                    if isinstance(sample.label, int):
+                        from sentence_transformers.losses import BatchHardTripletLoss
+                        self._loss_cls = BatchHardTripletLoss
+                    else:
+                        from sentence_transformers.losses import BatchAllTripletLoss
+                        self._loss_cls = BatchAllTripletLoss
+                        from sentence_transformers.datasets import SentenceLabelDataset
+                        self._dataset_type = SentenceLabelDataset
+            else:
+                if len(sample.texts) == 3:
+                    from sentence_transformers.losses import TripletLoss
+                    self._loss_cls = TripletLoss
+                else:
+                    from sentence_transformers.losses import MultipleNegativesRankingLoss
+                    self._loss_cls = MultipleNegativesRankingLoss
+
+    def init_model(self) -> None:
+        """
+        Initializes a model.
+        """
+        if "model_name_or_path" in self.model_kwargs:
+            self.model_kwargs.pop("model_name_or_path")
+        if "model_name" in self.model_kwargs:
+            self.model_kwargs.pop("model_name")
+
+        if "train_objectives" in self.trainer_kwargs:
+            self.trainer_kwargs.pop("train_objectives")
+        if "train_dataloader" in self.trainer_kwargs:
+            self.trainer_kwargs.pop("train_dataloader")
+
+        self._trainer = self._trainer_cls(self._model, **self.model_kwargs)
+    
+    def update_config(self, **kwargs) -> None:
+        """
+        Updates the configuration of the trainer, but the parameters depend on the trainer.subclass.
+        """
+        self.model_kwargs.update(filter_allowed_args(self._trainer_cls.__init__, **kwargs))
+        self.trainer_kwargs.update(filter_allowed_args(self._trainer_cls.fit, **kwargs))
+
+        if "batch_size" in kwargs:
+            self.dataloader_kwargs["batch_size"] = kwargs["batch_size"]
+
+        if "model" in self.model_kwargs:
+            self._model = self.model_kwargs["model"]
+            # self._model = self.model_kwargs["model_name_or_path"]
+
+    def train(self, output_dir: Optional[str] = None) -> None:
+        """
+        Trains the model.
+        """
+        from torch.utils.data import DataLoader
+        self.init_model()
+
+        if self._dataset_type:
+            dataloader = DataLoader(dataset=self._dataset_type(self._train_dataset), batch_size=self.dataloader_kwargs["batch_size"])
+        else:
+            dataloader = DataLoader(dataset=self._train_dataset, batch_size=self.dataloader_kwargs["batch_size"])
+
+        train_loss = self._loss_cls(self._trainer)
+
+        if self._cross_encoder:
+            train_objectives = dataloader
+        else:
+            train_objectives = [(dataloader, train_loss)]
+        
+        self._trainer.fit(
+            train_objectives,
+            **self.trainer_kwargs
+        )
+        # NOTE: We haven't used the evaluator yet
+
+        if output_dir is not None:
+            self.save(output_dir)
+
+    def predict(self, text: Union[List[str], str], as_argilla_records: bool = True, **kwargs):
+        """
+        Predicts the label of the text.
+        """
+        raise NotImplementedError("work in progress")
+
+    def save(self, output_dir: str) -> None:
+        """
+        Saves the model to the specified path.
+        """
+        if self._cross_encoder:
+            self._trainer.save(output_dir)
+        else:
+            # For the moment just save the in the simplest form, creating the model card or the
+            # dataset for example should be done taking the extra information from the argilla 
+            # dataset instead of the defaults
+            self._trainer.save(output_dir, model_name=None, create_model_card=False, train_datasets=None)
+
+    def __repr__(self) -> str:
+        return type(self).__name__

--- a/src/argilla/client/feedback/training/frameworks/sentence_transformers.py
+++ b/src/argilla/client/feedback/training/frameworks/sentence_transformers.py
@@ -146,7 +146,6 @@ class ArgillaSentenceTransformersTrainer(ArgillaTrainerSkeleton):
 
         if "model" in self.model_kwargs:
             self._model = self.model_kwargs["model"]
-            # self._model = self.model_kwargs["model_name_or_path"]
 
     def train(self, output_dir: Optional[str] = None) -> None:
         """

--- a/src/argilla/client/feedback/training/frameworks/sentence_transformers.py
+++ b/src/argilla/client/feedback/training/frameworks/sentence_transformers.py
@@ -193,6 +193,3 @@ class ArgillaSentenceTransformersTrainer(ArgillaTrainerSkeleton):
             # dataset for example should be done taking the extra information from the argilla 
             # dataset instead of the defaults
             self._trainer.save(output_dir, model_name=None, create_model_card=False, train_datasets=None)
-
-    def __repr__(self) -> str:
-        return type(self).__name__

--- a/src/argilla/client/feedback/training/schemas.py
+++ b/src/argilla/client/feedback/training/schemas.py
@@ -92,7 +92,7 @@ class TrainingData(ABC):
                 # with default and formatting_func either one can be None
                 if pydantic_field[-1] is not None:
                     pydantic_field_name, pydantic_field_value = pydantic_field
-                    if isinstance(pydantic_field_value, list):
+                    if isinstance(pydantic_field_value, (list, tuple, set)):
                         # NOTE: In the case of TrainingTaskForSentenceSimilarity with defaults,
                         # we need to grab multiple values, not just the text.
                         for pydantic_field_value_i in pydantic_field_value:

--- a/src/argilla/client/feedback/training/schemas.py
+++ b/src/argilla/client/feedback/training/schemas.py
@@ -1260,7 +1260,7 @@ class TrainingTaskForSentenceSimilarity(BaseModel, TrainingData):
             formatted_data = super()._format_data(dataset)
             # NOTE: Maybe this post processing of the formatted data can be simplified
             # or directly done in super()._format_data(dataset).
-            new_keys = {field.name: f"sentence-{i+1}" for i, field in enumerate(self.texts)}
+            new_keys = {field.name: f"sentence-{i}" for i, field in enumerate(self.texts, start=1)}
             if self.label:
                 new_keys.update({self.label.question.name: "label"})
 
@@ -1300,36 +1300,32 @@ class TrainingTaskForSentenceSimilarity(BaseModel, TrainingData):
         self, data: List[dict], train_size: float, seed: int
     ) -> Union["InputExample", Tuple["InputExample", "InputExample"]]:
         from sentence_transformers import InputExample
+        
+        if not len(data) > 0:
+            raise ValueError("The dataset must contain at least one sample to be able to train.")
 
         # Use the first sample to decide what type of dataset to generate:
-        sample_keys = data[0].keys()
-        if "label" in sample_keys:
-            if (len(sample_keys) == 3) and all(s in sample_keys for s in ["sentence-1", "sentence-2"]):
-                dataset_fields = lambda sample: {"texts": [sample["sentence-1"], sample["sentence-2"]], "label": sample["label"]}
-            elif all(s in sample_keys for s in ["sentence-1", "sentence-2", "sentence-3"]):
-                dataset_fields = lambda sample: {"texts": [sample["sentence-1"], sample["sentence-2"], sample["sentence-3"]], "label": sample["label"]}
-            elif (len(sample_keys) == 2) and ("sentence" in sample_keys):
-                raise ValueError(
-                    "Datasets containing a `sentence` and a `label` should be transformed "\
-                    "to contain triplets of `sentence-1`, `sentence-2`, `sentence-3` and `label`."\
-                    r"An example can be seen at: https://github.com/UKPLab/sentence-transformers/blob/master/examples/training/other/training_batch_hard_trec.py"
-                )
-            else:
-                raise ValueError(
-                    "Labeled datasets must contain a pair of `sentence-1` and "\
-                    "`sentence-2` or triplets `sentence-1`, `sentence-2`, `sentence-3` "\
-                    "as well as a `label`."
-                )
+        sample_keys = set(data[0].keys())
+        if sample_keys == {"label", "sentence-1", "sentence-2"}:
+            dataset_fields = lambda sample: {"texts": [sample["sentence-1"], sample["sentence-2"]], "label": sample["label"]}
+        elif sample_keys == sample_keys == {"label", "sentence-1", "sentence-2", "sentence-3"}:
+            dataset_fields = lambda sample: {"texts": [sample["sentence-1"], sample["sentence-2"], sample["sentence-3"]], "label": sample["label"]}
+        elif sample_keys == {"sentence-1", "sentence-2"}:
+            dataset_fields = lambda sample: {"texts": [sample["sentence-1"], sample["sentence-2"]]}
+        elif sample_keys == {"sentence-1", "sentence-2", "sentence-3"}:
+            dataset_fields = lambda sample: {"texts": [sample["sentence-1"], sample["sentence-2"], sample["sentence-3"]]}
+        elif sample_keys == {"label", "sentence"}:
+            raise ValueError(
+                "Datasets containing a `sentence` and a `label` should be transformed "\
+                "to contain triplets of `sentence-1`, `sentence-2`, `sentence-3` and `label`."\
+                r"An example can be seen at: https://github.com/UKPLab/sentence-transformers/blob/master/examples/training/other/training_batch_hard_trec.py"
+            )
         else:
-            if len(sample_keys) == 2:
-                dataset_fields = lambda sample: {"texts": [sample["sentence-1"], sample["sentence-2"]]}
-            elif len(sample_keys) == 3:
-                dataset_fields = lambda sample: {"texts": [sample["sentence-1"], sample["sentence-2"], sample["sentence-3"]]}
-            else:
-                raise ValueError(
-                    "Unlabeled datasets must contain a pair of `sentence-1` and "\
-                    "`sentence-2` or triplets `sentence-1`, `sentence-2`, `sentence-3`."
-                )
+            raise ValueError(
+                "Labeled datasets must contain a pair of `sentence-1` and "\
+                "`sentence-2` or triplets `sentence-1`, `sentence-2`, `sentence-3` "\
+                "and an optional `label`."
+            )
 
         train_samples = []
         for sample in data:

--- a/src/argilla/client/feedback/training/schemas.py
+++ b/src/argilla/client/feedback/training/schemas.py
@@ -1244,7 +1244,7 @@ class TrainingTaskForSentenceSimilarity(BaseModel, TrainingData):
             if "label" in outputs[0]:
                 _all_labels = set()
                 for sample in outputs:
-                    if isinstance(sample, list):
+                    if isinstance(sample, (list, tuple, set)):
                         for response in sample:
                             _all_labels.add(response["label"])
                     else:

--- a/src/argilla/client/feedback/training/schemas.py
+++ b/src/argilla/client/feedback/training/schemas.py
@@ -382,6 +382,23 @@ class TrainingTask:
     ) -> "TrainingTaskForChatCompletion":
         return TrainingTaskForChatCompletion(formatting_func=formatting_func)
 
+    @classmethod
+    def for_sentence_similarity(
+        cls,
+        formatting_func: Callable[[Dict[str, Any]], Union[None, Tuple[str, str, str], Iterator[Tuple[str, str, str]]]],
+    ) -> "TrainingTaskForSentenceSimilarity":
+        """
+        Return a task that can be used in `FeedbackDataset.prepare_for_training(framework="...", task)`
+        to extract data from the Feedback Dataset in a format suitable for sentence similarity.
+
+        Args:
+            formatting_func: A formatting function converting a dictionary of records into a dict.
+
+        Returns:
+            TrainingTaskForSentenceSimilarity: A task mapping instance to be used in `FeedbackDataset.prepare_for_training()`
+        """
+        return TrainingTaskForSentenceSimilarity(formatting_func=formatting_func)
+
 
 class TrainingTaskForTextClassificationFormat(BaseModel):
     """

--- a/src/argilla/client/feedback/training/schemas.py
+++ b/src/argilla/client/feedback/training/schemas.py
@@ -1139,7 +1139,7 @@ class TrainingTaskForSentenceSimilarity(BaseModel, TrainingData):
         return f"{self.__class__.__name__}\n\t formatting_func={self.formatting_func}"
 
     @requires_version("scikit-learn")
-    def _train_test_split(self, data: List[dict], train_size: float, seed: int) -> Tuple[List[dict], List[dict]]:
+    def _train_test_split(self, data: List[dict], train_size: float, seed: int, stratify = None) -> Tuple[List[dict], List[dict]]:
         from sklearn.model_selection import train_test_split
 
         return train_test_split(
@@ -1147,6 +1147,7 @@ class TrainingTaskForSentenceSimilarity(BaseModel, TrainingData):
             train_size=train_size,
             shuffle=True,
             random_state=seed,
+            stratify=stratify
         )
 
     @requires_version("sentence-transformers")
@@ -1190,7 +1191,12 @@ class TrainingTaskForSentenceSimilarity(BaseModel, TrainingData):
             train_samples.append(InputExample(guid=i, **dataset_fields(sample)))
         
         if train_size != 1:
-            train_data, test_data = self._train_test_split(train_samples, train_size, seed)
+            stratify = None
+            if (label := train_samples[0].label):
+                if isinstance(label, int):
+                    stratify = [example.label for example in train_samples]
+
+            train_data, test_data = self._train_test_split(train_samples, train_size, seed, stratify=stratify)
             return train_data, test_data
         else:
             return train_samples

--- a/src/argilla/client/feedback/training/schemas.py
+++ b/src/argilla/client/feedback/training/schemas.py
@@ -1220,8 +1220,14 @@ class TrainingTaskForSentenceSimilarity(BaseModel, TrainingData):
             return self.label.question.__id2label__
 
     def __repr__(self) -> str:
-        # TODO: Update to include texts/labels when found
-        return f"{self.__class__.__name__}\n\t formatting_func={self.formatting_func}"
+        return (
+            f"{self.__class__.__name__}"
+            f"\n\t texts={self.text.name}"
+            f"\n\t label={self.label.question.name}"
+            f"\n\t multi_label={self.__multi_label__}"
+            f"\n\t all_labels={self.__all_labels__}"
+            f"\n\t formatting_funct={self.formatting_func}"
+        )
 
     def _format_data(self, dataset: "FeedbackDataset") -> List[Dict[str, Any]]:
         if self.formatting_func:

--- a/src/argilla/client/feedback/training/schemas.py
+++ b/src/argilla/client/feedback/training/schemas.py
@@ -43,6 +43,7 @@ _LOGGER = logging.getLogger(__name__)
 if TYPE_CHECKING:
     import datasets
     import spacy
+    from sentence_transformers import InputExample
 
     from argilla.client.feedback.dataset import FeedbackDataset
 
@@ -1062,6 +1063,20 @@ class TrainingTaskForChatCompletion(BaseModel, TrainingData):
             return _dict_to_format(ds["train"]), _dict_to_format(ds["test"])
         else:
             return _dict_to_format(ds)
+
+
+class TrainingTaskForSentenceSimilarityFormat(BaseModel):
+    r"""
+    Union[
+        Dict[str, Union[float, int]],  # case 1 with with two string elements and one int/float, case 3 with one or three strings and one int/float.
+        Dict[str, str],                # case 2 with two elements, case 4 with three elements
+    ]
+
+    For a reference of the different cases take a look at:
+    https://huggingface.co/blog/how-to-train-sentence-transformers#how-to-prepare-your-dataset-for-training-a-sentence-transformers-model    
+    """
+
+    format: Union[Dict[str, Union[float, int]], Dict[str, str]]
 
 
 TrainingTaskTypes = Union[

--- a/src/argilla/client/feedback/training/schemas.py
+++ b/src/argilla/client/feedback/training/schemas.py
@@ -1337,9 +1337,8 @@ class TrainingTaskForSentenceSimilarity(BaseModel, TrainingData):
         
         if train_size != 1:
             stratify = None
-            if (label := train_samples[0].label):
-                if isinstance(label, int):
-                    stratify = [example.label for example in train_samples]
+            if (label := train_samples[0].label) and isinstance(label, int):
+                stratify = [example.label for example in train_samples]
 
             train_data, test_data = self._train_test_split(train_samples, train_size, seed, stratify=stratify)
             return train_data, test_data

--- a/src/argilla/client/models.py
+++ b/src/argilla/client/models.py
@@ -50,6 +50,7 @@ class Framework(Enum):
         openai: OpenAI LLMs
         trl: Transformer Reinforcement Learning
         trlx: Transformer Reinforcement Learning X
+        sentence-transformers: Sentence Transformers library
     """
 
     TRANSFORMERS = "transformers"
@@ -62,6 +63,7 @@ class Framework(Enum):
     OPENAI = "openai"
     TRL = "trl"
     TRLX = "trlx"
+    SENTENCE_TRANSFORMERS = "sentence-transformers"
     # AUTOTRAIN = "autotrain"
 
     @classmethod

--- a/tests/integration/client/feedback/training/test_sentence_transformers.py
+++ b/tests/integration/client/feedback/training/test_sentence_transformers.py
@@ -1,0 +1,217 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import TYPE_CHECKING, List, Callable, Union
+
+import pytest
+
+from argilla.client.feedback.dataset import FeedbackDataset
+from argilla.client.feedback.schemas.records import FeedbackRecord
+from argilla.client.feedback.training.base import ArgillaTrainer
+from argilla.client.feedback.training.schemas import (
+    TrainingTask,
+)
+
+from sentence_transformers import InputExample, SentenceTransformer, CrossEncoder
+
+from tests.integration.training.helpers import train_with_cleanup
+
+if TYPE_CHECKING:
+    from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQuestionTypes
+
+__OUTPUT_DIR__ = "tmp"
+__FRAMEWORK__ = "sentence-transformers"
+
+
+# All the formatting functions generate dummy datasets with the formats allowed
+
+def formatting_func_case_1_a(sample):
+    if sample.responses:
+        response = sample.responses[0]
+        if response.status == "submitted":
+            return {"sentence-1": sample.fields["text"], "sentence-2": sample.fields["text"], "label": 1}
+
+
+def formatting_func_case_1_b(sample):
+    if sample.responses:
+        response = sample.responses[0]
+        if response.status == "submitted":
+            return {"sentence-1": sample.fields["text"], "sentence-2": sample.fields["text"], "label": 0.786}
+
+
+def formatting_func_case_2(sample):
+    if sample.responses:
+        response = sample.responses[0]
+        if response.status == "submitted":
+            return {"sentence-1": sample.fields["text"], "sentence-2": sample.fields["text"]}
+
+
+def formatting_func_case_3_a(sample):
+    if sample.responses:
+        response = sample.responses[0]
+        if response.status == "submitted":
+            return {"sentence": sample.fields["text"], "label": 1}
+
+
+def formatting_func_case_3_b(sample):
+    if sample.responses:
+        response = sample.responses[0]
+        if response.status == "submitted":
+            return {"sentence-1": sample.fields["text"], "sentence-2": sample.fields["text"], "sentence-3": sample.fields["text"], "label": 1}
+
+
+def formatting_func_case_4(sample):
+    if sample.responses:
+        response = sample.responses[0]
+        if response.status == "submitted":
+            return {"sentence-1": sample.fields["text"], "sentence-2": sample.fields["text"], "sentence-3": sample.fields["text"]}
+
+
+def formatting_func_errored(sample):
+    if sample.responses:
+        response = sample.responses[0]
+        if response.status == "submitted":
+            return sample.fields["text"], sample.fields["text"], sample.fields["text"]
+
+
+
+@pytest.mark.parametrize(
+    "cross_encoder,model_type",
+    [
+        (False, SentenceTransformer),
+        (True, CrossEncoder)
+    ]
+)
+@pytest.mark.parametrize(
+    "formatting_func",
+    [
+        formatting_func_case_1_a,
+        formatting_func_case_1_b,
+        formatting_func_case_2,
+        formatting_func_case_3_b,
+        formatting_func_case_4,
+    ]
+)
+@pytest.mark.usefixtures(
+    "feedback_dataset_guidelines",
+    "feedback_dataset_fields",
+    "feedback_dataset_questions",
+    "feedback_dataset_records",
+)
+def test_prepare_for_training_sentence_transformers(
+    cross_encoder: bool,
+    model_type: Union[SentenceTransformer, CrossEncoder],
+    formatting_func: Callable,
+    feedback_dataset_guidelines: str,
+    feedback_dataset_fields: List["AllowedFieldTypes"],
+    feedback_dataset_questions: List["AllowedQuestionTypes"],
+    feedback_dataset_records: List[FeedbackRecord],
+) -> None:
+    dataset = FeedbackDataset(
+        guidelines=feedback_dataset_guidelines,
+        fields=feedback_dataset_fields,
+        questions=feedback_dataset_questions,
+    )
+    dataset.add_records(records=feedback_dataset_records * 2)
+
+    task = TrainingTask.for_sentence_similarity(formatting_func)
+    train_dataset = dataset.prepare_for_training(framework=__FRAMEWORK__, task=task)
+
+    assert isinstance(train_dataset, list)
+    assert isinstance(train_dataset[0], InputExample)
+    assert len(train_dataset) == 8
+
+    train_dataset, test_dataset = dataset.prepare_for_training(framework=__FRAMEWORK__, task=task, train_size=0.5)
+    assert len(train_dataset) == 4
+
+    if cross_encoder:
+        if ("case_3_b" in formatting_func.__name__) or ("case_4" in formatting_func.__name__):
+            with pytest.raises(ValueError, match=r"^Cross-encoders don't support training with triplets"):
+                trainer = ArgillaTrainer(
+                    dataset=dataset,
+                    task=task,
+                    framework="sentence-transformers",
+                    framework_kwargs={"cross_encoder": cross_encoder}
+                )
+            return
+
+    trainer = ArgillaTrainer(
+        dataset=dataset,
+        task=task,
+        framework=__FRAMEWORK__,
+        framework_kwargs={"cross_encoder": cross_encoder}
+    )
+    trainer.update_config(batch_size=2)
+    assert trainer._trainer.dataloader_kwargs["batch_size"] == 2
+    trainer.update_config(epochs=1)
+    assert trainer._trainer.trainer_kwargs["epochs"] == 1
+    train_with_cleanup(trainer, __OUTPUT_DIR__)
+    # Check we have a bi-encoder/cross-encoder
+    assert isinstance(trainer._trainer._trainer, model_type)
+
+    eval_trainer = ArgillaTrainer(
+        dataset=dataset,
+        task=task,
+        framework=__FRAMEWORK__,
+        train_size=0.5,
+        framework_kwargs={"cross_encoder": cross_encoder}
+    )
+    eval_trainer.update_config(epochs=1)
+    train_with_cleanup(eval_trainer, __OUTPUT_DIR__)
+
+
+@pytest.mark.parametrize("cross_encoder", [False, True])
+@pytest.mark.parametrize(
+    "formatting_func",
+    [
+        formatting_func_case_3_a,
+        formatting_func_errored
+    ]
+)
+@pytest.mark.usefixtures(
+    "feedback_dataset_guidelines",
+    "feedback_dataset_fields",
+    "feedback_dataset_questions",
+    "feedback_dataset_records",
+)
+def test_prepare_for_training_sentence_transformers_bad_format(
+    cross_encoder: bool,
+    formatting_func: Callable,
+    feedback_dataset_guidelines: str,
+    feedback_dataset_fields: List["AllowedFieldTypes"],
+    feedback_dataset_questions: List["AllowedQuestionTypes"],
+    feedback_dataset_records: List[FeedbackRecord],
+) -> None:
+    dataset = FeedbackDataset(
+        guidelines=feedback_dataset_guidelines,
+        fields=feedback_dataset_fields,
+        questions=feedback_dataset_questions,
+    )
+    dataset.add_records(records=feedback_dataset_records)
+
+    task = TrainingTask.for_sentence_similarity(formatting_func)
+
+    # Match the start of the error message only
+    if "errored" in formatting_func.__name__:
+        match_start = r"^formatting_func must return"
+    else:
+        match_start = r"^Datasets containing a `sentence`"
+
+    with pytest.raises(ValueError, match=match_start):
+        trainer = ArgillaTrainer(
+            dataset=dataset,
+            task=task,
+            framework="sentence-transformers",
+            framework_kwargs={"cross_encoder": cross_encoder}
+        )

--- a/tests/integration/client/feedback/training/test_sentence_transformers.py
+++ b/tests/integration/client/feedback/training/test_sentence_transformers.py
@@ -12,18 +12,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import TYPE_CHECKING, List, Callable, Union
+from typing import TYPE_CHECKING, Callable, List, Union
 
 import pytest
-
 from argilla.client.feedback.dataset import FeedbackDataset
 from argilla.client.feedback.schemas.records import FeedbackRecord
 from argilla.client.feedback.training.base import ArgillaTrainer
 from argilla.client.feedback.training.schemas import (
     TrainingTask,
 )
-
-from sentence_transformers import InputExample, SentenceTransformer, CrossEncoder
+from sentence_transformers import CrossEncoder, InputExample, SentenceTransformer
 
 from tests.integration.training.helpers import train_with_cleanup
 
@@ -35,6 +33,7 @@ __FRAMEWORK__ = "sentence-transformers"
 
 
 # All the formatting functions generate dummy datasets with the formats allowed (almost a copy than those of trl)
+
 
 def formatting_func_case_1_a(sample):
     labels = [
@@ -51,7 +50,7 @@ def formatting_func_case_1_a(sample):
         elif labels[0] == "c":
             return [
                 {"sentence-1": sample["text"], "sentence-2": sample["text"], "label": 1},
-                {"sentence-1": sample["text"], "sentence-2": sample["text"], "label": 0}
+                {"sentence-1": sample["text"], "sentence-2": sample["text"], "label": 0},
             ]
 
 
@@ -69,7 +68,7 @@ def formatting_func_case_1_b(sample):
         elif labels[0] == "c":
             return [
                 {"sentence-1": sample["text"], "sentence-2": sample["text"], "label": 0.786},
-                {"sentence-1": sample["text"], "sentence-2": sample["text"], "label": 0.56}
+                {"sentence-1": sample["text"], "sentence-2": sample["text"], "label": 0.56},
             ]
 
 
@@ -102,10 +101,7 @@ def formatting_func_case_3_a(sample):
         elif labels[0] == "b":
             return {"sentence": sample["text"], "label": 1}
         elif labels[0] == "c":
-            return [
-                {"sentence": sample["text"], "label": 1},
-                {"sentence": sample["text"], "label": 0}
-            ]
+            return [{"sentence": sample["text"], "label": 1}, {"sentence": sample["text"], "label": 0}]
 
 
 def formatting_func_case_3_b(sample):
@@ -118,11 +114,16 @@ def formatting_func_case_3_b(sample):
         if labels[0] == "a":
             return None
         elif labels[0] == "b":
-            return {"sentence-1": sample["text"], "sentence-2": sample["text"], "sentence-3": sample["text"], "label": 1}
+            return {
+                "sentence-1": sample["text"],
+                "sentence-2": sample["text"],
+                "sentence-3": sample["text"],
+                "label": 1,
+            }
         elif labels[0] == "c":
             return [
                 {"sentence-1": sample["text"], "sentence-2": sample["text"], "sentence-3": sample["text"], "label": 1},
-                {"sentence-1": sample["text"], "sentence-2": sample["text"], "sentence-3": sample["text"], "label": 0}
+                {"sentence-1": sample["text"], "sentence-2": sample["text"], "sentence-3": sample["text"], "label": 0},
             ]
 
 
@@ -151,14 +152,7 @@ def formatting_func_errored(sample):
         return sample["text"], sample["text"], sample["text"]
 
 
-
-@pytest.mark.parametrize(
-    "cross_encoder,model_type",
-    [
-        (False, SentenceTransformer),
-        (True, CrossEncoder)
-    ]
-)
+@pytest.mark.parametrize("cross_encoder,model_type", [(False, SentenceTransformer), (True, CrossEncoder)])
 @pytest.mark.parametrize(
     "formatting_func",
     [
@@ -167,7 +161,7 @@ def formatting_func_errored(sample):
         formatting_func_case_2,
         formatting_func_case_3_b,
         formatting_func_case_4,
-    ]
+    ],
 )
 @pytest.mark.usefixtures(
     "feedback_dataset_guidelines",
@@ -206,15 +200,12 @@ def test_prepare_for_training_sentence_transformers(
                     dataset=dataset,
                     task=task,
                     framework="sentence-transformers",
-                    framework_kwargs={"cross_encoder": cross_encoder}
+                    framework_kwargs={"cross_encoder": cross_encoder},
                 )
             return
 
     trainer = ArgillaTrainer(
-        dataset=dataset,
-        task=task,
-        framework=__FRAMEWORK__,
-        framework_kwargs={"cross_encoder": cross_encoder}
+        dataset=dataset, task=task, framework=__FRAMEWORK__, framework_kwargs={"cross_encoder": cross_encoder}
     )
     trainer.update_config(batch_size=2)
     assert trainer._trainer.data_kwargs["batch_size"] == 2
@@ -229,7 +220,7 @@ def test_prepare_for_training_sentence_transformers(
         task=task,
         framework=__FRAMEWORK__,
         train_size=0.5,
-        framework_kwargs={"cross_encoder": cross_encoder}
+        framework_kwargs={"cross_encoder": cross_encoder},
     )
     eval_trainer.update_config(epochs=1)
     train_with_cleanup(eval_trainer, __OUTPUT_DIR__)
@@ -239,13 +230,7 @@ def test_prepare_for_training_sentence_transformers(
 
 
 @pytest.mark.parametrize("cross_encoder", [False, True])
-@pytest.mark.parametrize(
-    "formatting_func",
-    [
-        formatting_func_case_3_a,
-        formatting_func_errored
-    ]
-)
+@pytest.mark.parametrize("formatting_func", [formatting_func_case_3_a, formatting_func_errored])
 @pytest.mark.usefixtures(
     "feedback_dataset_guidelines",
     "feedback_dataset_fields",
@@ -280,7 +265,7 @@ def test_prepare_for_training_sentence_transformers_bad_format(
             dataset=dataset,
             task=task,
             framework="sentence-transformers",
-            framework_kwargs={"cross_encoder": cross_encoder}
+            framework_kwargs={"cross_encoder": cross_encoder},
         )
 
 
@@ -295,7 +280,7 @@ def test_prepare_for_training_sentence_transformers_with_defaults(
     if use_label:
         task = TrainingTask.for_sentence_similarity(
             texts=[dataset.field_by_name("premise"), dataset.field_by_name("hypothesis")],
-            label=dataset.question_by_name("label")
+            label=dataset.question_by_name("label"),
         )
     else:
         task = TrainingTask.for_sentence_similarity(
@@ -303,10 +288,7 @@ def test_prepare_for_training_sentence_transformers_with_defaults(
         )
 
     trainer = ArgillaTrainer(
-        dataset=dataset,
-        task=task,
-        framework=__FRAMEWORK__,
-        framework_kwargs={"cross_encoder": cross_encoder}
+        dataset=dataset, task=task, framework=__FRAMEWORK__, framework_kwargs={"cross_encoder": cross_encoder}
     )
     trainer.update_config(batch_size=2)
     assert trainer._trainer.data_kwargs["batch_size"] == 2
@@ -319,7 +301,7 @@ def test_prepare_for_training_sentence_transformers_with_defaults(
         task=task,
         framework=__FRAMEWORK__,
         train_size=0.5,
-        framework_kwargs={"cross_encoder": cross_encoder}
+        framework_kwargs={"cross_encoder": cross_encoder},
     )
     eval_trainer.update_config(epochs=1)
     train_with_cleanup(eval_trainer, __OUTPUT_DIR__)

--- a/tests/integration/client/feedback/training/test_sentence_transformers.py
+++ b/tests/integration/client/feedback/training/test_sentence_transformers.py
@@ -97,10 +97,10 @@ def formatting_func_errored(sample):
     "formatting_func",
     [
         formatting_func_case_1_a,
-        # formatting_func_case_1_b,
-        # formatting_func_case_2,
-        # formatting_func_case_3_b,
-        # formatting_func_case_4,
+        formatting_func_case_1_b,
+        formatting_func_case_2,
+        formatting_func_case_3_b,
+        formatting_func_case_4,
     ]
 )
 @pytest.mark.usefixtures(

--- a/tests/integration/client/feedback/training/test_sentence_transformers.py
+++ b/tests/integration/client/feedback/training/test_sentence_transformers.py
@@ -205,7 +205,7 @@ def test_prepare_for_training_sentence_transformers(
         framework_kwargs={"cross_encoder": cross_encoder}
     )
     trainer.update_config(batch_size=2)
-    assert trainer._trainer.dataloader_kwargs["batch_size"] == 2
+    assert trainer._trainer.data_kwargs["batch_size"] == 2
     trainer.update_config(epochs=1)
     assert trainer._trainer.trainer_kwargs["epochs"] == 1
     train_with_cleanup(trainer, __OUTPUT_DIR__)
@@ -221,6 +221,10 @@ def test_prepare_for_training_sentence_transformers(
     )
     eval_trainer.update_config(epochs=1)
     train_with_cleanup(eval_trainer, __OUTPUT_DIR__)
+
+    # Check an evaluator has been set (for the cases that it does make sense)
+    if not "case_2" in formatting_func.__name__:
+        assert eval_trainer._trainer.trainer_kwargs["evaluator"]
 
     assert len(eval_trainer.predict([["first sentence", "second sentence"], ["to compare", "another one"]])) == 2
     assert len(eval_trainer.predict(["first sentence", ["to compare", "another one"]])) == 2

--- a/tests/integration/client/feedback/training/test_sentence_transformers.py
+++ b/tests/integration/client/feedback/training/test_sentence_transformers.py
@@ -97,10 +97,10 @@ def formatting_func_errored(sample):
     "formatting_func",
     [
         formatting_func_case_1_a,
-        formatting_func_case_1_b,
-        formatting_func_case_2,
-        formatting_func_case_3_b,
-        formatting_func_case_4,
+        # formatting_func_case_1_b,
+        # formatting_func_case_2,
+        # formatting_func_case_3_b,
+        # formatting_func_case_4,
     ]
 )
 @pytest.mark.usefixtures(
@@ -169,6 +169,9 @@ def test_prepare_for_training_sentence_transformers(
     )
     eval_trainer.update_config(epochs=1)
     train_with_cleanup(eval_trainer, __OUTPUT_DIR__)
+
+    assert len(eval_trainer.predict([["first sentence", "second sentence"], ["to compare", "another one"]])) == 2
+    assert len(eval_trainer.predict(["first sentence", ["to compare", "another one"]])) == 2
 
 
 @pytest.mark.parametrize("cross_encoder", [False, True])

--- a/tests/integration/client/feedback/training/test_sentence_transformers.py
+++ b/tests/integration/client/feedback/training/test_sentence_transformers.py
@@ -34,55 +34,109 @@ __OUTPUT_DIR__ = "tmp"
 __FRAMEWORK__ = "sentence-transformers"
 
 
-# All the formatting functions generate dummy datasets with the formats allowed
+# All the formatting functions generate dummy datasets with the formats allowed (almost a copy than those of trl)
 
 def formatting_func_case_1_a(sample):
-    if sample.responses:
-        response = sample.responses[0]
-        if response.status == "submitted":
-            return {"sentence-1": sample.fields["text"], "sentence-2": sample.fields["text"], "label": 1}
+    labels = [
+        annotation["value"]
+        for annotation in sample["question-3"]
+        if annotation["status"] == "submitted" and annotation["value"] is not None
+    ]
+    if labels:
+        # Three cases for the tests: None, one tuple and yielding multiple tuples
+        if labels[0] == "a":
+            return None
+        elif labels[0] == "b":
+            return {"sentence-1": sample["text"], "sentence-2": sample["text"], "label": 1}
+        elif labels[0] == "c":
+            return [{"sentence-1": sample["text"], "sentence-2": sample["text"], "label": 1}] * 2
 
 
 def formatting_func_case_1_b(sample):
-    if sample.responses:
-        response = sample.responses[0]
-        if response.status == "submitted":
-            return {"sentence-1": sample.fields["text"], "sentence-2": sample.fields["text"], "label": 0.786}
+    labels = [
+        annotation["value"]
+        for annotation in sample["question-3"]
+        if annotation["status"] == "submitted" and annotation["value"] is not None
+    ]
+    if labels:
+        if labels[0] == "a":
+            return None
+        elif labels[0] == "b":
+            return {"sentence-1": sample["text"], "sentence-2": sample["text"], "label": 0.786}
+        elif labels[0] == "c":
+            return [{"sentence-1": sample["text"], "sentence-2": sample["text"], "label": 0.786}] * 2
 
 
 def formatting_func_case_2(sample):
-    if sample.responses:
-        response = sample.responses[0]
-        if response.status == "submitted":
-            return {"sentence-1": sample.fields["text"], "sentence-2": sample.fields["text"]}
+    labels = [
+        annotation["value"]
+        for annotation in sample["question-3"]
+        if annotation["status"] == "submitted" and annotation["value"] is not None
+    ]
+    if labels:
+        # Three cases for the tests: None, one tuple and yielding multiple tuples
+        if labels[0] == "a":
+            return None
+        elif labels[0] == "b":
+            return {"sentence-1": sample["text"], "sentence-2": sample["text"]}
+        elif labels[0] == "c":
+            return [{"sentence-1": sample["text"], "sentence-2": sample["text"]}] * 2
 
 
 def formatting_func_case_3_a(sample):
-    if sample.responses:
-        response = sample.responses[0]
-        if response.status == "submitted":
-            return {"sentence": sample.fields["text"], "label": 1}
+    labels = [
+        annotation["value"]
+        for annotation in sample["question-3"]
+        if annotation["status"] == "submitted" and annotation["value"] is not None
+    ]
+    if labels:
+        # Three cases for the tests: None, one tuple and yielding multiple tuples
+        if labels[0] == "a":
+            return None
+        elif labels[0] == "b":
+            return {"sentence": sample["text"], "label": 1}
+        elif labels[0] == "c":
+            return [{"sentence": sample["text"], "label": 1}] * 2
 
 
 def formatting_func_case_3_b(sample):
-    if sample.responses:
-        response = sample.responses[0]
-        if response.status == "submitted":
-            return {"sentence-1": sample.fields["text"], "sentence-2": sample.fields["text"], "sentence-3": sample.fields["text"], "label": 1}
+    labels = [
+        annotation["value"]
+        for annotation in sample["question-3"]
+        if annotation["status"] == "submitted" and annotation["value"] is not None
+    ]
+    if labels:
+        if labels[0] == "a":
+            return None
+        elif labels[0] == "b":
+            return {"sentence-1": sample["text"], "sentence-2": sample["text"], "sentence-3": sample["text"], "label": 1}
+        elif labels[0] == "c":
+            return [{"sentence-1": sample["text"], "sentence-2": sample["text"], "sentence-3": sample["text"], "label": 1}] * 2
 
 
 def formatting_func_case_4(sample):
-    if sample.responses:
-        response = sample.responses[0]
-        if response.status == "submitted":
-            return {"sentence-1": sample.fields["text"], "sentence-2": sample.fields["text"], "sentence-3": sample.fields["text"]}
+    labels = [
+        annotation["value"]
+        for annotation in sample["question-3"]
+        if annotation["status"] == "submitted" and annotation["value"] is not None
+    ]
+    if labels:
+        if labels[0] == "a":
+            return None
+        elif labels[0] == "b":
+            return {"sentence-1": sample["text"], "sentence-2": sample["text"], "sentence-3": sample["text"]}
+        elif labels[0] == "c":
+            return [{"sentence-1": sample["text"], "sentence-2": sample["text"], "sentence-3": sample["text"]}] * 2
 
 
 def formatting_func_errored(sample):
-    if sample.responses:
-        response = sample.responses[0]
-        if response.status == "submitted":
-            return sample.fields["text"], sample.fields["text"], sample.fields["text"]
+    labels = [
+        annotation["value"]
+        for annotation in sample["question-3"]
+        if annotation["status"] == "submitted" and annotation["value"] is not None
+    ]
+    if labels:
+        return sample["text"], sample["text"], sample["text"]
 
 
 
@@ -130,10 +184,8 @@ def test_prepare_for_training_sentence_transformers(
 
     assert isinstance(train_dataset, list)
     assert isinstance(train_dataset[0], InputExample)
-    assert len(train_dataset) == 8
 
     train_dataset, test_dataset = dataset.prepare_for_training(framework=__FRAMEWORK__, task=task, train_size=0.5)
-    assert len(train_dataset) == 4
 
     if cross_encoder:
         if ("case_3_b" in formatting_func.__name__) or ("case_4" in formatting_func.__name__):


### PR DESCRIPTION
# Description

Includes integration with `sentence-transformers` to allow the `ArgillaTrainer` dealing with `sentence-similarity` tasks.

Closes #3316 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

The corresponding tests can be found at:

- [x] tests/integration/client/feedback/training/test_sentence_transformers.py

**Checklist**

- [x] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
