### PR TITLE
feat: make `settings` optional for `metadata_properties`

### DIFF
--- a/docker/scripts/load_data.py
+++ b/docker/scripts/load_data.py
@@ -28,6 +28,21 @@ class LoadDatasets:
         rg.init(api_key=api_key)
 
     @staticmethod
+    def load_news_text_summarization():
+        print("Loading News-text-summarization dataset")
+
+        # Load dataset from hub
+        dataset = load_dataset("argilla/news-summary", split="train")
+        dataset_rg = rg.read_datasets(dataset, task="Text2Text")
+
+        # Log the dataset
+        rg.log(
+            dataset_rg,
+            name="news-text-summarization",
+            tags={"description": "A text summarization dataset with news pieces and their predicted summaries."},
+        )
+
+    @staticmethod
     def load_sst_sentiment_explainability():
         print("Loading Sst-sentiment-explainability dataset")
 
@@ -51,21 +66,6 @@ class LoadDatasets:
                 "description": "The sst2 sentiment dataset with predictions from a pretrained pipeline and "
                 "explanations from Transformers Interpret."
             },
-        )
-
-    @staticmethod
-    def load_news_text_summarization():
-        print("Loading News-text-summarization dataset")
-
-        # Load dataset from hub
-        dataset = load_dataset("argilla/news-summary", split="train")
-        dataset_rg = rg.read_datasets(dataset, task="Text2Text")
-
-        # Log the dataset
-        rg.log(
-            dataset_rg,
-            name="news-text-summarization",
-            tags={"description": "A text summarization dataset with news pieces and their predicted summaries."},
         )
 
     @staticmethod
@@ -195,7 +195,7 @@ class LoadDatasets:
         return rg.FeedbackRecord(fields=fields, metadata=metadata)
 
     @staticmethod
-    def load_error_analysis():
+    def load_error_analysis(with_settings_options: bool = True):
         print("Loading Error Analysis dataset as a `FeedbackDataset` (Alpha)")
         df = pd.read_csv("https://raw.githubusercontent.com/argilla-io/dataset_examples/main/synthetic_data_v2.csv")
 
@@ -217,19 +217,34 @@ class LoadDatasets:
             rg.TextQuestion(name="note", title="Leave a note to describe the issue:", required=False),
         ]
 
-        metadata = [
-            rg.TermsMetadataProperty(name="correctness-langsmith", values=df.correctness_langsmith.unique().tolist()),
-            rg.TermsMetadataProperty(name="model-name", values=df.model_name.unique().tolist()),
-            rg.FloatMetadataProperty(name="temperature", min=df.temperature.min(), max=df.temperature.max()),
-            rg.IntegerMetadataProperty(name="max-tokens", min=df.max_tokens.min(), max=df.max_tokens.max()),
-            rg.FloatMetadataProperty(name="cpu-user", min=df.cpu_time_user.min(), max=df.cpu_time_user.max()),
-            rg.FloatMetadataProperty(name="cpu-system", min=df.cpu_time_system.min(), max=df.cpu_time_system.max()),
-            rg.TermsMetadataProperty(name="library-version", values=df.library_version.unique().tolist()),
-        ]
+        dataset_name = "error-analysis-with-feedback-alpha"
+
+        if with_settings_options:
+            metadata = [
+                rg.TermsMetadataProperty(
+                    name="correctness-langsmith", values=df.correctness_langsmith.unique().tolist()
+                ),
+                rg.TermsMetadataProperty(name="model-name", values=df.model_name.unique().tolist()),
+                rg.FloatMetadataProperty(name="temperature", min=df.temperature.min(), max=df.temperature.max()),
+                rg.FloatMetadataProperty(name="cpu-user", min=df.cpu_time_user.min(), max=df.cpu_time_user.max()),
+                rg.FloatMetadataProperty(name="cpu-system", min=df.cpu_time_system.min(), max=df.cpu_time_system.max()),
+                rg.TermsMetadataProperty(name="library-version", values=df.library_version.unique().tolist()),
+            ]
+        else:
+            dataset_name += "-no-settings"
+
+            metadata = [
+                rg.TermsMetadataProperty(name="correctness-langsmith"),
+                rg.TermsMetadataProperty(name="model-name"),
+                rg.FloatMetadataProperty(name="temperature"),
+                rg.FloatMetadataProperty(name="cpu-user"),
+                rg.FloatMetadataProperty(name="cpu-system"),
+                rg.TermsMetadataProperty(name="library-version"),
+            ]
 
         dataset = rg.FeedbackDataset(fields=fields, questions=questions, metadata_properties=metadata)
         dataset.add_records(records=[LoadDatasets.build_error_analysis_record(row) for _, row in df.iterrows()])
-        dataset.push_to_argilla(name="error-analysis-with-feedback-alpha")
+        dataset.push_to_argilla(name=dataset_name)
 
     @staticmethod
     def load_error_analysis_textcat_version():
@@ -259,12 +274,11 @@ if __name__ == "__main__":
                 response = requests.get("http://0.0.0.0:6900/")
                 if response.status_code == 200:
                     ld = LoadDatasets(API_KEY)
