### PR TITLE
feat: add `visible_options` ge than 3 value validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ These are the section headers that we use:
 - Display a `UserWarning` when the `user_id` in `Workspace.add_user` and `Workspace.delete_user` is the ID of an user with the owner role as they don't require explicit permissions ([#3716](https://github.com/argilla-io/argilla/issues/3716)).
 - Rename `tasks` sub-package to `cli` ([#3723](https://github.com/argilla-io/argilla/pull/3723)).
 - Changed `argilla database` command in the CLI to now be accessed via `argilla server database`, to be deprecated in the upcoming release ([#3754](https://github.com/argilla-io/argilla/pull/3754)).
+- Changed `visible_options` (of label and multi label selection questions) validation in the backend to check that the provided value is greater or equal than/to 3 and less or equal than/to the number of provided options ([#3773](https://github.com/argilla-io/argilla/pull/3773)).
 
 ### Fixed
 

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -16,14 +16,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
 
-from pydantic import (
-    BaseModel,
-    PositiveInt,
-    conlist,
-    constr,
-    root_validator,
-    validator,
-)
+from pydantic import BaseModel, conlist, constr, root_validator, validator
 from pydantic import Field as PydanticField
 from pydantic.utils import GetterDict
 
@@ -75,6 +68,7 @@ VALUE_TEXT_OPTION_DESCRIPTION_MAX_LENGTH = 1000
 
 LABEL_SELECTION_OPTIONS_MIN_ITEMS = 2
 LABEL_SELECTION_OPTIONS_MAX_ITEMS = 250
+LABEL_SELECTION_MIN_VISIBLE_OPTIONS = 3
 
 RANKING_OPTIONS_MIN_ITEMS = 2
 
@@ -251,7 +245,19 @@ class LabelSelectionQuestionSettingsCreate(UniqueValuesCheckerMixin):
         min_items=LABEL_SELECTION_OPTIONS_MIN_ITEMS,
         max_items=LABEL_SELECTION_OPTIONS_MAX_ITEMS,
     )
-    visible_options: Optional[PositiveInt] = None
+    visible_options: Optional[int] = PydanticField(None, ge=LABEL_SELECTION_MIN_VISIBLE_OPTIONS)
+
+    @root_validator
+    def check_visible_options_value(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        visible_options = values.get("visible_options")
+        if visible_options is not None:
+            num_options = len(values["options"])
+            if visible_options > num_options:
+                raise ValueError(
+                    "The value for 'visible_options' must be less or equal to the number of items in 'options'"
+                    f" ({num_options})"
+                )
+        return values
 
 
 class MultiLabelSelectionQuestionSettingsCreate(LabelSelectionQuestionSettingsCreate):

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -1640,26 +1640,6 @@ class TestSuiteDatasets:
                 {
                     "type": "label_selection",
                     "options": [
-                        {"value": "positive", "text": "Positive", "description": "Texts with positive sentiment"},
-                        {"value": "negative", "text": "Negative", "description": "Texts with negative sentiment"},
-                        {"value": "neutral", "text": "Neutral", "description": "Texts with neutral sentiment"},
-                    ],
-                    "visible_options": 10,
-                },
-                {
-                    "type": "label_selection",
-                    "options": [
-                        {"value": "positive", "text": "Positive", "description": "Texts with positive sentiment"},
-                        {"value": "negative", "text": "Negative", "description": "Texts with negative sentiment"},
-                        {"value": "neutral", "text": "Neutral", "description": "Texts with neutral sentiment"},
-                    ],
-                    "visible_options": 10,
-                },
-            ),
-            (
-                {
-                    "type": "label_selection",
-                    "options": [
                         {"value": "positive", "text": "Positive"},
                         {"value": "negative", "text": "Negative"},
                         {"value": "neutral", "text": "Neutral"},
@@ -2049,6 +2029,24 @@ class TestSuiteDatasets:
                     {"value": "b", "text": "b", "description": "b"},
                     {"value": "b", "text": "b", "description": "b"},
                 ],
+            },
+            {
+                "type": "label_selection",
+                "options": [
+                    {"value": "a", "text": "a", "description": "a"},
+                    {"value": "b", "text": "b", "description": "b"},
+                    {"value": "b", "text": "b", "description": "b"},
+                ],
+                "visible_options": 2,
+            },
+            {
+                "type": "label_selection",
+                "options": [
+                    {"value": "a", "text": "a", "description": "a"},
+                    {"value": "b", "text": "b", "description": "b"},
+                    {"value": "b", "text": "b", "description": "b"},
+                ],
+                "visible_options": 5,
             },
             {
                 "type": "ranking",

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -1640,17 +1640,17 @@ class TestSuiteDatasets:
                 {
                     "type": "label_selection",
                     "options": [
-                        {"value": "positive", "text": "Positive"},
-                        {"value": "negative", "text": "Negative"},
-                        {"value": "neutral", "text": "Neutral"},
+                        {"value": "positive", "text": "Positive", "description": "Text with a positive sentiment"},
+                        {"value": "negative", "text": "Negative", "description": "Text with a negative sentiment"},
+                        {"value": "neutral", "text": "Neutral", "description": "Text with a neutral sentiment"},
                     ],
                 },
                 {
                     "type": "label_selection",
                     "options": [
-                        {"value": "positive", "text": "Positive", "description": None},
-                        {"value": "negative", "text": "Negative", "description": None},
-                        {"value": "neutral", "text": "Neutral", "description": None},
+                        {"value": "positive", "text": "Positive", "description": "Text with a positive sentiment"},
+                        {"value": "negative", "text": "Negative", "description": "Text with a negative sentiment"},
+                        {"value": "neutral", "text": "Neutral", "description": "Text with a neutral sentiment"},
                     ],
                     "visible_options": None,
                 },

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -1657,6 +1657,26 @@ class TestSuiteDatasets:
             ),
             (
                 {
+                    "type": "label_selection",
+                    "options": [
+                        {"value": "positive", "text": "Positive"},
+                        {"value": "negative", "text": "Negative"},
+                        {"value": "neutral", "text": "Neutral"},
+                    ],
+                    "visible_options": 3,
+                },
+                {
+                    "type": "label_selection",
+                    "options": [
+                        {"value": "positive", "text": "Positive", "description": None},
+                        {"value": "negative", "text": "Negative", "description": None},
+                        {"value": "neutral", "text": "Neutral", "description": None},
+                    ],
+                    "visible_options": 3,
+                },
+            ),
+            (
+                {
                     "type": "ranking",
                     "options": [
                         {"value": "completion-a", "text": "Completion A", "description": "Completion A is the best"},


### PR DESCRIPTION
# Description

This PR updates the validation of the `visible_options` attribute of the label and multi label selection questions that now will have to be greater or equal than 3 and be less or equal to the number of provided `options`.

Closes #3672

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

In a local development environment:

- [x] Create label and multi label selection question with `visible_options<=3` returns a 422
- [x] Create label and multi label selection question with 3 `options` and `visible_options>len(options)` returns a 422

In addition the unit tests have been updated to cover the changes.

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
