### PR TITLE
fix: `rank=None` when `status=draft`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ These are the section headers that we use:
 - Add missing `draft` status in `ResponseSchema` as now there can be responses with `draft` status when annotating via the UI ([#3749](https://github.com/argilla-io/argilla/pull/3749)).
 - Searches when queried words are distributed along the record fields ([#3759](https://github.com/argilla-io/argilla/pull/3759)).
 - Fixed Python 3.11 compatibility issue with `/api/datasets` endpoints due to the `TaskType` enum replacement in the endpoint URL ([#3769](https://github.com/argilla-io/argilla/pull/3769)).
+- Fixed `RankingValueSchema` and `FeedbackRankingValueModel` schemas to allow `rank=None` when `status=draft` ([#3781](https://github.com/argilla-io/argilla/pull/3781)).
 
 ## [1.15.1](https://github.com/argilla-io/argilla/compare/v1.15.0...v1.15.1)
 

--- a/src/argilla/client/feedback/schemas/records.py
+++ b/src/argilla/client/feedback/schemas/records.py
@@ -40,7 +40,7 @@ class RankingValueSchema(BaseModel):
     """
 
     value: StrictStr
-    rank: conint(ge=1)
+    rank: Optional[conint(ge=1)] = None
 
 
 class ValueSchema(BaseModel):

--- a/src/argilla/client/sdk/v1/datasets/models.py
+++ b/src/argilla/client/sdk/v1/datasets/models.py
@@ -33,7 +33,7 @@ class FeedbackDatasetModel(BaseModel):
 
 class FeedbackRankingValueModel(BaseModel):
     value: StrictStr
-    rank: conint(ge=1)
+    rank: Optional[conint(ge=1)] = None
 
 
 class FeedbackValueModel(BaseModel):

--- a/tests/unit/client/feedback/schemas/test_records.py
+++ b/tests/unit/client/feedback/schemas/test_records.py
@@ -152,6 +152,7 @@ def test_value_schema(schema_kwargs: Dict[str, Any]) -> None:
     "schema_kwargs",
     [
         {"value": "question-1", "rank": 1},
+        {"value": "question-1", "rank": None},
     ],
 )
 def test_ranking_value_schema(schema_kwargs: Dict[str, Any]) -> None:


### PR DESCRIPTION
# Description

This PR addressed a bug reported in the Python SDK when trying to download records with draft responses for the `RankingQuestion`, as those will have `rank=None` when no rank is assigned, while for the rest of the responses those either appear in the payload with valid values (even those may be incomplete) or just don't appear.

Closes #3779 

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

- [X] Add unit tests for `RankingValueSchema` to ensure that `rank=None` is allowed

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)