### PR TITLE
feat: Add total records when fetching records with metadata filter

### DIFF
--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -380,6 +380,8 @@ class Record(BaseModel):
 
 class Records(BaseModel):
     items: List[Record]
+    # TODO(@frascuchon): Make it required once fetch records without metadata filter computes also the total
+    total: Optional[int] = None
 
 
 class UserSubmittedResponseCreate(BaseModel):

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -545,6 +545,7 @@ class TestSuiteDatasets:
 
         assert response.status_code == 200
         assert response.json() == {
+            "total": None,
             "items": [
                 {
                     "id": str(record_a.id),
@@ -830,7 +831,10 @@ class TestSuiteDatasets:
             params=query_params,
             headers=owner_auth_header,
         )
-        assert response.status_code == 200, response.json()
+        assert response.status_code == 200
+
+        response_json = response.json()
+        assert response_json["total"] == 2
 
         mock_search_engine.search.assert_called_once_with(
             dataset=dataset,
@@ -1031,6 +1035,7 @@ class TestSuiteDatasets:
 
         assert response.status_code == 200
         assert response.json() == {
+            "total": None,
             "items": [
                 {
                     "id": str(record_a.id),
@@ -1085,6 +1090,7 @@ class TestSuiteDatasets:
         )
 
         expected = {
+            "total": None,
             "items": [
                 {
                     "id": str(record_a.id),
@@ -1310,7 +1316,10 @@ class TestSuiteDatasets:
             params=query_params,
             headers=owner_auth_header,
         )
-        assert response.status_code == 200, response.json()
+        assert response.status_code == 200
+
+        response_json = response.json()
+        assert response_json["total"] == 2
 
         mock_search_engine.search.assert_called_once_with(
             dataset=dataset,


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR includes the  total number of records when some metadata filter is applied for endpoints `/api/v1/me/datasets/:dataset_id/records` and `/api/v1/datasets/:dataset_id/records`

In the future, this value will be computed for all cases and not only when metadata_filter is applied

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [X] Improvement (change adding some improvement to an existing functionality)

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
