### PR TITLE
Fix: add metadata property for datasets without metadata properties already defined

### DIFF
--- a/src/argilla/client/feedback/dataset/base.py
+++ b/src/argilla/client/feedback/dataset/base.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Dict, Generic, Iterable, List, Literal, O
 
 from pydantic import BaseModel, ValidationError
 
+from argilla.client.feedback.dataset import helpers
 from argilla.client.feedback.integrations.huggingface import HuggingFaceDatasetMixin
 from argilla.client.feedback.schemas.records import FeedbackRecord, SortBy
 from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedMetadataPropertyTypes, AllowedQuestionTypes
@@ -69,65 +70,10 @@ class FeedbackDatasetBase(ABC, Generic[R], metaclass=ABCMeta):
             TypeError: if `guidelines` is not None and not a string.
             ValueError: if `guidelines` is an empty string.
         """
-        if not isinstance(fields, list):
-            raise TypeError(f"Expected `fields` to be a list, got {type(fields)} instead.")
 
-        any_required = False
-        unique_names = set()
-        for field in fields:
-            if not isinstance(field, AllowedFieldTypes):
-                raise TypeError(
-                    f"Expected `fields` to be a list of `{AllowedFieldTypes.__name__}`, got {type(field)} instead."
-                )
-            if field.name in unique_names:
-                raise ValueError(f"Expected `fields` to have unique names, got {field.name} twice instead.")
-            unique_names.add(field.name)
-            if not any_required and field.required:
-                any_required = True
-
-        if not any_required:
-            raise ValueError("At least one field in `fields` must be required (`required=True`).")
-
-        self._fields = fields
-
-        if not isinstance(questions, list):
-            raise TypeError(f"Expected `questions` to be a list, got {type(questions)} instead.")
-
-        any_required = False
-        unique_names = set()
-        for question in questions:
-            if not isinstance(question, AllowedQuestionTypes.__args__):
-                raise TypeError(
-                    "Expected `questions` to be a list of"
-                    f" `{'`, `'.join([arg.__name__ for arg in AllowedQuestionTypes.__args__])}` got a"
-                    f" question in the list with type {type(question)} instead."
-                )
-            if question.name in unique_names:
-                raise ValueError(f"Expected `questions` to have unique names, got {question.name} twice instead.")
-            unique_names.add(question.name)
-            if not any_required and question.required:
-                any_required = True
-
-        if not any_required:
-            raise ValueError("At least one question in `questions` must be required (`required=True`).")
-
-        self._questions = questions
-
-        if metadata_properties is not None:
-            unique_names = set()
-            for metadata_property in metadata_properties:
-                if not isinstance(metadata_property, AllowedMetadataPropertyTypes.__args__):
-                    raise TypeError(
-                        f"Expected `metadata_properties` to be a list of"
-                        f" `{'`, `'.join([arg.__name__ for arg in AllowedMetadataPropertyTypes.__args__])}` got a"
-                        f" metadata property in the list with type type {type(metadata_property)} instead."
-                    )
-                if metadata_property.name in unique_names:
-                    raise ValueError(
-                        f"Expected `metadata_properties` to have unique names, got '{metadata_property.name}' twice instead."
-                    )
-                unique_names.add(metadata_property.name)
-        self._metadata_properties = metadata_properties
+        helpers.validate_fields(fields)
+        helpers.validate_questions(questions)
+        helpers.validate_metadata_properties(metadata_properties)
 
         if guidelines is not None:
             if not isinstance(guidelines, str):
@@ -139,6 +85,9 @@ class FeedbackDatasetBase(ABC, Generic[R], metaclass=ABCMeta):
                     "Expected `guidelines` to be either None (default) or a non-empty string, minimum length is 1."
                 )
 
+        self._fields = fields or []
+        self._questions = questions or []
+        self._metadata_properties = metadata_properties or []
         self._guidelines = guidelines
         self._allow_extra_metadata = allow_extra_metadata
 

--- a/src/argilla/client/feedback/dataset/helpers.py
+++ b/src/argilla/client/feedback/dataset/helpers.py
@@ -14,8 +14,77 @@
 
 import typing
 
+from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedMetadataPropertyTypes, AllowedQuestionTypes
+
 if typing.TYPE_CHECKING:
     from argilla.client.feedback.dataset.base import FeedbackDatasetBase
+
+
+def validate_fields(fields: typing.Union[AllowedFieldTypes, typing.List[AllowedFieldTypes]]):
+    """Validates that the fields used in the filters are valid."""
+    if not isinstance(fields, list):
+        raise TypeError(f"Expected `fields` to be a list, got {type(fields)} instead.")
+
+    any_required = False
+    unique_names = set()
+    for field in fields:
+        if not isinstance(field, AllowedFieldTypes):
+            raise TypeError(
+                f"Expected `fields` to be a list of `{AllowedFieldTypes.__name__}`, got {type(field)} instead."
+            )
+        if field.name in unique_names:
+            raise ValueError(f"Expected `fields` to have unique names, got {field.name} twice instead.")
+        unique_names.add(field.name)
+        if not any_required and field.required:
+            any_required = True
+
+    if not any_required:
+        raise ValueError("At least one field in `fields` must be required (`required=True`).")
+
+
+def validate_questions(questions: typing.Union[AllowedQuestionTypes, typing.List[AllowedQuestionTypes]]) -> None:
+    """Validates that the questions used in the filters are valid."""
+    if not isinstance(questions, list):
+        raise TypeError(f"Expected `questions` to be a list, got {type(questions)} instead.")
+
+    any_required = False
+    unique_names = set()
+    for question in questions:
+        if not isinstance(question, AllowedQuestionTypes.__args__):
+            raise TypeError(
+                "Expected `questions` to be a list of"
+                f" `{'`, `'.join([arg.__name__ for arg in AllowedQuestionTypes.__args__])}` got a"
+                f" question in the list with type {type(question)} instead."
+            )
+        if question.name in unique_names:
+            raise ValueError(f"Expected `questions` to have unique names, got {question.name} twice instead.")
+        unique_names.add(question.name)
+        if not any_required and question.required:
+            any_required = True
+
+    if not any_required:
+        raise ValueError("At least one question in `questions` must be required (`required=True`).")
+
+
+def validate_metadata_properties(metadata_properties: typing.List[AllowedMetadataPropertyTypes]) -> None:
+    """Validates that the metadata properties used in the filters are valid."""
+
+    if not metadata_properties:
+        return
+
+    unique_names = set()
+    for metadata_property in metadata_properties:
+        if not isinstance(metadata_property, AllowedMetadataPropertyTypes.__args__):
+            raise TypeError(
+                f"Expected `metadata_properties` to be a list of"
+                f" `{'`, `'.join([arg.__name__ for arg in AllowedMetadataPropertyTypes.__args__])}` got a"
+                f" metadata property in the list with type type {type(metadata_property)} instead."
+            )
+        if metadata_property.name in unique_names:
+            raise ValueError(
+                f"Expected `metadata_properties` to have unique names, got '{metadata_property.name}' twice instead."
+            )
+        unique_names.add(metadata_property.name)
 
 
 def validate_metadata_names(dataset: "FeedbackDatasetBase", names: typing.List[str]) -> None:

--- a/src/argilla/client/feedback/dataset/remote/dataset.py
+++ b/src/argilla/client/feedback/dataset/remote/dataset.py
@@ -357,7 +357,6 @@ class RemoteFeedbackDataset(FeedbackDatasetBase[RemoteFeedbackRecord]):
         self._fields = fields
         self._fields_schema = None
         self._questions = questions
-        self._metadata_properties = metadata_properties
         self._guidelines = guidelines
         self._allow_extra_metadata = allow_extra_metadata
 

--- a/tests/integration/client/feedback/dataset/remote/test_dataset.py
+++ b/tests/integration/client/feedback/dataset/remote/test_dataset.py
@@ -73,6 +73,7 @@ def test_dataset_with_metadata_properties():
     )
     return dataset
 
+
 @pytest.fixture()
 def test_dataset_with_metadata_properties():
     dataset = FeedbackDataset(
@@ -82,10 +83,9 @@ def test_dataset_with_metadata_properties():
             TermsMetadataProperty(name="terms-metadata", values=["a", "b", "c"]),
             IntegerMetadataProperty(name="integer-metadata"),
             FloatMetadataProperty(name="float-metadata", min=0.0, max=10.0),
-        ]
+        ],
     )
     return dataset
-
 
 
 @pytest.fixture
@@ -120,7 +120,9 @@ class TestRemoteFeedbackDataset:
             FeedbackRecord(fields={"text": "Hello world!"}, metadata={"unrelated-metadata": "unrelated-value"}),
         ],
     )
-    async def test_add_records(self, owner: "User", test_dataset_with_metadata_properties: FeedbackDataset, record: FeedbackRecord) -> None:
+    async def test_add_records(
+        self, owner: "User", test_dataset_with_metadata_properties: FeedbackDataset, record: FeedbackRecord
+    ) -> None:
         api.init(api_key=owner.api_key)
         ws = Workspace.create(name="test-workspace")
 
@@ -154,9 +156,9 @@ class TestRemoteFeedbackDataset:
         first_record = remote[0]
         assert first_record.metadata["terms-metadata"] == "a"
 
-    async def test_update_records_with_suggestions(self, owner: "User",
-                                                   test_dataset_with_metadata_properties: FeedbackDataset
-                                                   ):
+    async def test_update_records_with_suggestions(
+        self, owner: "User", test_dataset_with_metadata_properties: FeedbackDataset
+    ):
         rg.init(api_key=owner.api_key)
         ws = rg.Workspace.create(name="test-workspace")
 
@@ -183,9 +185,9 @@ class TestRemoteFeedbackDataset:
                 assert suggestion.question_name == "question"
                 assert suggestion.value == f"Hello world! for {record.fields['text']}"
 
-    async def test_update_records_with_empty_list_of_suggestions(self, owner: "User",
-                                                                 test_dataset_with_metadata_properties: FeedbackDataset
-                                                                 ):
+    async def test_update_records_with_empty_list_of_suggestions(
+        self, owner: "User", test_dataset_with_metadata_properties: FeedbackDataset
+    ):
         rg.init(api_key=owner.api_key)
         ws = rg.Workspace.create(name="test-workspace")
 
@@ -371,7 +373,8 @@ class TestRemoteFeedbackDataset:
         assert len(remote_dataset.metadata_properties) == len(test_dataset_with_metadata_properties.metadata_properties)
 
         for idx, (metadata_property, remote_metadata_property_cls) in enumerate(
-            zip(metadata_properties, RemoteMetadataPropertiesClasses), start=len(test_dataset_with_metadata_properties.metadata_properties)
+            zip(metadata_properties, RemoteMetadataPropertiesClasses),
+            start=len(test_dataset_with_metadata_properties.metadata_properties),
         ):
             remote_metadata_property = remote_dataset.add_metadata_property(metadata_property)
             assert isinstance(remote_metadata_property, remote_metadata_property_cls)
@@ -461,7 +464,9 @@ class TestRemoteFeedbackDataset:
         )
 
     @pytest.mark.parametrize("role", [UserRole.owner, UserRole.admin])
-    async def test_delete_records(self, owner: "User", test_dataset_with_metadata_properties: FeedbackDataset, role: UserRole) -> None:
+    async def test_delete_records(
+        self, owner: "User", test_dataset_with_metadata_properties: FeedbackDataset, role: UserRole
+    ) -> None:
         user = await UserFactory.create(role=role)
 
         api.init(api_key=owner.api_key)
@@ -488,7 +493,9 @@ class TestRemoteFeedbackDataset:
         assert len(remote.records) == 0
 
     @pytest.mark.parametrize("role", [UserRole.owner, UserRole.admin])
-    async def test_delete(self, owner: "User", test_dataset_with_metadata_properties: FeedbackDataset, role: UserRole) -> None:
+    async def test_delete(
+        self, owner: "User", test_dataset_with_metadata_properties: FeedbackDataset, role: UserRole
+    ) -> None:
         user = await UserFactory.create(role=role)
 
         api.init(api_key=owner.api_key)

--- a/tests/unit/client/feedback/dataset/local/test_dataset.py
+++ b/tests/unit/client/feedback/dataset/local/test_dataset.py
@@ -143,18 +143,20 @@ def test_add_records_validation_error(
 )
 def test_add_metadata_property(metadata_property: "AllowedMetadataPropertyTypes") -> None:
     dataset = FeedbackDataset(
-        fields=[TextField(name="required-field", required=True), TextField(name="optional-field", required=False)],
-        questions=[TextQuestion(name="question", required=True)],
-        metadata_properties=[
-            TermsMetadataProperty(name="terms-metadata", values=["a", "b", "c"]),
-            IntegerMetadataProperty(name="int-metadata", min=0, max=10),
-            FloatMetadataProperty(name="float-metadata", min=0.0, max=10.0),
+        fields=[
+            TextField(name="required-field"),
+            TextField(name="optional-field", required=False),
         ],
+        questions=[TextQuestion(name="question")],
     )
 
     new_metadata_property = dataset.add_metadata_property(metadata_property)
     assert new_metadata_property.name == metadata_property.name
-    assert len(dataset.metadata_properties) == 4
+    assert len(dataset.metadata_properties) == 1
+
+    current_number_of_metadata_properties = len(dataset.metadata_properties)
+    dataset.add_metadata_property(TermsMetadataProperty(name="new-metadata-property", values=["a", "b", "c"]))
+    assert len(dataset.metadata_properties) == current_number_of_metadata_properties + 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR fixes this workflow:
```python
ds = rg.FeedbackDataset.for_supervised_fine_tuning(
    context=True,
    use_markdown=True,
    guidelines=None,
    #metadata=metadata # I've just created a feature request for this
)
​
# In the meantime I want to update a dataset I've just created
metadata = [rg.TermsMetadataProperty(name="one_of_my_col", title="One of my col")]
for m in metadata:
  ds.add_metadata_property(m)
```

The `__init__` method defines an empty list for `_metadata_properties` attribute if `None` was passed. Otherwise, an error occurs when adding a new metadata property.

