### PR TITLE
feat: add `GET /api/v1/records/:record_id` endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ These are the section headers that we use:
 - Added `POST /api/v1/datasets/{dataset_id}/vectors-settings` endpoint for creating vector settings for a dataset ([#3776](https://github.com/argilla-io/argilla/pull/3776)).
 - Added `GET /api/v1/datasets/{dataset_id}/vectors-settings` endpoint for listing the vectors settings for a dataset ([#3776](https://github.com/argilla-io/argilla/pull/3776)).
 - Added `POST /api/v1/vectors-settings/{vector_settings_id}` endpoint for deleting a vector settings ([#3776](https://github.com/argilla-io/argilla/pull/3776)).
-- Added `GET /api/v1/records/:record_id` endpoint to get a specific record.
+- Added `GET /api/v1/records/:record_id` endpoint to get a specific record. ([#4039](https://github.com/argilla-io/argilla/pull/4039))
 
 ## [1.18.0]()
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ These are the section headers that we use:
 - Added `POST /api/v1/datasets/{dataset_id}/vectors-settings` endpoint for creating vector settings for a dataset ([#3776](https://github.com/argilla-io/argilla/pull/3776)).
 - Added `GET /api/v1/datasets/{dataset_id}/vectors-settings` endpoint for listing the vectors settings for a dataset ([#3776](https://github.com/argilla-io/argilla/pull/3776)).
 - Added `POST /api/v1/vectors-settings/{vector_settings_id}` endpoint for deleting a vector settings ([#3776](https://github.com/argilla-io/argilla/pull/3776)).
+- Added `GET /api/v1/records/:record_id` endpoint to get a specific record.
 
 ## [1.18.0]()
 

--- a/src/argilla/server/apis/v1/handlers/records.py
+++ b/src/argilla/server/apis/v1/handlers/records.py
@@ -50,6 +50,20 @@ async def _get_record(
     return record
 
 
+@router.get("/records/{record_id}", response_model=RecordSchema)
+async def get_record(
+    *,
+    db: AsyncSession = Depends(get_async_db),
+    record_id: UUID,
+    current_user: User = Security(auth.get_current_user),
+):
+    record = await _get_record(db, record_id, with_dataset=True, with_suggestions=True)
+
+    await authorize(current_user, RecordPolicyV1.get(record))
+
+    return record
+
+
 @router.patch("/records/{record_id}", status_code=status.HTTP_200_OK, response_model=RecordSchema)
 async def update_record(
     *,

--- a/src/argilla/server/policies.py
+++ b/src/argilla/server/policies.py
@@ -434,6 +434,15 @@ class MetadataPropertyPolicyV1:
 
 class RecordPolicyV1:
     @classmethod
+    def get(cls, record: Record) -> PolicyAction:
+        async def is_allowed(actor: User) -> bool:
+            return actor.is_owner or await _exists_workspace_user_by_user_and_workspace_id(
+                actor, record.dataset.workspace_id
+            )
+
+        return is_allowed
+
+    @classmethod
     def update(cls, record: Record) -> PolicyAction:
         async def is_allowed(actor: User) -> bool:
             return actor.is_owner or (


### PR DESCRIPTION
# Description

This PR adds a new `GET /api/v1/records/:record_id` endpoint to get specific records.

This feature is necessary to render a specific record when finding for similarity on the UI.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [x] Running tests locally.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)