### PR TITLE
feat: update `load_data.py` with datasets for comparison

### DIFF
--- a/docker/scripts/load_data.py
+++ b/docker/scripts/load_data.py
@@ -163,38 +163,6 @@ class LoadDatasets:
         dataset.push_to_argilla(name=repo_id.split("/")[-1])
 
     @staticmethod
-    def load_mock_dataset_for_filter_metadata():
-        print("Loading Mock dataset for metadata properties test")
-        import random
-
-        import argilla as rg
-
-        dataset = rg.FeedbackDataset.from_huggingface("argilla/oasst_response_quality", split="train")
-
-        records = dataset.records[:400]
-
-        for record in records:
-            record.metadata.update(
-                {
-                    "terms-prop": random.choice("abc"),
-                    "int-prop": random.randint(-10, 100),
-                    "float-prop": random.uniform(0, 100),
-                }
-            )
-        meta_ds = rg.FeedbackDataset(
-            fields=dataset.fields,
-            questions=dataset.questions,
-            metadata_properties=[
-                rg.TermsMetadataProperty(name="terms-prop", values=["a", "b", "c"]),
-                rg.IntegerMetadataProperty(name="int-prop", min=-10, max=100),
-                rg.FloatMetadataProperty(name="float-prop", min=0.0, max=100),
-            ],
-        )
-
-        meta_ds.add_records(records)
-        meta_ds.push_to_argilla("dataset-with-metadata-properties")
-
-    @staticmethod
     def build_error_analysis_record(
         row: pd.Series, legacy: bool = False
     ) -> Union[rg.FeedbackRecord, rg.TextClassificationRecord]:

--- a/docker/scripts/load_data.py
+++ b/docker/scripts/load_data.py
@@ -168,9 +168,13 @@ class LoadDatasets:
     ) -> Union[rg.FeedbackRecord, rg.TextClassificationRecord]:
         fields = {
             "user-message-1": row["HumanMessage1"],
-            "llm-output": f"```json\n{row['llm_output']}\n```",
-            "ai-message": row["AIMessage"],
-            "function-message": row["FunctionMessage"],
+            "llm-output": row["llm_output"]
+            if not row["llm_output"].__contains__("```json")
+            else row["llm_output"].replace("'", '"'),
+            "ai-message": (f"```json\n{row['AIMessage']}\n```" if not legacy else row["AIMessage"]).replace("'", '"'),
+            "function-message": (f"```json\n{row['FunctionMessage']}\n```" if not legacy else row["AIMessage"]).replace(
+                "'", '"'
+            ),
             "system-message": "You are an AI assistant name ACME",
             "langsmith-url": f"https://smith.langchain.com/o/{row['parent_id']}",
         }

--- a/docker/scripts/load_data.py
+++ b/docker/scripts/load_data.py
@@ -225,7 +225,7 @@ class LoadDatasets:
 
         dataset = rg.FeedbackDataset(fields=fields, questions=questions, metadata_properties=metadata)
         dataset.add_records(records=[LoadDatasets.build_error_analysis_record(row) for _, row in df.iterrows()])
-        dataset.push_to_argilla(name="error-analysis-with-feedback-alpha", workspace="admin")
+        dataset.push_to_argilla(name="error-analysis-with-feedback-alpha")
 
     @staticmethod
     def load_error_analysis_textcat_version():

--- a/docker/scripts/load_data.py
+++ b/docker/scripts/load_data.py
@@ -16,12 +16,11 @@ import sys
 import time
 from typing import Union
 
+import argilla as rg
 import pandas as pd
 import requests
-from datasets import load_dataset
-
-import argilla as rg
 from argilla.labeling.text_classification import Rule, add_rules
+from datasets import load_dataset
 
 
 class LoadDatasets:

--- a/docker/scripts/load_data.py
+++ b/docker/scripts/load_data.py
@@ -16,11 +16,12 @@ import sys
 import time
 from typing import Union
 
-import argilla as rg
 import pandas as pd
 import requests
-from argilla.labeling.text_classification import Rule, add_rules
 from datasets import load_dataset
+
+import argilla as rg
+from argilla.labeling.text_classification import Rule, add_rules
 
 
 class LoadDatasets:
@@ -217,7 +218,7 @@ class LoadDatasets:
             rg.TermsMetadataProperty(name="correctness-langsmith", values=df.correctness_langsmith.unique().tolist()),
             rg.TermsMetadataProperty(name="model-name", values=df.model_name.unique().tolist()),
             rg.FloatMetadataProperty(name="temperature", min=df.temperature.min(), max=df.temperature.max()),
-            rg.IntegerMetadataFilter(name="max-tokens", min=df.max_tokens.min(), max=df.max_tokens.max()),
+            rg.IntegerMetadataProperty(name="max-tokens", min=df.max_tokens.min(), max=df.max_tokens.max()),
             rg.FloatMetadataProperty(name="cpu-user", min=df.cpu_time_user.min(), max=df.cpu_time_user.max()),
             rg.FloatMetadataProperty(name="cpu-system", min=df.cpu_time_system.min(), max=df.cpu_time_system.max()),
             rg.TermsMetadataProperty(name="library-version", values=df.library_version.unique().tolist()),

--- a/docker/scripts/load_data.py
+++ b/docker/scripts/load_data.py
@@ -255,10 +255,8 @@ if __name__ == "__main__":
                 response = requests.get("http://0.0.0.0:6900/")
                 if response.status_code == 200:
                     ld = LoadDatasets(API_KEY)
-                    # TODO(@frascuchon): Remove these datasets creation
                     ld.load_error_analysis()
                     ld.load_error_analysis_textcat_version()
-                    # END
                     ld.load_feedback_dataset_from_huggingface(
                         repo_id="argilla/databricks-dolly-15k-curated-en",
                         split="train",

--- a/docker/scripts/load_data.py
+++ b/docker/scripts/load_data.py
@@ -288,7 +288,6 @@ if __name__ == "__main__":
                 if response.status_code == 200:
                     ld = LoadDatasets(API_KEY)
                     # TODO(@frascuchon): Remove these datasets creation
-                    ld.load_mock_dataset_for_filter_metadata()
                     ld.load_error_analysis()
                     ld.load_error_analysis_textcat_version()
                     # END


### PR DESCRIPTION
# Description

This PR adds a new dataset into the `load_data.py` script to be created by default on both the current alpha version for the `FeedbackDataset` updates, and also in the legacy/former format i.e. `DatasetForTextClassification`.

This is done for being able to compare the same dataset and the different features and visuals for both of them.

**Type of change**

- [X] New feature (non-breaking change which adds functionality)