### PR TITLE
feat: print connected Argilla server URL

### DIFF
--- a/src/argilla/cli/info/__main__.py
+++ b/src/argilla/cli/info/__main__.py
@@ -31,7 +31,8 @@ def info() -> None:
 
     init_callback()
 
-    server_info = Status(active_client().client).get_status()
+    client = active_client().client
+    server_info = Status(client).get_status()
 
     elasticsearch_version = (
         f"{server_info.elasticsearch.version.number} ({server_info.elasticsearch.version.distribution})"
@@ -41,6 +42,7 @@ def info() -> None:
 
     panel = get_argilla_themed_panel(
         Markdown(
+            f"Connected to {client.base_url}\n"
             f"- **Client version:** {version}\n"
             f"- **Server version:** {server_info.version}\n"
             f"- **ElasticSearch version:** {elasticsearch_version}\n"

--- a/tests/unit/cli/info/test_info.py
+++ b/tests/unit/cli/info/test_info.py
@@ -59,6 +59,7 @@ def test_info_command(cli_runner: "CliRunner", cli: "Typer", mocker: "MockerFixt
     assert f"Client version: {version}" in result.stdout
     assert "Server version: 1.2.3" in result.stdout
     assert "ElasticSearch version: 1.2.3" in result.stdout
+    status_get_status_mock.assert_called_once()
 
 
 @pytest.mark.usefixtures("not_logged_mock")


### PR DESCRIPTION
# Description

This PR updates the `info` command to also print the URL of the connected Argilla server.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

NA

**Checklist**

- [x] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
