### PR TITLE
feat: Add metadata properties to dataset card

### DIFF
--- a/src/argilla/client/feedback/integrations/huggingface/card/argilla_template.md
+++ b/src/argilla/client/feedback/integrations/huggingface/card/argilla_template.md
@@ -82,6 +82,11 @@ The **suggestions** are human or machine generated recommendations for each ques
 
 **✨ NEW** The **metadata** is a dictionary that can be used to provide additional information about the dataset record. This can be useful to provide additional context to the annotators, or to provide additional information about the dataset record itself. For example, you can use this to provide a link to the original source of the dataset record, or to provide additional information about the dataset record itself, such as the author, the date, or the source. The metadata is always optional, and can be potentially linked to the `metadata_properties` defined in the dataset configuration file in `argilla.yaml`.
 
+| Metadata Name | Title | Type | Values | Visible for Annotators |
+| ------------- | ----- | ---- | ------ | ---------------------- |
+{% for metadata in argilla_metadata_properties %} | {{ metadata.name }} | {{ metadata.title }} | {{ metadata.type }} | {% if metadata.values %}{{ metadata.values }}{% else %}{{ metadata.min }} - {{ metadata.max }}{% endif %} | {{ metadata.visible_for_annotators }} |
+{% endfor %}
+
 The **guidelines**, are optional as well, and are just a plain string that can be used to provide instructions to the annotators. Find those in the [annotation guidelines](#annotation-guidelines) section.
 
 ### Data Instances

--- a/src/argilla/client/feedback/integrations/huggingface/dataset.py
+++ b/src/argilla/client/feedback/integrations/huggingface/dataset.py
@@ -242,6 +242,7 @@ class HuggingFaceDatasetMixin:
                 argilla_fields=self.fields,
                 argilla_questions=self.questions,
                 argilla_guidelines=self.guidelines or None,
+                argilla_metadata_properties=self.metadata_properties,
                 argilla_record=json.loads(sample_argilla_record.json()),
                 huggingface_record=sample_huggingface_record,
             )

--- a/tests/unit/client/feedback/integrations/huggingface/card/test__dataset_card.py
+++ b/tests/unit/client/feedback/integrations/huggingface/card/test__dataset_card.py
@@ -38,10 +38,7 @@ from huggingface_hub import DatasetCardData
 
 if TYPE_CHECKING:
     from argilla.client.feedback.schemas import FeedbackRecord
-    from argilla.client.feedback.schemas.types import (
-        AllowedFieldTypes,
-        AllowedQuestionTypes,
-    )
+    from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQuestionTypes
 
 
 class TestSuiteArgillaDatasetCard:
