### PR TITLE
feat: Validate metadata names for filtering and sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ These are the section headers that we use:
 - Implemented `__len__` method for filtered datasets to return the number of records matching the provided filters. ([#3916](https://github.com/argilla-io/argilla/pull/3916))
 - Increase the default max result window for Elasticsearch created for Feedback datasets. ([#3929](https://github.com/argilla-io/argilla/pull/))
 - Force elastic index refresh after records creation. ([#3929](https://github.com/argilla-io/argilla/pull/))
+- Validate metadata fields for filtering and sorting in the Python SDK. ([#3993](https://github.com/argilla-io/argilla/pull/3993))
 
 ### Fixed
 

--- a/src/argilla/client/feedback/dataset/helpers.py
+++ b/src/argilla/client/feedback/dataset/helpers.py
@@ -1,0 +1,21 @@
+import typing
+
+
+if typing.TYPE_CHECKING:
+    from argilla.client.feedback.dataset.base import FeedbackDatasetBase
+
+
+def validate_metadata_names(dataset: "FeedbackDatasetBase", names: typing.List[str]) -> None:
+    """Validates that the metadata names used in the filters are valid."""
+
+    metadata_property_names = {metadata_property.name: True for metadata_property in dataset.metadata_properties}
+
+    if not metadata_property_names:
+        return
+
+    for name in set(names):
+        if not metadata_property_names.get(name):
+            raise ValueError(
+                f"The metadata property name `{name}` does not exist in the current `FeedbackDataset` in Argilla."
+                f" The existing metadata properties names are: {list(metadata_property_names.keys())}."
+            )

--- a/src/argilla/client/feedback/dataset/helpers.py
+++ b/src/argilla/client/feedback/dataset/helpers.py
@@ -1,5 +1,18 @@
-import typing
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 
+import typing
 
 if typing.TYPE_CHECKING:
     from argilla.client.feedback.dataset.base import FeedbackDatasetBase

--- a/src/argilla/client/feedback/dataset/remote/dataset.py
+++ b/src/argilla/client/feedback/dataset/remote/dataset.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
 
     import httpx
 
-    from argilla.client.feedback.dataset import FeedbackDataset
+    from argilla.client.feedback.dataset import FeedbackDataset, helpers
     from argilla.client.feedback.dataset.local import FeedbackDataset
     from argilla.client.feedback.schemas.enums import ResponseStatusFilter
     from argilla.client.feedback.schemas.metadata import MetadataFilters
@@ -441,6 +441,10 @@ class RemoteFeedbackDataset(FeedbackDatasetBase[RemoteFeedbackRecord]):
 
     def sort_by(self, sort: List[SortBy]) -> "RemoteFeedbackDataset":
         """Sorts the current `RemoteFeedbackDataset` based on the given sort fields and orders."""
+        helpers.validate_metadata_names(
+            dataset=self, names=[sort_.metadata_name for sort_ in sort if sort_.is_metadata_field]
+        )
+
         sorted_dataset = self._create_from_dataset(self)
         sorted_dataset._records = RemoteFeedbackRecords._create_from_dataset(sorted_dataset, sort_by=sort)
 
@@ -692,6 +696,10 @@ class RemoteFeedbackDataset(FeedbackDatasetBase[RemoteFeedbackRecord]):
         """
         if not response_status and not metadata_filters:
             raise ValueError("At least one of `response_status` or `metadata_filters` must be provided.")
+
+        helpers.validate_metadata_names(
+            dataset=self, names=[metadata_filter.name for metadata_filter in metadata_filters]
+        )
 
         filtered_dataset = RemoteFeedbackDataset._create_from_dataset(self)
         filtered_dataset._records = RemoteFeedbackRecords._create_from_dataset(

--- a/src/argilla/client/feedback/schemas/records.py
+++ b/src/argilla/client/feedback/schemas/records.py
@@ -281,3 +281,9 @@ class SortBy(BaseModel):
     def is_metadata_field(self) -> bool:
         """Returns whether the field is a metadata field."""
         return self.field.startswith("metadata.")
+
+    @property
+    def metadata_name(self) -> Optional[str]:
+        """Returns the name of the metadata field."""
+        if self.field.startswith("metadata."):
+            return self.field.split("metadata.")[1]

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -573,6 +573,7 @@ class MetadataQueryParams(BaseModel):
 
     @property
     def metadata_parsed(self) -> List[MetadataParsedQueryParam]:
+        # TODO: Validate metadata fields names from query params
         return [MetadataParsedQueryParam(q) for q in self.metadata]
 
 

--- a/tests/integration/client/feedback/dataset/remote/test_filter_and_sorting.py
+++ b/tests/integration/client/feedback/dataset/remote/test_filter_and_sorting.py
@@ -240,6 +240,27 @@ class TestFilteredRemoteFeedbackDataset:
 
         assert records == other_records
 
+    def test_sort_by_with_wrong_field(self, owner: "User", test_dataset: FeedbackDataset):
+        remote = self._create_test_dataset_with_records(owner, test_dataset)
+
+        with pytest.raises(
+            ValueError,
+            match="The metadata property name `unexpected-field` does not exist in the current `FeedbackDataset` "
+            "in Argilla. ",
+        ):
+            remote.sort_by([SortBy(field="metadata.unexpected-field", order="desc")])
+
+    def test_filter_by_wrong_field(self, owner: "User", test_dataset: FeedbackDataset):
+        remote = self._create_test_dataset_with_records(owner, test_dataset)
+
+        with pytest.raises(
+            ValueError,
+            match="The metadata property name `unexpected-field` does not exist in the current `FeedbackDataset` "
+            "in Argilla. ",
+        ):
+
+            remote.filter_by(metadata_filters=IntegerMetadataFilter(name="unexpected-field", ge=4, le=5))
+
     def _create_test_dataset_with_records(self, owner, test_dataset):
         api.init(api_key=owner.api_key)
         ws = Workspace.create(name="test-workspace")

--- a/tests/integration/client/feedback/dataset/remote/test_filter_and_sorting.py
+++ b/tests/integration/client/feedback/dataset/remote/test_filter_and_sorting.py
@@ -258,7 +258,6 @@ class TestFilteredRemoteFeedbackDataset:
             match="The metadata property name `unexpected-field` does not exist in the current `FeedbackDataset` "
             "in Argilla. ",
         ):
-
             remote.filter_by(metadata_filters=IntegerMetadataFilter(name="unexpected-field", ge=4, le=5))
 
     def _create_test_dataset_with_records(self, owner, test_dataset):


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

Add missing metadata filter and sort naming validation in the Python SDK.

Refs #3748 


