### PR TITLE
fix(search): Allow search terms distributed in different records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ These are the section headers that we use:
 - Fixed `Pending queue` pagination problems when during data annotation ([#3677](https://github.com/argilla-io/argilla/pull/3677))
 - Fixed `visible_labels` default value to be 20 just when `visible_labels` not provided and `len(labels) > 20`, otherwise it will either be the provided `visible_labels` value or `None`, for `LabelQuestion` and `MultiLabelQuestion` ([#3702](https://github.com/argilla-io/argilla/pull/3702)).
 - Fixed `DatasetCard` generation when `RemoteFeedbackDataset` contains suggestions ([#3718](https://github.com/argilla-io/argilla/pull/3718)).
+- Searches when queried words are distributed along the record fields ([3759](https://github.com/argilla-io/argilla/pull/3759))
 
 ## [1.15.0](https://github.com/argilla-io/argilla/compare/v1.14.1...v1.15.0)
 

--- a/src/argilla/server/search_engine.py
+++ b/src/argilla/server/search_engine.py
@@ -219,7 +219,7 @@ class SearchEngine:
             field_names = [
                 f"fields.{field.name}" for field in dataset.fields if field.settings.get("type") == FieldType.text
             ]
-            return {"multi_match": {"query": text.q, "fields": field_names, "operator": "and"}}
+            return {"multi_match": {"query": text.q, "type": "cross_fields", "fields": field_names, "operator": "and"}}
         else:
             # See https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
             return {"match": {f"fields.{text.field}": {"query": text.q, "operator": "and"}}}

--- a/tests/unit/server/test_search_engine.py
+++ b/tests/unit/server/test_search_engine.py
@@ -341,6 +341,7 @@ class TestSuiteElasticSearchEngine:
             (SearchQuery(text=TextQuery(q="cash")), 3),
             (SearchQuery(text=TextQuery(q="card payment")), 5),
             (SearchQuery(text=TextQuery(q="nothing")), 0),
+            (SearchQuery(text=TextQuery(q="rate negative")), 1),  # Terms are found in two different fields
             (SearchQuery(text=TextQuery(q="negative", field="label")), 4),
             (SearchQuery(text=TextQuery(q="00000", field="textId")), 1),
             (SearchQuery(text=TextQuery(q="card payment", field="text")), 5),


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR changes a wrong behavior in text search when searching several words. All the provided words must appear in the same record text field to match the results. With changes in this PR, the search will use all the fields to search the terms.

Refs #3731 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

This logic has been tested using a proper test for that. With the test case, I could reproduce the error and then after the fix, the test passed successfully. 

**Checklist**

- [X] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