+                    ld.load_error_analysis(with_settings_options=False)
                     ld.load_error_analysis()
                     ld.load_error_analysis_textcat_version()
                     ld.load_feedback_dataset_from_huggingface(
-                        repo_id="argilla/databricks-dolly-15k-curated-en",
-                        split="train",
-                        samples=100,
+                        repo_id="argilla/databricks-dolly-15k-curated-en", split="train", samples=100
                     )
 
                     if LOAD_DATASETS.lower() != "single":
@@ -277,14 +291,10 @@ if __name__ == "__main__":
                         ld.load_gutenberg_spacy_ner_monitoring()
                         # `FeedbackDataset`
                         ld.load_feedback_dataset_from_huggingface(
-                            repo_id="argilla/oasst_response_quality",
-                            split="train",
-                            samples=100,
+                            repo_id="argilla/oasst_response_quality", split="train", samples=100
                         )
                         ld.load_feedback_dataset_from_huggingface(
-                            repo_id="argilla/oasst_response_comparison",
-                            split="train",
-                            samples=100,
+                            repo_id="argilla/oasst_response_comparison", split="train", samples=100
                         )
             except requests.exceptions.ConnectionError:
                 pass

--- a/docker/scripts/load_data.py
+++ b/docker/scripts/load_data.py
@@ -195,7 +195,7 @@ class LoadDatasets:
         return rg.FeedbackRecord(fields=fields, metadata=metadata)
 
     @staticmethod
-    def load_error_analysis(with_settings_options: bool = True):
+    def load_error_analysis(with_metadata_property_options: bool = True):
         print("Loading Error Analysis dataset as a `FeedbackDataset` (Alpha)")
         df = pd.read_csv("https://raw.githubusercontent.com/argilla-io/dataset_examples/main/synthetic_data_v2.csv")
 
@@ -217,7 +217,7 @@ class LoadDatasets:
             rg.TextQuestion(name="note", title="Leave a note to describe the issue:", required=False),
         ]
 
