### PR TITLE
feat: add `username` option to `users` group of commands 

### DIFF
--- a/src/argilla/cli/users/__main__.py
+++ b/src/argilla/cli/users/__main__.py
@@ -12,6 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from typing import Optional
+
 import typer
 
 from argilla.cli.callback import init_callback
@@ -20,7 +22,44 @@ from .create import create_user
 from .delete import delete_user
 from .list import list_users
 
-app = typer.Typer(help="Holds CLI commands for user management.", no_args_is_help=True, callback=init_callback)
+_COMMANDS_REQUIRING_USER = ["delete"]
+
+
+def callback(
+    ctx: typer.Context,
+    username: Optional[str] = typer.Option(None, help="Username of the user to which apply the command."),
+) -> None:
+    init_callback()
+
+    if ctx.invoked_subcommand not in _COMMANDS_REQUIRING_USER:
+        return
+
+    if username is None:
+        raise typer.BadParameter("The command requires a username provided using '--username' option")
+
+    from argilla.cli.rich import echo_in_panel
+    from argilla.client.users import User
+
+    try:
+        user = User.from_name(username)
+    except ValueError as e:
+        echo_in_panel(
+            f"User with username={username} doesn't exist.", title="User not found", title_align="left", success=False
+        )
+        raise typer.Exit(code=1) from e
+    except RuntimeError as e:
+        echo_in_panel(
+            "An unexpected error occurred when trying to get the user.",
+            title="Unexpected error",
+            title_align="left",
+            success=False,
+        )
+        raise typer.Exit(code=1) from e
+
+    ctx.obj = user
+
+
+app = typer.Typer(help="Holds CLI commands for user management.", no_args_is_help=True, callback=callback)
 
 app.command(name="create", help="Creates a new user")(create_user)
 app.command(name="delete", help="Deletes a user")(delete_user)

--- a/src/argilla/cli/users/create.py
+++ b/src/argilla/cli/users/create.py
@@ -33,7 +33,6 @@ def create_user(
         help="A workspace name to which the user will be linked to. This option can be provided several times.",
     ),
 ) -> None:
-    from rich.console import Console
     from rich.markdown import Markdown
 
     from argilla.cli.rich import echo_in_panel

--- a/src/argilla/cli/users/delete.py
+++ b/src/argilla/cli/users/delete.py
@@ -12,20 +12,21 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from typing import TYPE_CHECKING
+
 import typer
 
-
-def delete_user(username: str = typer.Argument(..., help="The username of the user to be removed")) -> None:
-    from argilla.cli.rich import echo_in_panel
+if TYPE_CHECKING:
     from argilla.client.users import User
 
+
+def delete_user(ctx: typer.Context) -> None:
+    from argilla.cli.rich import echo_in_panel
+
+    user: "User" = ctx.obj
+
     try:
-        User.from_name(username).delete()
-    except ValueError as e:
-        echo_in_panel(
-            f"User with username={username} doesn't exist.", title="User not found", title_align="left", success=False
-        )
-        raise typer.Exit(code=1) from e
+        user.delete()
     except RuntimeError as e:
         echo_in_panel(
             "An unexpected error occurred when trying to remove the user.",
@@ -35,4 +36,4 @@ def delete_user(username: str = typer.Argument(..., help="The username of the us
         )
         raise typer.Exit(code=1) from e
 
-    echo_in_panel(f"User with username '{username}' has been removed!", title="User removed", title_align="left")
+    echo_in_panel(f"User with username={user.username} has been removed.", title="User removed", title_align="left")

--- a/tests/unit/cli/users/test_delete.py
+++ b/tests/unit/cli/users/test_delete.py
@@ -29,35 +29,35 @@ class TestSuiteDeleteUserCommand:
         user_from_name_mock = mocker.patch("argilla.client.users.User.from_name", return_value=user)
         user_delete_mock = mocker.patch("argilla.client.users.User.delete")
 
-        result = cli_runner.invoke(cli, "users delete unit-test")
+        result = cli_runner.invoke(cli, "users --username unit-test delete")
 
         assert result.exit_code == 0
         assert "User removed" in result.stdout
-        assert "User with username 'unit-test' has been removed!" in result.stdout
+        assert "User with username=unit-test has been removed" in result.stdout
         user_from_name_mock.assert_called_once_with("unit-test")
         user_delete_mock.assert_called_once()
 
-    @pytest.mark.parametrize(
-        "ExceptionType, expected_msg",
-        [
-            (ValueError, "User with username=unit-test doesn't exist"),
-            (RuntimeError, "An unexpected error occurred when trying to remove the user"),
-        ],
-    )
-    def test_delete_user_errors(
-        self,
-        cli_runner: "CliRunner",
-        cli: "Typer",
-        mocker: "MockerFixture",
-        ExceptionType: Type[Exception],
-        expected_msg: str,
+    def test_delete_user_not_found(
+        self, cli_runner: "CliRunner", cli: "Typer", mocker: "MockerFixture", user: "User"
     ) -> None:
-        user_from_name_mock = mocker.patch("argilla.client.users.User.from_name", side_effect=ExceptionType)
-        result = cli_runner.invoke(cli, "users delete unit-test")
+        user_from_name_mock = mocker.patch("argilla.client.users.User.from_name", side_effect=ValueError)
+        result = cli_runner.invoke(cli, "users --username unit-test delete")
 
         assert result.exit_code == 1
-        assert expected_msg in result.stdout
+        assert "User with username=unit-test doesn't exist." in result.stdout
         user_from_name_mock.assert_called_once_with("unit-test")
+
+    def test_delete_user_runtime_error(
+        self, cli_runner: "CliRunner", cli: "Typer", mocker: "MockerFixture", user: "User"
+    ) -> None:
+        user_delete_mock = mocker.patch.object(user, "delete", side_effect=RuntimeError)
+        user_from_name_mock = mocker.patch("argilla.client.users.User.from_name", return_value=user)
+        result = cli_runner.invoke(cli, "users --username unit-test delete")
+
+        assert result.exit_code == 1
+        assert "An unexpected error occurred when trying to remove the user" in result.stdout
+        user_from_name_mock.assert_called_once_with("unit-test")
+        user_delete_mock.assert_called_once()
 
 
 @pytest.mark.usefixtures("not_logged_mock")


### PR DESCRIPTION
# Description

This PR changes how the username is provided to the `argilla users delete` command. Now, the username has to be provided as a group option `argilla users --username bob delete`. This update has been done in order to be aligned how the rest of the commands works (`datasets` and `workspaces`), and to avoid having duplicate code in the future when performing an operation over a specific user.

**Type of change**
- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

In a local development environment:

- [x] `argilla users --username gabrielmbmb delete` works
- [x] `argilla users --username idonotexists delete` throws an error telling that the user doesn't exist

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
