### PR TITLE
docs: cheatsheet fixing typos gramamar and urls

### DIFF
--- a/docs/_source/_common/tabs/dataset_settings.md
+++ b/docs/_source/_common/tabs/dataset_settings.md
@@ -38,7 +38,7 @@ import argilla as rg
 
 settings = rg.TextClassificationSettings(label_schema=["A", "B", "C"])
 
-rg.configure_dataset(name="my_dataset", settings=settings)
+rg.configure_dataset_settings(name="my_dataset", settings=settings)
 ```
 :::
 
@@ -48,7 +48,7 @@ import argilla as rg
 
 settings = rg.TokenClassificationSettings(label_schema=["A", "B", "C"])
 
-rg.configure_dataset(name="my_dataset", settings=settings)
+rg.configure_dataset_settings(name="my_dataset", settings=settings)
 ```
 :::
 

--- a/docs/_source/_common/tabs/records_create.md
+++ b/docs/_source/_common/tabs/records_create.md
@@ -1,4 +1,4 @@
-We support different tasks within the Argilla eco-system focused on NLP: `Text Classification`, `Token Classification`, `Text2Text` and LLM-related `Feedback`. To know more about creation, take a look [here](/guides/log_load_and_prepare_data).
+We support different tasks within the Argilla eco-system focused on NLP: `Text Classification`, `Token Classification`, `Text2Text` and LLM-related `Feedback`. To know more about creation, take a look [here](/practical_guides/create_dataset.md).
 
 
 ::::{tab-set}

