### PR TITLE
chore: upgrade `setfit` and remove `huggingface_hub` restriction

### DIFF
--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -36,7 +36,7 @@ dependencies:
       # extra test dependencies
       - cleanlab~=2.0.0 # With this version, tests are failing
       - datasets>1.17.0,!= 2.3.2 # TODO: push_to_hub fails up to 2.3.2, check patches when they come out eventually
-      - huggingface_hub
+      - huggingface_hub>=0.5.0
       - flair>=0.12.2
       - faiss-cpu
       - flyingsquid
@@ -49,7 +49,7 @@ dependencies:
       - transformers[torch]>=4.30.0 # <- required for DPO with TRL
       - evaluate
       - seqeval
-      - setfit
+      - setfit>=0.7.0
       - span_marker
       - openai>=0.27.10
       - peft

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,8 +88,8 @@ integrations = [
     "cleanlab ~= 2.0.0",
     # TODO: `push_to_hub` fails up to 2.3.2, check patches when they come out eventually
     "datasets > 1.17.0,!= 2.3.2",
-    # TODO: some backward comp. problems introduced in 0.5.0. 0.13 does not match with setfit
-    "huggingface_hub >= 0.5.0,< 0.13",
+    # TODO: some backward comp. problems introduced in 0.5.0
+    "huggingface_hub >= 0.5.0",
     # Version 0.12 fixes a known installation issue related to `sentencepiece` and `tokenizers`, more at https://github.com/flairNLP/flair/issues/3129
     # Version 0.12.2 relaxes the `huggingface_hub` dependency
     "flair >= 0.12.2",
@@ -104,7 +104,7 @@ integrations = [
     "evaluate",
     "seqeval",
     "sentence-transformers",
-    "setfit",
+    "setfit>=0.7.0",
     "span_marker",
     "openai>=0.27.10",
     "peft",


### PR DESCRIPTION
# Description

This PR upgrades `setfit` to 0.7.0 or higher, as there was an incompatibility issue with `huggingface_hub` 0.12 or higher, which was preventing us to install the latest `huggingface_hub` version within the `integrations` extra requirements. So on, this PR akso removes the `huggingface_hub` restriction (while keeping the previous one `>=0.5.0` for backwards compatibility).

From now on, everyone should be able to `pip install argilla[integrations]` without a dependency version mismatch issue that was being triggered before due to the incompatibility of `datasets` and `huggingface_hub`, which was unrelated to `setfit`, but since the previous restriction on `huggingface_hub` was due to `setfit`, patching `setfit` fixes the rest of the issues.

**Type of change**

- [x] Dependency upgrade / fix (upgrades/downgrades/fixes a dependency related issue)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [x] Run `pip install -e ".[integrations]"` with a Python matrix from 3.8 to 3.11 and then running `pytest -s tests/integration` to re-run the integration tests to ensure that the fix does not affect any

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)