### PR TITLE
fix: create `inserted_at` and `update_at` attributes with proper precission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ These are the section headers that we use:
 
 - Updated active learning for text classification notebooks to pass ids of type int to `TextClassificationRecord` ([#3831](https://github.com/argilla-io/argilla/pull/3831)).
 - Fixed record fields validation that was preventing from logging records with optional fields (i.e. `required=True`) when the field value was `None` ([#3846](https://github.com/argilla-io/argilla/pull/3846)).
+- The `inserted_at` and `updated_at` attributes are create using the `utcnow` factory to avoid unexpected race conditions on timestamp creation ([#3945](https://github.com/argilla-io/argilla/pull/3945))
 
 ### Fixed
 

--- a/src/argilla/server/models/mixins.py
+++ b/src/argilla/server/models/mixins.py
@@ -160,7 +160,7 @@ class CRUDMixin:
 
 
 def _default_inserted_at(context: DefaultExecutionContext) -> datetime:
-    return context.get_current_parameters()["inserted_at"]
+    return context.get_current_parameters(isolate_multiinsert_groups=False)["inserted_at"]
 
 
 class TimestampMixin:

--- a/src/argilla/server/models/mixins.py
+++ b/src/argilla/server/models/mixins.py
@@ -20,6 +20,7 @@ from sqlalchemy import func, sql
 from sqlalchemy.dialects.mysql import insert as mysql_insert
 from sqlalchemy.dialects.postgresql import insert as postgres_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.engine.default import DefaultExecutionContext
 from sqlalchemy.orm import Mapped, mapped_column
 from typing_extensions import Self
 
@@ -158,6 +159,10 @@ class CRUDMixin:
         return self
 
 
+def _default_inserted_at(context: DefaultExecutionContext) -> datetime:
+    return context.get_current_parameters()["inserted_at"]
+
+
 class TimestampMixin:
-    inserted_at: Mapped[datetime] = mapped_column(default=func.now())
-    updated_at: Mapped[datetime] = mapped_column(default=func.now(), onupdate=func.now())
+    inserted_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(default=_default_inserted_at, onupdate=datetime.utcnow)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -213,8 +213,6 @@ class RecordFactory(BaseFactory):
     external_id = factory.Sequence(lambda n: f"external-id-{n}")
     dataset = factory.SubFactory(DatasetFactory)
 
-    inserted_at = factory.Sequence(lambda n: datetime.datetime.utcnow() + datetime.timedelta(seconds=n))
-
 
 class ResponseFactory(BaseFactory):
     class Meta:


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR forces `inserted_at` and `updated_at` attribute creation using the `datetime.utcnow` factory to avoid some unexpected scenarios with the `func.now()` SQLAlchemy function.

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

Locally tests with PostgreSQL and SQLite

**Checklist**

- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
