### PR TITLE
fix: make `values` in `{Remote}ResponseSchema` optional when `status=discarded`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ These are the section headers that we use:
 
 - Updated active learning for text classification notebooks to pass ids of type int to `TextClassificationRecord` ([#3831](https://github.com/argilla-io/argilla/pull/3831)).
 - Fixed record fields validation that was preventing from logging records with optional fields (i.e. `required=True`) when the field value was `None` ([#3846](https://github.com/argilla-io/argilla/pull/3846)).
+- Fixed response schemas to allow `values` to be `None` i.e. when a record is discarded the `response.values` are set to `None` ([#3926](https://github.com/argilla-io/argilla/pull/3926)).
 
 ### Fixed
 

--- a/src/argilla/client/feedback/schemas/records.py
+++ b/src/argilla/client/feedback/schemas/records.py
@@ -72,7 +72,7 @@ class ResponseSchema(BaseModel):
     """
 
     user_id: Optional[UUID] = None
-    values: Dict[str, ValueSchema]
+    values: Union[Dict[str, ValueSchema], None]
     status: ResponseStatus = ResponseStatus.submitted
 
     class Config:

--- a/src/argilla/client/feedback/schemas/records.py
+++ b/src/argilla/client/feedback/schemas/records.py
@@ -94,7 +94,9 @@ class ResponseSchema(BaseModel):
         to create a `ResponseSchema` for a `FeedbackRecord`."""
         return {
             "user_id": self.user_id,
-            "values": {question_name: value.dict() for question_name, value in self.values.items()},
+            "values": {question_name: value.dict() for question_name, value in self.values.items()}
+            if self.values is not None
+            else None,
             "status": self.status.value if hasattr(self.status, "value") else self.status,
         }
 

--- a/src/argilla/client/sdk/v1/datasets/models.py
+++ b/src/argilla/client/sdk/v1/datasets/models.py
@@ -55,7 +55,7 @@ class FeedbackResponseStatusFilter(str, Enum):
 
 class FeedbackResponseModel(BaseModel):
     id: UUID
-    values: Dict[str, FeedbackValueModel]
+    values: Union[Dict[str, FeedbackValueModel], None]
     status: FeedbackResponseStatus
     user_id: UUID
     inserted_at: datetime

--- a/tests/unit/client/feedback/schemas/remote/test_records.py
+++ b/tests/unit/client/feedback/schemas/remote/test_records.py
@@ -157,6 +157,20 @@ def test_remote_suggestion_schema_from_api(payload: FeedbackSuggestionModel) -> 
                 "status": "draft",
             },
         ),
+        (
+            {
+                "user_id": UUID("00000000-0000-0000-0000-000000000000"),
+                "values": None,
+                "status": "discarded",
+                "inserted_at": datetime.now(),
+                "updated_at": datetime.now(),
+            },
+            {
+                "user_id": UUID("00000000-0000-0000-0000-000000000000"),
+                "values": None,
+                "status": "discarded",
+            },
+        ),
     ],
 )
 def test_remote_response_schema(schema_kwargs: Dict[str, Any], server_payload: Dict[str, Any]) -> None:

--- a/tests/unit/client/feedback/schemas/test_records.py
+++ b/tests/unit/client/feedback/schemas/test_records.py
@@ -198,7 +198,7 @@ def test_ranking_value_schema_errors(
         },
         {"values": {"question-1": {"value": 1}}},
         {"values": {"question-1": {"value": "This is a value"}}, "status": "submitted"},
-        {"values": {"question-1": {"value": ["This is a value"]}}, "status": "discarded"},
+        {"values": None, "status": "discarded"},
     ],
 )
 def test_response_schema(schema_kwargs: Dict[str, Any]) -> None:


### PR DESCRIPTION
# Description

This PR addresses an issue with the `values` field for each `response` in a `FeedbackRecord`, since it can be `None` if the record is discarded, which was not being properly handled before. 

**Type of change**

- [X] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

- [X] Add unit tests for both `ResponseSchema` and `RemoteResponseSchema`

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)