### PR TITLE
docs: include inherited methods for `FeedbackDataset` class

### DIFF
--- a/docs/_source/reference/python/python_client.rst
+++ b/docs/_source/reference/python/python_client.rst
@@ -43,14 +43,16 @@ FeedbackDataset
 
 .. automodule:: argilla.client.feedback.dataset.local
    :members: FeedbackDataset
+   :inherited-members:
 
 .. automodule:: argilla.client.feedback.dataset.remote.dataset
    :members: RemoteFeedbackDataset, RemoteFeedbackRecords
+   :inherited-members:
 
 .. automodule:: argilla.client.feedback.dataset.mixins
-   :members: ArgillaToFromMixin
+   :members: ArgillaMixin, UnificationMixin
 
-.. automodule:: argilla.client.feedback.dataset.integrations.huggingface
+.. automodule:: argilla.client.feedback.integrations.huggingface
    :members: HuggingFaceDatasetMixin
 
 .. automodule:: argilla.client.feedback.schemas.questions
@@ -63,4 +65,4 @@ FeedbackDataset
    :members: FeedbackRecord, RemoteFeedbackRecord, ResponseSchema, SuggestionSchema, ValueSchema, RankingValueSchema
 
 .. automodule:: argilla.client.feedback.config
-   :members: FeedbackDatasetConfig
+   :members: DatasetConfig


### PR DESCRIPTION
# Description

This PR updates the Autodoc config of the Python client reference so the inherited methods (like `list`) in the `FeedbackDataset` class are also included in the docs.

Apart from that, this PR includes the fixes made by @tomaarsen that were shared in https://github.com/argilla-io/argilla/issues/3917

**Type of change**

- [x] Documentation update

**How Has This Been Tested**

- [x] `sphinx-autobuild` (read [Developer Documentation](https://docs.argilla.io/en/latest/community/developer_docs.html#building-the-documentation) for more details)

**Checklist**

- [x] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
