### PR TITLE
fix: configure metadata property for search engine

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -67,11 +67,11 @@ jobs:
           - searchEngineDockerImage: docker.elastic.co/elasticsearch/elasticsearch:7.17.11
             searchEngineDockerEnv: '{"discovery.type": "single-node", "xpack.security.enabled": "false"}'
             coverageReport: coverage-elasticsearch-7.17.11
-            runsOn: ubuntu-latest
+            runsOn: ubuntu-20.04
           - searchEngineDockerImage: opensearchproject/opensearch:2.4.1
             searchEngineDockerEnv: '{"discovery.type": "single-node", "plugins.security.disabled": "true"}'
             coverageReport: coverage-opensearch-2.4.1
-            runsOn: ubuntu-latest
+            runsOn: ubuntu-20.04
 #          - searchEngineDockerImage: opensearchproject/opensearch:1.3.11
 #            searchEngineDockerEnv: '{"discovery.type": "single-node", "plugins.security.disabled": "true"}'
 #            coverageReport: coverage-opensearch-1.3.11

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - python~=3.8.0
+  - python~=3.9.7
   - pip>=2.22.0
   - openjdk=11
   # pyparsing 3.0.5 seems to be buggy

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -233,7 +233,7 @@ async def create_metadata_property(
             autocommit=False,
         )
         if dataset.is_ready:
-            await search_engine.configure_metadata_property(metadata_property)
+            await search_engine.configure_metadata_property(dataset, metadata_property)
 
     await db.commit()
     return metadata_property

--- a/src/argilla/server/search_engine/base.py
+++ b/src/argilla/server/search_engine/base.py
@@ -209,7 +209,7 @@ class SearchEngine(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    async def configure_metadata_property(self, metadata_property: MetadataProperty):
+    async def configure_metadata_property(self, dataset: Dataset,  metadata_property: MetadataProperty):
         pass
 
     @abstractmethod

--- a/src/argilla/server/search_engine/base.py
+++ b/src/argilla/server/search_engine/base.py
@@ -209,7 +209,7 @@ class SearchEngine(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    async def configure_metadata_property(self, dataset: Dataset,  metadata_property: MetadataProperty):
+    async def configure_metadata_property(self, dataset: Dataset, metadata_property: MetadataProperty):
         pass
 
     @abstractmethod

--- a/src/argilla/server/search_engine/commons.py
+++ b/src/argilla/server/search_engine/commons.py
@@ -164,9 +164,9 @@ class BaseElasticAndOpenSearchEngine(SearchEngine):
         index_name = index_name_for_dataset(dataset)
         await self._create_index_request(index_name, mappings, settings)
 
-    async def configure_metadata_property(self, metadata_property: MetadataProperty):
+    async def configure_metadata_property(self, dataset: Dataset, metadata_property: MetadataProperty):
         mapping = _mapping_for_metadata_property(metadata_property)
-        index_name = await self._get_index_or_raise(metadata_property.dataset)
+        index_name = await self._get_index_or_raise(dataset)
 
         await self.put_index_mapping_request(index_name, mapping)
 

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -2741,7 +2741,7 @@ class TestSuiteDatasets:
             **metadata_property_json,
         }
 
-        mock_search_engine.configure_metadata_property.assert_called_once_with(created_metadata_property)
+        mock_search_engine.configure_metadata_property.assert_called_once_with(dataset, created_metadata_property)
 
     async def test_create_dataset_metadata_property_with_dataset_ready_and_search_engine_error(
         self, async_client: "AsyncClient", mock_search_engine: SearchEngine, db: "AsyncSession", owner_auth_header: dict


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR adapts the metadata property creation passing the original dataset as an argument for the search engine method, instead of fetching through the metadata property

Also, the segmentation fault problem in CI has been resolved by updating the Python interpreter to ~=3.9 

Closes #3901 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
