### PR TITLE
Hotfix: Always set pretrained_model_name_or_path as string

### DIFF
--- a/src/argilla/training/transformers.py
+++ b/src/argilla/training/transformers.py
@@ -96,7 +96,9 @@ class ArgillaTransformersTrainer(ArgillaTrainerSkeleton):
             ).rename_column("float_label", "label")
 
         self.model_kwargs = {}
-        self.model_kwargs["pretrained_model_name_or_path"] = self._model
+        self.model_kwargs["pretrained_model_name_or_path"] = (
+            self._model if isinstance(self._model, str) else self._model.config._name_or_path
+        )
 
         if self._record_class in [TextClassificationRecord, TokenClassificationRecord]:
             self.model_kwargs["num_labels"] = len(self._label_list)


### PR DESCRIPTION
Hello!

# Argilla Community Growers

Ever since #3751, `model` can also be an already initialized model. This edge case was being missed before. This should help with the test failures on #3911.

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

`pytest .\tests\integration\client\feedback\training\test_trainer.py::test_argilla_trainer_text_classification_with_model_tokenizer`

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

---

- Tom Aarsen