### PR TITLE
feat: add validation layer for `metadata_properties` and `metadata_filters`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ These are the section headers that we use:
 - Added new endpoint `GET /api/v1/datasets/:dataset_id/metadata-properties` for listing dataset metadata property ([#3813](https://github.com/argilla-io/argilla/pull/3813))
 - Added `TermsMetadataProperty`, `IntegerMetadataProperty` and `FloatMetadataProperty` classes allowing to define metadata properties for a `FeedbackDataset` ([#3818](https://github.com/argilla-io/argilla/pull/3818)).
 - Added `metadata_filters` to `filter_by` method in `RemoteFeedbackDataset` to filter based on metadata i.e. `TermsMetadataFilter`, `IntegerMetadataFilter`, and `FloatMetadataFilter` ([#3834](https://github.com/argilla-io/argilla/pull/3834)).
+- Added a validation layer for both `metadata_properties` and `metadata_filters` in their schemas and as part of the `add_records` and `filter_by` methods, respectively ([#3860](https://github.com/argilla-io/argilla/pull/3860)).
 
 ### Changed
 

--- a/src/argilla/client/feedback/constants.py
+++ b/src/argilla/client/feedback/constants.py
@@ -12,10 +12,17 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from argilla.client.feedback.schemas.enums import FieldTypes
+from typing import List
+
+from argilla.client.feedback.schemas.enums import FieldTypes, MetadataPropertyTypes
 
 FETCHING_BATCH_SIZE = 250
 PUSHING_BATCH_SIZE = 32
 DELETE_DATASET_RECORDS_MAX_NUMBER = 100
 
 FIELD_TYPE_TO_PYTHON_TYPE = {FieldTypes.text: str}
+METADATA_PROPERTY_TYPE_TO_PYTHON_TYPE = {
+    MetadataPropertyTypes.terms: List[str],
+    MetadataPropertyTypes.integer: int,
+    MetadataPropertyTypes.float: float,
+}

--- a/src/argilla/client/feedback/constants.py
+++ b/src/argilla/client/feedback/constants.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import List
+from pydantic import StrictFloat, StrictInt, StrictStr
 
 from argilla.client.feedback.schemas.enums import FieldTypes, MetadataPropertyTypes
 
@@ -21,8 +21,9 @@ PUSHING_BATCH_SIZE = 32
 DELETE_DATASET_RECORDS_MAX_NUMBER = 100
 
 FIELD_TYPE_TO_PYTHON_TYPE = {FieldTypes.text: str}
+# We are using `pydantic`'s strict types to avoid implicit type conversions
 METADATA_PROPERTY_TYPE_TO_PYTHON_TYPE = {
-    MetadataPropertyTypes.terms: List[str],
-    MetadataPropertyTypes.integer: int,
-    MetadataPropertyTypes.float: float,
+    MetadataPropertyTypes.terms: StrictStr,
+    MetadataPropertyTypes.integer: StrictInt,
+    MetadataPropertyTypes.float: StrictFloat,
 }

--- a/src/argilla/client/feedback/dataset/base.py
+++ b/src/argilla/client/feedback/dataset/base.py
@@ -284,7 +284,7 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin):
         if not hasattr(self, "_metadata_schema"):
             self._metadata_schema = None
 
-        if self._metadata_schema is None:
+        if self._metadata_schema is None and self.metadata_properties is not None:
             self._metadata_schema = generate_pydantic_schema_for_metadata(self.metadata_properties)
 
         for record in records:

--- a/src/argilla/client/feedback/dataset/base.py
+++ b/src/argilla/client/feedback/dataset/base.py
@@ -213,7 +213,27 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin):
     def metadata_properties(
         self,
     ) -> Union[List["AllowedMetadataPropertyTypes"], List["AllowedRemoteMetadataPropertyTypes"]]:
+        """Returns the metadata properties that will be indexed and could be used to filter the dataset."""
         return self._metadata_properties
+
+    def metadata_property_by_name(
+        self, name: str
+    ) -> Union["AllowedMetadataPropertyTypes", "AllowedRemoteMetadataPropertyTypes"]:
+        """Returns the metadata property by name if it exists. Othewise a `ValueError` is raised.
+
+        Args:
+            name: the name of the metadata property to return.
+
+        Raises:
+            ValueError: if the metadata property with the given name does not exist.
+        """
+        for metadata_property in self._metadata_properties:
+            if metadata_property.name == name:
+                return metadata_property
+        raise ValueError(
+            f"Metadata property with name='{name}' not found, available metadata property names are:"
+            f" {', '.join(m.name for m in self._metadata_properties)}"
+        )
 
     def _parse_records(
         self, records: Union[FeedbackRecord, Dict[str, Any], List[Union[FeedbackRecord, Dict[str, Any]]]]

--- a/src/argilla/client/feedback/dataset/base.py
+++ b/src/argilla/client/feedback/dataset/base.py
@@ -35,7 +35,7 @@ from argilla.client.feedback.training.schemas import (
     TrainingTaskForTextClassification,
     TrainingTaskTypes,
 )
-from argilla.client.feedback.utils import generate_pydantic_schema
+from argilla.client.feedback.utils import generate_pydantic_schema_for_fields
 from argilla.client.models import Framework
 from argilla.utils.dependency import require_dependencies, requires_dependencies
 
@@ -258,7 +258,7 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin):
             ValueError: if the `fields` schema does not match the `FeedbackRecord.fields` schema.
         """
         if self._fields_schema is None:
-            self._fields_schema = generate_pydantic_schema(self.fields)
+            self._fields_schema = generate_pydantic_schema_for_fields(self.fields)
 
         for record in records:
             try:

--- a/src/argilla/client/feedback/dataset/base.py
+++ b/src/argilla/client/feedback/dataset/base.py
@@ -140,9 +140,6 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin):
                     )
                 unique_names.add(metadata_property.name)
         self._metadata_properties = metadata_properties
-        self._metadata_properties_mapping = {
-            metadata_property.name: metadata_property for metadata_property in self._metadata_properties
-        }
 
         if guidelines is not None:
             if not isinstance(guidelines, str):
@@ -230,6 +227,11 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin):
         Raises:
             KeyError: if the metadata property with the given name does not exist.
         """
+        # TODO(alvarobartt): remove this when https://github.com/argilla-io/argilla/pull/3829 is merged
+        if not hasattr(self, "_metadata_properties_mapping") or self._metadata_properties_mapping is None:
+            self._metadata_properties_mapping = {
+                metadata_property.name: metadata_property for metadata_property in self._metadata_properties
+            }
         try:
             return self._metadata_properties_mapping[name]
         except KeyError:

--- a/src/argilla/client/feedback/dataset/base.py
+++ b/src/argilla/client/feedback/dataset/base.py
@@ -140,6 +140,9 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin):
                     )
                 unique_names.add(metadata_property.name)
         self._metadata_properties = metadata_properties
+        self._metadata_properties_mapping = {
+            metadata_property.name: metadata_property for metadata_property in self._metadata_properties
+        }
 
         if guidelines is not None:
             if not isinstance(guidelines, str):
@@ -225,15 +228,15 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin):
             name: the name of the metadata property to return.
 
         Raises:
-            ValueError: if the metadata property with the given name does not exist.
+            KeyError: if the metadata property with the given name does not exist.
         """
-        for metadata_property in self._metadata_properties:
-            if metadata_property.name == name:
-                return metadata_property
-        raise ValueError(
-            f"Metadata property with name='{name}' not found, available metadata property names are:"
-            f" {', '.join(m.name for m in self._metadata_properties)}"
-        )
+        try:
+            return self._metadata_properties_mapping[name]
+        except KeyError:
+            raise KeyError(
+                f"Metadata property with name='{name}' not found, available metadata property names are:"
+                f" {', '.join(self._metadata_properties_mapping.keys())}"
+            )
 
     def _parse_records(
         self, records: Union[FeedbackRecord, Dict[str, Any], List[Union[FeedbackRecord, Dict[str, Any]]]]

--- a/src/argilla/client/feedback/dataset/mixins.py
+++ b/src/argilla/client/feedback/dataset/mixins.py
@@ -303,7 +303,7 @@ class ArgillaMixin:
         return questions
 
     @staticmethod
-    def __get_metadata_properties(client: "httpx.Client", id: UUID) -> List["AllowedRemoteMetadataPropertiesTypes"]:
+    def __get_metadata_properties(client: "httpx.Client", id: UUID) -> List["AllowedRemoteMetadataPropertyTypes"]:
         metadata_properties = []
         for metadata_prop in datasets_api_v1.get_metadata_properties(client=client, id=id).parsed:
             metadata_properties.append(ArgillaMixin._parse_to_remote_metadata_property(metadata_prop))

--- a/src/argilla/client/feedback/dataset/remote/dataset.py
+++ b/src/argilla/client/feedback/dataset/remote/dataset.py
@@ -192,12 +192,12 @@ class RemoteFeedbackDataset(RemoteFeedbackDatasetBase[RemoteFeedbackRecords]):
             if not isinstance(metadata_filters, list):
                 metadata_filters = [metadata_filters]
             if not all(
-                metadata_filter in [metadata_property.name for metadata_property in self.metadata_properties]
+                metadata_filter.name in [metadata_property.name for metadata_property in self.metadata_properties]
                 for metadata_filter in metadata_filters
             ):
                 raise ValueError(
-                    f"Invalid `metadata_filters={metadata_filters}` provided, must be one"
-                    f" of: {[metadata_property.name for metadata_property in self.metadata_properties]}"
+                    f"Invalid `metadata_filters=[{', '.join(metadata_filter.name for metadata_filter in metadata_filters)}`"
+                    f" provided, must be one of: {[metadata_property.name for metadata_property in self.metadata_properties]}"
                 )
             for metadata_filter in metadata_filters:
                 metadata_property = self.metadata_property_by_name(name=metadata_filter.name)

--- a/src/argilla/client/feedback/dataset/remote/dataset.py
+++ b/src/argilla/client/feedback/dataset/remote/dataset.py
@@ -182,7 +182,7 @@ class RemoteFeedbackDataset(RemoteFeedbackDatasetBase[RemoteFeedbackRecords]):
         if response_status:
             if not isinstance(response_status, list):
                 response_status = [response_status]
-            if not all(status in FeedbackResponseStatusFilter for status in response_status):
+            if not all(status in [arg.value for arg in FeedbackResponseStatusFilter] for status in response_status):
                 raise ValueError(
                     f"Invalid `response_status={response_status}` provided, must be one"
                     f" of: {[arg.value for arg in FeedbackResponseStatusFilter]}"

--- a/src/argilla/client/feedback/dataset/remote/dataset.py
+++ b/src/argilla/client/feedback/dataset/remote/dataset.py
@@ -191,6 +191,11 @@ class RemoteFeedbackDataset(RemoteFeedbackDatasetBase[RemoteFeedbackRecords]):
         if metadata_filters:
             if not isinstance(metadata_filters, list):
                 metadata_filters = [metadata_filters]
+            # TODO(alvarobartt): remove this when https://github.com/argilla-io/argilla/pull/3829 is merged
+            if not hasattr(self, "_metadata_properties_mapping") or self._metadata_properties_mapping is None:
+                self._metadata_properties_mapping = {
+                    metadata_property.name: metadata_property for metadata_property in self._metadata_properties
+                }
             if not all(
                 metadata_filter.name in self._metadata_properties_mapping.keys() for metadata_filter in metadata_filters
             ):

--- a/src/argilla/client/feedback/dataset/remote/dataset.py
+++ b/src/argilla/client/feedback/dataset/remote/dataset.py
@@ -192,12 +192,11 @@ class RemoteFeedbackDataset(RemoteFeedbackDatasetBase[RemoteFeedbackRecords]):
             if not isinstance(metadata_filters, list):
                 metadata_filters = [metadata_filters]
             if not all(
-                metadata_filter.name in [metadata_property.name for metadata_property in self.metadata_properties]
-                for metadata_filter in metadata_filters
+                metadata_filter.name in self._metadata_properties_mapping.keys() for metadata_filter in metadata_filters
             ):
                 raise ValueError(
                     f"Invalid `metadata_filters=[{', '.join(metadata_filter.name for metadata_filter in metadata_filters)}`"
-                    f" provided, must be one of: {[metadata_property.name for metadata_property in self.metadata_properties]}"
+                    f" provided, must be one of: {self._metadata_properties_mapping.keys()}"
                 )
             for metadata_filter in metadata_filters:
                 metadata_property = self.metadata_property_by_name(name=metadata_filter.name)

--- a/src/argilla/client/feedback/dataset/remote/filtered.py
+++ b/src/argilla/client/feedback/dataset/remote/filtered.py
@@ -53,15 +53,16 @@ class FilteredRemoteFeedbackRecords(RemoteFeedbackRecordsBase):
             [metadata_filter.query_string for metadata_filter in metadata_filters] if metadata_filters else None
         )
 
-    def __len__(self) -> int:
-        warnings.warn(
+    def __len__(self) -> None:
+        # TODO: Replace with API call once ready!
+        raise NotImplementedError(
             "The `records` of a filtered dataset in Argilla are being lazily loaded"
             " and len computation may add undesirable extra computation. You can fetch"
             "records using\n`ds.pull()`\nor iterate over results to know the length of the result:\n"
             "`records = [r for r in ds.records]\n",
+            UserWarning,
             stacklevel=1,
         )
-        return 0
 
     def _fetch_records(self, offset: int, limit: int) -> "FeedbackRecordsModel":
         """Fetches a batch of records from Argilla."""

--- a/src/argilla/client/feedback/dataset/remote/filtered.py
+++ b/src/argilla/client/feedback/dataset/remote/filtered.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from argilla.client.feedback.dataset.remote.dataset import RemoteFeedbackDataset
     from argilla.client.feedback.schemas.records import FeedbackRecord
     from argilla.client.feedback.schemas.remote.records import RemoteFeedbackRecord
+    from argilla.client.feedback.schemas.types import AllowedRemoteFieldTypes, AllowedRemoteQuestionTypes
     from argilla.client.workspaces import Workspace
 
 

--- a/src/argilla/client/feedback/dataset/remote/filtered.py
+++ b/src/argilla/client/feedback/dataset/remote/filtered.py
@@ -60,8 +60,6 @@ class FilteredRemoteFeedbackRecords(RemoteFeedbackRecordsBase):
             " and len computation may add undesirable extra computation. You can fetch"
             "records using\n`ds.pull()`\nor iterate over results to know the length of the result:\n"
             "`records = [r for r in ds.records]\n",
-            UserWarning,
-            stacklevel=1,
         )
 
     def _fetch_records(self, offset: int, limit: int) -> "FeedbackRecordsModel":

--- a/src/argilla/client/feedback/schemas/metadata.py
+++ b/src/argilla/client/feedback/schemas/metadata.py
@@ -124,9 +124,9 @@ class TermsMetadataProperty(MetadataPropertySchema):
             )
 
     @property
-    def _pydantic_field_with_validator(self) -> Tuple[Dict[str, Tuple[StrictStr, ...]], Dict[str, Callable]]:
+    def _pydantic_field_with_validator(self) -> Tuple[Dict[str, Tuple[StrictStr, None]], Dict[str, Callable]]:
         return (
-            {self.name: (METADATA_PROPERTY_TYPE_TO_PYTHON_TYPE[self.type], ...)},
+            {self.name: (METADATA_PROPERTY_TYPE_TO_PYTHON_TYPE[self.type], None)},
             {f"{self.name}_validator": validator(self.name, allow_reuse=True)(self._all_values_exist)},
         )
 
@@ -176,9 +176,9 @@ class _NumericMetadataPropertySchema(MetadataPropertySchema):
     @property
     def _pydantic_field_with_validator(
         self,
-    ) -> Tuple[Dict[Union[StrictInt, StrictFloat], Tuple[str, ...]], Dict[str, Callable]]:
+    ) -> Tuple[Dict[Union[StrictInt, StrictFloat], Tuple[str, None]], Dict[str, Callable]]:
         return (
-            {self.name: (METADATA_PROPERTY_TYPE_TO_PYTHON_TYPE[self.type], ...)},
+            {self.name: (METADATA_PROPERTY_TYPE_TO_PYTHON_TYPE[self.type], None)},
             {f"{self.name}_validator": validator(self.name, allow_reuse=True)(self._value_in_bounds)},
         )
 

--- a/src/argilla/client/feedback/schemas/metadata.py
+++ b/src/argilla/client/feedback/schemas/metadata.py
@@ -15,7 +15,17 @@
 from abc import ABC, abstractmethod, abstractproperty
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
-from pydantic import BaseModel, Extra, Field, ValidationError, root_validator, validator
+from pydantic import (
+    BaseModel,
+    Extra,
+    Field,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+    ValidationError,
+    root_validator,
+    validator,
+)
 
 from argilla.client.feedback.constants import METADATA_PROPERTY_TYPE_TO_PYTHON_TYPE
 from argilla.client.feedback.schemas.enums import MetadataPropertyTypes
@@ -114,9 +124,9 @@ class TermsMetadataProperty(MetadataPropertySchema):
             )
 
     @property
-    def _pydantic_field_with_validator(self) -> Tuple[Dict[str, Tuple[str, ...]], Dict[str, Callable]]:
+    def _pydantic_field_with_validator(self) -> Tuple[Dict[str, Tuple[StrictStr, ...]], Dict[str, Callable]]:
         return (
-            {self.name: (str, ...)},
+            {self.name: (METADATA_PROPERTY_TYPE_TO_PYTHON_TYPE[self.type], ...)},
             {f"{self.name}_validator": validator(self.name, allow_reuse=True)(self._all_values_exist)},
         )
 
@@ -164,7 +174,9 @@ class _NumericMetadataPropertySchema(MetadataPropertySchema):
             )
 
     @property
-    def _pydantic_field_with_validator(self) -> Tuple[Dict[Union[int, float], Tuple[str, ...]], Dict[str, Callable]]:
+    def _pydantic_field_with_validator(
+        self,
+    ) -> Tuple[Dict[Union[StrictInt, StrictFloat], Tuple[str, ...]], Dict[str, Callable]]:
         return (
             {self.name: (METADATA_PROPERTY_TYPE_TO_PYTHON_TYPE[self.type], ...)},
             {f"{self.name}_validator": validator(self.name, allow_reuse=True)(self._value_in_bounds)},

--- a/src/argilla/client/feedback/schemas/metadata.py
+++ b/src/argilla/client/feedback/schemas/metadata.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from pydantic import (
@@ -65,9 +65,10 @@ class MetadataPropertySchema(BaseModel, ABC):
         extra = Extra.ignore
         exclude = {"type"}
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def server_settings(self) -> Dict[str, Any]:
-        return {}
+        ...
 
     def to_server_payload(self) -> Dict[str, Any]:
         return {
@@ -78,9 +79,10 @@ class MetadataPropertySchema(BaseModel, ABC):
             "settings": self.server_settings,
         }
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def _pydantic_field_with_validator(self) -> Tuple[Dict[str, Tuple[Any, ...]], Dict[str, Callable]]:
-        return ({}, {})
+        ...
 
     @abstractmethod
     def _validate_filter(self, metadata_filter: "MetadataFilters") -> None:
@@ -262,9 +264,10 @@ class MetadataFilterSchema(BaseModel, ABC):
         extra = Extra.forbid
         exclude = {"type"}
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def query_string(self) -> str:
-        return ""
+        ...
 
 
 class TermsMetadataFilter(MetadataFilterSchema):

--- a/src/argilla/client/feedback/utils.py
+++ b/src/argilla/client/feedback/utils.py
@@ -14,11 +14,12 @@
 
 from typing import TYPE_CHECKING, List, Optional, Union
 
-from pydantic import BaseModel, create_model
+from pydantic import BaseModel, Extra, create_model
 
 from argilla.client.api import active_client
 from argilla.client.feedback.constants import FIELD_TYPE_TO_PYTHON_TYPE
-from argilla.client.feedback.schemas.fields import FieldSchema
+from argilla.client.feedback.schemas.enums import MetadataPropertyTypes
+from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedMetadataPropertyTypes
 from argilla.client.sdk.v1.datasets import api as datasets_api_v1
 from argilla.client.workspaces import Workspace
 
@@ -28,12 +29,14 @@ if TYPE_CHECKING:
     from argilla.client.sdk.v1.datasets.models import FeedbackDatasetModel
 
 
-def generate_pydantic_schema_for_fields(fields: List[FieldSchema], name: Optional[str] = "FieldsSchema") -> BaseModel:
-    """Generates a `pydantic.BaseModel` schema from a list of `FieldSchema` objects to validate
+def generate_pydantic_schema_for_fields(
+    fields: List[AllowedFieldTypes], name: Optional[str] = "FieldsSchema"
+) -> BaseModel:
+    """Generates a `pydantic.BaseModel` schema from a list of `AllowedFieldTypes` objects to validate
     the fields of a `FeedbackDataset` object before inserting them.
 
     Args:
-        fields: the list of `FieldSchema` objects to generate the schema from.
+        fields: the list of `AllowedFieldTypes` objects to generate the schema from.
         name: the name of the `pydantic.BaseModel` schema to generate. Defaults to "FieldsSchema".
 
     Returns:
@@ -44,8 +47,8 @@ def generate_pydantic_schema_for_fields(fields: List[FieldSchema], name: Optiona
         ValueError: if one of the fields has an unsupported type.
 
     Examples:
-        >>> from argilla.client.feedback.schemas import TextField
-        >>> from argilla.client.feedback.dataset import generate_pydantic_schema_for_fields
+        >>> from argilla.client.feedback.schemas.fields import TextField
+        >>> from argilla.client.feedback.utils import generate_pydantic_schema_for_fields
         >>> fields = [
         ...     TextField(name="text", required=True),
         ...     TextField(name="label", required=True),
@@ -63,6 +66,52 @@ def generate_pydantic_schema_for_fields(fields: List[FieldSchema], name: Optiona
             )
         fields_schema.update({field.name: (FIELD_TYPE_TO_PYTHON_TYPE[field.type], ... if field.required else None)})
     return create_model(name, **fields_schema)
+
+
+def generate_pydantic_schema_for_metadata(
+    metadata_properties: List[AllowedMetadataPropertyTypes], name: Optional[str] = "MetadataSchema"
+) -> BaseModel:
+    """Generates a `pydantic.BaseModel` schema from a list of `AllowedMetadataPropertyTypes` objects to validate
+    the metadata of a `FeedbackDataset` object before inserting them.
+
+    Args:
+        metadata_properties: the list of `AllowedMetadataPropertyTypes` objects to generate the schema from.
+        name: the name of the `pydantic.BaseModel` schema to generate. Defaults to "MetadataSchema".
+
+    Returns:
+        A `pydantic.BaseModel` schema to validate the metadata of a `FeedbackDataset` object before
+        inserting them.
+
+    Raises:
+        ValueError: if one of the metadata properties has an unsupported type.
+
+    Examples:
+        >>> from argilla.client.feedback.schemas.metadata import IntegerMetadataProperty
+        >>> from argilla.client.feedback.utils import generate_pydantic_schema_for_metadata
+        >>> metadata_properties = [
+        ...     IntegerMetadataProperty(name="int-metadata", min=0, max=10),
+        ...     ...,
+        ... ]
+        >>> MetadataSchema = generate_pydantic_schema_for_metadata(metadata_properties)
+        >>> MetadataSchema(int-metadata=5)
+        MetadataSchema(int-metadata=5)
+    """
+    metadata_fields, metadata_validators = {}, {}
+
+    for metadata_property in metadata_properties:
+        if metadata_property.type not in MetadataPropertyTypes:
+            raise ValueError(
+                f"Metadata property {metadata_property.name} has an unsupported type: {metadata_property.type}, for the moment only the"
+                f" following types are supported: {[arg.value for arg in MetadataPropertyTypes]}"
+            )
+        pydantic_field, pydantic_validator = metadata_property._pydantic_field_with_validator
+        metadata_fields.update(pydantic_field)
+        metadata_validators.update(pydantic_validator)
+
+    class MetadataConfig:
+        extra = Extra.ignore
+
+    return create_model(name, **metadata_fields, __validators__=metadata_validators, __config__=MetadataConfig)
 
 
 def feedback_dataset_in_argilla(

--- a/src/argilla/client/feedback/utils.py
+++ b/src/argilla/client/feedback/utils.py
@@ -19,29 +19,35 @@ from pydantic import BaseModel, Extra, create_model
 from argilla.client.api import active_client
 from argilla.client.feedback.constants import FIELD_TYPE_TO_PYTHON_TYPE
 from argilla.client.feedback.schemas.enums import MetadataPropertyTypes
-from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedMetadataPropertyTypes
 from argilla.client.sdk.v1.datasets import api as datasets_api_v1
 from argilla.client.workspaces import Workspace
 
 if TYPE_CHECKING:
     import httpx
 
+    from argilla.client.feedback.schemas.types import (
+        AllowedFieldTypes,
+        AllowedMetadataPropertyTypes,
+        AllowedRemoteFieldTypes,
+        AllowedRemoteMetadataPropertyTypes,
+    )
     from argilla.client.sdk.v1.datasets.models import FeedbackDatasetModel
 
 
 def generate_pydantic_schema_for_fields(
-    fields: List[AllowedFieldTypes], name: Optional[str] = "FieldsSchema"
+    fields: List[Union["AllowedFieldTypes", "AllowedRemoteFieldTypes"]], name: Optional[str] = "FieldsSchema"
 ) -> BaseModel:
-    """Generates a `pydantic.BaseModel` schema from a list of `AllowedFieldTypes` objects to validate
-    the fields of a `FeedbackDataset` object before inserting them.
+    """Generates a `pydantic.BaseModel` schema from a list of `AllowedFieldTypes` or `AllowedRemoteFieldTypes`
+    objects to validate the fields of a `FeedbackDataset` or `RemoteFeedbackDataset` object, respectively,
+    before inserting them.
 
     Args:
-        fields: the list of `AllowedFieldTypes` objects to generate the schema from.
+        fields: the list of `AllowedFieldTypes` or `AllowedRemoteFieldTypes` objects to generate the schema from.
         name: the name of the `pydantic.BaseModel` schema to generate. Defaults to "FieldsSchema".
 
     Returns:
-        A `pydantic.BaseModel` schema to validate the fields of a `FeedbackDataset` object before
-        inserting them.
+        A `pydantic.BaseModel` schema to validate the fields of a `FeedbackDataset` or `RemoteFeedbackDataset`
+        object before inserting them.
 
     Raises:
         ValueError: if one of the fields has an unsupported type.
@@ -69,18 +75,21 @@ def generate_pydantic_schema_for_fields(
 
 
 def generate_pydantic_schema_for_metadata(
-    metadata_properties: List[AllowedMetadataPropertyTypes], name: Optional[str] = "MetadataSchema"
+    metadata_properties: List[Union["AllowedMetadataPropertyTypes", "AllowedRemoteMetadataPropertyTypes"]],
+    name: Optional[str] = "MetadataSchema",
 ) -> BaseModel:
-    """Generates a `pydantic.BaseModel` schema from a list of `AllowedMetadataPropertyTypes` objects to validate
-    the metadata of a `FeedbackDataset` object before inserting them.
+    """Generates a `pydantic.BaseModel` schema from a list of `AllowedMetadataPropertyTypes` or
+    `AllowedRemoteMetadataPropertyTypes` objects to validate the metadata of a `FeedbackDataset`
+    or `RemoteFeedbackDataset` object, respectively, before inserting them.
 
     Args:
-        metadata_properties: the list of `AllowedMetadataPropertyTypes` objects to generate the schema from.
+        metadata_properties: the list of `AllowedMetadataPropertyTypes` or `AllowedRemoteMetadataPropertyTypes`
+            objects to generate the schema from.
         name: the name of the `pydantic.BaseModel` schema to generate. Defaults to "MetadataSchema".
 
     Returns:
-        A `pydantic.BaseModel` schema to validate the metadata of a `FeedbackDataset` object before
-        inserting them.
+        A `pydantic.BaseModel` schema to validate the metadata of a `FeedbackDataset` or `RemoteFeedbackDataset`
+        object before inserting them.
 
     Raises:
         ValueError: if one of the metadata properties has an unsupported type.

--- a/src/argilla/client/feedback/utils.py
+++ b/src/argilla/client/feedback/utils.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from argilla.client.sdk.v1.datasets.models import FeedbackDatasetModel
 
 
-def generate_pydantic_schema(fields: List[FieldSchema], name: Optional[str] = "FieldsSchema") -> BaseModel:
+def generate_pydantic_schema_for_fields(fields: List[FieldSchema], name: Optional[str] = "FieldsSchema") -> BaseModel:
     """Generates a `pydantic.BaseModel` schema from a list of `FieldSchema` objects to validate
     the fields of a `FeedbackDataset` object before inserting them.
 
@@ -45,12 +45,12 @@ def generate_pydantic_schema(fields: List[FieldSchema], name: Optional[str] = "F
 
     Examples:
         >>> from argilla.client.feedback.schemas import TextField
-        >>> from argilla.client.feedback.dataset import generate_pydantic_schema
+        >>> from argilla.client.feedback.dataset import generate_pydantic_schema_for_fields
         >>> fields = [
         ...     TextField(name="text", required=True),
         ...     TextField(name="label", required=True),
         ... ]
-        >>> FieldsSchema = generate_pydantic_schema(fields)
+        >>> FieldsSchema = generate_pydantic_schema_for_fields(fields)
         >>> FieldsSchema(text="Hello", label="World")
         FieldsSchema(text='Hello', label='World')
     """

--- a/tests/integration/client/feedback/dataset/remote/test_filtered.py
+++ b/tests/integration/client/feedback/dataset/remote/test_filtered.py
@@ -20,12 +20,6 @@ import pytest
 from argilla.client import api
 from argilla.client.feedback.dataset.local import FeedbackDataset
 from argilla.client.feedback.dataset.remote.filtered import FilteredRemoteFeedbackDataset, FilteredRemoteFeedbackRecords
-from argilla.client.feedback.schemas.metadata import (
-    FloatMetadataFilter,
-    IntegerMetadataFilter,
-    MetadataFilters,
-    TermsMetadataFilter,
-)
 from argilla.client.feedback.schemas.records import FeedbackRecord
 from argilla.client.feedback.schemas.remote.records import RemoteFeedbackRecord
 from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQuestionTypes

--- a/tests/integration/client/feedback/dataset/test_dataset.py
+++ b/tests/integration/client/feedback/dataset/test_dataset.py
@@ -20,12 +20,7 @@ import pytest
 from argilla.client import api
 from argilla.client.feedback.config import DatasetConfig
 from argilla.client.feedback.dataset import FeedbackDataset
-from argilla.client.feedback.schemas import (
-    FeedbackRecord,
-    RatingQuestion,
-    TextField,
-    TextQuestion,
-)
+from argilla.client.feedback.schemas import FeedbackRecord, TextField, TextQuestion
 from argilla.client.feedback.schemas.remote.records import RemoteSuggestionSchema
 from argilla.client.feedback.training.schemas import TrainingTask
 from argilla.client.models import Framework
@@ -36,109 +31,6 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from tests.integration.helpers import SecuredClient
-
-
-def test_init(
-    feedback_dataset_guidelines: str,
-    feedback_dataset_fields: List["AllowedFieldTypes"],
-    feedback_dataset_questions: List["AllowedQuestionTypes"],
-) -> None:
-    dataset = FeedbackDataset(
-        guidelines=feedback_dataset_guidelines,
-        fields=feedback_dataset_fields,
-        questions=feedback_dataset_questions,
-    )
-
-    assert dataset.guidelines == feedback_dataset_guidelines
-    assert dataset.fields == feedback_dataset_fields
-    assert dataset.questions == feedback_dataset_questions
-
-
-def test_init_wrong_guidelines(
-    feedback_dataset_fields: List["AllowedFieldTypes"], feedback_dataset_questions: List["AllowedQuestionTypes"]
-) -> None:
-    with pytest.raises(TypeError, match="Expected `guidelines` to be"):
-        FeedbackDataset(
-            guidelines=[],
-            fields=feedback_dataset_fields,
-            questions=feedback_dataset_questions,
-        )
-    with pytest.raises(ValueError, match="Expected `guidelines` to be"):
-        FeedbackDataset(
-            guidelines="",
-            fields=feedback_dataset_fields,
-            questions=feedback_dataset_questions,
-        )
-
-
-def test_init_wrong_fields(
-    feedback_dataset_guidelines: str, feedback_dataset_questions: List["AllowedQuestionTypes"]
-) -> None:
-    with pytest.raises(TypeError, match="Expected `fields` to be a list"):
-        FeedbackDataset(
-            guidelines=feedback_dataset_guidelines,
-            fields=None,
-            questions=feedback_dataset_questions,
-        )
-    with pytest.raises(TypeError, match="Expected `fields` to be a list of `FieldSchema`"):
-        FeedbackDataset(
-            guidelines=feedback_dataset_guidelines,
-            fields=[{"wrong": "field"}],
-            questions=feedback_dataset_questions,
-        )
-    with pytest.raises(ValueError, match="At least one `FieldSchema` in `fields` must be required"):
-        FeedbackDataset(
-            guidelines=feedback_dataset_guidelines,
-            fields=[TextField(name="test", required=False)],
-            questions=feedback_dataset_questions,
-        )
-    with pytest.raises(ValueError, match="Expected `fields` to have unique names"):
-        FeedbackDataset(
-            guidelines=feedback_dataset_guidelines,
-            fields=[
-                TextField(name="test", required=True),
-                TextField(name="test", required=True),
-            ],
-            questions=feedback_dataset_questions,
-        )
-
-
-def test_init_wrong_questions(
-    feedback_dataset_guidelines: str, feedback_dataset_fields: List["AllowedFieldTypes"]
-) -> None:
-    with pytest.raises(TypeError, match="Expected `questions` to be a list, got"):
-        FeedbackDataset(
-            guidelines=feedback_dataset_guidelines,
-            fields=feedback_dataset_fields,
-            questions=None,
-        )
-    with pytest.raises(
-        TypeError,
-        match="Expected `questions` to be a list of",
-    ):
-        FeedbackDataset(
-            guidelines=feedback_dataset_guidelines,
-            fields=feedback_dataset_fields,
-            questions=[{"wrong": "question"}],
-        )
-    with pytest.raises(ValueError, match="At least one question in `questions` must be required"):
-        FeedbackDataset(
-            guidelines=feedback_dataset_guidelines,
-            fields=feedback_dataset_fields,
-            questions=[
-                TextQuestion(name="question-1", required=False),
-                RatingQuestion(name="question-2", values=[1, 2], required=False),
-            ],
-        )
-    with pytest.raises(ValueError, match="Expected `questions` to have unique names"):
-        FeedbackDataset(
-            guidelines=feedback_dataset_guidelines,
-            fields=feedback_dataset_fields,
-            questions=[
-                TextQuestion(name="question-1", required=True),
-                TextQuestion(name="question-1", required=True),
-            ],
-        )
 
 
 def test_create_dataset_with_suggestions(argilla_user: "ServerUser") -> None:

--- a/tests/integration/client/feedback/training/__init__.py
+++ b/tests/integration/client/feedback/training/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/unit/client/feedback/dataset/__init__.py
+++ b/tests/unit/client/feedback/dataset/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/unit/client/feedback/dataset/test_base.py
+++ b/tests/unit/client/feedback/dataset/test_base.py
@@ -16,13 +16,15 @@ from typing import TYPE_CHECKING, List
 
 import pytest
 from argilla.client.feedback.dataset.base import FeedbackDatasetBase
-from argilla.client.feedback.schemas import IntegerMetadataProperty, RatingQuestion, TextField, TextQuestion
+from argilla.client.feedback.schemas.fields import TextField
+from argilla.client.feedback.schemas.metadata import IntegerMetadataProperty
+from argilla.client.feedback.schemas.questions import RatingQuestion, TextQuestion
 
 if TYPE_CHECKING:
     from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQuestionTypes
 
 
-class FeedbackDataset(FeedbackDatasetBase):
+class TestFeedbackDataset(FeedbackDatasetBase):
     @property
     def records(self) -> None:
         pass
@@ -33,7 +35,7 @@ def test_init(
     feedback_dataset_fields: List["AllowedFieldTypes"],
     feedback_dataset_questions: List["AllowedQuestionTypes"],
 ) -> None:
-    dataset = FeedbackDataset(
+    dataset = TestFeedbackDataset(
         guidelines=feedback_dataset_guidelines,
         fields=feedback_dataset_fields,
         questions=feedback_dataset_questions,
@@ -61,13 +63,13 @@ def test_init_wrong_guidelines(
     feedback_dataset_fields: List["AllowedFieldTypes"], feedback_dataset_questions: List["AllowedQuestionTypes"]
 ) -> None:
     with pytest.raises(TypeError, match="Expected `guidelines` to be"):
-        FeedbackDataset(
+        TestFeedbackDataset(
             guidelines=[],
             fields=feedback_dataset_fields,
             questions=feedback_dataset_questions,
         )
     with pytest.raises(ValueError, match="Expected `guidelines` to be"):
-        FeedbackDataset(
+        TestFeedbackDataset(
             guidelines="",
             fields=feedback_dataset_fields,
             questions=feedback_dataset_questions,
@@ -78,25 +80,25 @@ def test_init_wrong_fields(
     feedback_dataset_guidelines: str, feedback_dataset_questions: List["AllowedQuestionTypes"]
 ) -> None:
     with pytest.raises(TypeError, match="Expected `fields` to be a list"):
-        FeedbackDataset(
+        TestFeedbackDataset(
             guidelines=feedback_dataset_guidelines,
             fields=None,
             questions=feedback_dataset_questions,
         )
     with pytest.raises(TypeError, match="Expected `fields` to be a list of `FieldSchema`"):
-        FeedbackDataset(
+        TestFeedbackDataset(
             guidelines=feedback_dataset_guidelines,
             fields=[{"wrong": "field"}],
             questions=feedback_dataset_questions,
         )
     with pytest.raises(ValueError, match="At least one `FieldSchema` in `fields` must be required"):
-        FeedbackDataset(
+        TestFeedbackDataset(
             guidelines=feedback_dataset_guidelines,
             fields=[TextField(name="test", required=False)],
             questions=feedback_dataset_questions,
         )
     with pytest.raises(ValueError, match="Expected `fields` to have unique names"):
-        FeedbackDataset(
+        TestFeedbackDataset(
             guidelines=feedback_dataset_guidelines,
             fields=[
                 TextField(name="test", required=True),
@@ -110,7 +112,7 @@ def test_init_wrong_questions(
     feedback_dataset_guidelines: str, feedback_dataset_fields: List["AllowedFieldTypes"]
 ) -> None:
     with pytest.raises(TypeError, match="Expected `questions` to be a list, got"):
-        FeedbackDataset(
+        TestFeedbackDataset(
             guidelines=feedback_dataset_guidelines,
             fields=feedback_dataset_fields,
             questions=None,
@@ -119,13 +121,13 @@ def test_init_wrong_questions(
         TypeError,
         match="Expected `questions` to be a list of",
     ):
-        FeedbackDataset(
+        TestFeedbackDataset(
             guidelines=feedback_dataset_guidelines,
             fields=feedback_dataset_fields,
             questions=[{"wrong": "question"}],
         )
     with pytest.raises(ValueError, match="At least one question in `questions` must be required"):
-        FeedbackDataset(
+        TestFeedbackDataset(
             guidelines=feedback_dataset_guidelines,
             fields=feedback_dataset_fields,
             questions=[
@@ -134,7 +136,7 @@ def test_init_wrong_questions(
             ],
         )
     with pytest.raises(ValueError, match="Expected `questions` to have unique names"):
-        FeedbackDataset(
+        TestFeedbackDataset(
             guidelines=feedback_dataset_guidelines,
             fields=feedback_dataset_fields,
             questions=[
@@ -150,14 +152,14 @@ def test_init_wrong_metadata_properties(
     feedback_dataset_questions: List["AllowedQuestionTypes"],
 ) -> None:
     with pytest.raises(TypeError, match="Expected `metadata_properties` to be a list"):
-        FeedbackDataset(
+        TestFeedbackDataset(
             guidelines=feedback_dataset_guidelines,
             fields=feedback_dataset_fields,
             questions=feedback_dataset_questions,
             metadata_properties=["wrong type"],
         )
     with pytest.raises(ValueError, match="Expected `metadata_properties` to have unique names"):
-        FeedbackDataset(
+        TestFeedbackDataset(
             guidelines=feedback_dataset_guidelines,
             fields=feedback_dataset_fields,
             questions=feedback_dataset_questions,

--- a/tests/unit/client/feedback/dataset/test_local.py
+++ b/tests/unit/client/feedback/dataset/test_local.py
@@ -1,0 +1,96 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+from argilla.client.feedback.dataset.local import FeedbackDataset
+from argilla.client.feedback.schemas.fields import TextField
+from argilla.client.feedback.schemas.metadata import (
+    FloatMetadataProperty,
+    IntegerMetadataProperty,
+    TermsMetadataProperty,
+)
+from argilla.client.feedback.schemas.questions import TextQuestion
+from argilla.client.feedback.schemas.records import FeedbackRecord
+
+
+@pytest.mark.parametrize(
+    "record",
+    [
+        FeedbackRecord(fields={"required-field": "text"}, metadata={"nested-metadata": {"a": 1}}),
+        FeedbackRecord(
+            fields={"required-field": "text", "optional-field": "text"},
+            metadata={"int-metadata": 1, "float-metadata": 1.0},
+        ),
+        FeedbackRecord(
+            fields={"required-field": "text", "optional-field": None},
+            metadata={"terms-metadata": "a", "more-metadata": 3},
+        ),
+    ],
+)
+def test_add_records_validation(record: "FeedbackRecord") -> None:
+    dataset = FeedbackDataset(
+        fields=[TextField(name="required-field", required=True), TextField(name="optional-field", required=False)],
+        questions=[TextQuestion(name="question", required=True)],
+        metadata_properties=[
+            TermsMetadataProperty(name="terms-metadata", values=["a", "b", "c"]),
+            IntegerMetadataProperty(name="int-metadata", min=0, max=10),
+            FloatMetadataProperty(name="float-metadata", min=0.0, max=10.0),
+        ],
+    )
+
+    dataset.add_records(record)
+    assert len(dataset.records) == 1
+    assert dataset.records[0] == record
+
+
+@pytest.mark.parametrize(
+    "record, exception_cls, exception_msg",
+    [
+        (FeedbackRecord(fields={}, metadata={}), ValueError, "required-field\n  field required"),
+        (
+            FeedbackRecord(fields={"optional-field": "text"}, metadata={}),
+            ValueError,
+            "required-field\n  field required",
+        ),
+        (
+            FeedbackRecord(fields={"required-field": "text"}, metadata={"terms-metadata": "d"}),
+            ValueError,
+            "terms-metadata\n  Provided 'terms-metadata=d' is not valid, only values in \['a', 'b', 'c'\] are allowed.",
+        ),
+        (
+            FeedbackRecord(fields={"required-field": "text"}, metadata={"int-metadata": 11}),
+            ValueError,
+            "int-metadata\n  Provided 'int-metadata=11' is not valid, only values between 0 and 10 are allowed.",
+        ),
+        (
+            FeedbackRecord(fields={"required-field": "text"}, metadata={"float-metadata": 11.0}),
+            ValueError,
+            "float-metadata\n  Provided 'float-metadata=11.0' is not valid, only values between 0.0 and 10.0 are allowed.",
+        ),
+    ],
+)
+def test_add_records_validation_error(record: FeedbackRecord, exception_cls: Exception, exception_msg: str) -> None:
+    dataset = FeedbackDataset(
+        fields=[TextField(name="required-field", required=True), TextField(name="optional-field", required=False)],
+        questions=[TextQuestion(name="question", required=True)],
+        metadata_properties=[
+            TermsMetadataProperty(name="terms-metadata", values=["a", "b", "c"]),
+            IntegerMetadataProperty(name="int-metadata", min=0, max=10),
+            FloatMetadataProperty(name="float-metadata", min=0.0, max=10.0),
+        ],
+    )
+
+    with pytest.raises(exception_cls, match=exception_msg):
+        dataset.add_records(record)
+    assert len(dataset.records) == 0

--- a/tests/unit/client/feedback/test_utils.py
+++ b/tests/unit/client/feedback/test_utils.py
@@ -1,0 +1,208 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import TYPE_CHECKING, Dict, List, Union
+
+import pytest
+from argilla.client.feedback.schemas.metadata import (
+    FloatMetadataProperty,
+    IntegerMetadataProperty,
+    TermsMetadataProperty,
+)
+from argilla.client.feedback.schemas.remote.metadata import (
+    RemoteFloatMetadataProperty,
+    RemoteIntegerMetadataProperty,
+    RemoteTermsMetadataProperty,
+)
+from argilla.client.feedback.utils import generate_pydantic_schema_for_metadata
+from pydantic import ValidationError
+
+if TYPE_CHECKING:
+    from argilla.client.feedback.schemas.types import AllowedMetadataPropertyTypes, AllowedRemoteMetadataPropertyTypes
+
+
+@pytest.mark.parametrize(
+    "metadata_properties, validation_data",
+    [
+        (
+            [TermsMetadataProperty(name="terms-metadata", values=["a", "b", "c"])],
+            {"terms-metadata": "a"},
+        ),
+        (
+            [IntegerMetadataProperty(name="int-metadata", min=0, max=10)],
+            {"int-metadata": 1},
+        ),
+        (
+            [FloatMetadataProperty(name="float-metadata", min=0.0, max=10.0)],
+            {"float-metadata": 1.0},
+        ),
+        (
+            [
+                TermsMetadataProperty(name="terms-metadata", values=["a", "b", "c"]),
+                IntegerMetadataProperty(name="int-metadata", min=0, max=10),
+                FloatMetadataProperty(name="float-metadata", min=0.0, max=10.0),
+            ],
+            {"terms-metadata": "a", "int-metadata": 1, "float-metadata": 1.0},
+        ),
+    ],
+)
+def test_generate_pydantic_schema_for_metadata(
+    metadata_properties: List["AllowedMetadataPropertyTypes"], validation_data: Dict[str, Union[str, int, float]]
+) -> None:
+    MetadataSchema = generate_pydantic_schema_for_metadata(
+        metadata_properties=metadata_properties, name="MetadataSchema"
+    )
+    assert MetadataSchema(**validation_data)
+
+
+@pytest.mark.parametrize(
+    "metadata_properties, validation_data, exception_cls, exception_msg",
+    [
+        (
+            [TermsMetadataProperty(name="terms-metadata", values=["a", "b", "c"])],
+            {"terms-metadata": "d"},
+            ValidationError,
+            "terms-metadata\n  Provided 'terms-metadata=d' is not valid, only values in \['a', 'b', 'c'\] are allowed",
+        ),
+        (
+            [TermsMetadataProperty(name="terms-metadata", values=["a", "b", "c"])],
+            {"terms-metadata": 1},
+            ValidationError,
+            "terms-metadata\n  str type expected",
+        ),
+        (
+            [IntegerMetadataProperty(name="int-metadata", min=0, max=10)],
+            {"int-metadata": -10},
+            ValidationError,
+            "int-metadata\n  Provided 'int-metadata=-10' is not valid, only values between 0 and 10 are allowed.",
+        ),
+        (
+            [IntegerMetadataProperty(name="int-metadata", min=0, max=10)],
+            {"int-metadata": "wrong"},
+            ValidationError,
+            "int-metadata\n  value is not a valid int",
+        ),
+        (
+            [FloatMetadataProperty(name="float-metadata", min=0.0, max=10.0)],
+            {"float-metadata": 100.0},
+            ValidationError,
+            "float-metadata\n  Provided 'float-metadata=100.0' is not valid, only values between 0.0 and 10.0 are allowed.",
+        ),
+        (
+            [FloatMetadataProperty(name="float-metadata", min=0.0, max=10.0)],
+            {"float-metadata": "wrong"},
+            ValidationError,
+            "float-metadata\n  value is not a valid float",
+        ),
+    ],
+)
+def test_generate_pydantic_schema_for_metadata_errors(
+    metadata_properties: List["AllowedMetadataPropertyTypes"],
+    validation_data: Dict[str, Union[str, int, float]],
+    exception_cls: Exception,
+    exception_msg: str,
+) -> None:
+    MetadataSchema = generate_pydantic_schema_for_metadata(
+        metadata_properties=metadata_properties, name="MetadataSchema"
+    )
+    with pytest.raises(exception_cls, match=exception_msg):
+        MetadataSchema(**validation_data)
+
+
+@pytest.mark.parametrize(
+    "metadata_properties, validation_data",
+    [
+        (
+            [RemoteTermsMetadataProperty(name="terms-metadata", values=["a", "b", "c"])],
+            {"terms-metadata": "a"},
+        ),
+        (
+            [RemoteIntegerMetadataProperty(name="int-metadata", min=0, max=10)],
+            {"int-metadata": 1},
+        ),
+        (
+            [RemoteFloatMetadataProperty(name="float-metadata", min=0.0, max=10.0)],
+            {"float-metadata": 1.0},
+        ),
+        (
+            [
+                RemoteTermsMetadataProperty(name="terms-metadata", values=["a", "b", "c"]),
+                RemoteIntegerMetadataProperty(name="int-metadata", min=0, max=10),
+                RemoteFloatMetadataProperty(name="float-metadata", min=0.0, max=10.0),
+            ],
+            {"terms-metadata": "a", "int-metadata": 1, "float-metadata": 1.0},
+        ),
+    ],
+)
+def test_generate_pydantic_schema_for_remote_metadata(
+    metadata_properties: List["AllowedRemoteMetadataPropertyTypes"], validation_data: Dict[str, Union[str, int, float]]
+) -> None:
+    RemoteMetadataSchema = generate_pydantic_schema_for_metadata(
+        metadata_properties=metadata_properties, name="RemoteMetadataSchema"
+    )
+    assert RemoteMetadataSchema(**validation_data)
+
+
+@pytest.mark.parametrize(
+    "metadata_properties, validation_data, exception_cls, exception_msg",
+    [
+        (
+            [RemoteTermsMetadataProperty(name="terms-metadata", values=["a", "b", "c"])],
+            {"terms-metadata": "d"},
+            ValidationError,
+            "terms-metadata\n  Provided 'terms-metadata=d' is not valid, only values in \['a', 'b', 'c'\] are allowed",
+        ),
+        (
+            [RemoteTermsMetadataProperty(name="terms-metadata", values=["a", "b", "c"])],
+            {"terms-metadata": 1},
+            ValidationError,
+            "terms-metadata\n  str type expected",
+        ),
+        (
+            [RemoteIntegerMetadataProperty(name="int-metadata", min=0, max=10)],
+            {"int-metadata": -10},
+            ValidationError,
+            "int-metadata\n  Provided 'int-metadata=-10' is not valid, only values between 0 and 10 are allowed.",
+        ),
+        (
+            [RemoteIntegerMetadataProperty(name="int-metadata", min=0, max=10)],
+            {"int-metadata": "wrong"},
+            ValidationError,
+            "int-metadata\n  value is not a valid int",
+        ),
+        (
+            [RemoteFloatMetadataProperty(name="float-metadata", min=0.0, max=10.0)],
+            {"float-metadata": 100.0},
+            ValidationError,
+            "float-metadata\n  Provided 'float-metadata=100.0' is not valid, only values between 0.0 and 10.0 are allowed.",
+        ),
+        (
+            [RemoteFloatMetadataProperty(name="float-metadata", min=0.0, max=10.0)],
+            {"float-metadata": "wrong"},
+            ValidationError,
+            "float-metadata\n  value is not a valid float",
+        ),
+    ],
+)
+def test_generate_pydantic_schema_for_remote_metadata_errors(
+    metadata_properties: List["AllowedRemoteMetadataPropertyTypes"],
+    validation_data: Dict[str, Union[str, int, float]],
+    exception_cls: Exception,
+    exception_msg: str,
+) -> None:
+    RemoteMetadataSchema = generate_pydantic_schema_for_metadata(
+        metadata_properties=metadata_properties, name="RemoteMetadataSchema"
+    )
+    with pytest.raises(exception_cls, match=exception_msg):
+        RemoteMetadataSchema(**validation_data)


### PR DESCRIPTION
# Description

This PR adds a validation layer for both the `metadata_properties` when `metadata` is provided via `FeedbackRecord` when adding that record to either a local or existing `FeedbackDataset`, as well as validating the `metadata_filters` provided to the `filter_by` method for `RemoteFeedbackDataset`.

These validation layers would help reduce the API workload as the validation will be done client-side, which implies that the client will handle the validation first.

In this case, as we have the following properties: `TermsMetadataProperty`, `IntegerMetadataProperty` and `FloatMetadataProperty`; we'll need to ensure that the values provided for those are correct, both on `add_records` and also on `filter_by`.

The approach is similar to the one already implemented for the `fields` of a `FeedbackRecord`, but extending it to the `metadata_properties` to also include a validation layer that ensures not just the type of the value provided, but whether it's compliant with the pre-defined values for `TermMetadataProperty` or the pre-defined boundaries for both `IntegerMetadataProperty` and `FloatMetadataProperty`. The core difference is that besides the `pydantic` validation, there's also a method in each property that validates the values provided in the filters related to those metadata properties.

Closes #3859

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [x] Add unit tests for the `generate_pydantic_schema_for_metadata` method
- [x] Add unit tests for both `_validate_filter` and `_pydantic_field_with_validator` in each property i.e. `TermsMetadataProperty`, `IntegerMetadataProperty`, and `FloatMetadataProperty`
- [x] Add unit tests for `add_records` with both correct and wrong `metadata`
- [x] Add integration tests for `add_records` and `filter_by` to ensure that the validation is correct both before and after applying those ops

**Checklist**

- [ ] I added relevant documentation
- [X] follows the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)