@@ -117,9 +114,7 @@ class TestSuiteArgillaDatasetCard:
     ) -> None:
         card = ArgillaDatasetCard.from_template(
             card_data=DatasetCardData(
-                language="en",
-                size_categories="n<1K",
-                tags=["rlfh", "argilla", "human-feedback"],
+                language="en", size_categories="n<1K", tags=["rlfh", "argilla", "human-feedback"],
             ),
             template_path=ArgillaDatasetCard.default_template_path,
             repo_id=repo_id,

--- a/tests/unit/client/feedback/integrations/huggingface/card/test__dataset_card.py
+++ b/tests/unit/client/feedback/integrations/huggingface/card/test__dataset_card.py
@@ -114,7 +114,9 @@ class TestSuiteArgillaDatasetCard:
     ) -> None:
         card = ArgillaDatasetCard.from_template(
             card_data=DatasetCardData(
-                language="en", size_categories="n<1K", tags=["rlfh", "argilla", "human-feedback"],
+                language="en",
+                size_categories="n<1K",
+                tags=["rlfh", "argilla", "human-feedback"],
             ),
             template_path=ArgillaDatasetCard.default_template_path,
             repo_id=repo_id,

--- a/tests/unit/client/feedback/integrations/huggingface/card/test__dataset_card.py
+++ b/tests/unit/client/feedback/integrations/huggingface/card/test__dataset_card.py
@@ -13,12 +13,18 @@
 #  limitations under the License.
 
 import json
+import re
 from typing import TYPE_CHECKING, List
 from uuid import uuid4
 
 import pytest
 from argilla.client.feedback.integrations.huggingface.card import ArgillaDatasetCard
 from argilla.client.feedback.schemas.fields import TextField
+from argilla.client.feedback.schemas.metadata import (
+    FloatMetadataProperty,
+    IntegerMetadataProperty,
+    TermsMetadataProperty,
+)
 from argilla.client.feedback.schemas.questions import (
     LabelQuestion,
     MultiLabelQuestion,
@@ -27,16 +33,20 @@ from argilla.client.feedback.schemas.questions import (
     TextQuestion,
 )
 from argilla.client.feedback.schemas.records import FeedbackRecord
+from argilla.client.feedback.schemas.types import AllowedMetadataPropertyTypes
 from huggingface_hub import DatasetCardData
 
 if TYPE_CHECKING:
     from argilla.client.feedback.schemas import FeedbackRecord
-    from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedQuestionTypes
+    from argilla.client.feedback.schemas.types import (
+        AllowedFieldTypes,
+        AllowedQuestionTypes,
+    )
 
 
 class TestSuiteArgillaDatasetCard:
     @pytest.mark.parametrize(
-        "repo_id,fields,questions,guidelines,record",
+        "repo_id,fields,questions,guidelines,metadata_properties,record",
         [
             (
                 f"argilla/dataset-card-{uuid4()}",
@@ -49,6 +59,11 @@ class TestSuiteArgillaDatasetCard:
                     RankingQuestion(name="ranking-question", values=["a", "b", "c"]),
                 ],
                 "## Guidelines",
+                [
+                    TermsMetadataProperty(name="color", values=["red", "blue"]),
+                    IntegerMetadataProperty(name="day", min=0, max=31, visible_for_annotators=False),
+                    FloatMetadataProperty(name="price", min=0, max=100),
+                ],
                 FeedbackRecord(
                     fields={"text-field": "text"},
                     responses=[
@@ -98,16 +113,20 @@ class TestSuiteArgillaDatasetCard:
         questions: List["AllowedQuestionTypes"],
         guidelines: str,
         record: FeedbackRecord,
+        metadata_properties: List[AllowedMetadataPropertyTypes],
     ) -> None:
         card = ArgillaDatasetCard.from_template(
             card_data=DatasetCardData(
-                language="en", size_categories="n<1K", tags=["rlfh", "argilla", "human-feedback"]
+                language="en",
+                size_categories="n<1K",
+                tags=["rlfh", "argilla", "human-feedback"],
             ),
             template_path=ArgillaDatasetCard.default_template_path,
             repo_id=repo_id,
             argilla_fields=fields,
             argilla_questions=questions,
             argilla_guidelines=guidelines,
+            argilla_metadata_properties=metadata_properties,
             argilla_record=json.loads(record.json()),
             huggingface_record=record.json(),
         )
@@ -118,3 +137,11 @@ class TestSuiteArgillaDatasetCard:
         assert all(field.name in card.content for field in fields)
         assert all(question.name in card.content for question in questions)
         assert guidelines in card.content
+        assert re.search("\| color \| color \| terms \| \['red', 'blue'\] \| True \|", card.content)
+        assert re.search("\| day \| day \| integer \| 0 - 31 \| False \|", card.content)
+        assert re.search("\| price \| price \| float \| 0\.0 - 100\.0 \| True \|", card.content)
+
+        # In case we implement new metadata_property types and forget about the poor little dataset cards ...
+        for allowed_metadata_type in AllowedMetadataPropertyTypes.__args__:
+            if allowed_metadata_type not in [type(metadata) for metadata in metadata_properties]:
+                raise NotImplementedError(f"ArgillaDatasetCard not tested for '{allowed_metadata_type}'.")


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

Adds the metadata_properties of a FeedbackDataset to the dataset card when pushed to the Hugging Face Hub

Closes #4007 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [x] tests/unit/client/feedback/integrations/huggingface/card/test__dataset_card.py

**Checklist**

- [x] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
