### PR TITLE
feat: add `title` and drop `description` from Python SDK

### DIFF
--- a/src/argilla/client/feedback/schemas/metadata.py
+++ b/src/argilla/client/feedback/schemas/metadata.py
@@ -66,6 +66,10 @@ class MetadataPropertySchema(BaseModel, ABC):
         extra = Extra.forbid
         exclude = {"type"}
 
+    @validator("title", always=True)
+    def title_must_have_value(cls, v: Optional[str], values: Dict[str, Any]) -> str:
+        return values.get("name") if not v else v
+
     @property
     @abstractmethod
     def server_settings(self) -> Dict[str, Any]:

--- a/src/argilla/client/feedback/schemas/metadata.py
+++ b/src/argilla/client/feedback/schemas/metadata.py
@@ -43,7 +43,8 @@ class MetadataPropertySchema(BaseModel, ABC):
 
     Args:
         name: The name of the metadata property.
-        title: A title of the metadata property (what's shown in the UI). Defaults to `None`.
+        title: A title of the metadata property (what's shown in the UI). Defaults to `None`,
+            which means that if not provided then the `name` will be used as the `title`.
         visible_for_annotators: Whether the metadata property should be visible for
             users with the `annotator` role. Defaults to `True`.
         type: The type of the metadata property. A value should be set for this
@@ -100,7 +101,8 @@ class TermsMetadataProperty(MetadataPropertySchema):
 
     Args:
         name: The name of the metadata property.
-        title: A title of the metadata property (what's shown in the UI). Defaults to `None`.
+        title: A title of the metadata property (what's shown in the UI). Defaults to `None`,
+            which means that if not provided then the `name` will be used as the `title`.
         visible_for_annotators: Whether the metadata property should be visible for
             users with the `annotator` role. Defaults to `True`.
         values: A list of possible values for the metadata property. It must contain
@@ -160,7 +162,8 @@ class _NumericMetadataPropertySchema(MetadataPropertySchema):
 
     Args:
         name: The name of the metadata property.
-        title: A title of the metadata property (what's shown in the UI). Defaults to `None`.
+        title: A title of the metadata property (what's shown in the UI). Defaults to `None`,
+            which means that if not provided then the `name` will be used as the `title`.
         visible_for_annotators: Whether the metadata property should be visible for
             users with the `annotator` role. Defaults to `True`.
         min: The lower bound of the numeric value. Must be provided and be lower than
@@ -244,7 +247,8 @@ class IntegerMetadataProperty(_NumericMetadataPropertySchema):
 
     Args:
         name: The name of the metadata property.
-        title: A title of the metadata property (what's shown in the UI). Defaults to `None`.
+        title: A title of the metadata property (what's shown in the UI). Defaults to `None`,
+            which means that if not provided then the `name` will be used as the `title`.
         visible_for_annotators: Whether the metadata property should be visible for
             users with the `annotator` role. Defaults to `True`.
         min: The lower bound of the integer value. Must be provided, and be lower than
@@ -269,7 +273,8 @@ class FloatMetadataProperty(_NumericMetadataPropertySchema):
 
     Args:
         name: The name of the metadata property.
-        title: A title of the metadata property (what's shown in the UI). Defaults to `None`.
+        title: A title of the metadata property (what's shown in the UI). Defaults to `None`,
+            which means that if not provided then the `name` will be used as the `title`.
         visible_for_annotators: Whether the metadata property should be visible for
             users with the `annotator` role. Defaults to `True`.
         min: The lower bound of the float value. Must be provided, and be lower than

--- a/src/argilla/client/feedback/schemas/metadata.py
+++ b/src/argilla/client/feedback/schemas/metadata.py
@@ -43,7 +43,7 @@ class MetadataPropertySchema(BaseModel, ABC):
 
     Args:
         name: The name of the metadata property.
-        description: A description of the metadata property. Defaults to `None`.
+        title: A title of the metadata property (what's shown in the UI). Defaults to `None`.
         visible_for_annotators: Whether the metadata property should be visible for
             users with the `annotator` role. Defaults to `True`.
         type: The type of the metadata property. A value should be set for this
@@ -57,7 +57,7 @@ class MetadataPropertySchema(BaseModel, ABC):
     """
 
     name: str = Field(..., regex=r"^(?=.*[a-z0-9])[a-z0-9_-]+$")
-    description: Optional[str] = None
+    title: Optional[str] = None
     visible_for_annotators: Optional[bool] = True
     type: MetadataPropertyTypes = Field(..., allow_mutation=False)
 
@@ -74,7 +74,7 @@ class MetadataPropertySchema(BaseModel, ABC):
     def to_server_payload(self) -> Dict[str, Any]:
         return {
             "name": self.name,
-            "description": self.description,
+            "title": self.title,
             "visible_for_annotators": self.visible_for_annotators,
             "settings": self.server_settings,
         }
@@ -96,7 +96,9 @@ class TermsMetadataProperty(MetadataPropertySchema):
 
     Args:
         name: The name of the metadata property.
-        description: A description of the metadata property. Defaults to `None`.
+        title: A title of the metadata property (what's shown in the UI). Defaults to `None`.
+        visible_for_annotators: Whether the metadata property should be visible for
+            users with the `annotator` role. Defaults to `True`.
         values: A list of possible values for the metadata property. It must contain
             at least one value.
 
@@ -154,7 +156,9 @@ class _NumericMetadataPropertySchema(MetadataPropertySchema):
 
     Args:
         name: The name of the metadata property.
-        description: A description of the metadata property. Defaults to `None`.
+        title: A title of the metadata property (what's shown in the UI). Defaults to `None`.
+        visible_for_annotators: Whether the metadata property should be visible for
+            users with the `annotator` role. Defaults to `True`.
         min: The lower bound of the numeric value. Must be provided and be lower than
             the `max` value.
         max: The upper bound of the numeric value. Must be provided and be greater
@@ -236,7 +240,9 @@ class IntegerMetadataProperty(_NumericMetadataPropertySchema):
 
     Args:
         name: The name of the metadata property.
-        description: A description of the metadata property. Defaults to `None`.
+        title: A title of the metadata property (what's shown in the UI). Defaults to `None`.
+        visible_for_annotators: Whether the metadata property should be visible for
+            users with the `annotator` role. Defaults to `True`.
         min: The lower bound of the integer value. Must be provided, and be lower than
             the `max` value.
         max: The upper bound of the integer value. Must be provided, and be greater than
@@ -259,7 +265,9 @@ class FloatMetadataProperty(_NumericMetadataPropertySchema):
 
     Args:
         name: The name of the metadata property.
-        description: A description of the metadata property. Defaults to `None`.
+        title: A title of the metadata property (what's shown in the UI). Defaults to `None`.
+        visible_for_annotators: Whether the metadata property should be visible for
+            users with the `annotator` role. Defaults to `True`.
         min: The lower bound of the float value. Must be provided, and be lower than
             the `max` value.
         max: The upper bound of the float value. Must be provided, and be greater than

--- a/src/argilla/client/feedback/schemas/remote/metadata.py
+++ b/src/argilla/client/feedback/schemas/remote/metadata.py
@@ -47,7 +47,7 @@ class RemoteTermsMetadataProperty(TermsMetadataProperty, _RemoteMetadataProperty
     def to_local(self) -> TermsMetadataProperty:
         return TermsMetadataProperty(
             name=self.name,
-            description=self.description,
+            title=self.title,
             visible_for_annotators=self.visible_for_annotators,
             values=self.values,
         )
@@ -60,7 +60,7 @@ class RemoteTermsMetadataProperty(TermsMetadataProperty, _RemoteMetadataProperty
             client=client,
             id=payload.id,
             name=payload.name,
-            description=payload.description,
+            title=payload.title,
             visible_for_annotators=payload.visible_for_annotators,
             values=payload.settings.get("values", None),
         )
@@ -70,7 +70,7 @@ class RemoteIntegerMetadataProperty(IntegerMetadataProperty, _RemoteMetadataProp
     def to_local(self) -> IntegerMetadataProperty:
         return IntegerMetadataProperty(
             name=self.name,
-            description=self.description,
+            title=self.title,
             visible_for_annotators=self.visible_for_annotators,
             min=self.min,
             max=self.max,
@@ -84,7 +84,7 @@ class RemoteIntegerMetadataProperty(IntegerMetadataProperty, _RemoteMetadataProp
             client=client,
             id=payload.id,
             name=payload.name,
-            description=payload.description,
+            title=payload.title,
             visible_for_annotators=payload.visible_for_annotators,
             min=payload.settings.get("min", None),
             max=payload.settings.get("max", None),
@@ -95,7 +95,7 @@ class RemoteFloatMetadataProperty(FloatMetadataProperty, _RemoteMetadataProperty
     def to_local(self) -> FloatMetadataProperty:
         return FloatMetadataProperty(
             name=self.name,
-            description=self.description,
+            title=self.title,
             visible_for_annotators=self.visible_for_annotators,
             min=self.min,
             max=self.max,
@@ -109,7 +109,7 @@ class RemoteFloatMetadataProperty(FloatMetadataProperty, _RemoteMetadataProperty
             client=client,
             id=payload.id,
             name=payload.name,
-            description=payload.description,
+            title=payload.title,
             visible_for_annotators=payload.visible_for_annotators,
             min=payload.settings.get("min", None),
             max=payload.settings.get("max", None),

--- a/src/argilla/client/sdk/v1/datasets/models.py
+++ b/src/argilla/client/sdk/v1/datasets/models.py
@@ -112,8 +112,8 @@ class FeedbackQuestionModel(BaseModel):
 class FeedbackMetadataPropertyModel(BaseModel):
     id: UUID
     name: str
-    title: Optional[str] = None
-    visible_for_annotators: Optional[bool] = True
+    title: str
+    visible_for_annotators: bool
     settings: Dict[str, Any]
     inserted_at: datetime
     updated_at: datetime

--- a/src/argilla/client/sdk/v1/datasets/models.py
+++ b/src/argilla/client/sdk/v1/datasets/models.py
@@ -112,7 +112,7 @@ class FeedbackQuestionModel(BaseModel):
 class FeedbackMetadataPropertyModel(BaseModel):
     id: UUID
     name: str
-    description: Optional[str] = None
+    title: Optional[str] = None
     visible_for_annotators: Optional[bool] = True
     settings: Dict[str, Any]
     inserted_at: datetime

--- a/tests/integration/client/sdk/v1/test_datasets.py
+++ b/tests/integration/client/sdk/v1/test_datasets.py
@@ -279,7 +279,7 @@ async def test_add_metadata_property(role: UserRole) -> None:
         id=dataset.id,
         metadata_property={
             "name": "test_metadata_property",
-            "description": "test_description",
+            "title": "test_metadata_property_title",
             "settings": {"type": "terms", "values": ["a", "b", "c"]},
         },
     )

--- a/tests/unit/client/feedback/schemas/remote/test_metadata.py
+++ b/tests/unit/client/feedback/schemas/remote/test_metadata.py
@@ -35,31 +35,46 @@ from argilla.client.sdk.v1.datasets.models import FeedbackMetadataPropertyModel
     "schema_kwargs, server_payload",
     [
         (
-            {"name": "a"},
-            {"name": "a", "title": None, "visible_for_annotators": True, "settings": {"type": "terms"}},
-        ),
-        (
-            {"name": "a", "title": "b"},
-            {"name": "a", "title": "b", "visible_for_annotators": True, "settings": {"type": "terms"}},
-        ),
-        (
-            {"name": "a", "visible_for_annotators": False},
-            {"name": "a", "title": None, "visible_for_annotators": False, "settings": {"type": "terms"}},
-        ),
-        (
-            {"name": "a", "values": ["a"]},
+            {"name": "terms-metadata"},
             {
-                "name": "a",
-                "title": None,
+                "name": "terms-metadata",
+                "title": "terms-metadata",
+                "visible_for_annotators": True,
+                "settings": {"type": "terms"},
+            },
+        ),
+        (
+            {"name": "terms-metadata", "title": "alt-title"},
+            {
+                "name": "terms-metadata",
+                "title": "alt-title",
+                "visible_for_annotators": True,
+                "settings": {"type": "terms"},
+            },
+        ),
+        (
+            {"name": "terms-metadata", "visible_for_annotators": False},
+            {
+                "name": "terms-metadata",
+                "title": "terms-metadata",
+                "visible_for_annotators": False,
+                "settings": {"type": "terms"},
+            },
+        ),
+        (
+            {"name": "terms-metadata", "values": ["a"]},
+            {
+                "name": "terms-metadata",
+                "title": "terms-metadata",
                 "visible_for_annotators": True,
                 "settings": {"type": "terms", "values": ["a"]},
             },
         ),
         (
-            {"name": "a", "values": ["a", "b", "c"]},
+            {"name": "terms-metadata", "values": ["a", "b", "c"]},
             {
-                "name": "a",
-                "title": None,
+                "name": "terms-metadata",
+                "title": "terms-metadata",
                 "visible_for_annotators": True,
                 "settings": {"type": "terms", "values": ["a", "b", "c"]},
             },
@@ -84,8 +99,8 @@ def test_remote_terms_metadata_property(schema_kwargs: Dict[str, Any], server_pa
     [
         FeedbackMetadataPropertyModel(
             id=uuid4(),
-            name="a",
-            title="A",
+            name="terms-metadata",
+            title="alt-title",
             visible_for_annotators=True,
             settings={"type": "terms"},
             inserted_at=datetime.now(),
@@ -93,8 +108,8 @@ def test_remote_terms_metadata_property(schema_kwargs: Dict[str, Any], server_pa
         ),
         FeedbackMetadataPropertyModel(
             id=uuid4(),
-            name="b",
-            title=None,
+            name="terms-metadata",
+            title="terms-metadata",
             visible_for_annotators=False,
             settings={"type": "terms", "values": ["a", "b", "c"]},
             inserted_at=datetime.now(),
@@ -113,40 +128,55 @@ def test_remote_terms_metadata_property_from_api(payload: FeedbackMetadataProper
     "schema_kwargs, server_payload",
     [
         (
-            {"name": "a"},
-            {"name": "a", "title": None, "visible_for_annotators": True, "settings": {"type": "integer"}},
-        ),
-        (
-            {"name": "a", "title": "b"},
-            {"name": "a", "title": "b", "visible_for_annotators": True, "settings": {"type": "integer"}},
-        ),
-        (
-            {"name": "a", "visible_for_annotators": False},
-            {"name": "a", "title": None, "visible_for_annotators": False, "settings": {"type": "integer"}},
-        ),
-        (
-            {"name": "a", "min": 0},
+            {"name": "int-metadata"},
             {
-                "name": "a",
-                "title": None,
+                "name": "int-metadata",
+                "title": "int-metadata",
+                "visible_for_annotators": True,
+                "settings": {"type": "integer"},
+            },
+        ),
+        (
+            {"name": "int-metadata", "title": "alt-title"},
+            {
+                "name": "int-metadata",
+                "title": "alt-title",
+                "visible_for_annotators": True,
+                "settings": {"type": "integer"},
+            },
+        ),
+        (
+            {"name": "int-metadata", "visible_for_annotators": False},
+            {
+                "name": "int-metadata",
+                "title": "int-metadata",
+                "visible_for_annotators": False,
+                "settings": {"type": "integer"},
+            },
+        ),
+        (
+            {"name": "int-metadata", "min": 0},
+            {
+                "name": "int-metadata",
+                "title": "int-metadata",
                 "visible_for_annotators": True,
                 "settings": {"type": "integer", "min": 0},
             },
         ),
         (
-            {"name": "a", "max": 10},
+            {"name": "int-metadata", "max": 10},
             {
-                "name": "a",
-                "title": None,
+                "name": "int-metadata",
+                "title": "int-metadata",
                 "visible_for_annotators": True,
                 "settings": {"type": "integer", "max": 10},
             },
         ),
         (
-            {"name": "a", "min": 0, "max": 10},
+            {"name": "int-metadata", "min": 0, "max": 10},
             {
-                "name": "a",
-                "title": None,
+                "name": "int-metadata",
+                "title": "int-metadata",
                 "visible_for_annotators": True,
                 "settings": {"type": "integer", "min": 0, "max": 10},
             },
@@ -171,8 +201,8 @@ def test_remote_integer_metadata_property(schema_kwargs: Dict[str, Any], server_
     [
         FeedbackMetadataPropertyModel(
             id=uuid4(),
-            name="a",
-            title="A",
+            name="int-metadata",
+            title="alt-title",
             visible_for_annotators=True,
             settings={"type": "integer"},
             inserted_at=datetime.now(),
@@ -180,8 +210,8 @@ def test_remote_integer_metadata_property(schema_kwargs: Dict[str, Any], server_
         ),
         FeedbackMetadataPropertyModel(
             id=uuid4(),
-            name="b",
-            title=None,
+            name="int-metadata",
+            title="int-metadata",
             visible_for_annotators=True,
             settings={"type": "integer", "min": 0},
             inserted_at=datetime.now(),
@@ -189,8 +219,8 @@ def test_remote_integer_metadata_property(schema_kwargs: Dict[str, Any], server_
         ),
         FeedbackMetadataPropertyModel(
             id=uuid4(),
-            name="c",
-            title=None,
+            name="int-metadata",
+            title="int-metadata",
             visible_for_annotators=False,
             settings={"type": "integer", "min": 0, "max": 10},
             inserted_at=datetime.now(),
@@ -209,40 +239,55 @@ def test_remote_integer_metadata_property_from_api(payload: FeedbackMetadataProp
     "schema_kwargs, server_payload",
     [
         (
-            {"name": "a"},
-            {"name": "a", "title": None, "visible_for_annotators": True, "settings": {"type": "float"}},
-        ),
-        (
-            {"name": "a", "title": "b"},
-            {"name": "a", "title": "b", "visible_for_annotators": True, "settings": {"type": "float"}},
-        ),
-        (
-            {"name": "a", "visible_for_annotators": False},
-            {"name": "a", "title": None, "visible_for_annotators": False, "settings": {"type": "float"}},
-        ),
-        (
-            {"name": "a", "min": 0.0},
+            {"name": "float-metadata"},
             {
-                "name": "a",
-                "title": None,
+                "name": "float-metadata",
+                "title": "float-metadata",
+                "visible_for_annotators": True,
+                "settings": {"type": "float"},
+            },
+        ),
+        (
+            {"name": "float-metadata", "title": "alt-title"},
+            {
+                "name": "float-metadata",
+                "title": "alt-title",
+                "visible_for_annotators": True,
+                "settings": {"type": "float"},
+            },
+        ),
+        (
+            {"name": "float-metadata", "visible_for_annotators": False},
+            {
+                "name": "float-metadata",
+                "title": "float-metadata",
+                "visible_for_annotators": False,
+                "settings": {"type": "float"},
+            },
+        ),
+        (
+            {"name": "float-metadata", "min": 0.0},
+            {
+                "name": "float-metadata",
+                "title": "float-metadata",
                 "visible_for_annotators": True,
                 "settings": {"type": "float", "min": 0.0},
             },
         ),
         (
-            {"name": "a", "max": 10.0},
+            {"name": "float-metadata", "max": 10.0},
             {
-                "name": "a",
-                "title": None,
+                "name": "float-metadata",
+                "title": "float-metadata",
                 "visible_for_annotators": True,
                 "settings": {"type": "float", "max": 10.0},
             },
         ),
         (
-            {"name": "a", "min": 0.0, "max": 10.0},
+            {"name": "float-metadata", "min": 0.0, "max": 10.0},
             {
-                "name": "a",
-                "title": None,
+                "name": "float-metadata",
+                "title": "float-metadata",
                 "visible_for_annotators": True,
                 "settings": {"type": "float", "min": 0.0, "max": 10.0},
             },
@@ -267,8 +312,8 @@ def test_remote_float_metadata_property(schema_kwargs: Dict[str, Any], server_pa
     [
         FeedbackMetadataPropertyModel(
             id=uuid4(),
-            name="a",
-            title="A",
+            name="float-metadata",
+            title="alt-title",
             visible_for_annotators=True,
             settings={"type": "float"},
             inserted_at=datetime.now(),
@@ -276,8 +321,8 @@ def test_remote_float_metadata_property(schema_kwargs: Dict[str, Any], server_pa
         ),
         FeedbackMetadataPropertyModel(
             id=uuid4(),
-            name="b",
-            title=None,
+            name="float-metadata",
+            title="float-metadata",
             visible_for_annotators=True,
             settings={"type": "float", "min": 0.0},
             inserted_at=datetime.now(),
@@ -285,8 +330,8 @@ def test_remote_float_metadata_property(schema_kwargs: Dict[str, Any], server_pa
         ),
         FeedbackMetadataPropertyModel(
             id=uuid4(),
-            name="c",
-            title=None,
+            name="float-metadata",
+            title="float-metadata",
             visible_for_annotators=False,
             settings={"type": "float", "min": 0.0, "max": 10.0},
             inserted_at=datetime.now(),

--- a/tests/unit/client/feedback/schemas/remote/test_metadata.py
+++ b/tests/unit/client/feedback/schemas/remote/test_metadata.py
@@ -36,21 +36,21 @@ from argilla.client.sdk.v1.datasets.models import FeedbackMetadataPropertyModel
     [
         (
             {"name": "a"},
-            {"name": "a", "description": None, "visible_for_annotators": True, "settings": {"type": "terms"}},
+            {"name": "a", "title": None, "visible_for_annotators": True, "settings": {"type": "terms"}},
         ),
         (
-            {"name": "a", "description": "b"},
-            {"name": "a", "description": "b", "visible_for_annotators": True, "settings": {"type": "terms"}},
+            {"name": "a", "title": "b"},
+            {"name": "a", "title": "b", "visible_for_annotators": True, "settings": {"type": "terms"}},
         ),
         (
             {"name": "a", "visible_for_annotators": False},
-            {"name": "a", "description": None, "visible_for_annotators": False, "settings": {"type": "terms"}},
+            {"name": "a", "title": None, "visible_for_annotators": False, "settings": {"type": "terms"}},
         ),
         (
             {"name": "a", "values": ["a"]},
             {
                 "name": "a",
-                "description": None,
+                "title": None,
                 "visible_for_annotators": True,
                 "settings": {"type": "terms", "values": ["a"]},
             },
@@ -59,7 +59,7 @@ from argilla.client.sdk.v1.datasets.models import FeedbackMetadataPropertyModel
             {"name": "a", "values": ["a", "b", "c"]},
             {
                 "name": "a",
-                "description": None,
+                "title": None,
                 "visible_for_annotators": True,
                 "settings": {"type": "terms", "values": ["a", "b", "c"]},
             },
@@ -85,7 +85,7 @@ def test_remote_terms_metadata_property(schema_kwargs: Dict[str, Any], server_pa
         FeedbackMetadataPropertyModel(
             id=uuid4(),
             name="a",
-            description="A",
+            title="A",
             visible_for_annotators=True,
             settings={"type": "terms"},
             inserted_at=datetime.now(),
@@ -94,7 +94,7 @@ def test_remote_terms_metadata_property(schema_kwargs: Dict[str, Any], server_pa
         FeedbackMetadataPropertyModel(
             id=uuid4(),
             name="b",
-            description=None,
+            title=None,
             visible_for_annotators=False,
             settings={"type": "terms", "values": ["a", "b", "c"]},
             inserted_at=datetime.now(),
@@ -114,21 +114,21 @@ def test_remote_terms_metadata_property_from_api(payload: FeedbackMetadataProper
     [
         (
             {"name": "a"},
-            {"name": "a", "description": None, "visible_for_annotators": True, "settings": {"type": "integer"}},
+            {"name": "a", "title": None, "visible_for_annotators": True, "settings": {"type": "integer"}},
         ),
         (
-            {"name": "a", "description": "b"},
-            {"name": "a", "description": "b", "visible_for_annotators": True, "settings": {"type": "integer"}},
+            {"name": "a", "title": "b"},
+            {"name": "a", "title": "b", "visible_for_annotators": True, "settings": {"type": "integer"}},
         ),
         (
             {"name": "a", "visible_for_annotators": False},
-            {"name": "a", "description": None, "visible_for_annotators": False, "settings": {"type": "integer"}},
+            {"name": "a", "title": None, "visible_for_annotators": False, "settings": {"type": "integer"}},
         ),
         (
             {"name": "a", "min": 0},
             {
                 "name": "a",
-                "description": None,
+                "title": None,
                 "visible_for_annotators": True,
                 "settings": {"type": "integer", "min": 0},
             },
@@ -137,7 +137,7 @@ def test_remote_terms_metadata_property_from_api(payload: FeedbackMetadataProper
             {"name": "a", "max": 10},
             {
                 "name": "a",
-                "description": None,
+                "title": None,
                 "visible_for_annotators": True,
                 "settings": {"type": "integer", "max": 10},
             },
@@ -146,7 +146,7 @@ def test_remote_terms_metadata_property_from_api(payload: FeedbackMetadataProper
             {"name": "a", "min": 0, "max": 10},
             {
                 "name": "a",
-                "description": None,
+                "title": None,
                 "visible_for_annotators": True,
                 "settings": {"type": "integer", "min": 0, "max": 10},
             },
@@ -172,7 +172,7 @@ def test_remote_integer_metadata_property(schema_kwargs: Dict[str, Any], server_
         FeedbackMetadataPropertyModel(
             id=uuid4(),
             name="a",
-            description="A",
+            title="A",
             visible_for_annotators=True,
             settings={"type": "integer"},
             inserted_at=datetime.now(),
@@ -181,7 +181,7 @@ def test_remote_integer_metadata_property(schema_kwargs: Dict[str, Any], server_
         FeedbackMetadataPropertyModel(
             id=uuid4(),
             name="b",
-            description=None,
+            title=None,
             visible_for_annotators=True,
             settings={"type": "integer", "min": 0},
             inserted_at=datetime.now(),
@@ -190,7 +190,7 @@ def test_remote_integer_metadata_property(schema_kwargs: Dict[str, Any], server_
         FeedbackMetadataPropertyModel(
             id=uuid4(),
             name="c",
-            description=None,
+            title=None,
             visible_for_annotators=False,
             settings={"type": "integer", "min": 0, "max": 10},
             inserted_at=datetime.now(),
@@ -210,21 +210,21 @@ def test_remote_integer_metadata_property_from_api(payload: FeedbackMetadataProp
     [
         (
             {"name": "a"},
-            {"name": "a", "description": None, "visible_for_annotators": True, "settings": {"type": "float"}},
+            {"name": "a", "title": None, "visible_for_annotators": True, "settings": {"type": "float"}},
         ),
         (
-            {"name": "a", "description": "b"},
-            {"name": "a", "description": "b", "visible_for_annotators": True, "settings": {"type": "float"}},
+            {"name": "a", "title": "b"},
+            {"name": "a", "title": "b", "visible_for_annotators": True, "settings": {"type": "float"}},
         ),
         (
             {"name": "a", "visible_for_annotators": False},
-            {"name": "a", "description": None, "visible_for_annotators": False, "settings": {"type": "float"}},
+            {"name": "a", "title": None, "visible_for_annotators": False, "settings": {"type": "float"}},
         ),
         (
             {"name": "a", "min": 0.0},
             {
                 "name": "a",
-                "description": None,
+                "title": None,
                 "visible_for_annotators": True,
                 "settings": {"type": "float", "min": 0.0},
             },
@@ -233,7 +233,7 @@ def test_remote_integer_metadata_property_from_api(payload: FeedbackMetadataProp
             {"name": "a", "max": 10.0},
             {
                 "name": "a",
-                "description": None,
+                "title": None,
                 "visible_for_annotators": True,
                 "settings": {"type": "float", "max": 10.0},
             },
@@ -242,7 +242,7 @@ def test_remote_integer_metadata_property_from_api(payload: FeedbackMetadataProp
             {"name": "a", "min": 0.0, "max": 10.0},
             {
                 "name": "a",
-                "description": None,
+                "title": None,
                 "visible_for_annotators": True,
                 "settings": {"type": "float", "min": 0.0, "max": 10.0},
             },
@@ -268,7 +268,7 @@ def test_remote_float_metadata_property(schema_kwargs: Dict[str, Any], server_pa
         FeedbackMetadataPropertyModel(
             id=uuid4(),
             name="a",
-            description="A",
+            title="A",
             visible_for_annotators=True,
             settings={"type": "float"},
             inserted_at=datetime.now(),
@@ -277,7 +277,7 @@ def test_remote_float_metadata_property(schema_kwargs: Dict[str, Any], server_pa
         FeedbackMetadataPropertyModel(
             id=uuid4(),
             name="b",
-            description=None,
+            title=None,
             visible_for_annotators=True,
             settings={"type": "float", "min": 0.0},
             inserted_at=datetime.now(),
@@ -286,7 +286,7 @@ def test_remote_float_metadata_property(schema_kwargs: Dict[str, Any], server_pa
         FeedbackMetadataPropertyModel(
             id=uuid4(),
             name="c",
-            description=None,
+            title=None,
             visible_for_annotators=False,
             settings={"type": "float", "min": 0.0, "max": 10.0},
             inserted_at=datetime.now(),

--- a/tests/unit/client/feedback/schemas/test_metadata.py
+++ b/tests/unit/client/feedback/schemas/test_metadata.py
@@ -31,10 +31,10 @@ from pydantic import ValidationError, create_model
     "schema_kwargs, server_payload, metadata_filter, metadata_property_to_validate",
     [
         (
-            {"name": "terms-metadata", "description": "b"},
+            {"name": "terms-metadata", "title": "b"},
             {
                 "name": "terms-metadata",
-                "description": "b",
+                "title": "b",
                 "visible_for_annotators": True,
                 "settings": {"type": "terms"},
             },
@@ -42,10 +42,10 @@ from pydantic import ValidationError, create_model
             {"terms-metadata": "a"},
         ),
         (
-            {"name": "terms-metadata", "description": "b", "values": ["a", "b", "c"]},
+            {"name": "terms-metadata", "title": "b", "values": ["a", "b", "c"]},
             {
                 "name": "terms-metadata",
-                "description": "b",
+                "title": "b",
                 "visible_for_annotators": True,
                 "settings": {"type": "terms", "values": ["a", "b", "c"]},
             },
@@ -60,7 +60,7 @@ from pydantic import ValidationError, create_model
             },
             {
                 "name": "terms-metadata",
-                "description": None,
+                "title": None,
                 "visible_for_annotators": False,
                 "settings": {"type": "terms", "values": ["a", "b", "c"]},
             },
@@ -119,10 +119,10 @@ def test_terms_metadata_property_errors(
     "schema_kwargs, server_payload, metadata_filter, metadata_property_to_validate",
     [
         (
-            {"name": "int-metadata", "description": "b"},
+            {"name": "int-metadata", "title": "b"},
             {
                 "name": "int-metadata",
-                "description": "b",
+                "title": "b",
                 "visible_for_annotators": True,
                 "settings": {"type": "integer"},
             },
@@ -137,7 +137,7 @@ def test_terms_metadata_property_errors(
             },
             {
                 "name": "int-metadata",
-                "description": None,
+                "title": None,
                 "visible_for_annotators": False,
                 "settings": {"type": "integer", "max": 5},
             },
@@ -148,7 +148,7 @@ def test_terms_metadata_property_errors(
             {"name": "int-metadata", "min": 5},
             {
                 "name": "int-metadata",
-                "description": None,
+                "title": None,
                 "visible_for_annotators": True,
                 "settings": {"type": "integer", "min": 5},
             },
@@ -159,7 +159,7 @@ def test_terms_metadata_property_errors(
             {"name": "int-metadata", "min": 5, "max": 10},
             {
                 "name": "int-metadata",
-                "description": None,
+                "title": None,
                 "visible_for_annotators": True,
                 "settings": {"type": "integer", "min": 5, "max": 10},
             },
@@ -218,10 +218,10 @@ def test_integer_metadata_property_errors(
     "schema_kwargs, server_payload, metadata_filter, metadata_property_to_validate",
     [
         (
-            {"name": "float-metadata", "description": "b"},
+            {"name": "float-metadata", "title": "b"},
             {
                 "name": "float-metadata",
-                "description": "b",
+                "title": "b",
                 "visible_for_annotators": True,
                 "settings": {"type": "float"},
             },
@@ -236,7 +236,7 @@ def test_integer_metadata_property_errors(
             },
             {
                 "name": "float-metadata",
-                "description": None,
+                "title": None,
                 "visible_for_annotators": False,
                 "settings": {"type": "float", "max": 5.0},
             },
@@ -247,7 +247,7 @@ def test_integer_metadata_property_errors(
             {"name": "float-metadata", "min": 5.0},
             {
                 "name": "float-metadata",
-                "description": None,
+                "title": None,
                 "visible_for_annotators": True,
                 "settings": {"type": "float", "min": 5.0},
             },
@@ -258,7 +258,7 @@ def test_integer_metadata_property_errors(
             {"name": "float-metadata", "min": 5.0, "max": 10.0},
             {
                 "name": "float-metadata",
-                "description": None,
+                "title": None,
                 "visible_for_annotators": True,
                 "settings": {"type": "float", "min": 5.0, "max": 10.0},
             },

--- a/tests/unit/client/feedback/schemas/test_metadata.py
+++ b/tests/unit/client/feedback/schemas/test_metadata.py
@@ -31,10 +31,10 @@ from pydantic import ValidationError, create_model
     "schema_kwargs, server_payload, metadata_filter, metadata_property_to_validate",
     [
         (
-            {"name": "terms-metadata", "title": "b"},
+            {"name": "terms-metadata", "title": "alt-title"},
             {
                 "name": "terms-metadata",
-                "title": "b",
+                "title": "alt-title",
                 "visible_for_annotators": True,
                 "settings": {"type": "terms"},
             },
@@ -42,10 +42,10 @@ from pydantic import ValidationError, create_model
             {"terms-metadata": "a"},
         ),
         (
-            {"name": "terms-metadata", "title": "b", "values": ["a", "b", "c"]},
+            {"name": "terms-metadata", "values": ["a", "b", "c"]},
             {
                 "name": "terms-metadata",
-                "title": "b",
+                "title": "terms-metadata",
                 "visible_for_annotators": True,
                 "settings": {"type": "terms", "values": ["a", "b", "c"]},
             },
@@ -60,7 +60,7 @@ from pydantic import ValidationError, create_model
             },
             {
                 "name": "terms-metadata",
-                "title": None,
+                "title": "terms-metadata",
                 "visible_for_annotators": False,
                 "settings": {"type": "terms", "values": ["a", "b", "c"]},
             },
@@ -119,10 +119,10 @@ def test_terms_metadata_property_errors(
     "schema_kwargs, server_payload, metadata_filter, metadata_property_to_validate",
     [
         (
-            {"name": "int-metadata", "title": "b"},
+            {"name": "int-metadata", "title": "alt-title"},
             {
                 "name": "int-metadata",
-                "title": "b",
+                "title": "alt-title",
                 "visible_for_annotators": True,
                 "settings": {"type": "integer"},
             },
@@ -137,7 +137,7 @@ def test_terms_metadata_property_errors(
             },
             {
                 "name": "int-metadata",
-                "title": None,
+                "title": "int-metadata",
                 "visible_for_annotators": False,
                 "settings": {"type": "integer", "max": 5},
             },
@@ -148,7 +148,7 @@ def test_terms_metadata_property_errors(
             {"name": "int-metadata", "min": 5},
             {
                 "name": "int-metadata",
-                "title": None,
+                "title": "int-metadata",
                 "visible_for_annotators": True,
                 "settings": {"type": "integer", "min": 5},
             },
@@ -159,7 +159,7 @@ def test_terms_metadata_property_errors(
             {"name": "int-metadata", "min": 5, "max": 10},
             {
                 "name": "int-metadata",
-                "title": None,
+                "title": "int-metadata",
                 "visible_for_annotators": True,
                 "settings": {"type": "integer", "min": 5, "max": 10},
             },
@@ -218,10 +218,10 @@ def test_integer_metadata_property_errors(
     "schema_kwargs, server_payload, metadata_filter, metadata_property_to_validate",
     [
         (
-            {"name": "float-metadata", "title": "b"},
+            {"name": "float-metadata", "title": "alt-title"},
             {
                 "name": "float-metadata",
-                "title": "b",
+                "title": "alt-title",
                 "visible_for_annotators": True,
                 "settings": {"type": "float"},
             },
@@ -236,7 +236,7 @@ def test_integer_metadata_property_errors(
             },
             {
                 "name": "float-metadata",
-                "title": None,
+                "title": "float-metadata",
                 "visible_for_annotators": False,
                 "settings": {"type": "float", "max": 5.0},
             },
@@ -247,7 +247,7 @@ def test_integer_metadata_property_errors(
             {"name": "float-metadata", "min": 5.0},
             {
                 "name": "float-metadata",
-                "title": None,
+                "title": "float-metadata",
                 "visible_for_annotators": True,
                 "settings": {"type": "float", "min": 5.0},
             },
@@ -258,7 +258,7 @@ def test_integer_metadata_property_errors(
             {"name": "float-metadata", "min": 5.0, "max": 10.0},
             {
                 "name": "float-metadata",
-                "title": None,
+                "title": "float-metadata",
                 "visible_for_annotators": True,
                 "settings": {"type": "float", "min": 5.0, "max": 10.0},
             },


### PR DESCRIPTION
# Description

This PR adds the `title` field to the `TermsMetadataProperty`, `IntegerMetadataProperty`, and `FloatMetadataProperty` schemas, and drops the `description`. Also the docstrings have been updated accordingly.

This PR needs to be merged after #3952.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [X] Re-run `pytest -s tests/unit`

**Checklist**

- [x] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
