### PR TITLE
fix: a lot of typos identified thanks to `codespell`

### DIFF
--- a/src/argilla/client/api.py
+++ b/src/argilla/client/api.py
@@ -84,7 +84,7 @@ def init(
     Args:
         api_url: Address of the REST API. If `None` (default) and the env variable ``ARGILLA_API_URL`` is not set,
             it will default to `http://localhost:6900`.
-        api_key: Authentification key for the REST API. If `None` (default) and the env variable ``ARGILLA_API_KEY``
+        api_key: Authentication key for the REST API. If `None` (default) and the env variable ``ARGILLA_API_KEY``
             is not set, it will default to `argilla.apikey`.
         workspace: The workspace to which records will be logged/loaded. If `None` (default) and the
             env variable ``ARGILLA_WORKSPACE`` is not set, it will default to the private user workspace.

--- a/src/argilla/client/client.py
+++ b/src/argilla/client/client.py
@@ -107,7 +107,7 @@ class Argilla:
         Args:
             api_url: Address of the REST API. If `None` (default) and the env variable ``ARGILLA_API_URL`` is not set,
                 it will default to `http://localhost:6900`.
-            api_key: Authentification key for the REST API. If `None` (default) and the env variable ``ARGILLA_API_KEY``
+            api_key: Authentication key for the REST API. If `None` (default) and the env variable ``ARGILLA_API_KEY``
                 is not set, it will default to `argilla.apikey`.
             workspace: The workspace to which records will be logged/loaded. If `None` (default) and the
                 env variable ``ARGILLA_WORKSPACE`` is not set, it will default to the private user workspace.

--- a/src/argilla/client/feedback/dataset/base.py
+++ b/src/argilla/client/feedback/dataset/base.py
@@ -183,7 +183,7 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin, Generic[R]):
         return self._fields
 
     def field_by_name(self, name: str) -> Union[AllowedFieldTypes, "AllowedRemoteFieldTypes"]:
-        """Returns the field by name if it exists. Othewise a `ValueError` is raised.
+        """Returns the field by name if it exists. Otherwise a `ValueError` is raised.
 
         Args:
             name: the name of the field to return.
@@ -205,7 +205,7 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin, Generic[R]):
         return self._questions
 
     def question_by_name(self, name: str) -> Union[AllowedQuestionTypes, "AllowedRemoteQuestionTypes"]:
-        """Returns the question by name if it exists. Othewise a `ValueError` is raised.
+        """Returns the question by name if it exists. Otherwise a `ValueError` is raised.
 
         Args:
             name: the name of the question to return.
@@ -231,7 +231,7 @@ class FeedbackDatasetBase(ABC, HuggingFaceDatasetMixin, Generic[R]):
     def metadata_property_by_name(
         self, name: str
     ) -> Union["AllowedMetadataPropertyTypes", "AllowedRemoteMetadataPropertyTypes"]:
-        """Returns the metadata property by name if it exists. Othewise a `ValueError` is raised.
+        """Returns the metadata property by name if it exists. Otherwise a `ValueError` is raised.
 
         Args:
             name: the name of the metadata property to return.