--- a/docs/_source/_common/tabs/train_update_config.md
+++ b/docs/_source/_common/tabs/train_update_config.md
@@ -243,7 +243,7 @@ trainer.update_config(
 :::{tab-item} TRL
 
 ```python
-# parameters from `trl.RewardTrainer`, `trl.SFTTrainer`, `trl.PPOTrainer` or `trl.DPOTrainer`.
+# Parameters from `trl.RewardTrainer`, `trl.SFTTrainer`, `trl.PPOTrainer` or `trl.DPOTrainer`.
 # `transformers.TrainingArguments`
 trainer.update_config(
     per_device_train_batch_size = 8,
@@ -275,7 +275,7 @@ trainer.update_config(
 :::{tab-item} sentence-transformers
 
 ```python
-# parameters related to the model initialization from `sentence_transformers.SentenceTransformer`
+# Parameters related to the model initialization from `sentence_transformers.SentenceTransformer`
 trainer.update_config(
     model="sentence-transformers/all-MiniLM-L6-v2",
     modules = False,
@@ -305,7 +305,7 @@ trainer.update_config(
     loss_fct = None
     activation_fct = nn.Identity(),
 )
-# the remaining arguments are common for both procedures
+# The remaining arguments are common for both procedures
 trainer.update_config(
     evaluator: SentenceEvaluator = evaluation.EmbeddingSimilarityEvaluator,
     epochs: int = 1,

--- a/docs/_source/getting_started/cheatsheet.md
+++ b/docs/_source/getting_started/cheatsheet.md
@@ -11,19 +11,19 @@
 
 ## Connect to Argilla
 
-To get started with your data from our Python library, we first need to connect to our FastAPI server. This is done via `httpx` using an API key and a URL. Or take a more extensive look [here](/guides/log_load_and_prepare_data).
+To get started with your data from our Python library, we first need to connect to our FastAPI server. This is done via `httpx` using an API key and a URL. Or take a more extensive look [here](/getting_started/quickstart_installation).
 
 ```{include} /_common/tabs/argilla_connect.md
 ```
 
 ## Configure datasets
 
-Before getting started with any textual data project, we advise setting up annotation guidelines and a labeling schema. Need some more context? Take look [here](/guides/log_load_and_prepare_data).
+Before getting started with any textual data project, we advise setting up annotation guidelines and a labeling schema. Need some more context? Take a look [here](/getting_started/quickstart_workflow).
 
 ```{include} /_common/tabs/dataset_settings.md
 ```
 
-Note that feedback datasets support different types of questions. For more info on each of them, check out [this section](../guides/llms/practical_guides/create_dataset.md#define-questions).
+Note that feedback datasets support different types of questions. For more info on each of them, check out [this section](/getting_started/quickstart_workflow_feedback).
 
 ```{include} /_common/tabs/question_settings.md
 ```
@@ -35,7 +35,7 @@ Note that feedback datasets support different types of questions. For more info 
 
 ## Query datasets
 
-To search your data from the UI or the Python library, you need to be able to write Lucene Query Language (LQL), which is native to Elastic Search and Open Search. To know more about querying and searching, take a look [here](/guides/query_datasets.md).
+To search your data from the UI or the Python library, you need to be able to write Lucene Query Language (LQL), which is native to Elastic Search and Open Search. To know more about querying and searching, take a look [here](/practical_guides/filter_dataset).
 
 ::::{tab-set}
 
@@ -88,7 +88,7 @@ Inclusive ranges are specified with square brackets and exclusive ranges are wit
 :::{tab-item} operators
 
 You can combine an arbitrary amount of terms and fields in your search using the familiar boolean operators `AND`, `OR` and `NOT`.
-Following examples showcase the power of these operators:
+The following examples showcase the power of these operators:
 
 - `text:(quick AND fox)`: Returns records that contain the word *quick* and *fox*. The `AND` operator is the default operator, so `text:(quick fox)` is equivalent.
 - `text:(quick OR brown)`: Returns records that contain either the word *quick* or *brown*.
@@ -135,7 +135,7 @@ Wildcard searches can be run on individual search terms, using `?` to replace a 
 
 ## Semantic search
 
-Semantic search or vector search is an amazingly powerful tool to sift through text based on sensical intuition instead of keywords. We use the native Elastic Search vector support to empower our users to navigate their records. Want to know more about this? Take a look [here](/guides/label_records_with_semanticsearch.md).
+Semantic search or vector search is an amazingly powerful tool to sift through text based on sensical intuition instead of keywords. We use the native Elastic Search vector support to empower our users to navigate their records. Want to know more about this? Take a look [here](/tutorials/techniques/semantic_search).
 
 ::::{tab-set}
 
@@ -156,7 +156,7 @@ rg.log(name="dataset", records=record)
 ```python
 import argilla as rg
 
-# We resturn the 50 most similar records
+# We return the 50 most similar records
 records = rg.load(name="dataset", vector=("my_vector_name", [0, 43, 1985]))
 ```
 :::
@@ -167,7 +167,7 @@ records = rg.load(name="dataset", vector=("my_vector_name", [0, 43, 1985]))
 
 ## Weak supervision
 
-Weak supervision for NLP is like teaching a model with "approximate" answers instead of perfect ones. It uses clever tricks and shortcuts to avoid the need for labor-intensive labeling. It's like giving the model training wheels to learn on its own. While it's not as accurate as traditional supervision, it allows training on a much larger scale. Want to know more, look [here](/guides/programmatic_labeling_with_rules.md).
+Weak supervision for NLP is like teaching a model with "approximate" answers instead of perfect ones. It uses clever tricks and shortcuts to avoid the need for labor-intensive labeling. It's like giving the model training wheels to learn on its own. While it's not as accurate as traditional supervision, it allows training on a much larger scale. Want to know more, look [here](/tutorials/techniques/weak_supervision).
 
 ::::{tab-set}
 
@@ -222,7 +222,7 @@ rg.log(records_for_training, name="majority_voter_results")
 
 ## Train Models
 
-We love our open-source training libraries as much as you do, so we provide integrations with all of them to limit the time you spend on data preparation and have more fun with actual training. We support `spacy`, `transformers`, `setfit`, `openai`, `autotrain`, and way more. Want to get to know all support? Train/fine-tune a model from a `FeedbackDataset` as explained [here](/guides/llms/practical_guides/practical_guides/fine_tune.html), or either a `TextClassificationDataset` or a `TokenClassificationDataset`[here](/guides/train_a_model.md).
+We love our open-source training libraries as much as you do, so we provide integrations with all of them to limit the time you spend on data preparation and have more fun with actual training. We support `spacy`, `transformers`, `setfit`, `openai`, `autotrain`, and way more. Want to get to know all support? Train/fine-tune a model from a `FeedbackDataset` as explained [here](/practical_guides/fine_tune.md#feedback-dataset), or either a `TextClassificationDataset` or a `TokenClassificationDataset`[here](/practical_guides/fine_tune.md#other-datasets).
 
 ```python
 from argilla.training import ArgillaTrainer


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

Fixing the grammar, typos and URLs of the Cheatsheet. It also fixes the dead URL of the common file, as it appears here too

Closes #3865 

**Type of change**

(Remember to title the PR according to the type of change)

- [X] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes.)

- [X] `sphinx-autobuild` (read [Developer Documentation](https://docs.argilla.io/en/latest/community/developer_docs.html#building-the-documentation) for more details)

**Checklist**

- [ ] I added relevant documentation
- [X] I followed the style guidelines of this project
- [X] I did a self-review of my code
- [X] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
