### PR TITLE
feat: update `FilteredRemoteFeedbackRecords.__len__` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ These are the section headers that we use:
 - Updated active learning for text classification notebooks to use the most recent small-text version ([#3831](https://github.com/argilla-io/argilla/pull/3831)).
 - Changed argilla dataset name in the active learning for text classification notebooks to be consistent with the default names in the huggingface spaces ([#3831](https://github.com/argilla-io/argilla/pull/3831)).
 - Updated `GET /api/v1/datasets/{dataset_id}/records`, `GET /api/v1/me/datasets/{dataset_id}/records` and `POST /api/v1/me/datasets/{dataset_id}/records/search` endpoints to return the `total` number of records ([#3848](https://github.com/argilla-io/argilla/pull/3848) & [#3903](https://github.com/argilla-io/argilla/pull/3903)).
+- Updated `FilteredRemoteFeedbackRecords.__len__` method to return the number of records matching the provided filters ([#3916](https://github.com/argilla-io/argilla/pull/3916)).
 
 ### Fixed
 

--- a/src/argilla/client/feedback/dataset/remote/filtered.py
+++ b/src/argilla/client/feedback/dataset/remote/filtered.py
@@ -53,14 +53,8 @@ class FilteredRemoteFeedbackRecords(RemoteFeedbackRecordsBase):
             [metadata_filter.query_string for metadata_filter in metadata_filters] if metadata_filters else None
         )
 
-    def __len__(self) -> None:
-        # TODO: Replace with API call once ready!
-        raise NotImplementedError(
-            "The `records` of a filtered dataset in Argilla are being lazily loaded"
-            " and len computation may add undesirable extra computation. You can fetch"
-            "records using\n`ds.pull()`\nor iterate over results to know the length of the result:\n"
-            "`records = [r for r in ds.records]\n",
-        )
+    def __len__(self) -> int:
+        return self._fetch_records(offset=0, limit=0).total
 
     def _fetch_records(self, offset: int, limit: int) -> "FeedbackRecordsModel":
         """Fetches a batch of records from Argilla."""

--- a/src/argilla/client/sdk/v1/datasets/models.py
+++ b/src/argilla/client/sdk/v1/datasets/models.py
@@ -84,6 +84,7 @@ class FeedbackItemModel(BaseModel):
 
 class FeedbackRecordsModel(BaseModel):
     items: List[FeedbackItemModel]
+    total: int
 
 
 class FeedbackFieldModel(BaseModel):


### PR DESCRIPTION
# Description

This PR updates the `__len__` method of the `FilteredRemoteFeedbackRecords` to return the real number of records matching the filters. To do so, we're not using any special endpoint but the list dataset records with `offset=0` and `limit=0`.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

In a local development environment:

```python
import random
import argilla as rg

dataset = rg.FeedbackDataset(
    fields=[
        rg.TextField(name="text")
    ],
    questions=[
        rg.TextQuestion(name="question", required=True)
    ],
    metadata_properties=[
        rg.TermsMetadataProperty(name="letters", values=["a", "b", "c"])
    ]
)

records = [rg.FeedbackRecord(
        fields={"text": "Hello world!" * random.randint(5, 50)},
        responses=[{"values": {"question": {"value": "Hello world!" * random.randint(5, 50)}}}],
        metadata={"letters": random.choice(["a", "b", "c"])}
    ) for _ in range(100000)]

dataset.add_records(records)
remote_dataset = dataset.push_to_argilla(name="random-dataset-2", workspace="gabriel")
filtered_dataset = remote_dataset.filter_by(metadata_filters=[rg.TermsMetadataFilter(name="letters", values=["a"])])
len(filtered_dataset) # ~= 33000
```

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
