### PR TITLE
feat: convert method to `asynccontextmanager`

### DIFF
--- a/src/argilla/server/search_engine/__init__.py
+++ b/src/argilla/server/search_engine/__init__.py
@@ -12,11 +12,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from typing import AsyncGenerator
+
 from ..settings import settings
 from .base import *
 from .elasticsearch import ElasticSearchEngine
 from .opensearch import OpenSearchEngine
 
 
-async def get_search_engine():
-    yield SearchEngine.search_engine_by_name(settings.search_engine)
+async def get_search_engine() -> AsyncGenerator[SearchEngine, None]:
+    async with SearchEngine.get_by_name(settings.search_engine) as engine:
+        yield engine


### PR DESCRIPTION
# Description

A small update to rename `SearchEngine.search_engine_by_name` method to `SearchEngine.get_by_name` to be less redundant and also transform it to be a context manager, so it could be used outside of the FastAPI context too.

**Type of change**

- [x] Refactor (change restructuring the codebase without changing functionality)
- [ ] 
**How Has This Been Tested**

NA

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
