### PR TITLE
feat: add `pytest-env` dependency and set `ARGILLA_ENABLE_TELEMETRY=0`

### DIFF
--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -14,6 +14,7 @@ dependencies:
   - pytest-cov
   - pytest-mock
   - pytest-asyncio
+  - pytest-env
   - factory_boy~=3.2.1
   # docs, pandoc needs conda ...
   - pandoc==2.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ tests = [
     "pytest-cov",
     "pytest-mock",
     "pytest-asyncio",
+    "pytest-env",
     "factory_boy ~= 3.2.1",
 ]
 
@@ -142,7 +143,7 @@ log_format = "%(asctime)s %(name)s %(levelname)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"
 log_cli = "True"
 testpaths = ["tests"]
-env = ["ARGILLA_DATABASE_URL=sqlite+aiosqlite://$HOME/.argilla/test.db"]
+env = ["ARGILLA_ENABLE_TELEMETRY=0"]
 
 
 [tool.coverage.run]


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR adds the `pytest-env` dependency to the group of `tests` dependencies. `pytest-env` enables setting environment variables values for the tests.

In addition, the`pytest` configuration section in the `pyproject.toml` file has been updated to automatically set `ARGILLA_ENABLE_TELEMETRY=0`. 

Closes #3921

**Type of change**

- [x] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

N/A

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
