### PR TITLE
fix: `quickstart.Dockerfile` after updating `Dockerfile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ These are the section headers that we use:
 
 ## [Unreleased]()
 
+### Changed
+
+- Updated `Dockerfile` to use multi stage build ([#3221](https://github.com/argilla-io/argilla/pull/3221) and [#3793](https://github.com/argilla-io/argilla/pull/3793)).
+
 ## [1.16.0](https://github.com/argilla-io/argilla/compare/v1.15.1...v1.16.0)
 
 ### Added

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,21 +23,22 @@ ENV DEFAULT_USER_API_KEY=argilla.apikey
 ENV USERS_DB=/config/.users.yml
 ENV UVICORN_PORT=6900
 
-RUN useradd -ms /bin/bash worker
+RUN useradd -ms /bin/bash argilla
 
 # Create argilla volume
 RUN mkdir -p "$ARGILLA_HOME_PATH" && \
-  chown worker:worker "$ARGILLA_HOME_PATH"
+  chown argilla:argilla "$ARGILLA_HOME_PATH"
 VOLUME $ARGILLA_HOME_PATH
 
-COPY scripts/start_argilla_server.sh /home/worker
-COPY --chown=worker:worker --from=builder /opt/venv /opt/venv
+COPY scripts/start_argilla_server.sh /home/argilla
+# Destination folder must be the same as the builder one. Otherwise installed script won't work (since the installation fixes the path inside the script)
+COPY --chown=argilla:argilla --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-WORKDIR /home/worker
+WORKDIR /home/argilla
 RUN chmod +x start_argilla_server.sh
 
-USER worker
+USER argilla
 
 # Exposing ports
 EXPOSE 6900

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,12 @@ ENV USERS_DB=/config/.users.yml
 ENV UVICORN_PORT=6900
 
 RUN useradd -ms /bin/bash worker
+
+# Create argilla volume
+RUN mkdir -p "$ARGILLA_HOME_PATH" && \
+  chown worker:worker "$ARGILLA_HOME_PATH"
+VOLUME $ARGILLA_HOME_PATH
+
 COPY scripts/start_argilla_server.sh /home/worker
 COPY --chown=worker:worker --from=builder /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,17 +2,16 @@ FROM python:3.10.12-slim AS builder
 
 # Copying argilla distribution files
 COPY dist/*.whl /packages/
-RUN python -m venv /my-virtual-env
-ENV PATH="/my-virtual-env/bin:$PATH"
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 RUN apt-get update && \
-    apt-get install -y python-dev-is-python3 libpq-dev gcc && \
-    pip install uvicorn[standard] && \
-    for wheel in /packages/*.whl; do pip install "$wheel"[server,postgresql]; done && \
-    apt-get remove -y python-dev-is-python3 libpq-dev gcc && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /packages
-
+  apt-get install -y python-dev-is-python3 libpq-dev gcc && \
+  pip install uvicorn[standard] && \
+  for wheel in /packages/*.whl; do pip install "$wheel"[server,postgresql]; done && \
+  apt-get remove -y python-dev-is-python3 libpq-dev gcc && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* && \
+  rm -rf /packages
 
 FROM python:3.10.12-slim
 
@@ -26,13 +25,8 @@ ENV UVICORN_PORT=6900
 
 RUN useradd -ms /bin/bash worker
 COPY scripts/start_argilla_server.sh /home/worker
-COPY --chown=worker:worker --from=builder /my-virtual-env /home/worker/my-virtual-env
-ENV PATH="/home/worker/my-virtual-env/bin:$PATH"
-
-# Create argilla volume
-RUN mkdir -p "$ARGILLA_HOME_PATH" && \
-    chown worker:worker "$ARGILLA_HOME_PATH"
-VOLUME $ARGILLA_HOME_PATH
+COPY --chown=worker:worker --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 WORKDIR /home/worker
 RUN chmod +x start_argilla_server.sh
@@ -42,4 +36,4 @@ USER worker
 # Exposing ports
 EXPOSE 6900
 
-CMD /bin/bash start_argilla_server.sh
+CMD ["/bin/bash", "start_argilla_server.sh"]

--- a/docker/quickstart.Dockerfile
+++ b/docker/quickstart.Dockerfile
@@ -5,9 +5,9 @@ FROM argilla/argilla-server:${ARGILLA_VERSION}
 USER root
 
 RUN apt-get update && apt-get install -y \
-    apt-transport-https \
-    gnupg \
-    wget
+  apt-transport-https \
+  gnupg \
+  wget
 
 # Install Elasticsearch signing key
 RUN wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg
@@ -20,33 +20,28 @@ COPY scripts/* /
 COPY quickstart.requirements.txt /packages/requirements.txt
 
 RUN \
-    # Indicate that this is a quickstart deployment
-    echo -e "{  \"deployment\":  \"quickstart\" }" > /usr/local/lib/python3.10/site-packages/argilla/server/static/deployment.json && \
-    # Create an user to run the Argilla server and Elasticsearch
-    useradd -ms /bin/bash argilla && \
-    # Create a directory where Elasticsearch and Argilla will store their data
-    mkdir /data && \
-    # Install Elasticsearch and configure it
-    apt-get update && apt-get install -y elasticsearch=8.8.2 && \
-    chown -R argilla:argilla /usr/share/elasticsearch /etc/elasticsearch /var/lib/elasticsearch /var/log/elasticsearch && \
-    chown argilla:argilla /etc/default/elasticsearch && \
-    # Install quickstart image dependencies
-    pip install -r /packages/requirements.txt && \
-    chmod +x /start_quickstart_argilla.sh && \
-    # Give ownership of the data directory to the argilla user
-    chown -R argilla:argilla /data && \
-    # Clean up
-    apt-get remove -y wget gnupg && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /packages
+  # Indicate that this is a quickstart deployment
+  echo -e "{  \"deployment\":  \"quickstart\" }" > /opt/venv/lib/python3.10/site-packages/argilla/server/static/deployment.json && \
+  # Create a directory where Elasticsearch and Argilla will store their data
+  mkdir /data && \
+  # Install Elasticsearch and configure it
+  apt-get update && apt-get install -y elasticsearch=8.8.2 && \
+  chown -R worker:worker /usr/share/elasticsearch /etc/elasticsearch /var/lib/elasticsearch /var/log/elasticsearch && \
+  chown worker:worker /etc/default/elasticsearch && \
+  # Install quickstart image dependencies
+  pip install -r /packages/requirements.txt && \
+  chmod +x /start_quickstart_argilla.sh && \
+  # Give ownership of the data directory to the argilla user
+  chown -R worker:worker /data && \
+  # Clean up
+  apt-get remove -y wget gnupg && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* && \
+  rm -rf /packages
 
 COPY config/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml
 
-# echo -e "{  \"deployment\":  \"quickstart\" }" \
-# > /usr/local/lmib/python/dist-packages/argilla/server/static/deployment.json
-
-USER argilla
+USER worker
 
 ENV ELASTIC_CONTAINER=true
 

--- a/docker/quickstart.Dockerfile
+++ b/docker/quickstart.Dockerfile
@@ -16,7 +16,8 @@ RUN wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | gpg --dearmo
 RUN echo "deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://artifacts.elastic.co/packages/8.x/apt stable main" | tee /etc/apt/sources.list.d/elastic-8.x.list
 
 # Copy Argilla distribution files
-COPY scripts/* /
+COPY scripts/start_quickstart_argilla.sh /home/worker
+COPY scripts/load_data.py /home/worker
 COPY quickstart.requirements.txt /packages/requirements.txt
 
 RUN \
@@ -30,7 +31,7 @@ RUN \
   chown worker:worker /etc/default/elasticsearch && \
   # Install quickstart image dependencies
   pip install -r /packages/requirements.txt && \
-  chmod +x /start_quickstart_argilla.sh && \
+  chmod +x /home/worker/start_quickstart_argilla.sh && \
   # Give ownership of the data directory to the argilla user
   chown -R worker:worker /data && \
   # Clean up
@@ -63,4 +64,4 @@ ENV UVICORN_PORT=6900
 
 ENV ES_JAVA_OPTS=-'Xms512m -Xmx512m'
 
-CMD ["/start_quickstart_argilla.sh"]
+CMD ["/bin/bash", "start_quickstart_argilla.sh"]

--- a/docker/quickstart.Dockerfile
+++ b/docker/quickstart.Dockerfile
@@ -16,8 +16,8 @@ RUN wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | gpg --dearmo
 RUN echo "deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://artifacts.elastic.co/packages/8.x/apt stable main" | tee /etc/apt/sources.list.d/elastic-8.x.list
 
 # Copy Argilla distribution files
-COPY scripts/start_quickstart_argilla.sh /home/worker
-COPY scripts/load_data.py /home/worker
+COPY scripts/start_quickstart_argilla.sh /home/argilla
+COPY scripts/load_data.py /home/argilla
 COPY quickstart.requirements.txt /packages/requirements.txt
 
 RUN \
@@ -27,13 +27,13 @@ RUN \
   mkdir /data && \
   # Install Elasticsearch and configure it
   apt-get update && apt-get install -y elasticsearch=8.8.2 && \
-  chown -R worker:worker /usr/share/elasticsearch /etc/elasticsearch /var/lib/elasticsearch /var/log/elasticsearch && \
-  chown worker:worker /etc/default/elasticsearch && \
+  chown -R argilla:argilla /usr/share/elasticsearch /etc/elasticsearch /var/lib/elasticsearch /var/log/elasticsearch && \
+  chown argilla:argilla /etc/default/elasticsearch && \
   # Install quickstart image dependencies
   pip install -r /packages/requirements.txt && \
-  chmod +x /home/worker/start_quickstart_argilla.sh && \
+  chmod +x /home/argilla/start_quickstart_argilla.sh && \
   # Give ownership of the data directory to the argilla user
-  chown -R worker:worker /data && \
+  chown -R argilla:argilla /data && \
   # Clean up
   apt-get remove -y wget gnupg && \
   apt-get clean && \
@@ -42,7 +42,7 @@ RUN \
 
 COPY config/elasticsearch.yml /etc/elasticsearch/elasticsearch.yml
 
-USER worker
+USER argilla
 
 ENV ELASTIC_CONTAINER=true
 

--- a/docker/scripts/start_quickstart_argilla.sh
+++ b/docker/scripts/start_quickstart_argilla.sh
@@ -38,7 +38,7 @@ python -m argilla server database users create \
 	--workspace "$ARGILLA_WORKSPACE"
 
 # Load data
-python /load_data.py "$OWNER_API_KEY" "$LOAD_DATASETS" &
+python load_data.py "$OWNER_API_KEY" "$LOAD_DATASETS" &
 
 # Start Argilla
 echo "Starting Argilla"


### PR DESCRIPTION
# Description

This PR updates the `quickstart.Dockerfile` so it's compatible with the updates done for the `Dockerfile` in https://github.com/argilla-io/argilla/pull/3221.

Also, the `Dockerfile` has been updated to create the virtualenv in a common path between the `builder` stage and the final stage, otherwise, Python binaries will throw this error:

```
bash: /home/worker/my-virtual-env/bin/uvicorn: cannot execute: required file not found
```

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

- [x] `docker build . -t argilla/argilla-server:v1.17.0`
- [x] `docker run argilla/argilla-server:v1.17.0`
- [x] `docker build . --build-arg ARGILLA_VERSION=1.17.0 -f quickstart.Dockerfile -t argilla/argilla-quickstart:v1.17.0`
- [x] `docker run argilla/argilla-quickstart:v1.17.0`

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