-        dataset_name = "error-analysis-with-feedback-alpha"
+        dataset_name = "error-analysis-with-feedback"
 
         if with_settings_options:
             metadata = [

--- a/docker/scripts/load_data.py
+++ b/docker/scripts/load_data.py
@@ -219,7 +219,7 @@ class LoadDatasets:
 
         dataset_name = "error-analysis-with-feedback"
 
-        if with_settings_options:
+        if with_metadata_property_options:
             metadata = [
                 rg.TermsMetadataProperty(
                     name="correctness-langsmith", values=df.correctness_langsmith.unique().tolist()
@@ -274,7 +274,7 @@ if __name__ == "__main__":
                 response = requests.get("http://0.0.0.0:6900/")
                 if response.status_code == 200:
                     ld = LoadDatasets(API_KEY)
-                    ld.load_error_analysis(with_settings_options=False)
+                    ld.load_error_analysis(with_metadata_property_options=False)
                     ld.load_error_analysis()
                     ld.load_error_analysis_textcat_version()
                     ld.load_feedback_dataset_from_huggingface(

--- a/src/argilla/client/feedback/dataset/base.py
+++ b/src/argilla/client/feedback/dataset/base.py
@@ -305,7 +305,8 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin):
                     self._metadata_schema.parse_obj(record.metadata)
                 except ValidationError as e:
                     raise ValueError(
-                        f"`FeedbackRecord.metadata` does not match the expected schema, with exception: {e}"
+                        f"`FeedbackRecord.metadata` {record.metadata} does not match the expected schema,"
+                        f" with exception: {e}"
                     ) from e
 
     def _parse_and_validate_records(

--- a/src/argilla/client/feedback/schemas/metadata.py
+++ b/src/argilla/client/feedback/schemas/metadata.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from pydantic import (
     BaseModel,
@@ -26,7 +26,6 @@ from pydantic import (
     root_validator,
     validator,
 )
-from pydantic.generics import GenericModel
 
 from argilla.client.feedback.constants import METADATA_PROPERTY_TYPE_TO_PYTHON_TYPE
 from argilla.client.feedback.schemas.enums import MetadataPropertyTypes

--- a/src/argilla/client/feedback/schemas/metadata.py
+++ b/src/argilla/client/feedback/schemas/metadata.py
@@ -173,7 +173,7 @@ class _NumericMetadataPropertySchema(MetadataPropertySchema):
 
     def _value_in_bounds(self, provided_value: Optional[Union[int, float]]) -> Union[int, float]:
         if provided_value is not None and (
-            self.max and provided_value > self.max or self.min and provided_value < self.min
+            (self.min is not None and self.min > provided_value) or (self.max is not None and self.max < provided_value)
         ):
             raise ValueError(
                 f"Provided '{self.name}={provided_value}' is not valid, only values between {self.min} and {self.max} are allowed."

--- a/src/argilla/client/feedback/schemas/metadata.py
+++ b/src/argilla/client/feedback/schemas/metadata.py
@@ -120,11 +120,12 @@ class TermsMetadataProperty(MetadataPropertySchema):
     def server_settings(self) -> Dict[str, Any]:
         return {"type": self.type, "values": self.values}
 
-    def _all_values_exist(self, introduced_value: str) -> None:
-        if introduced_value not in self.values:
+    def _all_values_exist(self, introduced_value: Optional[str] = None) -> str:
+        if introduced_value is not None and introduced_value not in self.values:
             raise ValueError(
                 f"Provided '{self.name}={introduced_value}' is not valid, only values in {self.values} are allowed."
             )
+        return introduced_value
 
     @property
     def _pydantic_field_with_validator(self) -> Tuple[Dict[str, Tuple[StrictStr, None]], Dict[str, Callable]]:
@@ -170,11 +171,14 @@ class _NumericMetadataPropertySchema(MetadataPropertySchema):
             settings["max"] = self.max
         return settings
 
-    def _value_in_bounds(self, provided_value: Union[int, float]) -> None:
-        if self.max and provided_value > self.max or self.min and provided_value < self.min:
+    def _value_in_bounds(self, provided_value: Optional[Union[int, float]]) -> Union[int, float]:
+        if provided_value is not None and (
+            self.max and provided_value > self.max or self.min and provided_value < self.min
+        ):
             raise ValueError(
                 f"Provided '{self.name}={provided_value}' is not valid, only values between {self.min} and {self.max} are allowed."
             )
+        return provided_value
 
     @property
     def _pydantic_field_with_validator(

--- a/src/argilla/client/feedback/schemas/metadata.py
+++ b/src/argilla/client/feedback/schemas/metadata.py
@@ -124,7 +124,10 @@ class TermsMetadataProperty(MetadataPropertySchema):
 
     @property
     def server_settings(self) -> Dict[str, Any]:
-        return {"type": self.type, "values": self.values}
+        settings: Dict[str, Any] = {"type": self.type.value}
+        if self.values is not None:
+            settings["values"] = self.values
+        return settings
 
     def _all_values_exist(self, introduced_value: Optional[str] = None) -> str:
         if introduced_value is not None and self.values is not None and introduced_value not in self.values:

--- a/src/argilla/client/feedback/schemas/metadata.py
+++ b/src/argilla/client/feedback/schemas/metadata.py
@@ -107,13 +107,19 @@ class TermsMetadataProperty(MetadataPropertySchema):
     """
 
     type: MetadataPropertyTypes = MetadataPropertyTypes.terms
-    values: Optional[List[str]] = Field(None, min_items=TERMS_METADATA_PROPERTY_MIN_VALUES)
+    values: Optional[List[str]] = None
 
     @validator("values")
-    def check_values(cls, terms_values: List[str], values: Dict[str, Any]) -> List[str]:
-        if len(set(terms_values)) != len(terms_values):
-            name = values.get("name")
-            raise ValueError(f"`TermsMetadataProperty` with name={name} cannot have repeated `values`")
+    def check_values(cls, terms_values: Union[List[str], None], values: Dict[str, Any]) -> List[str]:
+        if terms_values is not None:
+            if len(terms_values) < TERMS_METADATA_PROPERTY_MIN_VALUES:
+                raise ValueError(
+                    f"`TermsMetadataProperty` with name={values.get('name')} must have at least {TERMS_METADATA_PROPERTY_MIN_VALUES} `values`"
+                )
+            if len(set(terms_values)) != len(terms_values):
+                raise ValueError(
+                    f"`TermsMetadataProperty` with name={values.get('name')} cannot have repeated `values`"
+                )
         return terms_values
 
     @property
@@ -121,7 +127,7 @@ class TermsMetadataProperty(MetadataPropertySchema):
         return {"type": self.type, "values": self.values}
 
     def _all_values_exist(self, introduced_value: Optional[str] = None) -> str:
-        if introduced_value is not None and introduced_value not in self.values:
+        if introduced_value is not None and self.values is not None and introduced_value not in self.values:
             raise ValueError(
                 f"Provided '{self.name}={introduced_value}' is not valid, only values in {self.values} are allowed."
             )
@@ -219,8 +225,8 @@ class IntegerMetadataProperty(_NumericMetadataPropertySchema):
     """
 
     type: MetadataPropertyTypes = MetadataPropertyTypes.integer
-    min: int  # TODO: should be `Optional[int] = None`
-    max: int  # TODO: should be `Optional[int] = None`
+    min: Optional[int] = None
+    max: Optional[int] = None
 
 
 class FloatMetadataProperty(_NumericMetadataPropertySchema):
@@ -242,8 +248,8 @@ class FloatMetadataProperty(_NumericMetadataPropertySchema):
     """
 
     type: MetadataPropertyTypes = MetadataPropertyTypes.float
-    min: float  # TODO: should be `Optional[float] = None`
-    max: float  # TODO: should be `Optional[float] = None`
+    min: Optional[float] = None
+    max: Optional[float] = None
 
 
 class MetadataFilterSchema(BaseModel, ABC):

--- a/src/argilla/client/feedback/schemas/remote/metadata.py
+++ b/src/argilla/client/feedback/schemas/remote/metadata.py
@@ -42,7 +42,7 @@ class RemoteTermsMetadataProperty(TermsMetadataProperty, RemoteSchema):
             description=payload.description,
             # TODO: uncomment once API is ready
             # visible_for_annotators=payload.visible_for_annotators,
-            values=payload.settings.get("values"),
+            values=payload.settings.get("values", None),
         )
 
 
@@ -64,8 +64,8 @@ class RemoteIntegerMetadataProperty(IntegerMetadataProperty, RemoteSchema):
             description=payload.description,
             # TODO: uncomment once API is ready
             # visible_for_annotators=payload.visible_for_annotators,
-            min=payload.settings.get("min"),
-            max=payload.settings.get("max"),
+            min=payload.settings.get("min", None),
+            max=payload.settings.get("max", None),
         )
 
 
@@ -87,6 +87,6 @@ class RemoteFloatMetadataProperty(FloatMetadataProperty, RemoteSchema):
             description=payload.description,
             # TODO: uncomment once API is ready
             # visible_for_annotators=payload.visible_for_annotators,
-            min=payload.settings.get("min"),
-            max=payload.settings.get("max"),
+            min=payload.settings.get("min", None),
+            max=payload.settings.get("max", None),
         )

--- a/src/argilla/server/models/metadata_properties.py
+++ b/src/argilla/server/models/metadata_properties.py
@@ -41,10 +41,10 @@ class BaseMetadataPropertySettings(BaseModel, ABC):
 
 class TermsMetadataPropertySettings(BaseMetadataPropertySettings):
     type: Literal[MetadataPropertyType.terms]
-    values: List[str]
+    values: Optional[List[str]] = None
 
     def check_metadata(self, value: str) -> None:
-        if value not in self.values:
+        if self.values is not None and value not in self.values:
             raise ValueError(f"'{value}' is not an allowed term.")
 
 

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -449,7 +449,7 @@ class NumericMetadataProperty(GenericModel, Generic[NT]):
 
 class TermsMetadataPropertyCreate(BaseModel):
     type: Literal[MetadataPropertyType.terms]
-    values: List[str] = PydanticField(..., min_items=TERMS_METADATA_PROPERTY_MIN_VALUES)
+    values: Optional[List[str]] = PydanticField(None, min_items=TERMS_METADATA_PROPERTY_MIN_VALUES)
 
 
 class IntegerMetadataPropertyCreate(NumericMetadataProperty[int]):
@@ -483,7 +483,7 @@ class MetadataPropertyCreate(BaseModel):
 
 class TermsMetadataProperty(BaseModel):
     type: Literal[MetadataPropertyType.terms]
-    values: List[str]
+    values: Optional[List[str]] = None
 
 
 class IntegerMetadataProperty(BaseModel):

--- a/tests/unit/client/feedback/schemas/remote/test_metadata.py
+++ b/tests/unit/client/feedback/schemas/remote/test_metadata.py
@@ -1,0 +1,241 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from datetime import datetime
+from typing import Any, Dict
+from uuid import uuid4
+
+import pytest
+from argilla.client.feedback.schemas.enums import MetadataPropertyTypes
+from argilla.client.feedback.schemas.metadata import (
+    FloatMetadataProperty,
+    IntegerMetadataProperty,
+    TermsMetadataProperty,
+)
+from argilla.client.feedback.schemas.remote.metadata import (
+    RemoteFloatMetadataProperty,
+    RemoteIntegerMetadataProperty,
+    RemoteTermsMetadataProperty,
+)
+from argilla.client.sdk.v1.datasets.models import FeedbackMetadataPropertyModel
+
+
+@pytest.mark.parametrize(
+    "schema_kwargs, server_payload",
+    [
+        (
+            {"name": "a"},
+            {"name": "a", "description": None, "settings": {"type": "terms"}},
+        ),
+        (
+            {"name": "a", "description": "b"},
+            {"name": "a", "description": "b", "settings": {"type": "terms"}},
+        ),
+        (
+            {"name": "a", "values": ["a"]},
+            {"name": "a", "description": None, "settings": {"type": "terms", "values": ["a"]}},
+        ),
+        (
+            {"name": "a", "values": ["a", "b", "c"]},
+            {"name": "a", "description": None, "settings": {"type": "terms", "values": ["a", "b", "c"]}},
+        ),
+    ],
+)
+def test_remote_terms_metadata_property(schema_kwargs: Dict[str, Any], server_payload: Dict[str, Any]) -> None:
+    text_field = RemoteTermsMetadataProperty(**schema_kwargs)
+    assert text_field.type == MetadataPropertyTypes.terms
+    assert text_field.server_settings == server_payload["settings"]
+    assert text_field.to_server_payload() == server_payload
+
+    local_text_field = text_field.to_local()
+    assert isinstance(local_text_field, TermsMetadataProperty)
+    assert local_text_field.type == MetadataPropertyTypes.terms
+    assert local_text_field.server_settings == server_payload["settings"]
+    assert local_text_field.to_server_payload() == server_payload
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        FeedbackMetadataPropertyModel(
+            id=uuid4(),
+            name="a",
+            description="A",
+            settings={"type": "terms"},
+            inserted_at=datetime.now(),
+            updated_at=datetime.now(),
+        ),
+        FeedbackMetadataPropertyModel(
+            id=uuid4(),
+            name="b",
+            description=None,
+            settings={"type": "terms", "values": ["a", "b", "c"]},
+            inserted_at=datetime.now(),
+            updated_at=datetime.now(),
+        ),
+    ],
+)
+def test_remote_terms_metadata_property_from_api(payload: FeedbackMetadataPropertyModel) -> None:
+    text_field = RemoteTermsMetadataProperty.from_api(payload)
+    assert text_field.type == MetadataPropertyTypes.terms
+    assert text_field.server_settings == payload.settings
+    assert text_field.to_server_payload() == payload.dict(exclude={"id", "inserted_at", "updated_at"})
+
+
+@pytest.mark.parametrize(
+    "schema_kwargs, server_payload",
+    [
+        (
+            {"name": "a"},
+            {"name": "a", "description": None, "settings": {"type": "integer"}},
+        ),
+        (
+            {"name": "a", "description": "b"},
+            {"name": "a", "description": "b", "settings": {"type": "integer"}},
+        ),
+        (
+            {"name": "a", "min": 0},
+            {"name": "a", "description": None, "settings": {"type": "integer", "min": 0}},
+        ),
+        (
+            {"name": "a", "max": 10},
+            {"name": "a", "description": None, "settings": {"type": "integer", "max": 10}},
+        ),
+        (
+            {"name": "a", "min": 0, "max": 10},
+            {"name": "a", "description": None, "settings": {"type": "integer", "min": 0, "max": 10}},
+        ),
+    ],
+)
+def test_remote_integer_metadata_property(schema_kwargs: Dict[str, Any], server_payload: Dict[str, Any]) -> None:
+    text_field = RemoteIntegerMetadataProperty(**schema_kwargs)
+    assert text_field.type == MetadataPropertyTypes.integer
+    assert text_field.server_settings == server_payload["settings"]
+    assert text_field.to_server_payload() == server_payload
+
+    local_text_field = text_field.to_local()
+    assert isinstance(local_text_field, IntegerMetadataProperty)
+    assert local_text_field.type == MetadataPropertyTypes.integer
+    assert local_text_field.server_settings == server_payload["settings"]
+    assert local_text_field.to_server_payload() == server_payload
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        FeedbackMetadataPropertyModel(
+            id=uuid4(),
+            name="a",
+            description="A",
+            settings={"type": "integer"},
+            inserted_at=datetime.now(),
+            updated_at=datetime.now(),
+        ),
+        FeedbackMetadataPropertyModel(
+            id=uuid4(),
+            name="b",
+            description=None,
+            settings={"type": "integer", "min": 0},
+            inserted_at=datetime.now(),
+            updated_at=datetime.now(),
+        ),
+        FeedbackMetadataPropertyModel(
+            id=uuid4(),
+            name="c",
+            description=None,
+            settings={"type": "integer", "min": 0, "max": 10},
+            inserted_at=datetime.now(),
+            updated_at=datetime.now(),
+        ),
+    ],
+)
+def test_remote_integer_metadata_property_from_api(payload: FeedbackMetadataPropertyModel) -> None:
+    text_field = RemoteIntegerMetadataProperty.from_api(payload)
+    assert text_field.type == MetadataPropertyTypes.integer
+    assert text_field.server_settings == payload.settings
+    assert text_field.to_server_payload() == payload.dict(exclude={"id", "inserted_at", "updated_at"})
+
+
+@pytest.mark.parametrize(
+    "schema_kwargs, server_payload",
+    [
+        (
+            {"name": "a"},
+            {"name": "a", "description": None, "settings": {"type": "float"}},
+        ),
+        (
+            {"name": "a", "description": "b"},
+            {"name": "a", "description": "b", "settings": {"type": "float"}},
+        ),
+        (
+            {"name": "a", "min": 0.0},
+            {"name": "a", "description": None, "settings": {"type": "float", "min": 0.0}},
+        ),
+        (
+            {"name": "a", "max": 10.0},
+            {"name": "a", "description": None, "settings": {"type": "float", "max": 10.0}},
+        ),
+        (
+            {"name": "a", "min": 0.0, "max": 10.0},
+            {"name": "a", "description": None, "settings": {"type": "float", "min": 0.0, "max": 10.0}},
+        ),
+    ],
+)
+def test_remote_float_metadata_property(schema_kwargs: Dict[str, Any], server_payload: Dict[str, Any]) -> None:
+    text_field = RemoteFloatMetadataProperty(**schema_kwargs)
+    assert text_field.type == MetadataPropertyTypes.float
+    assert text_field.server_settings == server_payload["settings"]
+    assert text_field.to_server_payload() == server_payload
+
+    local_text_field = text_field.to_local()
+    assert isinstance(local_text_field, FloatMetadataProperty)
+    assert local_text_field.type == MetadataPropertyTypes.float
+    assert local_text_field.server_settings == server_payload["settings"]
+    assert local_text_field.to_server_payload() == server_payload
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        FeedbackMetadataPropertyModel(
+            id=uuid4(),
+            name="a",
+            description="A",
+            settings={"type": "float"},
+            inserted_at=datetime.now(),
+            updated_at=datetime.now(),
+        ),
+        FeedbackMetadataPropertyModel(
+            id=uuid4(),
+            name="b",
+            description=None,
+            settings={"type": "float", "min": 0.0},
+            inserted_at=datetime.now(),
+            updated_at=datetime.now(),
+        ),
+        FeedbackMetadataPropertyModel(
+            id=uuid4(),
+            name="c",
+            description=None,
+            settings={"type": "float", "min": 0.0, "max": 10.0},
+            inserted_at=datetime.now(),
+            updated_at=datetime.now(),
+        ),
+    ],
+)
+def test_remote_float_metadata_property_from_api(payload: FeedbackMetadataPropertyModel) -> None:
+    text_field = RemoteFloatMetadataProperty.from_api(payload)
+    assert text_field.type == MetadataPropertyTypes.float
+    assert text_field.server_settings == payload.settings
+    assert text_field.to_server_payload() == payload.dict(exclude={"id", "inserted_at", "updated_at"})

--- a/tests/unit/client/feedback/schemas/test_metadata.py
+++ b/tests/unit/client/feedback/schemas/test_metadata.py
@@ -31,6 +31,17 @@ from pydantic import ValidationError, create_model
     "schema_kwargs, server_payload, metadata_filter, metadata_property_to_validate",
     [
         (
+            {"name": "terms-metadata", "description": "b"},
+            {
+                "name": "terms-metadata",
+                "description": "b",
+                # "visible_for_annotators": True,
+                "settings": {"type": "terms", "values": None},
+            },
+            TermsMetadataFilter(name="terms-metadata", values=["a", "b", "c"]),
+            {"terms-metadata": "a"},
+        ),
+        (
             {"name": "terms-metadata", "description": "b", "values": ["a", "b", "c"]},
             {
                 "name": "terms-metadata",
@@ -83,7 +94,7 @@ def test_terms_metadata_property(
         (
             {"name": "terms-metadata-property", "values": []},
             ValidationError,
-            "1 validation error for TermsMetadataProperty\nvalues\n  ensure this value has at least 1 items",
+            "1 validation error for TermsMetadataProperty\nvalues\n  `TermsMetadataProperty` with name=terms-metadata-property must have at least 1 `values`",
         ),
         (
             {"name": "terms-metadata-property", "values": ["a", "a"]},
@@ -102,38 +113,43 @@ def test_terms_metadata_property_errors(
 @pytest.mark.parametrize(
     "schema_kwargs, server_payload, metadata_filter, metadata_property_to_validate",
     [
-        # TODO: uncomment this unit tests case once min and max are optional
-        # (
-        #     {"name": "a", "description": "b"},
-        #     {
-        #         "name": "a",
-        #         "description": "b",
-        #         # "visible_for_annotators": True,
-        #         "settings": {"type": "integer"},
-        #     },
-        # ),
-        # (
-        #     {
-        #         "name": "a",
-        #         # "visible_for_annotators": False,
-        #         "max": 5,
-        #     },
-        #     {
-        #         "name": "a",
-        #         "description": None,
-        #         # "visible_for_annotators": False,
-        #         "settings": {"type": "integer", "max": 5},
-        #     },
-        # ),
-        # (
-        #     {"name": "a", "min": 5},
-        #     {
-        #         "name": "a",
-        #         "description": None,
-        #         # "visible_for_annotators": True,
-        #         "settings": {"type": "integer", "min": 5},
-        #     },
-        # ),
+        (
+            {"name": "int-metadata", "description": "b"},
+            {
+                "name": "int-metadata",
+                "description": "b",
+                # "visible_for_annotators": True,
+                "settings": {"type": "integer"},
+            },
+            IntegerMetadataFilter(name="int-metadata", le=10, ge=5),
+            {"int-metadata": 7},
+        ),
+        (
+            {
+                "name": "int-metadata",
+                # "visible_for_annotators": False,
+                "max": 5,
+            },
+            {
+                "name": "int-metadata",
+                "description": None,
+                # "visible_for_annotators": False,
+                "settings": {"type": "integer", "max": 5},
+            },
+            IntegerMetadataFilter(name="int-metadata", le=5, ge=0),
+            {"int-metadata": 3},
+        ),
+        (
+            {"name": "int-metadata", "min": 5},
+            {
+                "name": "int-metadata",
+                "description": None,
+                # "visible_for_annotators": True,
+                "settings": {"type": "integer", "min": 5},
+            },
+            IntegerMetadataFilter(name="int-metadata", le=10, ge=5),
+            {"int-metadata": 7},
+        ),
         (
             {"name": "int-metadata", "min": 5, "max": 10},
             {
@@ -170,16 +186,6 @@ def test_integer_metadata_property(
     [
         ({"name": "a b"}, ValidationError, "name\n  string does not match regex"),
         (
-            {"name": "integer-metadata-property", "min": 5},
-            ValidationError,
-            "1 validation error for IntegerMetadataProperty\nmax\n  field required",
-        ),
-        (
-            {"name": "integer-metadata-property", "max": 5},
-            ValidationError,
-            "1 validation error for IntegerMetadataProperty\nmin\n  field required",
-        ),
-        (
             {"name": "int-metadata-property", "min": 5, "max": 5},
             ValidationError,
             "1 validation error for IntegerMetadataProperty\n__root__\n  `IntegerMetadataProperty` with name=int-metadata-property cannot have `max` less or equal than `min`",
@@ -201,38 +207,43 @@ def test_integer_metadata_property_errors(
 @pytest.mark.parametrize(
     "schema_kwargs, server_payload, metadata_filter, metadata_property_to_validate",
     [
-        # TODO: uncomment this unit tests case once min and max are optional
-        # (
-        #     {"name": "a", "description": "b"},
-        #     {
-        #         "name": "a",
-        #         "description": "b",
-        #         # "visible_for_annotators": True,
-        #         "settings": {"type": "float"},
-        #     },
-        # ),
-        # (
-        #     {
-        #         "name": "a",
-        #         # "visible_for_annotators": False,
-        #         "max": 5.0,
-        #     },
-        #     {
-        #         "name": "a",
-        #         "description": None,
-        #         # "visible_for_annotators": False,
-        #         "settings": {"type": "float", "max": 5.0},
-        #     },
-        # ),
-        # (
-        #     {"name": "a", "min": 5.0},
-        #     {
-        #         "name": "a",
-        #         "description": None,
-        #         # "visible_for_annotators": True,
-        #         "settings": {"type": "float", "min": 5.0},
-        #     },
-        # ),
+        (
+            {"name": "float-metadata", "description": "b"},
+            {
+                "name": "float-metadata",
+                "description": "b",
+                # "visible_for_annotators": True,
+                "settings": {"type": "float"},
+            },
+            FloatMetadataFilter(name="float-metadata", le=10.0, ge=5.0),
+            {"float-metadata": 7.5},
+        ),
+        (
+            {
+                "name": "float-metadata",
+                # "visible_for_annotators": False,
+                "max": 5.0,
+            },
+            {
+                "name": "float-metadata",
+                "description": None,
+                # "visible_for_annotators": False,
+                "settings": {"type": "float", "max": 5.0},
+            },
+            FloatMetadataFilter(name="float-metadata", le=5.0, ge=0.0),
+            {"float-metadata": 2.5},
+        ),
+        (
+            {"name": "float-metadata", "min": 5.0},
+            {
+                "name": "float-metadata",
+                "description": None,
+                # "visible_for_annotators": True,
+                "settings": {"type": "float", "min": 5.0},
+            },
+            FloatMetadataFilter(name="float-metadata", le=10.0, ge=5.0),
+            {"float-metadata": 7.5},
+        ),
         (
             {"name": "float-metadata", "min": 5.0, "max": 10.0},
             {
@@ -268,16 +279,6 @@ def test_float_metadata_property(
     "schema_kwargs, exception_cls, exception_message",
     [
         ({"name": "a b"}, ValidationError, "name\n  string does not match regex"),
-        (
-            {"name": "float-metadata-property", "min": 5.0},
-            ValidationError,
-            "1 validation error for FloatMetadataProperty\nmax\n  field required",
-        ),
-        (
-            {"name": "float-metadata-property", "max": 5.0},
-            ValidationError,
-            "1 validation error for FloatMetadataProperty\nmin\n  field required",
-        ),
         (
             {"name": "float-metadata-property", "min": 5.0, "max": 5.0},
             ValidationError,

--- a/tests/unit/client/feedback/schemas/test_metadata.py
+++ b/tests/unit/client/feedback/schemas/test_metadata.py
@@ -36,7 +36,7 @@ from pydantic import ValidationError, create_model
                 "name": "terms-metadata",
                 "description": "b",
                 # "visible_for_annotators": True,
-                "settings": {"type": "terms", "values": None},
+                "settings": {"type": "terms"},
             },
             TermsMetadataFilter(name="terms-metadata", values=["a", "b", "c"]),
             {"terms-metadata": "a"},

--- a/tests/unit/client/feedback/test_utils.py
+++ b/tests/unit/client/feedback/test_utils.py
@@ -154,7 +154,6 @@ def test_generate_pydantic_schema_for_remote_metadata(
     assert RemoteMetadataSchema(**validation_data).dict() == validation_data
 
 
-
 @pytest.mark.parametrize(
     "metadata_properties, validation_data, ExceptionCls, exception_msg",
     [

--- a/tests/unit/client/feedback/test_utils.py
+++ b/tests/unit/client/feedback/test_utils.py
@@ -155,7 +155,7 @@ def test_generate_pydantic_schema_for_remote_metadata(
 
 
 @pytest.mark.parametrize(
-    "metadata_properties, validation_data, ExceptionCls, exception_msg",
+    "metadata_properties, validation_data, exception_cls, exception_msg",
     [
         (
             [RemoteTermsMetadataProperty(name="terms-metadata", values=["a", "b", "c"])],
@@ -198,11 +198,11 @@ def test_generate_pydantic_schema_for_remote_metadata(
 def test_generate_pydantic_schema_for_remote_metadata_errors(
     metadata_properties: List["AllowedRemoteMetadataPropertyTypes"],
     validation_data: Dict[str, Union[str, int, float]],
-    ExceptionCls: Type[Exception],
+    exception_cls: Type[Exception],
     exception_msg: str,
 ) -> None:
     RemoteMetadataSchema = generate_pydantic_schema_for_metadata(
         metadata_properties=metadata_properties, name="RemoteMetadataSchema"
     )
-    with pytest.raises(ExceptionCls, match=exception_msg):
+    with pytest.raises(exception_cls, match=exception_msg):
         RemoteMetadataSchema(**validation_data)

--- a/tests/unit/client/feedback/test_utils.py
+++ b/tests/unit/client/feedback/test_utils.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import TYPE_CHECKING, Dict, List, Union
+from typing import TYPE_CHECKING, Dict, List, Type, Union
 
 import pytest
 from argilla.client.feedback.schemas.metadata import (
@@ -151,11 +151,12 @@ def test_generate_pydantic_schema_for_remote_metadata(
     RemoteMetadataSchema = generate_pydantic_schema_for_metadata(
         metadata_properties=metadata_properties, name="RemoteMetadataSchema"
     )
-    assert RemoteMetadataSchema(**validation_data)
+    assert RemoteMetadataSchema(**validation_data).dict() == validation_data
+
 
 
 @pytest.mark.parametrize(
-    "metadata_properties, validation_data, exception_cls, exception_msg",
+    "metadata_properties, validation_data, ExceptionCls, exception_msg",
     [
         (
             [RemoteTermsMetadataProperty(name="terms-metadata", values=["a", "b", "c"])],
@@ -198,11 +199,11 @@ def test_generate_pydantic_schema_for_remote_metadata(
 def test_generate_pydantic_schema_for_remote_metadata_errors(
     metadata_properties: List["AllowedRemoteMetadataPropertyTypes"],
     validation_data: Dict[str, Union[str, int, float]],
-    exception_cls: Exception,
+    ExceptionCls: Type[Exception],
     exception_msg: str,
 ) -> None:
     RemoteMetadataSchema = generate_pydantic_schema_for_metadata(
         metadata_properties=metadata_properties, name="RemoteMetadataSchema"
     )
-    with pytest.raises(exception_cls, match=exception_msg):
+    with pytest.raises(ExceptionCls, match=exception_msg):
         RemoteMetadataSchema(**validation_data)

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -2667,14 +2667,17 @@ class TestSuiteDatasets:
     @pytest.mark.parametrize(
         ("settings", "expected_settings"),
         [
+            ({"type": "terms"}, {"type": "terms", "values": None}),
             ({"type": "terms", "values": ["a"]}, {"type": "terms", "values": ["a"]}),
             (
                 {"type": "terms", "values": ["a", "b", "c", "d", "e"]},
                 {"type": "terms", "values": ["a", "b", "c", "d", "e"]},
             ),
+            ({"type": "integer"}, {"type": "integer", "min": None, "max": None}),
             ({"type": "integer", "min": 2}, {"type": "integer", "min": 2, "max": None}),
             ({"type": "integer", "max": 10}, {"type": "integer", "min": None, "max": 10}),
             ({"type": "integer", "min": 2, "max": 10}, {"type": "integer", "min": 2, "max": 10}),
+            ({"type": "float"}, {"type": "float", "min": None, "max": None}),
             ({"type": "float", "min": 2}, {"type": "float", "min": 2, "max": None}),
             ({"type": "float", "max": 10}, {"type": "float", "min": None, "max": 10}),
             ({"type": "float", "min": 2, "max": 10}, {"type": "float", "min": 2, "max": 10}),

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -3346,6 +3346,7 @@ class TestSuiteDatasets:
         "MetadataPropertyFactoryType, settings, value",
         [
             (TermsMetadataPropertyFactory, {"values": ["a", "b", "c"]}, "c"),
+            (TermsMetadataPropertyFactory, {"values": None}, "c"),
             (IntegerMetadataPropertyFactory, {"min": 0, "max": 10}, 5),
             (FloatMetadataPropertyFactory, {"min": 0.0, "max": 1}, 0.5),
             (FloatMetadataPropertyFactory, {"min": 0.3, "max": 0.5}, 0.35),


### PR DESCRIPTION
# Description

This PR introduces the possibility to define `metadata_properties` without `settings` i.e. without a specific values or range of values to validate.

This PR affects both the API and the Python client.

**Type of change**

- [X] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [X] Add unit tests for `Remote{Terms,Integer,Float}MetadataProperty` to ensure that `None` (optional) values are handled properly
- [X] Add unit tests for `{Terms,Integer,Float}MetadataProperty` to ensure that `None` (optional) values are handled properly
- [X] Add unit tests for the API to ensure that `None` (optional) values are handled properly

**Checklist**

- [ ] I added relevant documentation
- [X] I followed the style guidelines of this project
- [X] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [X] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)