### PR TITLE
feat: remove type from metadata properties

### DIFF
--- a/src/argilla/server/alembic/versions/7cbcccf8b57a_create_metadata_properties_table.py
+++ b/src/argilla/server/alembic/versions/7cbcccf8b57a_create_metadata_properties_table.py
@@ -36,10 +36,8 @@ def upgrade() -> None:
         sa.Column("id", sa.Uuid(), nullable=False),
         sa.Column("name", sa.String(), nullable=False),
         sa.Column("title", sa.Text(), nullable=False),
-        # TODO: We should move type column to settings as an attribute (as we are already doing for Fields and Questions).
-        sa.Column("type", sa.Text(), nullable=False),
-        sa.Column("allowed_roles", sa.JSON(), server_default="[]", nullable=False),
         sa.Column("settings", sa.JSON(), nullable=False),
+        sa.Column("allowed_roles", sa.JSON(), server_default="[]", nullable=False),
         sa.Column("dataset_id", sa.Uuid(), nullable=False),
         sa.Column("inserted_at", sa.DateTime(), nullable=False),
         sa.Column("updated_at", sa.DateTime(), nullable=False),

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -250,7 +250,6 @@ async def create_metadata_property(
             db,
             name=metadata_property_create.name,
             title=metadata_property_create.title,
-            type=metadata_property_create.settings.type,
             settings=metadata_property_create.settings.dict(),
             allowed_roles=_allowed_roles_for_metadata_property_create(metadata_property_create),
             dataset_id=dataset.id,

--- a/src/argilla/server/models/database.py
+++ b/src/argilla/server/models/database.py
@@ -187,7 +187,6 @@ class MetadataProperty(DatabaseModel):
 
     name: Mapped[str] = mapped_column(String, index=True)
     title: Mapped[str] = mapped_column(Text)
-    type: Mapped[MetadataPropertyType] = mapped_column(Text)
     settings: Mapped[dict] = mapped_column(MutableDict.as_mutable(JSON), default={})
     allowed_roles: Mapped[List[UserRole]] = mapped_column(MutableList.as_mutable(JSON), default=[], server_default="[]")
     dataset_id: Mapped[UUID] = mapped_column(ForeignKey("datasets.id", ondelete="CASCADE"), index=True)
@@ -195,6 +194,10 @@ class MetadataProperty(DatabaseModel):
     dataset: Mapped["Dataset"] = relationship(back_populates="metadata_properties")
 
     __table_args__ = (UniqueConstraint("name", "dataset_id", name="metadata_property_name_dataset_id_uq"),)
+
+    @property
+    def type(self) -> MetadataPropertyType:
+        return self.settings["type"]
 
     @property
     def parsed_settings(self) -> MetadataPropertySettings:
@@ -206,8 +209,7 @@ class MetadataProperty(DatabaseModel):
 
     def __repr__(self):
         return (
-            f"MetadataProperty(id={str(self.id)!r}, name={self.name!r}, type={self.type!r}, "
-            f"dataset_id={str(self.dataset_id)!r}, "
+            f"MetadataProperty(id={str(self.id)!r}, name={self.name!r}, dataset_id={str(self.dataset_id)!r}, "
             f"inserted_at={str(self.inserted_at)!r}, updated_at={str(self.updated_at)!r})"
         )
 

--- a/src/argilla/server/models/database.py
+++ b/src/argilla/server/models/database.py
@@ -197,7 +197,7 @@ class MetadataProperty(DatabaseModel):
 
     @property
     def type(self) -> MetadataPropertyType:
-        return self.settings["type"]
+        return MetadataPropertyType(self.settings["type"])
 
     @property
     def parsed_settings(self) -> MetadataPropertySettings:

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -259,17 +259,14 @@ class MetadataPropertyFactory(BaseFactory):
 
 
 class TermsMetadataPropertyFactory(MetadataPropertyFactory):
-    type = MetadataPropertyType.terms
     settings = {"type": MetadataPropertyType.terms, "values": ["a", "b", "c"]}
 
 
 class IntegerMetadataPropertyFactory(MetadataPropertyFactory):
-    type = MetadataPropertyType.integer
     settings = {"type": MetadataPropertyType.integer}
 
 
 class FloatMetadataPropertyFactory(MetadataPropertyFactory):
-    type = MetadataPropertyType.float
     settings = {"type": MetadataPropertyType.float}
 
 

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -795,49 +795,49 @@ class TestSuiteDatasets:
         ("property_config", "param_value", "expected_filter_class", "expected_filter_args"),
         [
             (
-                {"name": "terms_prop", "type": "terms"},
+                {"name": "terms_prop", "settings": {"type": "terms"}},
                 "value",
                 TermsMetadataFilter,
                 dict(values=["value"]),
             ),
             (
-                {"name": "terms_prop", "type": "terms"},
+                {"name": "terms_prop", "settings": {"type": "terms"}},
                 "value1,value2",
                 TermsMetadataFilter,
                 dict(values=["value1", "value2"]),
             ),
             (
-                {"name": "integer_prop", "type": "integer"},
+                {"name": "integer_prop", "settings": {"type": "integer"}},
                 '{"ge": 10, "le": 20}',
                 IntegerMetadataFilter,
                 dict(ge=10, le=20),
             ),
             (
-                {"name": "integer_prop", "type": "integer"},
+                {"name": "integer_prop", "settings": {"type": "integer"}},
                 '{"ge": 20}',
                 IntegerMetadataFilter,
                 dict(ge=20, high=None),
             ),
             (
-                {"name": "integer_prop", "type": "integer"},
+                {"name": "integer_prop", "settings": {"type": "integer"}},
                 '{"le": 20}',
                 IntegerMetadataFilter,
                 dict(ge=None, le=20),
             ),
             (
-                {"name": "float_prop", "type": "float"},
+                {"name": "float_prop", "settings": {"type": "float"}},
                 '{"ge": -1.30, "le": 23.23}',
                 FloatMetadataFilter,
                 dict(ge=-1.30, le=23.23),
             ),
             (
-                {"name": "float_prop", "type": "float"},
+                {"name": "float_prop", "settings": {"type": "float"}},
                 '{"ge": 23.23}',
                 FloatMetadataFilter,
                 dict(ge=23.23, high=None),
             ),
             (
-                {"name": "float_prop", "type": "float"},
+                {"name": "float_prop", "settings": {"type": "float"}},
                 '{"le": 11.32}',
                 FloatMetadataFilter,
                 dict(ge=None, le=11.32),
@@ -859,7 +859,9 @@ class TestSuiteDatasets:
         dataset, _, records, _, _ = await self.create_dataset_with_user_responses(owner, workspace)
 
         metadata_property = await MetadataPropertyFactory.create(
-            **property_config, settings={"type": property_config["type"]}, dataset=dataset
+            name=property_config["name"],
+            settings=property_config["settings"],
+            dataset=dataset,
         )
 
         mock_search_engine.search.return_value = SearchResponses(
@@ -1395,49 +1397,49 @@ class TestSuiteDatasets:
         ("property_config", "param_value", "expected_filter_class", "expected_filter_args"),
         [
             (
-                {"name": "terms_prop", "type": "terms"},
+                {"name": "terms_prop", "settings": {"type": "terms"}},
                 "value",
                 TermsMetadataFilter,
                 dict(values=["value"]),
             ),
             (
-                {"name": "terms_prop", "type": "terms"},
+                {"name": "terms_prop", "settings": {"type": "terms"}},
                 "value1,value2",
                 TermsMetadataFilter,
                 dict(values=["value1", "value2"]),
             ),
             (
-                {"name": "integer_prop", "type": "integer"},
+                {"name": "integer_prop", "settings": {"type": "integer"}},
                 '{"ge": 10, "le": 20}',
                 IntegerMetadataFilter,
                 dict(ge=10, le=20),
             ),
             (
-                {"name": "integer_prop", "type": "integer"},
+                {"name": "integer_prop", "settings": {"type": "integer"}},
                 '{"ge": 20}',
                 IntegerMetadataFilter,
                 dict(ge=20, le=None),
             ),
             (
-                {"name": "integer_prop", "type": "integer"},
+                {"name": "integer_prop", "settings": {"type": "integer"}},
                 '{"le": 20}',
                 IntegerMetadataFilter,
                 dict(ge=None, le=20),
             ),
             (
-                {"name": "float_prop", "type": "float"},
+                {"name": "float_prop", "settings": {"type": "float"}},
                 '{"ge": -1.30, "le": 23.23}',
                 FloatMetadataFilter,
                 dict(ge=-1.30, le=23.23),
             ),
             (
-                {"name": "float_prop", "type": "float"},
+                {"name": "float_prop", "settings": {"type": "float"}},
                 '{"ge": 23.23}',
                 FloatMetadataFilter,
                 dict(ge=23.23, le=None),
             ),
             (
-                {"name": "float_prop", "type": "float"},
+                {"name": "float_prop", "settings": {"type": "float"}},
                 '{"le": 11.32}',
                 FloatMetadataFilter,
                 dict(ge=None, le=11.32),
@@ -1459,7 +1461,9 @@ class TestSuiteDatasets:
         dataset, _, records, _, _ = await self.create_dataset_with_user_responses(owner, workspace)
 
         metadata_property = await MetadataPropertyFactory.create(
-            **property_config, settings={"type": property_config["type"]}, dataset=dataset
+            name=property_config["name"],
+            settings=property_config["settings"],
+            dataset=dataset,
         )
 
         mock_search_engine.search.return_value = SearchResponses(
@@ -3462,7 +3466,7 @@ class TestSuiteDatasets:
         dataset = await DatasetFactory.create(status=DatasetStatus.ready)
         await TextFieldFactory.create(name="completion", dataset=dataset)
         await TextQuestionFactory.create(name="corrected", dataset=dataset)
-        await MetadataPropertyFactoryType.create(name="metadata-property", dataset=dataset, settings=settings)
+        await MetadataPropertyFactoryType.create(name="metadata-property", settings=settings, dataset=dataset)
 
         records_json = {
             "items": [
@@ -4152,49 +4156,49 @@ class TestSuiteDatasets:
         ("property_config", "param_value", "expected_filter_class", "expected_filter_args"),
         [
             (
-                {"name": "terms_prop", "type": "terms"},
+                {"name": "terms_prop", "settings": {"type": "terms"}},
                 "value",
                 TermsMetadataFilter,
                 dict(values=["value"]),
             ),
             (
-                {"name": "terms_prop", "type": "terms"},
+                {"name": "terms_prop", "settings": {"type": "terms"}},
                 "value1,value2",
                 TermsMetadataFilter,
                 dict(values=["value1", "value2"]),
             ),
             (
-                {"name": "integer_prop", "type": "integer"},
+                {"name": "integer_prop", "settings": {"type": "integer"}},
                 '{"ge": 10, "le": 20}',
                 IntegerMetadataFilter,
                 dict(ge=10, le=20),
             ),
             (
-                {"name": "integer_prop", "type": "integer"},
+                {"name": "integer_prop", "settings": {"type": "integer"}},
                 '{"ge": 20}',
                 IntegerMetadataFilter,
                 dict(ge=20, high=None),
             ),
             (
-                {"name": "integer_prop", "type": "integer"},
+                {"name": "integer_prop", "settings": {"type": "integer"}},
                 '{"le": 20}',
                 IntegerMetadataFilter,
                 dict(low=None, le=20),
             ),
             (
-                {"name": "float_prop", "type": "float"},
+                {"name": "float_prop", "settings": {"type": "float"}},
                 '{"ge": -1.30, "le": 23.23}',
                 FloatMetadataFilter,
                 dict(ge=-1.30, le=23.23),
             ),
             (
-                {"name": "float_prop", "type": "float"},
+                {"name": "float_prop", "settings": {"type": "float"}},
                 '{"ge": 23.23}',
                 FloatMetadataFilter,
                 dict(ge=23.23, high=None),
             ),
             (
-                {"name": "float_prop", "type": "float"},
+                {"name": "float_prop", "settings": {"type": "float"}},
                 '{"le": 11.32}',
                 FloatMetadataFilter,
                 dict(low=None, le=11.32),
@@ -4216,7 +4220,9 @@ class TestSuiteDatasets:
         dataset, _, records, _, _ = await self.create_dataset_with_user_responses(owner, workspace)
 
         metadata_property = await MetadataPropertyFactory.create(
-            **property_config, settings={"type": property_config["type"]}, dataset=dataset
+            name=property_config["name"],
+            settings=property_config["settings"],
+            dataset=dataset,
         )
 
         mock_search_engine.search.return_value = SearchResponses(
@@ -4251,20 +4257,20 @@ class TestSuiteDatasets:
     @pytest.mark.parametrize(
         ("property_config", "wrong_value"),
         [
-            ({"name": "terms_prop", "type": "terms"}, None),
-            ({"name": "terms_prop", "type": "terms"}, "terms_prop"),
-            ({"name": "terms_prop", "type": "terms"}, "terms_prop:"),
-            ({"name": "terms_prop", "type": "terms"}, "wrong-value"),
-            ({"name": "integer_prop", "type": "integer"}, None),
-            ({"name": "integer_prop", "type": "integer"}, "integer_prop"),
-            ({"name": "integer_prop", "type": "integer"}, "integer_prop:"),
-            ({"name": "integer_prop", "type": "integer"}, "integer_prop:{}"),
-            ({"name": "integer_prop", "type": "integer"}, "wrong-value"),
-            ({"name": "float_prop", "type": "float"}, None),
-            ({"name": "float_prop", "type": "float"}, "float_prop"),
-            ({"name": "float_prop", "type": "float"}, "float_prop:"),
-            ({"name": "float_prop", "type": "float"}, "float_prop:{}"),
-            ({"name": "float_prop", "type": "float"}, "wrong-value"),
+            ({"name": "terms_prop", "settings": {"type": "terms"}}, None),
+            ({"name": "terms_prop", "settings": {"type": "terms"}}, "terms_prop"),
+            ({"name": "terms_prop", "settings": {"type": "terms"}}, "terms_prop:"),
+            ({"name": "terms_prop", "settings": {"type": "terms"}}, "wrong-value"),
+            ({"name": "integer_prop", "settings": {"type": "integer"}}, None),
+            ({"name": "integer_prop", "settings": {"type": "integer"}}, "integer_prop"),
+            ({"name": "integer_prop", "settings": {"type": "integer"}}, "integer_prop:"),
+            ({"name": "integer_prop", "settings": {"type": "integer"}}, "integer_prop:{}"),
+            ({"name": "integer_prop", "settings": {"type": "integer"}}, "wrong-value"),
+            ({"name": "float_prop", "settings": {"type": "float"}}, None),
+            ({"name": "float_prop", "settings": {"type": "float"}}, "float_prop"),
+            ({"name": "float_prop", "settings": {"type": "float"}}, "float_prop:"),
+            ({"name": "float_prop", "settings": {"type": "float"}}, "float_prop:{}"),
+            ({"name": "float_prop", "settings": {"type": "float"}}, "wrong-value"),
         ],
     )
     async def test_search_dataset_records_with_wrong_metadata_filter_values(
@@ -4280,7 +4286,9 @@ class TestSuiteDatasets:
         dataset, _, records, _, _ = await self.create_dataset_with_user_responses(owner, workspace)
 
         await MetadataPropertyFactory.create(
-            **property_config, settings={"type": property_config["type"]}, dataset=dataset
+            name=property_config["name"],
+            settings=property_config["settings"],
+            dataset=dataset,
         )
 
         mock_search_engine.search.return_value = SearchResponses(


### PR DESCRIPTION
# Description

This PR removes the `type` column from the `metadata_properties` and left only the `type` available inside `settings`.

**How Has This Been Tested**

- [ ] Fixing some unit tests.
- [ ] Running unit tests using PostgreSQL.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)