### PR TITLE
fix: Python 3.11 support due to `Enum` usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ These are the section headers that we use:
 - Fixed `DatasetCard` generation when `RemoteFeedbackDataset` contains suggestions ([#3718](https://github.com/argilla-io/argilla/pull/3718)).
 - Add missing `draft` status in `ResponseSchema` as now there can be responses with `draft` status when annotating via the UI ([#3749](https://github.com/argilla-io/argilla/pull/3749)).
 - Searches when queried words are distributed along the record fields ([#3759](https://github.com/argilla-io/argilla/pull/3759)).
+- Fixed Python 3.11 compatibility issue with `/api/datasets` endpoints due to the `TaskType` enum replacement in the endpoint URL ([#3769](https://github.com/argilla-io/argilla/pull/3769)).
 
 ## [1.15.1](https://github.com/argilla-io/argilla/compare/v1.15.0...v1.15.1)
 

--- a/src/argilla/server/apis/v0/handlers/metrics.py
+++ b/src/argilla/server/apis/v0/handlers/metrics.py
@@ -60,8 +60,8 @@ class MetricSummaryParams:
 
 
 def configure_router(router: APIRouter, cfg: TaskConfig):
-    base_metrics_endpoint = f"/{cfg.task}/{{name}}/metrics"
-    new_base_metrics_endpoint = f"/{{name}}/{cfg.task}/metrics"
+    base_metrics_endpoint = f"/{cfg.task.value}/{{name}}/metrics"
+    new_base_metrics_endpoint = f"/{{name}}/{cfg.task.value}/metrics"
 
     @deprecate_endpoint(
         path=base_metrics_endpoint,

--- a/src/argilla/server/apis/v0/handlers/text2text.py
+++ b/src/argilla/server/apis/v0/handlers/text2text.py
@@ -29,9 +29,7 @@ from argilla.server.apis.v0.models.text2text import (
 )
 from argilla.server.commons.config import TasksFactory
 from argilla.server.commons.models import TaskType
-from argilla.server.errors import EntityNotFoundError
 from argilla.server.models import User
-from argilla.server.schemas.v0.datasets import CreateDatasetRequest
 from argilla.server.security import auth
 from argilla.server.services.datasets import DatasetsService
 from argilla.server.services.tasks.text2text import Text2TextService

--- a/src/argilla/server/apis/v0/handlers/text2text.py
+++ b/src/argilla/server/apis/v0/handlers/text2text.py
@@ -38,7 +38,7 @@ from argilla.server.services.tasks.text2text.models import ServiceText2TextQuery
 
 def configure_router():
     task_type = TaskType.text2text
-    base_endpoint = "/{name}/" + task_type
+    base_endpoint = f"/{{name}}/{task_type.value}"
 
     TasksFactory.register_task(
         task_type=TaskType.text2text,

--- a/src/argilla/server/apis/v0/handlers/text_classification.py
+++ b/src/argilla/server/apis/v0/handlers/text_classification.py
@@ -51,6 +51,8 @@ from argilla.server.services.tasks.text_classification.model import (
 
 def configure_router():
     task_type = TaskType.text_classification
+    base_endpoint = f"/{{name}}/{task_type.value}"
+    new_base_endpoint = f"/{task_type.value}/{{name}}"
 
     TasksFactory.register_task(
         task_type=task_type,
@@ -59,9 +61,6 @@ def configure_router():
         record_class=ServiceTextClassificationRecord,
         metrics=TextClassificationMetrics,
     )
-
-    base_endpoint = f"/{{name}}/{task_type}"
-    new_base_endpoint = f"/{task_type}/{{name}}"
 
     router = APIRouter(tags=[task_type], prefix="/datasets")
 

--- a/src/argilla/server/apis/v0/handlers/text_classification.py
+++ b/src/argilla/server/apis/v0/handlers/text_classification.py
@@ -37,9 +37,7 @@ from argilla.server.apis.v0.models.text_classification import (
 from argilla.server.apis.v0.validators.text_classification import DatasetValidator
 from argilla.server.commons.config import TasksFactory
 from argilla.server.commons.models import TaskType
-from argilla.server.errors import EntityNotFoundError
 from argilla.server.models import User
-from argilla.server.schemas.v0.datasets import CreateDatasetRequest
 from argilla.server.security import auth
 from argilla.server.services.datasets import DatasetsService
 from argilla.server.services.tasks.text_classification import TextClassificationService

--- a/src/argilla/server/apis/v0/handlers/text_classification_dataset_settings.py
+++ b/src/argilla/server/apis/v0/handlers/text_classification_dataset_settings.py
@@ -25,17 +25,17 @@ from argilla.server.services.datasets import DatasetsService
 
 
 def configure_router(router: APIRouter):
-    task = TaskType.text_classification
-    base_endpoint = f"/{task}/{{name}}/settings"
-    new_base_endpoint = f"/{{name}}/{task}/settings"
+    task_type = TaskType.text_classification
+    base_endpoint = f"/{task_type.value}/{{name}}/settings"
+    new_base_endpoint = f"/{{name}}/{task_type.value}/settings"
 
     @deprecate_endpoint(
         path=base_endpoint,
         new_path=new_base_endpoint,
         router_method=router.get,
-        name=f"get_dataset_settings_for_{task}",
-        operation_id=f"get_dataset_settings_for_{task}",
-        description=f"Get the {task} dataset settings",
+        name=f"get_dataset_settings_for_{task_type.value}",
+        operation_id=f"get_dataset_settings_for_{task_type.value}",
+        description=f"Get the {task_type.value} dataset settings",
         response_model_exclude_none=True,
         response_model=TextClassificationSettings,
     )
@@ -49,7 +49,7 @@ def configure_router(router: APIRouter):
             user=current_user,
             name=name,
             workspace=ws_params.workspace,
-            task=task,
+            task=task_type,
         )
 
         settings = await datasets.get_settings(
@@ -59,14 +59,14 @@ def configure_router(router: APIRouter):
 
     @router.patch(
         path=new_base_endpoint,
-        name=f"save_dataset_settings_for_{task}",
-        operation_id=f"save_dataset_settings_for_{task}",
-        description=f"Save the {task} dataset settings",
+        name=f"save_dataset_settings_for_{task_type.value}",
+        operation_id=f"save_dataset_settings_for_{task_type.value}",
+        description=f"Save the {task_type.value} dataset settings",
         response_model_exclude_none=True,
         response_model=TextClassificationSettings,
     )
     async def save_settings(
-        request: TextClassificationSettings = Body(..., description=f"The {task} dataset settings"),
+        request: TextClassificationSettings = Body(..., description=f"The {task_type.value} dataset settings"),
         name: str = DATASET_NAME_PATH_PARAM,
         ws_params: CommonTaskHandlerDependencies = Depends(),
         datasets: DatasetsService = Depends(DatasetsService.get_instance),
@@ -76,7 +76,7 @@ def configure_router(router: APIRouter):
         found_ds = await datasets.find_by_name(
             user=current_user,
             name=name,
-            task=task,
+            task=task_type,
             workspace=ws_params.workspace,
         )
         await validator.validate_dataset_settings(user=current_user, dataset=found_ds, settings=request)
@@ -90,18 +90,18 @@ def configure_router(router: APIRouter):
     # TODO: This will be remove in next iteration
     router.put(
         path=base_endpoint,
-        name=f"old_save_dataset_settings_for_{task}",
-        operation_id=f"old_save_dataset_settings_for_{task}",
-        description=f"Save the {task} dataset settings",
+        name=f"old_save_dataset_settings_for_{task_type.value}",
+        operation_id=f"old_save_dataset_settings_for_{task_type.value}",
+        description=f"Save the {task_type.value} dataset settings",
         deprecated=True,
         response_model_exclude_none=True,
         response_model=TextClassificationSettings,
     )(save_settings)
     router.put(
         path=new_base_endpoint,
-        name=f"new_save_dataset_settings_for_{task}_put",
-        operation_id=f"new_save_dataset_settings_for_{task}_put",
-        description=f"Save the {task} dataset settings",
+        name=f"new_save_dataset_settings_for_{task_type.value}_put",
+        operation_id=f"new_save_dataset_settings_for_{task_type.value}_put",
+        description=f"Save the {task_type.value} dataset settings",
         deprecated=True,
         response_model_exclude_none=True,
         response_model=TextClassificationSettings,
@@ -111,9 +111,9 @@ def configure_router(router: APIRouter):
         path=base_endpoint,
         new_path=new_base_endpoint,
         router_method=router.delete,
-        operation_id=f"delete_{task}_settings",
-        name=f"delete_{task}_settings",
-        description=f"Delete {task} dataset settings",
+        operation_id=f"delete_{task_type.value}_settings",
+        name=f"delete_{task_type.value}_settings",
+        description=f"Delete {task_type.value} dataset settings",
     )
     async def delete_settings(
         name: str = DATASET_NAME_PATH_PARAM,
@@ -124,7 +124,7 @@ def configure_router(router: APIRouter):
         found_ds = await datasets.find_by_name(
             user=user,
             name=name,
-            task=task,
+            task=task_type,
             workspace=ws_params.workspace,
         )
 

--- a/src/argilla/server/apis/v0/handlers/token_classification.py
+++ b/src/argilla/server/apis/v0/handlers/token_classification.py
@@ -42,7 +42,7 @@ from argilla.server.services.tasks.token_classification.model import (
 
 def configure_router():
     task_type = TaskType.token_classification
-    base_endpoint = f"/{{name}}/{task_type}"
+    base_endpoint = f"/{{name}}/{task_type.value}"
 
     TasksFactory.register_task(
         task_type=task_type,

--- a/src/argilla/server/apis/v0/handlers/token_classification.py
+++ b/src/argilla/server/apis/v0/handlers/token_classification.py
@@ -29,9 +29,7 @@ from argilla.server.apis.v0.models.token_classification import (
 from argilla.server.apis.v0.validators.token_classification import DatasetValidator
 from argilla.server.commons.config import TasksFactory
 from argilla.server.commons.models import TaskType
-from argilla.server.errors import EntityNotFoundError
 from argilla.server.models import User
-from argilla.server.schemas.v0.datasets import CreateDatasetRequest
 from argilla.server.security import auth
 from argilla.server.services.datasets import DatasetsService
 from argilla.server.services.tasks.token_classification import TokenClassificationService

--- a/src/argilla/server/apis/v0/handlers/token_classification_dataset_settings.py
+++ b/src/argilla/server/apis/v0/handlers/token_classification_dataset_settings.py
@@ -25,17 +25,17 @@ from argilla.server.services.datasets import DatasetsService
 
 
 def configure_router(router: APIRouter):
-    task = TaskType.token_classification
-    base_endpoint = f"/{task}/{{name}}/settings"
-    new_base_endpoint = f"/{{name}}/{task}/settings"
+    task_type = TaskType.token_classification
+    base_endpoint = f"/{task_type.value}/{{name}}/settings"
+    new_base_endpoint = f"/{{name}}/{task_type.value}/settings"
 
     @deprecate_endpoint(
         path=base_endpoint,
         new_path=new_base_endpoint,
         router_method=router.get,
-        name=f"get_dataset_settings_for_{task}",
-        operation_id=f"get_dataset_settings_for_{task}",
-        description=f"Get the {task} dataset settings",
+        name=f"get_dataset_settings_for_{task_type.value}",
+        operation_id=f"get_dataset_settings_for_{task_type.value}",
+        description=f"Get the {task_type.value} dataset settings",
         response_model_exclude_none=True,
         response_model=TokenClassificationSettings,
     )
@@ -49,7 +49,7 @@ def configure_router(router: APIRouter):
             user=current_user,
             name=name,
             workspace=ws_params.workspace,
-            task=task,
+            task=task_type,
         )
 
         settings = await datasets.get_settings(
@@ -59,14 +59,14 @@ def configure_router(router: APIRouter):
 
     @router.patch(
         path=new_base_endpoint,
-        name=f"save_dataset_settings_for_{task}",
-        operation_id=f"save_dataset_settings_for_{task}",
-        description=f"Save the {task} dataset settings",
+        name=f"save_dataset_settings_for_{task_type.value}",
+        operation_id=f"save_dataset_settings_for_{task_type.value}",
+        description=f"Save the {task_type.value} dataset settings",
         response_model_exclude_none=True,
         response_model=TokenClassificationSettings,
     )
     async def save_settings(
-        request: TokenClassificationSettings = Body(..., description=f"The {task} dataset settings"),
+        request: TokenClassificationSettings = Body(..., description=f"The {task_type.value} dataset settings"),
         name: str = DATASET_NAME_PATH_PARAM,
         ws_params: CommonTaskHandlerDependencies = Depends(),
         datasets: DatasetsService = Depends(DatasetsService.get_instance),
@@ -76,7 +76,7 @@ def configure_router(router: APIRouter):
         found_ds = await datasets.find_by_name(
             user=current_user,
             name=name,
-            task=task,
+            task=task_type,
             workspace=ws_params.workspace,
         )
 
@@ -93,18 +93,18 @@ def configure_router(router: APIRouter):
     # TODO: This will be remove in next iteration
     router.put(
         path=base_endpoint,
-        name=f"old_save_dataset_settings_for_{task}",
-        operation_id=f"old_save_dataset_settings_for_{task}",
-        description=f"Save the {task} dataset settings",
+        name=f"old_save_dataset_settings_for_{task_type.value}",
+        operation_id=f"old_save_dataset_settings_for_{task_type.value}",
+        description=f"Save the {task_type.value} dataset settings",
         deprecated=True,
         response_model_exclude_none=True,
         response_model=TokenClassificationSettings,
     )(save_settings)
     router.put(
         path=new_base_endpoint,
-        name=f"new_save_dataset_settings_for_{task}_put",
-        operation_id=f"new_save_dataset_settings_for_{task}_put",
-        description=f"Save the {task} dataset settings",
+        name=f"new_save_dataset_settings_for_{task_type.value}_put",
+        operation_id=f"new_save_dataset_settings_for_{task_type.value}_put",
+        description=f"Save the {task_type.value} dataset settings",
         deprecated=True,
         response_model_exclude_none=True,
         response_model=TokenClassificationSettings,
@@ -114,9 +114,9 @@ def configure_router(router: APIRouter):
         path=base_endpoint,
         new_path=new_base_endpoint,
         router_method=router.delete,
-        operation_id=f"delete_{task}_settings",
-        name=f"delete_{task}_settings",
-        description=f"Delete {task} dataset settings",
+        operation_id=f"delete_{task_type.value}_settings",
+        name=f"delete_{task_type.value}_settings",
+        description=f"Delete {task_type.value} dataset settings",
     )
     async def delete_settings(
         name: str = DATASET_NAME_PATH_PARAM,
@@ -127,7 +127,7 @@ def configure_router(router: APIRouter):
         found_ds = await datasets.find_by_name(
             user=current_user,
             name=name,
-            task=task,
+            task=task_type,
             workspace=ws_params.workspace,
         )
 

--- a/src/argilla/server/daos/backend/query_helpers.py
+++ b/src/argilla/server/daos/backend/query_helpers.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from enum import Enum
 from typing import Any, Dict, List, Optional, Type, Union
 
 from pydantic import BaseModel
@@ -175,10 +176,10 @@ class filters:
         return {"terms": {field: values}}
 
     @staticmethod
-    def term_filter(field: str, value: Any) -> Optional[Dict[str, Any]]:
+    def term_filter(field: str, value: Union[str, Enum]) -> Optional[Dict[str, Any]]:
         if value is None:
             return None
-        return {"term": {field: value}}
+        return {"term": {field: value.value if isinstance(value, Enum) else value}}
 
     @staticmethod
     def range_filter(

--- a/src/argilla/server/daos/models/records.py
+++ b/src/argilla/server/daos/models/records.py
@@ -12,6 +12,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+
 import uuid
 import warnings
 from datetime import datetime

--- a/src/argilla/server/services/datasets.py
+++ b/src/argilla/server/services/datasets.py
@@ -14,7 +14,8 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Type, TypeVar, cast
+from enum import Enum
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
 
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -81,7 +82,7 @@ class DatasetsService:
         name: str,
         workspace: str,
         as_dataset_class: Type[ServiceDataset] = ServiceBaseDataset,
-        task: Optional[str] = None,
+        task: Optional[Union[str, Enum]] = None,
     ) -> ServiceDataset:
         found_dataset = self.__dao__.find_by_name(name=name, workspace=workspace, as_dataset_class=as_dataset_class)
 

--- a/src/argilla/server/services/tasks/text2text/models.py
+++ b/src/argilla/server/services/tasks/text2text/models.py
@@ -17,7 +17,6 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 
 from argilla.server.commons.models import PredictionStatus, TaskType
-from argilla.server.services.datasets import ServiceBaseDataset
 from argilla.server.services.search.model import ServiceBaseRecordsQuery, ServiceScoreRange
 from argilla.server.services.tasks.commons import ServiceBaseAnnotation, ServiceBaseRecord
 

--- a/src/argilla/server/services/tasks/token_classification/model.py
+++ b/src/argilla/server/services/tasks/token_classification/model.py
@@ -12,13 +12,13 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Any, Dict, List, Optional, Set, Tuple
+
+from typing import Dict, List, Optional, Set, Tuple
 
 from pydantic import BaseModel, Field, validator
 
 from argilla._constants import DEFAULT_MAX_KEYWORD_LENGTH
 from argilla.server.commons.models import PredictionStatus, TaskType
-from argilla.server.services.datasets import ServiceBaseDataset
 from argilla.server.services.search.model import ServiceBaseRecordsQuery, ServiceScoreRange
 from argilla.server.services.tasks.commons import ServiceBaseAnnotation, ServiceBaseRecord
 from argilla.utils import SpanUtils


### PR DESCRIPTION
# Description

This PR fixes a bug related to the `TaskType` enum usage to build the `api/datasets/` (V0) Argilla endpoints, as since Python 3.11 the `Enum` attributes no longer provide the actual value, but the enum instead.

This mainly affects the string replacements such as f-strings, since the value is not injected, but the enum instead, e.g. `TaskType.token_classification` is an enum in Python 3.11 but to get its value one should `TaskType.token_classification.value`.

While string comparisons, dict keys, and any other operator that implies a comparison between a value and an `Enum` is preserved, and the value will be used in those scenarios.

Closes #3686

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

As we're not planning to add a Python matrix with the supported Python versions (3.8, 3.9, 3.10, and 3.11) in the CI pipeline for the moment, we've ran the unit and integration tests on Python 3.11, as well as deployed Argilla via `argilla server start` and everything works fine so far.

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [X] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)