### PR TITLE
refactor: Using the `metadata.name` instead `metadata.id` for search index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ These are the section headers that we use:
 - Increase the default max result window for Elasticsearch created for Feedback datasets. ([#3929](https://github.com/argilla-io/argilla/pull/))
 - Force elastic index refresh after records creation. ([#3929](https://github.com/argilla-io/argilla/pull/))
 - Validate metadata fields for filtering and sorting in the Python SDK. ([#3993](https://github.com/argilla-io/argilla/pull/3993))
+- Using metadata property name instead of id for indexing data in search engine index. ([#3994](https://github.com/argilla-io/argilla/pull/3994))
 
 ### Fixed
 

--- a/src/argilla/client/feedback/dataset/remote/dataset.py
+++ b/src/argilla/client/feedback/dataset/remote/dataset.py
@@ -15,7 +15,7 @@
 import textwrap
 import warnings
 from datetime import datetime
-from typing import Any, Dict, Iterator, List, Optional, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Union
 
 from tqdm import trange
 

--- a/src/argilla/server/search_engine/commons.py
+++ b/src/argilla/server/search_engine/commons.py
@@ -138,9 +138,13 @@ def _mapping_for_metadata_property(metadata_property: MetadataProperty) -> dict:
 
 def _aggregation_for_metadata_property(metadata_property: MetadataProperty) -> dict:
     if metadata_property.type == MetadataPropertyType.terms:
-        return {f"{metadata_property.name}": {"terms": {"field": _mapping_key_for_metadata_property(metadata_property)}}}
+        return {
+            f"{metadata_property.name}": {"terms": {"field": _mapping_key_for_metadata_property(metadata_property)}}
+        }
     if metadata_property.type in [MetadataPropertyType.integer, MetadataPropertyType.float]:
-        return {f"{metadata_property.name}": {"stats": {"field": _mapping_key_for_metadata_property(metadata_property)}}}
+        return {
+            f"{metadata_property.name}": {"stats": {"field": _mapping_key_for_metadata_property(metadata_property)}}
+        }
     else:
         raise ValueError(f"Cannot process request for metadata property {metadata_property}")
 

--- a/src/argilla/server/search_engine/commons.py
+++ b/src/argilla/server/search_engine/commons.py
@@ -65,7 +65,7 @@ def _build_metadata_field_payload(dataset: Dataset, metadata: Union[Dict[str, An
     for metadata_property in dataset.metadata_properties:
         value = metadata.get(metadata_property.name)
         if value is not None:
-            search_engine_metadata[str(metadata_property.id)] = value
+            search_engine_metadata[str(metadata_property.name)] = value
 
     return search_engine_metadata
 
@@ -120,7 +120,7 @@ def _mapping_for_field(field: Field) -> dict:
 
 
 def _mapping_key_for_metadata_property(metadata_property: MetadataProperty) -> str:
-    return f"metadata.{metadata_property.id}"
+    return f"metadata.{metadata_property.name}"
 
 
 def _mapping_for_metadata_property(metadata_property: MetadataProperty) -> dict:
@@ -138,9 +138,9 @@ def _mapping_for_metadata_property(metadata_property: MetadataProperty) -> dict:
 
 def _aggregation_for_metadata_property(metadata_property: MetadataProperty) -> dict:
     if metadata_property.type == MetadataPropertyType.terms:
-        return {f"{metadata_property.id}": {"terms": {"field": _mapping_key_for_metadata_property(metadata_property)}}}
+        return {f"{metadata_property.name}": {"terms": {"field": _mapping_key_for_metadata_property(metadata_property)}}}
     if metadata_property.type in [MetadataPropertyType.integer, MetadataPropertyType.float]:
-        return {f"{metadata_property.id}": {"stats": {"field": _mapping_key_for_metadata_property(metadata_property)}}}
+        return {f"{metadata_property.name}": {"stats": {"field": _mapping_key_for_metadata_property(metadata_property)}}}
     else:
         raise ValueError(f"Cannot process request for metadata property {metadata_property}")
 

--- a/tests/unit/server/search_engine/test_opensearch_engine.py
+++ b/tests/unit/server/search_engine/test_opensearch_engine.py
@@ -798,7 +798,8 @@ class TestSuiteOpenSearchEngine:
                 "updated_at": record.updated_at.isoformat(),
                 "responses": {},
                 "metadata": {
-                    str(metadata_prop.name): record.metadata_[metadata_prop.name] for metadata_prop in metadata_properties
+                    str(metadata_prop.name): record.metadata_[metadata_prop.name]
+                    for metadata_prop in metadata_properties
                 },
             }
             for record in records

--- a/tests/unit/server/search_engine/test_opensearch_engine.py
+++ b/tests/unit/server/search_engine/test_opensearch_engine.py
@@ -334,7 +334,7 @@ class TestSuiteOpenSearchEngine:
         assert opensearch.indices.exists(index=index_name)
 
         index = opensearch.indices.get(index=index_name)[index_name]
-        assert index["mappings"]["properties"]["metadata"]["properties"][str(float_property.id)] == {"type": "float"}
+        assert index["mappings"]["properties"]["metadata"]["properties"][str(float_property.name)] == {"type": "float"}
 
     async def test_create_index_for_dataset_with_metadata_properties(
         self,
@@ -380,9 +380,9 @@ class TestSuiteOpenSearchEngine:
                 "metadata": {
                     "dynamic": "false",
                     "properties": {
-                        str(terms_property.id): {"type": "keyword"},
-                        str(integer_property.id): {"type": "long"},
-                        str(float_property.id): {"type": "float"},
+                        str(terms_property.name): {"type": "keyword"},
+                        str(integer_property.name): {"type": "long"},
+                        str(float_property.name): {"type": "float"},
                     },
                 },
             },
@@ -765,7 +765,7 @@ class TestSuiteOpenSearchEngine:
         index = opensearch.indices.get(index=index_name)[index_name]
         assert index["mappings"]["properties"]["metadata"] == {
             "dynamic": "false",
-            "properties": {str(terms_property.id): {"type": "keyword"}},
+            "properties": {str(terms_property.name): {"type": "keyword"}},
         }
 
     async def test_index_records_with_metadata(self, opensearch_engine: OpenSearchEngine, opensearch: OpenSearch):
@@ -798,7 +798,7 @@ class TestSuiteOpenSearchEngine:
                 "updated_at": record.updated_at.isoformat(),
                 "responses": {},
                 "metadata": {
-                    str(metadata_prop.id): record.metadata_[metadata_prop.name] for metadata_prop in metadata_properties
+                    str(metadata_prop.name): record.metadata_[metadata_prop.name] for metadata_prop in metadata_properties
                 },
             }
             for record in records


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR changes how metadata info is indexed in Elasticsearch, by using names instead of ids. The aim of this code refactoring is to make raw indexes more user-friendly and let the possibility of using the Lucene query DSL for filtering data from Argilla (as we already do for other tasks).

