### PR TITLE
docs: Fix some code snippets for unification strategies

### DIFF
--- a/docs/_source/_common/tabs/unfication_strategies.md
+++ b/docs/_source/_common/tabs/unfication_strategies.md
@@ -3,15 +3,15 @@
 :::{tab-item} LabelQuestion
 
 ```python
-from argilla import RatingQuestionStrategy, FeedbackRecord
+from argilla import RatingQuestionStrategy, FeedbackDataset
 
 dataset = FeedbackDataset.from_huggingface(
     repo_id="argilla/stackoverflow_feedback_demo"
 )
 strategy = LabelQuestionStrategy("majority") # "disagreement", "majority_weighted (WIP)"
 dataset.unify_responses(
-    question=dataset.get_question_by_name("title_question_fit")
-    strategy=strategy
+    question=dataset.question_by_name("title_question_fit"),
+    strategy=strategy,
 )
 dataset.records[0].unified_responses
 ```
@@ -22,15 +22,15 @@ dataset.records[0].unified_responses
 :::{tab-item} MultiLabelQuestion
 
 ```python
-from argilla import RatingQuestionStrategy, FeedbackRecord
+from argilla import RatingQuestionStrategy, FeedbackDataset
 
 dataset = FeedbackDataset.from_huggingface(
     repo_id="argilla/stackoverflow_feedback_demo"
 )
 strategy = MultiLabelQuestionStrategy("majority") # "disagreement", "majority_weighted (WIP)"
 dataset.unify_responses(
-    question=dataset.get_question_by_name("tags")
-    strategy=strategy
+    question=dataset.question_by_name("tags"),
+    strategy=strategy,
 )
 dataset.records[0].unified_responses
 ```
@@ -40,15 +40,15 @@ dataset.records[0].unified_responses
 :::{tab-item} RankingQuestion
 
 ```python
-from argilla import RankingQuestionStrategy, FeedbackRecord
+from argilla import RankingQuestionStrategy, FeedbackDataset
 
 dataset = FeedbackDataset.from_huggingface(
     repo_id="argilla/stackoverflow_feedback_demo"
 )
 strategy = RankingQuestionStrategy("majority") # "mean", "max", "min"
 dataset.unify_responses(
-    question=dataset.get_question_by_name("relevance_ranking")
-    strategy=strategy
+    question=dataset.question_by_name("relevance_ranking"),
+    strategy=strategy,
 )
 dataset.records[0].unified_responses
 ```
@@ -58,15 +58,15 @@ dataset.records[0].unified_responses
 :::{tab-item} RatingQuestion
 
 ```python
-from argilla import RatingQuestionStrategy, FeedbackRecord
+from argilla import RatingQuestionStrategy, FeedbackDataset
 
 dataset = FeedbackDataset.from_huggingface(
     repo_id="argilla/stackoverflow_feedback_demo"
 )
 strategy = RatingQuestionStrategy("majority") # "mean", "max", "min"
 dataset.unify_responses(
-    question=dataset.get_question_by_name("answer_quality")
-    strategy=strategy
+    question=dataset.question_by_name("answer_quality"),
+    strategy=strategy,
 )
 dataset.records[0].unified_responses
 ```

--- a/docs/_source/_common/tabs/unfication_strategies.md
+++ b/docs/_source/_common/tabs/unfication_strategies.md
@@ -3,7 +3,7 @@
 :::{tab-item} LabelQuestion
 
 ```python
-from argilla import RatingQuestionStrategy, FeedbackDataset
+from argilla import LabelQuestionStrategy, FeedbackDataset
 
 dataset = FeedbackDataset.from_huggingface(
     repo_id="argilla/stackoverflow_feedback_demo"
@@ -22,7 +22,7 @@ dataset.records[0].unified_responses
 :::{tab-item} MultiLabelQuestion
 
 ```python
-from argilla import RatingQuestionStrategy, FeedbackDataset
+from argilla import MultiLabelQuestionStrategy, FeedbackDataset
 
 dataset = FeedbackDataset.from_huggingface(
     repo_id="argilla/stackoverflow_feedback_demo"


### PR DESCRIPTION
# Description

Resolve the immediately-fixable issues from #3807, but does not immediately close that issue, as the `unified_responses` don't exist anymore, but are still listed in the docs. cc @davidberenstein1957 

**Type of change**

- [x] Documentation update

**How Has This Been Tested**

It hasn't.

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)

---

- Tom Aarsen