--- a/src/argilla/client/feedback/dataset/remote/dataset.py
+++ b/src/argilla/client/feedback/dataset/remote/dataset.py
@@ -286,7 +286,7 @@ class RemoteFeedbackDataset(FeedbackDatasetBase[RemoteFeedbackRecord]):
         """Initializes a `RemoteFeedbackDataset` instance in Argilla.
 
         Note:
-            This class is not intended to be initiallised directly. Instead, use
+            This class is not intended to be initialised directly. Instead, use
             `FeedbackDataset.from_argilla` to get an instance of this class.
 
         Args:

--- a/src/argilla/client/feedback/integrations/huggingface/card/argilla_template.md
+++ b/src/argilla/client/feedback/integrations/huggingface/card/argilla_template.md
@@ -64,7 +64,7 @@ There are no leaderboards associated with this dataset.
 
 The dataset is created in Argilla with: **fields**, **questions**, **suggestions**, and **guidelines**.
 
-The **fields** are the dataset records themselves, for the moment just text fields are suppported. These are the ones that will be used to provide responses to the questions.
+The **fields** are the dataset records themselves, for the moment just text fields are supported. These are the ones that will be used to provide responses to the questions.
 
 | Field Name | Title | Type | Required | Markdown |
 | ---------- | ----- | ---- | -------- | -------- |
@@ -100,7 +100,7 @@ While the same record in HuggingFace `datasets` looks as follows:
 
 Among the dataset fields, we differentiate between the following:
 
-* **Fields:** These are the dataset records themselves, for the moment just text fields are suppported. These are the ones that will be used to provide responses to the questions.
+* **Fields:** These are the dataset records themselves, for the moment just text fields are supported. These are the ones that will be used to provide responses to the questions.
     {% for field in argilla_fields %}
     * {% if field.required == false %}(optional) {% endif %}**{{ field.name }}** is of type `{{ field.type }}`.{% endfor %}
 

--- a/src/argilla/client/feedback/integrations/huggingface/model_card/model_card.py
+++ b/src/argilla/client/feedback/integrations/huggingface/model_card/model_card.py
@@ -477,7 +477,7 @@ class TRLModelCardData(FrameworkCardData):
     def _update_config__repr__(self) -> Optional[str]:
         if self.task_type == "for_proximal_policy_optimization":
             # Similar to what happens with spacy, the current implementation
-            # doesnt' render appropriately, for the moment let for the user to be written by hand.
+            # doesn't render appropriately, for the moment let for the user to be written by hand.
             return
 
         else:

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -112,7 +112,7 @@ class RatingQuestion(QuestionSchema, LabelMappingMixin):
     Args:
         type: The type of the question. Defaults to 'rating' and cannot/shouldn't be
             modified.
-        values: The list of interger values of the rating question. There is not need
+        values: The list of integer values of the rating question. There is not need
             for the values to be sequential, but they must be unique, contain at least two
             unique integers in the range [1, 10].
 

--- a/src/argilla/client/feedback/schemas/records.py
+++ b/src/argilla/client/feedback/schemas/records.py
@@ -152,7 +152,7 @@ class FeedbackRecord(BaseModel):
             record itself.
         metadata: Metadata to be included to enrich the information for a given record.
             Note that the metadata is not shown in the UI so you'll just be able to see
-            that programatically after pulling the records. Defaults to None.
+            that programmatically after pulling the records. Defaults to None.
         responses: Responses given by either the current user, or one or a collection of
             users that must exist in Argilla. Each response corresponds to one of the
             `FeedbackDataset` questions, so the values should match the question type.

--- a/src/argilla/client/feedback/training/schemas.py
+++ b/src/argilla/client/feedback/training/schemas.py
@@ -407,7 +407,7 @@ class TrainingTask:
             [Dict[str, Any]], Union[None, Tuple[str, str, str, str], Iterator[Tuple[str, str, str, str]]]
         ],
     ) -> "TrainingTaskForChatCompletion":
-        """Training data for chat comletion
+        """Training data for chat completion
         Args:
             formatting_func: A formatting function converting a dictionary of records into zero,
                 one or more chat-turn-role-content text tuples.
@@ -1346,7 +1346,7 @@ class TrainingTaskForChatCompletionFormat(BaseModel):
 
 
 class TrainingTaskForChatCompletion(BaseModel, TrainingData):
-    """Training data for chat comletion
+    """Training data for chat completion
 
     Args:
         formatting_func: A formatting function converting a dictionary of records into zero,

--- a/src/argilla/client/users.py
+++ b/src/argilla/client/users.py
@@ -165,7 +165,7 @@ class User:
                 client = client.httpx
             return client
         except Exception as e:
-            raise RuntimeError(f"The `rg.active_client()` is not available or not respoding.") from e
+            raise RuntimeError(f"The `rg.active_client()` is not available or not responding.") from e
 
     @allowed_for_roles(roles=[UserRole.owner])
     def delete(self) -> None:

--- a/src/argilla/client/workspaces.py
+++ b/src/argilla/client/workspaces.py
@@ -259,7 +259,7 @@ class Workspace:
         try:
             return active_client().http_client.httpx
         except Exception as e:
-            raise RuntimeError(f"The `rg.active_client()` is not available or not respoding.") from e
+            raise RuntimeError(f"The `rg.active_client()` is not available or not responding.") from e
 
     @classmethod
     def _new_instance(

--- a/src/argilla/metrics/commons.py
+++ b/src/argilla/metrics/commons.py
@@ -80,7 +80,7 @@ def keywords(name: str, query: Optional[str] = None, size: int = 20) -> MetricSu
         query:
             An ElasticSearch query with the [query string syntax](https://docs.argilla.io/en/latest/practical_guides/filter_dataset.html)
         size:
-            The number of kewords to retrieve. Default to `20`
+            The number of keywords to retrieve. Default to `20`
 
     Returns:
         The dataset keywords occurrence distribution

--- a/src/argilla/metrics/token_classification/metrics.py
+++ b/src/argilla/metrics/token_classification/metrics.py
@@ -60,7 +60,7 @@ def tokens_length(name: str, query: Optional[str] = None, interval: int = 1) -> 
 
 
 def token_frequency(name: str, query: Optional[str] = None, tokens: int = 1000) -> MetricSummary:
-    """Computes the token frequency distribution for a numbe of tokens.
+    """Computes the token frequency distribution for a number of tokens.
 
     Args:
         name: The dataset name.

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -183,7 +183,7 @@ class _ArgillaSpaCyTrainerBase(ArgillaTrainerSkeleton):
 
         self._logger.warning(
             "Note that the spaCy training is expected to be used through the CLI rather"
-            " than programatically, so the dataset needs to be dumped into the disk and"
+            " than programmatically, so the dataset needs to be dumped into the disk and"
             " then loaded from disk. More information at"
             " https://spacy.io/usage/training#api"
         )


### PR DESCRIPTION
# Description

This PR just fixes a lot of typos along the codebase under `src/argilla` using the following command `codespell src/argilla/ --skip src/argilla/server/static` via https://github.com/codespell-project/codespell, so kudos to them!

**Type of change**

- [x] Typo fix (fixes grammar and spelling errors)