### PR TITLE
feat: Increase the default `max_result_window` for es search engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@ These are the section headers that we use:
 - Increase the default max result window for Elasticsearch created for Feedback datasets ([#3929](https://github.com/argilla-io/argilla/pull/)).
 - Force elastic index refresh after records creation ([#3929](https://github.com/argilla-io/argilla/pull/)).
 
-
 ### Fixed
 
 - Updated active learning for text classification notebooks to pass ids of type int to `TextClassificationRecord` ([#3831](https://github.com/argilla-io/argilla/pull/3831)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ These are the section headers that we use:
 - Changed argilla dataset name in the active learning for text classification notebooks to be consistent with the default names in the huggingface spaces ([#3831](https://github.com/argilla-io/argilla/pull/3831)).
 - Updated `GET /api/v1/datasets/{dataset_id}/records`, `GET /api/v1/me/datasets/{dataset_id}/records` and `POST /api/v1/me/datasets/{dataset_id}/records/search` endpoints to return the `total` number of records ([#3848](https://github.com/argilla-io/argilla/pull/3848) & [#3903](https://github.com/argilla-io/argilla/pull/3903)).
 - Updated `FilteredRemoteFeedbackRecords.__len__` method to return the number of records matching the provided filters ([#3916](https://github.com/argilla-io/argilla/pull/3916)).
+- Increase the default max result window for Elasticsearch created for Feedback datasets ([#3929](https://github.com/argilla-io/argilla/pull/)).
+- Force elastic index refresh after records creation ([#3929](https://github.com/argilla-io/argilla/pull/)).
+
 
 ### Fixed
 

--- a/src/argilla/server/search_engine/commons.py
+++ b/src/argilla/server/search_engine/commons.py
@@ -531,5 +531,5 @@ class BaseElasticAndOpenSearchEngine(SearchEngine):
         pass
 
     @abstractmethod
-    def _refresh_index_request(self, index_name:str):
+    def _refresh_index_request(self, index_name: str):
         pass

--- a/src/argilla/server/search_engine/commons.py
+++ b/src/argilla/server/search_engine/commons.py
@@ -151,11 +151,13 @@ class BaseElasticAndOpenSearchEngine(SearchEngine):
     The rest of the code will be shared by both implementation
     """
 
-    es_number_of_shards: int
-    es_number_of_replicas: int
+    number_of_shards: int
+    number_of_replicas: int
 
     # See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-settings.html#search-settings-max-buckets
     max_terms_size: int = 2 ^ 14
+    # See https://www.elastic.co/guide/en/elasticsearch/reference/5.1/index-modules.html#dynamic-index-settings
+    max_result_window: int = 500000
 
     async def create_index(self, dataset: Dataset):
         settings = self._configure_index_settings()
@@ -190,6 +192,7 @@ class BaseElasticAndOpenSearchEngine(SearchEngine):
         ]
 
         await self._bulk_op_request(bulk_actions)
+        await self._refresh_index_request(index_name)
 
     async def update_record_response(self, response: Response):
         record = response.record
@@ -525,4 +528,8 @@ class BaseElasticAndOpenSearchEngine(SearchEngine):
     @abstractmethod
     async def _bulk_op_request(self, actions: List[Dict[str, Any]]):
         """Executes request for bulk operations"""
+        pass
+
+    @abstractmethod
+    def _refresh_index_request(self, index_name:str):
         pass

--- a/src/argilla/server/search_engine/elasticsearch.py
+++ b/src/argilla/server/search_engine/elasticsearch.py
@@ -51,8 +51,8 @@ class ElasticSearchEngine(BaseElasticAndOpenSearchEngine):
         )
         return cls(
             config=config,
-            es_number_of_shards=settings.es_records_index_shards,
-            es_number_of_replicas=settings.es_records_index_replicas,
+            number_of_shards=settings.es_records_index_shards,
+            number_of_replicas=settings.es_records_index_replicas,
         )
 
     async def close(self):
@@ -60,8 +60,9 @@ class ElasticSearchEngine(BaseElasticAndOpenSearchEngine):
 
     def _configure_index_settings(self) -> Dict[str, Any]:
         return {
-            "number_of_shards": self.es_number_of_shards,
-            "number_of_replicas": self.es_number_of_replicas,
+            "max_result_window": self.max_result_window,
+            "number_of_shards": self.number_of_shards,
+            "number_of_replicas": self.number_of_replicas,
         }
 
     async def _create_index_request(self, index_name: str, mappings: dict, settings: dict) -> None:
@@ -103,3 +104,6 @@ class ElasticSearchEngine(BaseElasticAndOpenSearchEngine):
         _, errors = await helpers.async_bulk(client=self.client, actions=actions, raise_on_error=False)
         if errors:
             raise RuntimeError(errors)
+
+    async def _refresh_index_request(self, index_name: str):
+        await self.client.indices.refresh(index_name)

--- a/src/argilla/server/search_engine/opensearch.py
+++ b/src/argilla/server/search_engine/opensearch.py
@@ -41,8 +41,8 @@ class OpenSearchEngine(BaseElasticAndOpenSearchEngine):
         )
         return cls(
             config=config,
-            es_number_of_shards=settings.es_records_index_shards,
-            es_number_of_replicas=settings.es_records_index_replicas,
+            number_of_shards=settings.es_records_index_shards,
+            number_of_replicas=settings.es_records_index_replicas,
         )
 
     async def close(self):
@@ -50,8 +50,9 @@ class OpenSearchEngine(BaseElasticAndOpenSearchEngine):
 
     def _configure_index_settings(self):
         return {
-            "number_of_shards": self.es_number_of_shards,
-            "number_of_replicas": self.es_number_of_replicas,
+            "max_result_window": self.max_result_window,
+            "number_of_shards": self.number_of_shards,
+            "number_of_replicas": self.number_of_replicas,
         }
 
     async def _create_index_request(self, index_name: str, mappings: dict, settings: dict) -> None:
@@ -96,3 +97,6 @@ class OpenSearchEngine(BaseElasticAndOpenSearchEngine):
         _, errors = await helpers.async_bulk(client=self.client, actions=actions, raise_on_error=False)
         if errors:
             raise RuntimeError(errors)
+
+    async def _refresh_index_request(self, index_name: str):
+        await self.client.indices.refresh(index=index_name)

--- a/tests/unit/server/search_engine/test_elasticsearch_engine.py
+++ b/tests/unit/server/search_engine/test_elasticsearch_engine.py
@@ -187,7 +187,7 @@ async def test_banking_sentiment_dataset(elasticsearch_engine: ElasticSearchEngi
 
 @pytest_asyncio.fixture()
 async def elasticsearch_engine(elasticsearch_config: dict) -> AsyncGenerator[ElasticSearchEngine, None]:
-    engine = ElasticSearchEngine(config=elasticsearch_config, es_number_of_replicas=0, es_number_of_shards=1)
+    engine = ElasticSearchEngine(config=elasticsearch_config, number_of_replicas=0, number_of_shards=1)
     yield engine
 
     await engine.client.close()
@@ -232,8 +232,8 @@ class TestSuiteElasticSearchEngine:
                 "responses": {"dynamic": "true", "type": "object"},
             },
         }
-        assert index["settings"]["index"]["number_of_shards"] == str(elasticsearch_engine.es_number_of_shards)
-        assert index["settings"]["index"]["number_of_replicas"] == str(elasticsearch_engine.es_number_of_replicas)
+        assert index["settings"]["index"]["number_of_shards"] == str(elasticsearch_engine.number_of_shards)
+        assert index["settings"]["index"]["number_of_replicas"] == str(elasticsearch_engine.number_of_replicas)
 
     async def test_create_index_for_dataset_with_fields(
         self,

--- a/tests/unit/server/search_engine/test_opensearch_engine.py
+++ b/tests/unit/server/search_engine/test_opensearch_engine.py
@@ -213,7 +213,7 @@ async def test_banking_sentiment_dataset(opensearch_engine: OpenSearchEngine, op
 
 @pytest_asyncio.fixture()
 async def opensearch_engine(elasticsearch_config: dict) -> AsyncGenerator[OpenSearchEngine, None]:
-    engine = OpenSearchEngine(config=elasticsearch_config, es_number_of_replicas=0, es_number_of_shards=1)
+    engine = OpenSearchEngine(config=elasticsearch_config, number_of_replicas=0, number_of_shards=1)
     yield engine
 
     await engine.client.close()
@@ -267,8 +267,9 @@ class TestSuiteOpenSearchEngine:
                 "metadata": {"dynamic": "false", "type": "object"},
             },
         }
-        assert index["settings"]["index"]["number_of_shards"] == str(opensearch_engine.es_number_of_shards)
-        assert index["settings"]["index"]["number_of_replicas"] == str(opensearch_engine.es_number_of_replicas)
+        assert index["settings"]["index"]["max_result_window"] == str(opensearch_engine.max_result_window)
+        assert index["settings"]["index"]["number_of_shards"] == str(opensearch_engine.number_of_shards)
+        assert index["settings"]["index"]["number_of_replicas"] == str(opensearch_engine.number_of_replicas)
 
     async def test_create_index_for_dataset_with_fields(
         self,


### PR DESCRIPTION
# Description

This PR increases the `max_result_window` settings property for the created elasticsearch index in feedback datasets. This change mitigates possible error scanning data.

Also, the record addition forces an index to refresh to make records available after the creation


