### PR TITLE
fix(chore): add `argilla_model_card.md` to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,9 @@ version = { attr = "argilla.__version__" }
 "argilla.client.feedback.integrations.huggingface.card" = [
     "argilla_template.md",
 ]
+"argilla.client.feedback.integrations.huggingface.model_card" = [
+    "argilla_model_template.md",
+]
 
 [tool.pytest.ini_options]
 log_format = "%(asctime)s %(name)s %(levelname)s %(message)s"

--- a/src/argilla/client/feedback/integrations/huggingface/card/__init__.py
+++ b/src/argilla/client/feedback/integrations/huggingface/card/__init__.py
@@ -15,7 +15,4 @@
 from ._dataset_card import ArgillaDatasetCard
 from ._parser import size_categories_parser
 
-__all__ = [
-    "ArgillaDatasetCard",
-    "size_categories_parser",
-]
+__all__ = ["ArgillaDatasetCard", "size_categories_parser"]

--- a/src/argilla/client/feedback/integrations/huggingface/model_card/__init__.py
+++ b/src/argilla/client/feedback/integrations/huggingface/model_card/__init__.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from .model_card import (
+from argilla.client.feedback.integrations.huggingface.model_card.model_card import (
     ArgillaModelCard,
     FrameworkCardData,
     OpenAIModelCardData,


### PR DESCRIPTION
# Description

This PR addresses some pending fixes as a follow up of #3969 (as pointed out by @alvarobartt), which were preventing the `ModelCard` to be generated once the package is uploaded to PyPI as the file was kept locally as not as part of the `package-files`.

Besides that, this PR also fixes some minor style improvements to keep consistency with the rest of the codebase.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
