### PR TITLE
fix(API): Count records without (response) duplication

### DIFF
--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -390,7 +390,9 @@ async def list_records_by_dataset_id(
     records_query = records_query.order_by(Record.inserted_at.asc()).offset(offset).limit(limit)
     result_records = await db.execute(records_query)
 
-    count_query = records_query.with_only_columns(func.count()).order_by(None).offset(None).limit(None)
+    count_query = (
+        records_query.with_only_columns(func.count(Record.id.distinct())).order_by(None).offset(None).limit(None)
+    )
     result_count = await db.execute(count_query)
 
     return result_records.unique().scalars().all(), result_count.scalar_one()

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -962,10 +962,7 @@ class TestSuiteDatasets:
         )
 
     async def test_list_dataset_records_with_multiple_response_per_record(
-        self,
-        async_client: "AsyncClient",
-        owner: "User",
-        owner_auth_header: dict
+        self, async_client: "AsyncClient", owner: "User", owner_auth_header: dict
     ):
         dataset = await DatasetFactory.create()
         record = await RecordFactory.create(dataset=dataset)

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -908,21 +908,23 @@ class TestSuiteDatasets:
         owner_auth_header: dict,
         response_status_filter: Union[str, List[str]],
     ):
-        num_responses_per_status = 10
+        num_records_per_response_status = 10
         response_values = {"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}}
 
         dataset = await DatasetFactory.create()
         # missing responses
-        await RecordFactory.create_batch(size=num_responses_per_status, dataset=dataset)
+        await RecordFactory.create_batch(size=num_records_per_response_status, dataset=dataset)
         # discarded responses
-        await self.create_records_with_response(num_responses_per_status, dataset, owner, ResponseStatus.discarded)
+        await self.create_records_with_response(
+            num_records_per_response_status, dataset, owner, ResponseStatus.discarded
+        )
         # submitted responses
         await self.create_records_with_response(
-            num_responses_per_status, dataset, owner, ResponseStatus.submitted, response_values
+            num_records_per_response_status, dataset, owner, ResponseStatus.submitted, response_values
         )
         # drafted responses
         await self.create_records_with_response(
-            num_responses_per_status, dataset, owner, ResponseStatus.draft, response_values
+            num_records_per_response_status, dataset, owner, ResponseStatus.draft, response_values
         )
 
         other_dataset = await DatasetFactory.create()
@@ -943,12 +945,13 @@ class TestSuiteDatasets:
         assert response.status_code == 200
         response_json = response.json()
 
-        assert len(response_json["items"]) == (num_responses_per_status * len(response_status_filter))
+        assert response_json["total"] == (num_records_per_response_status * len(response_status_filter))
+        assert len(response_json["items"]) == (num_records_per_response_status * len(response_status_filter))
 
         if "missing" in response_status_filter:
             assert (
                 len([record for record in response_json["items"] if len(record["responses"]) == 0])
-                >= num_responses_per_status
+                >= num_records_per_response_status
             )
         assert all(
             [
@@ -957,6 +960,28 @@ class TestSuiteDatasets:
                 if len(record["responses"]) > 0
             ]
         )
+
+    async def test_list_dataset_records_with_multiple_response_per_record(
+        self,
+        async_client: "AsyncClient",
+        owner: "User",
+        owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+        record = await RecordFactory.create(dataset=dataset)
+        await ResponseFactory.create(record=record)
+        await ResponseFactory.create(record=record)
+
+        response = await async_client.get(
+            f"/api/v1/datasets/{dataset.id}/records?include=responses", headers=owner_auth_header
+        )
+
+        assert response.status_code == 200
+        response_json = response.json()
+
+        assert response_json["total"] == 1
+        assert len(response_json["items"]) == 1
+        assert len(response_json["items"][0]["responses"]) == 2
 
     @pytest.mark.parametrize(
         "sorts",


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR fixes the count computation for records with more than one response. The change includes a distinct records count, otherwise, the count will take into account duplicated record lines per each different response.

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


**Checklist**

- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
