### PR TITLE
feat: update to `fastapi>=0.103.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 server = [
     # Basic dependencies
-    "fastapi >= 0.75,< 0.89",
+    "fastapi >= 0.103.1",
     "opensearch-py ~= 2.0.0",
     "elasticsearch8[async] ~= 8.7.0",
     "uvicorn[standard] >= 0.15.0,< 0.21.0",
@@ -134,7 +134,9 @@ where = ["src"]
 version = { attr = "argilla.__version__" }
 
 [tool.setuptools.package-data]
-"argilla.client.feedback.integrations.huggingface.card" = ["argilla_template.md"]
+"argilla.client.feedback.integrations.huggingface.card" = [
+    "argilla_template.md",
+]
 
 [tool.pytest.ini_options]
 log_format = "%(asctime)s %(name)s %(levelname)s %(message)s"

--- a/src/argilla/server/apis/v1/handlers/responses.py
+++ b/src/argilla/server/apis/v1/handlers/responses.py
@@ -14,7 +14,7 @@
 
 from uuid import UUID
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Security, status
+from fastapi import APIRouter, Depends, HTTPException, Security, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from argilla.server.contexts import datasets
@@ -45,7 +45,7 @@ async def update_response(
     db: AsyncSession = Depends(get_async_db),
     search_engine: SearchEngine = Depends(get_search_engine),
     response_id: UUID,
-    response_update: ResponseUpdate = Body(..., discriminator="status"),
+    response_update: ResponseUpdate,
     current_user: User = Security(auth.get_current_user),
 ):
     response = await _get_response(db, response_id)

--- a/src/argilla/server/apis/v1/handlers/responses.py
+++ b/src/argilla/server/apis/v1/handlers/responses.py
@@ -14,7 +14,7 @@
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Security, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Security, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from argilla.server.contexts import datasets
@@ -45,7 +45,7 @@ async def update_response(
     db: AsyncSession = Depends(get_async_db),
     search_engine: SearchEngine = Depends(get_search_engine),
     response_id: UUID,
-    response_update: ResponseUpdate,
+    response_update: ResponseUpdate = Body(..., discriminator="status"),
     current_user: User = Security(auth.get_current_user),
 ):
     response = await _get_response(db, response_id)

--- a/src/argilla/server/errors/adapter.py
+++ b/src/argilla/server/errors/adapter.py
@@ -15,6 +15,7 @@
 import logging
 
 import pydantic
+from fastapi.exceptions import RequestValidationError
 
 from argilla.server.errors.base_errors import BadRequestError, GenericServerError, ServerError, ValidationError
 
@@ -24,8 +25,9 @@ _LOGGER = logging.getLogger("argilla")
 def exception_to_argilla_error(error: Exception) -> ServerError:
     if isinstance(error, ServerError):
         return error
+
     _LOGGER.error(error)
-    if isinstance(error, pydantic.error_wrappers.ValidationError):
+    if isinstance(error, RequestValidationError):
         return ValidationError(error)
 
     if isinstance(error, AssertionError):

--- a/src/argilla/server/errors/base_errors.py
+++ b/src/argilla/server/errors/base_errors.py
@@ -60,7 +60,6 @@ class ValidationError(ServerError):
     HTTP_STATUS = status.HTTP_422_UNPROCESSABLE_ENTITY
 
     def __init__(self, error: pydantic.ValidationError):
-        self.model = error.model.__name__
         self.errors = error.errors()
 
 

--- a/src/argilla/server/schemas/v1/responses.py
+++ b/src/argilla/server/schemas/v1/responses.py
@@ -16,7 +16,8 @@ from datetime import datetime
 from typing import Any, Dict, Literal, Optional, Union
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from fastapi import Body
+from pydantic import BaseModel
 
 try:
     from typing import Annotated
@@ -62,4 +63,6 @@ class DraftResponseUpdate(BaseModel):
     status: Literal[ResponseStatus.draft]
 
 
-ResponseUpdate = Union[SubmittedResponseUpdate, DiscardedResponseUpdate, DraftResponseUpdate]
+ResponseUpdate = Annotated[
+    Union[SubmittedResponseUpdate, DiscardedResponseUpdate, DraftResponseUpdate], Body(..., discriminator="status")
+]

--- a/src/argilla/server/schemas/v1/responses.py
+++ b/src/argilla/server/schemas/v1/responses.py
@@ -62,6 +62,4 @@ class DraftResponseUpdate(BaseModel):
     status: Literal[ResponseStatus.draft]
 
 
-ResponseUpdate = Annotated[
-    Union[SubmittedResponseUpdate, DiscardedResponseUpdate, DraftResponseUpdate], Field(discriminator="status")
-]
+ResponseUpdate = Union[SubmittedResponseUpdate, DiscardedResponseUpdate, DraftResponseUpdate]

--- a/tests/unit/server/api/v0/test_datasets.py
+++ b/tests/unit/server/api/v0/test_datasets.py
@@ -233,7 +233,6 @@ class TestSuiteDatasetApi:
                             "type": "value_error.str.regex",
                         }
                     ],
-                    "model": "Request",
                 },
             }
         }

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -2325,7 +2325,6 @@ class TestSuiteDatasets:
             "detail": {
                 "code": "argilla.api.errors::ValidationError",
                 "params": {
-                    "model": "Request",
                     "errors": [
                         {
                             "loc": ["body", "items", 0, "responses"],


### PR DESCRIPTION
# Description

This PR updates `fastapi` dependency to `>=0.103.1`. In addition, it updates some pieces of the codebase that were not working after updating `fastapi`. 

The `RequestValidationError` is not a `ValidationError` subclass anymore, so we cannot return the name of the model for which the validation failed anymore.

Closes #3566

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

After updating the dependency, I tested that all the unit tests were working.

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
