### PR TITLE
fix: ensure `argilla database` backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ These are the section headers that we use:
 - Updated `PUT /api/v1/responses/{response_id}` to replace `values` stored with received `values` in request ([#3711](https://github.com/argilla-io/argilla/pull/3711)).
 - Display a `UserWarning` when the `user_id` in `Workspace.add_user` and `Workspace.delete_user` is the ID of an user with the owner role as they don't require explicit permissions ([#3716](https://github.com/argilla-io/argilla/issues/3716)).
 - Rename `tasks` sub-package to `cli` ([#3723](https://github.com/argilla-io/argilla/pull/3723)).
+- Changed `argilla database` command in the CLI to now be accessed via `argilla server database`, to be deprecated in the upcoming release ([#3754](https://github.com/argilla-io/argilla/pull/3754)).
 
 ### Fixed
 

--- a/src/argilla/cli/app.py
+++ b/src/argilla/cli/app.py
@@ -61,9 +61,12 @@ app.add_typer(whoami_app, name="whoami")
 app.add_typer(workspaces_app, name="workspaces")
 
 if is_package_with_extras_installed("argilla", ["server"]):
+    from argilla.cli.callback import deprecated_database_cmd_callback
     from argilla.cli.server import app as server_app
+    from argilla.cli.server.database import app as deprecated_app
 
     app.add_typer(server_app, name="server")
+    app.add_typer(deprecated_app, name="database", callback=deprecated_database_cmd_callback)
 
 if __name__ == "__main__":
     app()

--- a/src/argilla/cli/app.py
+++ b/src/argilla/cli/app.py
@@ -66,7 +66,7 @@ if is_package_with_extras_installed("argilla", ["server"]):
     from argilla.cli.server.database import app as deprecated_app
 
     app.add_typer(server_app, name="server")
-    app.add_typer(deprecated_app, name="database", callback=deprecated_database_cmd_callback)
+    app.add_typer(deprecated_app, name="database", callback=deprecated_database_cmd_callback, deprecated=True)
 
 if __name__ == "__main__":
     app()

--- a/src/argilla/cli/callback.py
+++ b/src/argilla/cli/callback.py
@@ -39,3 +39,12 @@ def init_callback() -> None:
             success=False,
         )
         raise typer.Exit(code=1) from e
+
+
+def deprecated_database_cmd_callback(ctx: typer.Context) -> None:
+    echo_in_panel(
+        f"Instead you should run `argilla server database {ctx.invoked_subcommand}`",
+        title="Deprecated command",
+        title_align="left",
+        success=False,
+    )


### PR DESCRIPTION
# Description

This PR adds back the `argilla database` command but now being a shortcut over `argilla server database` in order to ensure the backwards compatibility before Argilla 1.16.0 is released.

It's been done by adding a `callback` to the `typer` application so that when calling `argilla database` it's internally redirected to `argilla server database` and a warning is displayed in the console to let the user know that's going to be deprecated and what's the correct command.

**Type of change**

- [X] Backwards compatibility of existing feature to avoid breaking changes

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)