### PR TITLE
fix: Force `inserted_at` generation from factories

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import datetime
 import inspect
 
 import factory
@@ -212,6 +212,8 @@ class RecordFactory(BaseFactory):
     }
     external_id = factory.Sequence(lambda n: f"external-id-{n}")
     dataset = factory.SubFactory(DatasetFactory)
+
+    inserted_at = factory.Sequence(lambda n: datetime.datetime.utcnow() + datetime.timedelta(seconds=n))
 
 
 class ResponseFactory(BaseFactory):

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import time
 from datetime import datetime
 from typing import TYPE_CHECKING, List, Optional, Tuple, Type, Union
 from unittest.mock import ANY, MagicMock
@@ -757,7 +757,7 @@ class TestSuiteDatasets:
                 fields={"input": "input_b", "output": "output_b"}, metadata_={"unit": "test"}, dataset=dataset
             ),
             await RecordFactory.create(
-                fields={"input": "input_c", "output": "output_c"}, dataset=dataset, inserted_at=datetime.utcnow()
+                fields={"input": "input_c", "output": "output_c"}, dataset=dataset
             ),
         ]
 

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -756,9 +756,7 @@ class TestSuiteDatasets:
             await RecordFactory.create(
                 fields={"input": "input_b", "output": "output_b"}, metadata_={"unit": "test"}, dataset=dataset
             ),
-            await RecordFactory.create(
-                fields={"input": "input_c", "output": "output_c"}, dataset=dataset
-            ),
+            await RecordFactory.create(fields={"input": "input_c", "output": "output_c"}, dataset=dataset),
         ]
 
         responses = [


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR fixes some test units running with PostgreSQL. For those cases, the `inserted_at` value is generated without sequentiality. The PR includes changes for factories to provide a sequential value for `inserted_at`.


**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

Tested locally using PostgreSQL

**Checklist**

- [ ] I added relevant documentation
- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
