### PR TITLE
fix: Allow pull datasets without records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ These are the section headers that we use:
 
 - Updated `Dockerfile` to use multi stage build ([#3221](https://github.com/argilla-io/argilla/pull/3221) and [#3793](https://github.com/argilla-io/argilla/pull/3793)).
 
+### Fixed
+
+- Fixed allow pull datasets without records ([#3851](https://github.com/argilla-io/argilla/pull/3851))
+
 ## [1.16.0](https://github.com/argilla-io/argilla/compare/v1.15.1...v1.16.0)
 
 ### Added

--- a/src/argilla/client/feedback/dataset/remote/base.py
+++ b/src/argilla/client/feedback/dataset/remote/base.py
@@ -277,7 +277,9 @@ class RemoteFeedbackDatasetBase(Generic[T], FeedbackDatasetBase):
             guidelines=self.guidelines,
             metadata_properties=self.metadata_properties,
         )
-        instance.add_records(
-            records=[record.to_local() for record in self._records],
-        )
+        records = [record.to_local() for record in self._records]
+
+        if records:
+            instance.add_records(records=records)
+
         return instance

--- a/src/argilla/client/feedback/dataset/remote/base.py
+++ b/src/argilla/client/feedback/dataset/remote/base.py
@@ -279,7 +279,7 @@ class RemoteFeedbackDatasetBase(Generic[T], FeedbackDatasetBase):
         )
         records = [record.to_local() for record in self._records]
 
-        if records:
+        if len(records) > 0:
             instance.add_records(records=records)
 
         return instance

--- a/src/argilla/client/feedback/dataset/remote/filtered.py
+++ b/src/argilla/client/feedback/dataset/remote/filtered.py
@@ -52,7 +52,7 @@ class FilteredRemoteFeedbackRecords(RemoteFeedbackRecordsBase):
             [metadata_filter.query_string for metadata_filter in metadata_filters] if metadata_filters else None
         )
 
-    def __len__(self) -> None:
+    def __len__(self) -> int:
         warnings.warn(
             "The `records` of a filtered dataset in Argilla are being lazily loaded"
             " and len computation may add undesirable extra computation. You can fetch"
@@ -60,6 +60,7 @@ class FilteredRemoteFeedbackRecords(RemoteFeedbackRecordsBase):
             "`records = [r for r in ds.records]\n",
             stacklevel=1,
         )
+        return 0
 
     def _fetch_records(self, offset: int, limit: int) -> "FeedbackRecordsModel":
         """Fetches a batch of records from Argilla."""

--- a/tests/integration/client/feedback/dataset/remote/test_dataset.py
+++ b/tests/integration/client/feedback/dataset/remote/test_dataset.py
@@ -13,16 +13,20 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import TYPE_CHECKING, List
+from typing import List, TYPE_CHECKING
 from uuid import UUID
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from argilla import FeedbackRecord
 from argilla.client import api
 from argilla.client.feedback.dataset import FeedbackDataset
 from argilla.client.feedback.dataset.remote.dataset import RemoteFeedbackDataset
+from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQuestionTypes
 from argilla.client.sdk.users.models import UserRole
 from argilla.client.workspaces import Workspace
-
+from argilla.server.models import User as ServerUser
 from tests.factories import (
     DatasetFactory,
     RecordFactory,
@@ -151,3 +155,31 @@ class TestRemoteFeedbackDataset:
         assert isinstance(remote_dataset.url, str)
         assert isinstance(remote_dataset.created_at, datetime)
         assert isinstance(remote_dataset.updated_at, datetime)
+
+    async def test_pull_without_results(
+        self,
+        argilla_user: ServerUser,
+        feedback_dataset_guidelines: str,
+        feedback_dataset_fields: List[AllowedFieldTypes],
+        feedback_dataset_questions: List[AllowedQuestionTypes],
+        feedback_dataset_records: List[FeedbackRecord],
+        db: AsyncSession,
+    ) -> None:
+
+        api.active_api()
+        api.init(api_key=argilla_user.api_key)
+
+        dataset = FeedbackDataset(
+            guidelines=feedback_dataset_guidelines,
+            fields=feedback_dataset_fields,
+            questions=feedback_dataset_questions,
+        )
+        dataset.push_to_argilla(name="test-dataset")
+
+        await db.refresh(argilla_user, attribute_names=["datasets"])
+
+        same_dataset = FeedbackDataset.from_argilla("test-dataset")
+        local_copy = same_dataset.pull()
+
+        assert local_copy is not None
+        assert local_copy.records == []

--- a/tests/integration/client/feedback/dataset/remote/test_dataset.py
+++ b/tests/integration/client/feedback/dataset/remote/test_dataset.py
@@ -13,12 +13,10 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import List, TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 from uuid import UUID
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession
-
 from argilla import FeedbackRecord
 from argilla.client import api
 from argilla.client.feedback.dataset import FeedbackDataset
@@ -27,6 +25,8 @@ from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQues
 from argilla.client.sdk.users.models import UserRole
 from argilla.client.workspaces import Workspace
 from argilla.server.models import User as ServerUser
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from tests.factories import (
     DatasetFactory,
     RecordFactory,
@@ -165,7 +165,6 @@ class TestRemoteFeedbackDataset:
         feedback_dataset_records: List[FeedbackRecord],
         db: AsyncSession,
     ) -> None:
-
         api.active_api()
         api.init(api_key=argilla_user.api_key)
 

--- a/tests/integration/client/feedback/dataset/remote/test_filtered.py
+++ b/tests/integration/client/feedback/dataset/remote/test_filtered.py
@@ -17,8 +17,6 @@ from typing import List, Union
 from uuid import UUID
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession
-
 from argilla.client import api
 from argilla.client.feedback.dataset.local import FeedbackDataset
 from argilla.client.feedback.dataset.remote.filtered import FilteredRemoteFeedbackDataset, FilteredRemoteFeedbackRecords
@@ -34,8 +32,8 @@ from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQues
 from argilla.client.sdk.users.models import UserRole
 from argilla.client.sdk.v1.datasets.models import FeedbackResponseStatusFilter
 from argilla.client.workspaces import Workspace
-
 from argilla.server.models import User
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from tests.factories import (
     DatasetFactory,
@@ -85,7 +83,6 @@ class TestFilteredRemoteFeedbackDataset:
         feedback_dataset_records: List[FeedbackRecord],
         db: AsyncSession,
     ) -> None:
-
         api.active_api()
         api.init(api_key=argilla_user.api_key)
 


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

Fixed for `ds.pull()` with datasets without records.

Also, the `__len__` for the filtered dataset returns a 0 instead of `None`. Otherwise, the `len(ds)` fails with a confusing error to the user.


