### PR TITLE
refactor(engine): define a base search engine

### DIFF
--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -364,7 +364,7 @@ async def search_dataset_records(
 
     search_responses = await search_engine.search(
         dataset=dataset,
-        query=search_engine_query,
+        query=search_engine_query.text,
         user_response_status_filter=user_response_status_filter,
         offset=offset,
         limit=limit,

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -29,7 +29,7 @@ from pydantic.utils import GetterDict
 
 from argilla.server.schemas.base import UpdateSchema
 from argilla.server.schemas.v1.suggestions import Suggestion, SuggestionCreate
-from argilla.server.search_engine import Query
+from argilla.server.search_engine import StringQuery
 
 try:
     from typing import Annotated
@@ -409,8 +409,12 @@ class RecordsCreate(BaseModel):
     items: conlist(item_type=RecordCreate, min_items=RECORDS_CREATE_MIN_ITEMS, max_items=RECORDS_CREATE_MAX_ITEMS)
 
 
+class TextQuery(BaseModel):
+    text: StringQuery
+
+
 class SearchRecordsQuery(BaseModel):
-    query: Query
+    query: TextQuery
 
 
 class SearchRecord(BaseModel):

--- a/src/argilla/server/search_engine/__init__.py
+++ b/src/argilla/server/search_engine/__init__.py
@@ -1,2 +1,16 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 from .base import *
 from .opensearch import OpenSearchEngine, get_search_engine

--- a/src/argilla/server/search_engine/__init__.py
+++ b/src/argilla/server/search_engine/__init__.py
@@ -1,0 +1,2 @@
+from .base import *
+from .opensearch import OpenSearchEngine, get_search_engine

--- a/src/argilla/server/search_engine/base.py
+++ b/src/argilla/server/search_engine/base.py
@@ -14,13 +14,22 @@
 
 import dataclasses
 from abc import ABCMeta, abstractmethod
-from typing import Any, Dict, Iterable, List, Literal, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 from uuid import UUID
 
 from pydantic import BaseModel
 
 from argilla.server.enums import ResponseStatus, ResponseStatusFilter
 from argilla.server.models import Dataset, Record, Response, User
+
+__all__ = [
+    "SearchEngine",
+    "UserResponse",
+    "StringQuery",
+    "UserResponseStatusFilter",
+    "SearchResponseItem",
+    "SearchResponses",
+]
 
 
 class UserResponse(BaseModel):

--- a/src/argilla/server/search_engine/base.py
+++ b/src/argilla/server/search_engine/base.py
@@ -1,3 +1,17 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import dataclasses
 from abc import ABCMeta, abstractmethod
 from typing import Any, Dict, Iterable, List, Literal, Optional, Union
@@ -73,4 +87,3 @@ class SearchEngine(metaclass=ABCMeta):
         limit: int = 100,
     ) -> SearchResponses:
         pass
-

--- a/src/argilla/server/search_engine/base.py
+++ b/src/argilla/server/search_engine/base.py
@@ -1,0 +1,76 @@
+import dataclasses
+from abc import ABCMeta, abstractmethod
+from typing import Any, Dict, Iterable, List, Literal, Optional, Union
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from argilla.server.enums import ResponseStatus, ResponseStatusFilter
+from argilla.server.models import Dataset, Record, Response, User
+
+
+class UserResponse(BaseModel):
+    values: Optional[Dict[str, Any]]
+    status: ResponseStatus
+
+
+@dataclasses.dataclass
+class StringQuery:
+    q: str
+    field: Optional[str] = None
+
+
+@dataclasses.dataclass
+class UserResponseStatusFilter:
+    user: User
+    statuses: List[ResponseStatusFilter]
+
+
+@dataclasses.dataclass
+class SearchResponseItem:
+    record_id: UUID
+    score: Optional[float]
+
+
+@dataclasses.dataclass
+class SearchResponses:
+    items: List[SearchResponseItem]
+    total: int = 0
+
+
+class SearchEngine(metaclass=ABCMeta):
+    @abstractmethod
+    async def create_index(self, dataset: Dataset):
+        pass
+
+    @abstractmethod
+    async def delete_index(self, dataset: Dataset):
+        pass
+
+    @abstractmethod
+    async def add_records(self, dataset: Dataset, records: Iterable[Record]):
+        pass
+
+    @abstractmethod
+    async def delete_records(self, dataset: Dataset, records: Iterable[Record]):
+        pass
+
+    @abstractmethod
+    async def update_record_response(self, response: Response):
+        pass
+
+    @abstractmethod
+    async def delete_record_response(self, response: Response):
+        pass
+
+    @abstractmethod
+    async def search(
+        self,
+        dataset: Dataset,
+        query: Union[StringQuery, str],
+        user_response_status_filter: Optional[UserResponseStatusFilter] = None,
+        offset: int = 0,
+        limit: int = 100,
+    ) -> SearchResponses:
+        pass
+

--- a/src/argilla/server/search_engine/opensearch.py
+++ b/src/argilla/server/search_engine/opensearch.py
@@ -30,9 +30,14 @@ from argilla.server.models import (
     Response,
     ResponseStatus,
 )
-from argilla.server.search_engine.base import (SearchEngine, SearchResponseItem, SearchResponses, StringQuery,
-                                               UserResponse,
-                                               UserResponseStatusFilter, )
+from argilla.server.search_engine.base import (
+    SearchEngine,
+    SearchResponseItem,
+    SearchResponses,
+    StringQuery,
+    UserResponse,
+    UserResponseStatusFilter,
+)
 from argilla.server.settings import settings
 
 

--- a/src/argilla/server/search_engine/opensearch.py
+++ b/src/argilla/server/search_engine/opensearch.py
@@ -29,8 +29,10 @@ from argilla.server.models import (
     Record,
     Response,
     ResponseStatus,
-    User,
 )
+from argilla.server.search_engine.base import (SearchEngine, SearchResponseItem, SearchResponses, StringQuery,
+                                               UserResponse,
+                                               UserResponseStatusFilter, )
 from argilla.server.settings import settings
 
 
@@ -47,11 +49,6 @@ class SearchDocumentGetter(GetterDict):
         return super().get(key, default)
 
 
-class UserResponse(BaseModel):
-    values: Optional[Dict[str, Any]]
-    status: ResponseStatus
-
-
 class SearchDocument(BaseModel):
     id: UUID
     fields: Dict[str, Any]
@@ -64,36 +61,7 @@ class SearchDocument(BaseModel):
 
 
 @dataclasses.dataclass
-class TextQuery:
-    q: str
-    field: Optional[str] = None
-
-
-@dataclasses.dataclass
-class Query:
-    text: TextQuery
-
-
-@dataclasses.dataclass
-class UserResponseStatusFilter:
-    user: User
-    statuses: List[ResponseStatusFilter]
-
-
-@dataclasses.dataclass
-class SearchResponseItem:
-    record_id: UUID
-    score: Optional[float]
-
-
-@dataclasses.dataclass
-class SearchResponses:
-    items: List[SearchResponseItem]
-    total: int = 0
-
-
-@dataclasses.dataclass
-class SearchEngine:
+class OpenSearchEngine(SearchEngine):
     config: Dict[str, Any]
 
     es_number_of_shards: int
@@ -177,7 +145,7 @@ class SearchEngine:
     async def search(
         self,
         dataset: Dataset,
-        query: Union[Query, str],
+        query: Union[StringQuery, str],
         user_response_status_filter: Optional[UserResponseStatusFilter] = None,
         offset: int = 0,
         limit: int = 100,
@@ -185,9 +153,9 @@ class SearchEngine:
         # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html
 
         if isinstance(query, str):
-            query = Query(text=TextQuery(q=query))
+            query = StringQuery(q=query)
 
-        text_query = self._text_query_builder(dataset, text=query.text)
+        text_query = self._text_query_builder(dataset, text=query)
 
         bool_query = {"must": [text_query]}
         if user_response_status_filter:
@@ -213,7 +181,7 @@ class SearchEngine:
         return SearchResponses(items=items, total=total)
 
     @staticmethod
-    def _text_query_builder(dataset: Dataset, text: TextQuery) -> dict:
+    def _text_query_builder(dataset: Dataset, text: StringQuery) -> dict:
         if not text.field:
             # See https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html
             field_names = [
@@ -315,7 +283,7 @@ async def get_search_engine() -> AsyncGenerator[SearchEngine, None]:
         retry_on_timeout=True,
         max_retries=5,
     )
-    search_engine = SearchEngine(
+    search_engine = OpenSearchEngine(
         config,
         es_number_of_shards=settings.es_records_index_shards,
         es_number_of_replicas=settings.es_records_index_replicas,

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -51,11 +51,10 @@ from argilla.server.schemas.v1.datasets import (
     VALUE_TEXT_OPTION_VALUE_MAX_LENGTH,
 )
 from argilla.server.search_engine import (
-    Query,
     SearchEngine,
     SearchResponseItem,
     SearchResponses,
-    TextQuery,
+    StringQuery,
     UserResponseStatusFilter,
 )
 from sqlalchemy import func, select
@@ -2996,11 +2995,9 @@ class TestSuiteDatasets:
 
         mock_search_engine.search.assert_called_once_with(
             dataset=dataset,
-            query=Query(
-                text=TextQuery(
-                    q="Hello",
-                    field="input",
-                )
+            query=StringQuery(
+                q="Hello",
+                field="input",
             ),
             user_response_status_filter=None,
             offset=0,
@@ -3074,11 +3071,9 @@ class TestSuiteDatasets:
 
         mock_search_engine.search.assert_called_once_with(
             dataset=dataset,
-            query=Query(
-                text=TextQuery(
-                    q="Hello",
-                    field="input",
-                )
+            query=StringQuery(
+                q="Hello",
+                field="input",
             ),
             user_response_status_filter=None,
             offset=0,
@@ -3186,7 +3181,7 @@ class TestSuiteDatasets:
 
         mock_search_engine.search.assert_called_once_with(
             dataset=dataset,
-            query=Query(text=TextQuery(q="Hello", field="input")),
+            query=StringQuery(q="Hello", field="input"),
             user_response_status_filter=UserResponseStatusFilter(user=owner, statuses=[ResponseStatusFilter.submitted]),
             offset=0,
             limit=LIST_DATASET_RECORDS_LIMIT_DEFAULT,
@@ -3217,7 +3212,7 @@ class TestSuiteDatasets:
 
         mock_search_engine.search.assert_called_once_with(
             dataset=dataset,
-            query=Query(text=TextQuery(q="Hello", field="input")),
+            query=StringQuery(q="Hello", field="input"),
             user_response_status_filter=None,
             offset=0,
             limit=5,

--- a/tests/unit/server/conftest.py
+++ b/tests/unit/server/conftest.py
@@ -23,7 +23,7 @@ from argilla.server.daos.datasets import DatasetsDAO
 from argilla.server.daos.records import DatasetRecordsDAO
 from argilla.server.database import get_async_db
 from argilla.server.models import User, UserRole, Workspace
-from argilla.server.search_engine import SearchEngine, get_search_engine
+from argilla.server.search_engine import OpenSearchEngine, SearchEngine, get_search_engine
 from argilla.server.server import argilla_app
 from argilla.server.services.datasets import DatasetsService
 from argilla.server.settings import settings
@@ -42,8 +42,8 @@ def elasticsearch_config():
 
 
 @pytest_asyncio.fixture()
-async def elastic_search_engine(elasticsearch_config: dict) -> AsyncGenerator[SearchEngine, None]:
-    engine = SearchEngine(config=elasticsearch_config, es_number_of_replicas=0, es_number_of_shards=1)
+async def opensearch_engine(elasticsearch_config: dict) -> AsyncGenerator[OpenSearchEngine, None]:
+    engine = OpenSearchEngine(config=elasticsearch_config, es_number_of_replicas=0, es_number_of_shards=1)
     yield engine
 
     await engine.client.close()

--- a/tests/unit/server/test_opensearch_engine.py
+++ b/tests/unit/server/test_opensearch_engine.py
@@ -19,11 +19,11 @@ import pytest
 import pytest_asyncio
 from argilla.server.enums import ResponseStatusFilter
 from argilla.server.models import Dataset, User
-from argilla.server.search_engine.opensearch import OpenSearchEngine
 from argilla.server.search_engine import (
     StringQuery,
     UserResponseStatusFilter,
 )
+from argilla.server.search_engine.opensearch import OpenSearchEngine
 from opensearchpy import OpenSearch, RequestError, helpers
 from sqlalchemy.orm import Session
 

--- a/tests/unit/server/test_opensearch_engine.py
+++ b/tests/unit/server/test_opensearch_engine.py
@@ -13,16 +13,15 @@
 #  limitations under the License.
 
 import random
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Union
 
 import pytest
 import pytest_asyncio
 from argilla.server.enums import ResponseStatusFilter
 from argilla.server.models import Dataset, User
-from argilla.server.search_engine import Query as SearchQuery
+from argilla.server.search_engine.opensearch import OpenSearchEngine
 from argilla.server.search_engine import (
-    SearchEngine,
-    TextQuery,
+    StringQuery,
     UserResponseStatusFilter,
 )
 from opensearchpy import OpenSearch, RequestError, helpers
@@ -75,7 +74,7 @@ async def dataset_for_pagination(opensearch: OpenSearch):
 
 @pytest_asyncio.fixture(scope="function")
 @pytest.mark.asyncio
-async def test_banking_sentiment_dataset(elastic_search_engine: SearchEngine) -> Dataset:
+async def test_banking_sentiment_dataset(opensearch_engine: OpenSearchEngine) -> Dataset:
     text_question = await TextQuestionFactory()
     rating_question = await RatingQuestionFactory()
 
@@ -88,9 +87,9 @@ async def test_banking_sentiment_dataset(elastic_search_engine: SearchEngine) ->
         questions=[text_question, rating_question],
     )
 
-    await elastic_search_engine.create_index(dataset)
+    await opensearch_engine.create_index(dataset)
 
-    await elastic_search_engine.add_records(
+    await opensearch_engine.add_records(
         dataset,
         records=[
             await RecordFactory.create(
@@ -175,21 +174,21 @@ async def test_banking_sentiment_dataset(elastic_search_engine: SearchEngine) ->
 
 
 @pytest.mark.asyncio
-class TestSuiteElasticSearchEngine:
-    async def test_get_index_or_raise(self, elastic_search_engine: SearchEngine):
+class TestSuiteOpenSearchEngine:
+    async def test_get_index_or_raise(self, opensearch_engine: OpenSearchEngine):
         dataset = await DatasetFactory.create()
         with pytest.raises(
             ValueError, match=f"Cannot access to index for dataset {dataset.id}: the specified index does not exist"
         ):
-            await elastic_search_engine._get_index_or_raise(dataset)
+            await opensearch_engine._get_index_or_raise(dataset)
 
     async def test_create_index_for_dataset(
-        self, elastic_search_engine: SearchEngine, db: "AsyncSession", opensearch: OpenSearch
+        self, opensearch_engine: OpenSearchEngine, db: "AsyncSession", opensearch: OpenSearch
     ):
         dataset = await DatasetFactory.create()
         await dataset.awaitable_attrs.fields
         await dataset.awaitable_attrs.questions
-        await elastic_search_engine.create_index(dataset)
+        await opensearch_engine.create_index(dataset)
 
         index_name = f"rg.{dataset.id}"
         assert opensearch.indices.exists(index=index_name)
@@ -205,12 +204,12 @@ class TestSuiteElasticSearchEngine:
                 "responses": {"dynamic": "true", "type": "object"},
             },
         }
-        assert index["settings"]["index"]["number_of_shards"] == str(elastic_search_engine.es_number_of_shards)
-        assert index["settings"]["index"]["number_of_replicas"] == str(elastic_search_engine.es_number_of_replicas)
+        assert index["settings"]["index"]["number_of_shards"] == str(opensearch_engine.es_number_of_shards)
+        assert index["settings"]["index"]["number_of_replicas"] == str(opensearch_engine.es_number_of_replicas)
 
     async def test_create_index_for_dataset_with_fields(
         self,
-        elastic_search_engine: SearchEngine,
+        opensearch_engine: OpenSearchEngine,
         opensearch: OpenSearch,
         db: Session,
     ):
@@ -219,7 +218,7 @@ class TestSuiteElasticSearchEngine:
         await dataset.awaitable_attrs.fields
         await dataset.awaitable_attrs.questions
 
-        await elastic_search_engine.create_index(dataset)
+        await opensearch_engine.create_index(dataset)
 
         index_name = f"rg.{dataset.id}"
         assert opensearch.indices.exists(index=index_name)
@@ -243,7 +242,7 @@ class TestSuiteElasticSearchEngine:
     )
     async def test_create_index_for_dataset_with_questions(
         self,
-        elastic_search_engine: SearchEngine,
+        opensearch_engine: OpenSearchEngine,
         opensearch: OpenSearch,
         text_ann_size: int,
         rating_ann_size: int,
@@ -257,7 +256,7 @@ class TestSuiteElasticSearchEngine:
         dataset = await DatasetFactory.create(questions=all_questions)
         await dataset.awaitable_attrs.fields
 
-        await elastic_search_engine.create_index(dataset)
+        await opensearch_engine.create_index(dataset)
 
         index_name = f"rg.{dataset.id}"
         assert opensearch.indices.exists(index=index_name)
@@ -311,18 +310,18 @@ class TestSuiteElasticSearchEngine:
         }
 
     async def test_create_index_with_existing_index(
-        self, elastic_search_engine: SearchEngine, opensearch: OpenSearch, db: Session
+        self, opensearch_engine: OpenSearchEngine, opensearch: OpenSearch, db: Session
     ):
         dataset = await DatasetFactory.create()
         await dataset.awaitable_attrs.fields
         await dataset.awaitable_attrs.questions
-        await elastic_search_engine.create_index(dataset)
+        await opensearch_engine.create_index(dataset)
 
         index_name = f"rg.{dataset.id}"
         assert opensearch.indices.exists(index=index_name)
 
         with pytest.raises(RequestError, match="resource_already_exists_exception"):
-            await elastic_search_engine.create_index(dataset)
+            await opensearch_engine.create_index(dataset)
 
     @pytest.mark.parametrize(
         ("query", "expected_items"),
@@ -335,28 +334,28 @@ class TestSuiteElasticSearchEngine:
             ("00000", 1),
             ("card payment", 5),
             ("nothing", 0),
-            (SearchQuery(text=TextQuery(q="card")), 5),
-            (SearchQuery(text=TextQuery(q="account")), 1),
-            (SearchQuery(text=TextQuery(q="payment")), 6),
-            (SearchQuery(text=TextQuery(q="cash")), 3),
-            (SearchQuery(text=TextQuery(q="card payment")), 5),
-            (SearchQuery(text=TextQuery(q="nothing")), 0),
-            (SearchQuery(text=TextQuery(q="negative", field="label")), 4),
-            (SearchQuery(text=TextQuery(q="00000", field="textId")), 1),
-            (SearchQuery(text=TextQuery(q="card payment", field="text")), 5),
+            (StringQuery(q="card"), 5),
+            (StringQuery(q="account"), 1),
+            (StringQuery(q="payment"), 6),
+            (StringQuery(q="cash"), 3),
+            (StringQuery(q="card payment"), 5),
+            (StringQuery(q="nothing"), 0),
+            (StringQuery(q="negative", field="label"), 4),
+            (StringQuery(q="00000", field="textId"), 1),
+            (StringQuery(q="card payment", field="text"), 5),
         ],
     )
     async def test_search_with_query_string(
         self,
-        elastic_search_engine: SearchEngine,
+        opensearch_engine: OpenSearchEngine,
         opensearch: OpenSearch,
         test_banking_sentiment_dataset: Dataset,
-        query: str,
+        query: Union[str, StringQuery],
         expected_items: int,
     ):
         opensearch.indices.refresh(index=f"rg.{test_banking_sentiment_dataset.id}")
 
-        result = await elastic_search_engine.search(test_banking_sentiment_dataset, query=query)
+        result = await opensearch_engine.search(test_banking_sentiment_dataset, query=query)
 
         assert len(result.items) == expected_items
         assert result.total == expected_items
@@ -384,7 +383,7 @@ class TestSuiteElasticSearchEngine:
     )
     async def test_search_with_response_status_filter(
         self,
-        elastic_search_engine: SearchEngine,
+        opensearch_engine: OpenSearchEngine,
         opensearch: OpenSearch,
         test_banking_sentiment_dataset: Dataset,
         statuses: List[ResponseStatusFilter],
@@ -394,29 +393,29 @@ class TestSuiteElasticSearchEngine:
 
         await self._configure_record_responses(opensearch, test_banking_sentiment_dataset, statuses, user)
 
-        result = await elastic_search_engine.search(
+        result = await opensearch_engine.search(
             test_banking_sentiment_dataset,
-            query=SearchQuery(text=TextQuery(q="payment")),
+            query=StringQuery(q="payment"),
             user_response_status_filter=UserResponseStatusFilter(user=user, statuses=statuses),
         )
         assert len(result.items) == expected_items
         assert result.total == expected_items
 
     async def test_search_with_response_status_filter_does_not_affect_the_result_scores(
-        self, elastic_search_engine: SearchEngine, opensearch: OpenSearch, test_banking_sentiment_dataset: Dataset
+        self, opensearch_engine: OpenSearchEngine, opensearch: OpenSearch, test_banking_sentiment_dataset: Dataset
     ):
         user = await UserFactory.create()
 
         all_statuses = [ResponseStatusFilter.missing, ResponseStatusFilter.draft, ResponseStatusFilter.discarded]
         await self._configure_record_responses(opensearch, test_banking_sentiment_dataset, all_statuses, user)
 
-        no_filter_results = await elastic_search_engine.search(
+        no_filter_results = await opensearch_engine.search(
             test_banking_sentiment_dataset,
-            query=SearchQuery(text=TextQuery(q="payment")),
+            query=StringQuery(q="payment"),
         )
-        results = await elastic_search_engine.search(
+        results = await opensearch_engine.search(
             test_banking_sentiment_dataset,
-            query=SearchQuery(text=TextQuery(q="payment")),
+            query=StringQuery(q="payment"),
             user_response_status_filter=UserResponseStatusFilter(user=user, statuses=all_statuses),
         )
         assert len(no_filter_results.items) == len(results.items)
@@ -426,15 +425,13 @@ class TestSuiteElasticSearchEngine:
     @pytest.mark.parametrize(("offset", "limit"), [(0, 50), (10, 5), (0, 0), (90, 100)])
     async def test_search_with_pagination(
         self,
-        elastic_search_engine: SearchEngine,
+        opensearch_engine: OpenSearchEngine,
         opensearch: OpenSearch,
         dataset_for_pagination: Dataset,
         offset: int,
         limit: int,
     ):
-        results = await elastic_search_engine.search(
-            dataset_for_pagination, query="documents", offset=offset, limit=limit
-        )
+        results = await opensearch_engine.search(dataset_for_pagination, query="documents", offset=offset, limit=limit)
 
         assert len(results.items) == min(len(dataset_for_pagination.records) - offset, limit)
         assert results.total == 100
@@ -442,7 +439,7 @@ class TestSuiteElasticSearchEngine:
         records = sorted(dataset_for_pagination.records, key=lambda r: r.id)
         assert [record.id for record in records[offset : offset + limit]] == [item.record_id for item in results.items]
 
-    async def test_add_records(self, elastic_search_engine: SearchEngine, opensearch: OpenSearch):
+    async def test_add_records(self, opensearch_engine: OpenSearchEngine, opensearch: OpenSearch):
         text_fields = await TextFieldFactory.create_batch(5)
         dataset = await DatasetFactory.create(fields=text_fields, questions=[])
         records = await RecordFactory.create_batch(
@@ -452,8 +449,8 @@ class TestSuiteElasticSearchEngine:
             responses=[],
         )
 
-        await elastic_search_engine.create_index(dataset)
-        await elastic_search_engine.add_records(dataset, records)
+        await opensearch_engine.create_index(dataset)
+        await opensearch_engine.add_records(dataset, records)
 
         index_name = f"rg.{dataset.id}"
         opensearch.indices.refresh(index=index_name)
@@ -461,7 +458,7 @@ class TestSuiteElasticSearchEngine:
         es_docs = [hit["_source"] for hit in opensearch.search(index=index_name)["hits"]["hits"]]
         assert es_docs == [{"id": str(record.id), "fields": record.fields, "responses": {}} for record in records]
 
-    async def test_delete_records(self, elastic_search_engine: SearchEngine, opensearch: OpenSearch):
+    async def test_delete_records(self, opensearch_engine: OpenSearchEngine, opensearch: OpenSearch):
         text_fields = await TextFieldFactory.create_batch(5)
         dataset = await DatasetFactory.create(fields=text_fields, questions=[])
         records = await RecordFactory.create_batch(
@@ -471,11 +468,11 @@ class TestSuiteElasticSearchEngine:
             responses=[],
         )
 
-        await elastic_search_engine.create_index(dataset)
-        await elastic_search_engine.add_records(dataset, records)
+        await opensearch_engine.create_index(dataset)
+        await opensearch_engine.add_records(dataset, records)
 
         records_to_delete, records_to_keep = records[:5], records[5:]
-        await elastic_search_engine.delete_records(dataset, records_to_delete)
+        await opensearch_engine.delete_records(dataset, records_to_delete)
 
         index_name = f"rg.{dataset.id}"
         opensearch.indices.refresh(index=index_name)
@@ -498,7 +495,7 @@ class TestSuiteElasticSearchEngine:
 
     async def test_update_record_response(
         self,
-        elastic_search_engine: SearchEngine,
+        opensearch_engine: OpenSearchEngine,
         opensearch: OpenSearch,
         test_banking_sentiment_dataset: Dataset,
     ):
@@ -508,7 +505,7 @@ class TestSuiteElasticSearchEngine:
         response = await ResponseFactory.create(record=record, values={question.name: {"value": "test"}})
         record = await response.awaitable_attrs.record
         await record.awaitable_attrs.dataset
-        await elastic_search_engine.update_record_response(response)
+        await opensearch_engine.update_record_response(response)
 
         index_name = f"rg.{test_banking_sentiment_dataset.id}"
         opensearch.indices.refresh(index=index_name)
@@ -537,7 +534,7 @@ class TestSuiteElasticSearchEngine:
 
     async def test_delete_record_response(
         self,
-        elastic_search_engine: SearchEngine,
+        opensearch_engine: OpenSearchEngine,
         opensearch: OpenSearch,
         db: Session,
         test_banking_sentiment_dataset: Dataset,
@@ -548,7 +545,7 @@ class TestSuiteElasticSearchEngine:
         response = await ResponseFactory.create(record=record, values={question.name: {"value": "test"}})
         record = await response.awaitable_attrs.record
         await record.awaitable_attrs.dataset
-        await elastic_search_engine.update_record_response(response)
+        await opensearch_engine.update_record_response(response)
 
         index_name = f"rg.{test_banking_sentiment_dataset.id}"
 
@@ -562,7 +559,7 @@ class TestSuiteElasticSearchEngine:
             }
         }
 
-        await elastic_search_engine.delete_record_response(response)
+        await opensearch_engine.delete_record_response(response)
 
         opensearch.indices.refresh(index=index_name)
 


### PR DESCRIPTION
# Description

This PR adds a refactor in the `search_engine` in which a base class is defined and all implementation details are moved to the `OpenSearchEngine`  implementation.

This will be the base to extend and integrate different search engines in Argilla.

Also, some minor changes are done in the search engine data models that affect some API schema definitions.

Refs #3028 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Refactor (change restructuring the codebase without changing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

Everything is working as expected in a local deployment

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)