### PR TITLE
feat: add computing `total` in listing endpoints when no search engine

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -55,27 +55,27 @@ jobs:
     strategy:
       matrix:
         include:
-# TODO(@frascuchon): Apply this for separate Release pipelines
-#          - searchEngineDockerImage: docker.elastic.co/elasticsearch/elasticsearch:8.8.2
-#            searchEngineDockerEnv: '{"discovery.type": "single-node", "xpack.security.enabled": "false"}'
-#            coverageReport: coverage-elasticsearch-8.8.2
-#            runsOn: ubuntu-latest
-#          - searchEngineDockerImage: docker.elastic.co/elasticsearch/elasticsearch:8.0.1
-#            searchEngineDockerEnv: '{"discovery.type": "single-node", "xpack.security.enabled": "false"}'
-#            coverageReport: coverage-elasticsearch-8.0.1
-#            runsOn: ubuntu-latest
+          # TODO(@frascuchon): Apply this for separate Release pipelines
+          #          - searchEngineDockerImage: docker.elastic.co/elasticsearch/elasticsearch:8.8.2
+          #            searchEngineDockerEnv: '{"discovery.type": "single-node", "xpack.security.enabled": "false"}'
+          #            coverageReport: coverage-elasticsearch-8.8.2
+          #            runsOn: ubuntu-latest
+          #          - searchEngineDockerImage: docker.elastic.co/elasticsearch/elasticsearch:8.0.1
+          #            searchEngineDockerEnv: '{"discovery.type": "single-node", "xpack.security.enabled": "false"}'
+          #            coverageReport: coverage-elasticsearch-8.0.1
+          #            runsOn: ubuntu-latest
           - searchEngineDockerImage: docker.elastic.co/elasticsearch/elasticsearch:7.17.11
             searchEngineDockerEnv: '{"discovery.type": "single-node", "xpack.security.enabled": "false"}'
             coverageReport: coverage-elasticsearch-7.17.11
-            runsOn: ubuntu-latest
+            runsOn: ubuntu-20.04
           - searchEngineDockerImage: opensearchproject/opensearch:2.4.1
             searchEngineDockerEnv: '{"discovery.type": "single-node", "plugins.security.disabled": "true"}'
             coverageReport: coverage-opensearch-2.4.1
-            runsOn: ubuntu-latest
-#          - searchEngineDockerImage: opensearchproject/opensearch:1.3.11
-#            searchEngineDockerEnv: '{"discovery.type": "single-node", "plugins.security.disabled": "true"}'
-#            coverageReport: coverage-opensearch-1.3.11
-#            runsOn: ubuntu-latest
+            runsOn: ubuntu-20.04
+    #          - searchEngineDockerImage: opensearchproject/opensearch:1.3.11
+    #            searchEngineDockerEnv: '{"discovery.type": "single-node", "plugins.security.disabled": "true"}'
+    #            coverageReport: coverage-opensearch-1.3.11
+    #            runsOn: ubuntu-latest
     name: Run unit tests
     uses: ./.github/workflows/run-python-tests.yml
     needs: check_repo_files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ These are the section headers that we use:
 - Updated `Dockerfile` to use multi stage build ([#3221](https://github.com/argilla-io/argilla/pull/3221) and [#3793](https://github.com/argilla-io/argilla/pull/3793)).
 - Updated active learning for text classification notebooks to use the most recent small-text version ([#3831](https://github.com/argilla-io/argilla/pull/3831)).
 - Changed argilla dataset name in the active learning for text classification notebooks to be consistent with the default names in the huggingface spaces ([#3831](https://github.com/argilla-io/argilla/pull/3831)).
+- Updated `GET /api/v1/datasets/{dataset_id}/records`, `GET /api/v1/me/datasets/{dataset_id}/records` and `POST /api/v1/me/datasets/{dataset_id}/records/search` endpoints to return the `total` number of records ([#3848](https://github.com/argilla-io/argilla/pull/3848) & [#3903](https://github.com/argilla-io/argilla/pull/3903)).
 
 ### Fixed
 

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -339,9 +339,7 @@ async def list_current_user_dataset_records(
             sort_by_query_param=sort_by_query_param or {RecordSortField.inserted_at.value: "asc"},
         )
     else:
-        # TODO(@frascuchon): Compute also total for this case
-        total = None
-        records = await datasets.list_records_by_dataset_id(
+        records, total = await datasets.list_records_by_dataset_id(
             db,
             dataset_id,
             current_user.id,
@@ -385,8 +383,7 @@ async def list_dataset_records(
             sort_by_query_param=sort_by_query_param or {RecordSortField.inserted_at.value: "asc"},
         )
     else:
-        total = None
-        records = await datasets.list_records_by_dataset_id(
+        records, total = await datasets.list_records_by_dataset_id(
             db, dataset_id, include=include, response_statuses=response_statuses, offset=offset, limit=limit
         )
 

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -549,7 +549,7 @@ class TestSuiteDatasets:
 
         assert response.status_code == 200
         assert response.json() == {
-            "total": None,
+            "total": 3,
             "items": [
                 {
                     "id": str(record_a.id),
@@ -1138,7 +1138,7 @@ class TestSuiteDatasets:
 
         assert response.status_code == 200
         assert response.json() == {
-            "total": None,
+            "total": 3,
             "items": [
                 {
                     "id": str(record_a.id),
@@ -1193,7 +1193,7 @@ class TestSuiteDatasets:
         )
 
         expected = {
-            "total": None,
+            "total": 3,
             "items": [
                 {
                     "id": str(record_a.id),


### PR DESCRIPTION
# Description

This PR adds counting the total records matching the query in the listing records endpoints when the search engine is not used. Therefore, the listing records endpoints will return an integer value in the `total` field of the payload no matter the search engine is used (metadata properties where used for filtering) or not.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

Unit tests has been updated.

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
