### PR TITLE
feat: add `RemoteResponseSchema.{inserted_at,updated_at}` fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ These are the section headers that we use:
 
 ## [Unreleased]()
 
+### Added
+
+- Added fields `inserted_at` and `updated_at` in `RemoteResponseSchema` ([#3822](https://github.com/argilla-io/argilla/pull/3822)).
+
 ### Changed
 
 - Updated `Dockerfile` to use multi stage build ([#3221](https://github.com/argilla-io/argilla/pull/3221) and [#3793](https://github.com/argilla-io/argilla/pull/3793)).

--- a/src/argilla/client/feedback/schemas/remote/records.py
+++ b/src/argilla/client/feedback/schemas/remote/records.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import warnings
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 from uuid import UUID
 
@@ -78,6 +79,9 @@ class RemoteSuggestionSchema(SuggestionSchema, RemoteSchema):
 
 
 class RemoteResponseSchema(ResponseSchema, RemoteSchema):
+    inserted_at: datetime
+    updated_at: datetime
+
     def to_local(self) -> "ResponseSchema":
         """Converts the `RemoteResponseSchema` to a `ResponseSchema`."""
         return ResponseSchema(
@@ -92,6 +96,8 @@ class RemoteResponseSchema(ResponseSchema, RemoteSchema):
             user_id=payload.user_id,
             values=payload.values,
             status=payload.status,
+            inserted_at=payload.inserted_at,
+            updated_at=payload.updated_at,
         )
 
 

--- a/tests/unit/client/feedback/schemas/remote/test_records.py
+++ b/tests/unit/client/feedback/schemas/remote/test_records.py
@@ -303,7 +303,7 @@ def test_remote_feedback_record(schema_kwargs: Dict[str, Any], server_payload: D
         ),
     ],
 )
-def test_remote_suggestion_schema_from_api(payload: FeedbackItemModel) -> None:
+def test_remote_feedback_record_schema_from_api(payload: FeedbackItemModel) -> None:
     record = RemoteFeedbackRecord.from_api(
         payload, question_id_to_name={payload.suggestions[0].question_id: "question-1"}
     )

--- a/tests/unit/client/feedback/schemas/remote/test_records.py
+++ b/tests/unit/client/feedback/schemas/remote/test_records.py
@@ -129,6 +129,8 @@ def test_remote_suggestion_schema_from_api(payload: FeedbackSuggestionModel) -> 
                     "question-4": {"value": [{"value": "a", "rank": 1}, {"value": "b", "rank": 2}]},
                 },
                 "status": "submitted",
+                "inserted_at": datetime.now(),
+                "updated_at": datetime.now(),
             },
             {
                 "user_id": UUID("00000000-0000-0000-0000-000000000000"),
@@ -146,6 +148,8 @@ def test_remote_suggestion_schema_from_api(payload: FeedbackSuggestionModel) -> 
                 "user_id": UUID("00000000-0000-0000-0000-000000000000"),
                 "values": {"question-1": {"value": "a"}},
                 "status": "draft",
+                "inserted_at": datetime.now(),
+                "updated_at": datetime.now(),
             },
             {
                 "user_id": UUID("00000000-0000-0000-0000-000000000000"),
@@ -213,6 +217,8 @@ def test_remote_response_schema_from_api(payload: FeedbackResponseModel) -> None
                     {
                         "values": {"question-1": {"value": "This is the first answer"}, "question-2": {"value": 5}},
                         "status": "submitted",
+                        "inserted_at": datetime.now(),
+                        "updated_at": datetime.now(),
                     },
                 ],
                 "suggestions": [
@@ -318,7 +324,7 @@ def test_remote_feedback_record_schema_from_api(payload: FeedbackItemModel) -> N
         }
     ) == payload.dict(
         exclude={
-            "responses": {"__all__": {"id", "inserted_at", "updated_at"}},
+            "responses": {"__all__": {"id"}},
             "suggestions": ...,
             "inserted_at": ...,
             "updated_at": ...,


### PR DESCRIPTION
# Description

This PR adds both `inserted_at` and `updated_at` fields to `RemoteResponseSchema` to use those values that were previously discarded when pulling the responses from the API, which is useful for further analysis as requested by @davidberenstein1957.

Closes #3820

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [X] Add unit tests for both `inserted_at` and `updated_at` fields in `RemoteResponseSchema`

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [X] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)