### PR TITLE
feat: update `PATCH /api/v1/datasets/{dataset_id}/records` endpoint to update vectors

### DIFF
--- a/.github/workflows/run-python-tests.yml
+++ b/.github/workflows/run-python-tests.yml
@@ -93,9 +93,6 @@ jobs:
         env:
           ARGILLA_ENABLE_TELEMETRY: 0
         run: |
-          df -h
-          # ulimit to avoid segmentation fault
-          ulimit -c unlimited
           pip install -e ".[server,listeners]"
           pytest --cov=argilla --cov-report=xml:${{ env.COVERAGE_REPORT }}.xml ${{ inputs.pytestArgs }} -vs
       - name: Upload coverage report artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,9 @@ These are the section headers that we use:
 ### Changed
 
 - Updated `POST /api/v1/datasets/:dataset_id/records` endpoint to allow to create records with `vectors` ([#4022](https://github.com/argilla-io/argilla/pull/4022))
-- Update `PATCH /api/v1/datasets/:dataset_id/records` endpoint to allow to update records with `vectors` ([#4062](https://github.com/argilla-io/argilla/pull/4062))
-- Update `PATCH /api/v1/records/:record_id` endpoint to allow to update record with `vectors` ([#4062](https://github.com/argilla-io/argilla/pull/4062))
-- Update `BaseElasticAndOpenSearchEngine.index_records` method to also index record vectors ([#4062](https://github.com/argilla-io/argilla/pull/4062))
+- Update `PATCH /api/v1/datasets/:dataset_id/records` endpoint to allow to update records with `vectors`. ([#4062](https://github.com/argilla-io/argilla/pull/4062))
+- Update `PATCH /api/v1/records/:record_id` endpoint to allow to update record with `vectors`. ([#4062](https://github.com/argilla-io/argilla/pull/4062))
+- Update `BaseElasticAndOpenSearchEngine.index_records` method to also index record vectors. ([#4062](https://github.com/argilla-io/argilla/pull/4062))
 
 ## [1.18.0]()
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ These are the section headers that we use:
 ### Changed
 
 - Updated `POST /api/v1/datasets/:dataset_id/records` endpoint to allow to create records with `vectors` ([#4022](https://github.com/argilla-io/argilla/pull/4022))
+- Update `PATCH /api/v1/datasets/:dataset_id/records` endpoint to allow to update records with `vectors` ([#4062](https://github.com/argilla-io/argilla/pull/4062))
+- Update `PATCH /api/v1/records/:record_id` endpoint to allow to update record with `vectors` ([#4062](https://github.com/argilla-io/argilla/pull/4062))
+- Update `BaseElasticAndOpenSearchEngine.index_records` method to also index record vectors ([#4062](https://github.com/argilla-io/argilla/pull/4062))
 
 ## [1.18.0]()
 

--- a/src/argilla/server/apis/v1/handlers/records.py
+++ b/src/argilla/server/apis/v1/handlers/records.py
@@ -39,9 +39,13 @@ router = APIRouter(tags=["records"])
 
 
 async def _get_record(
-    db: AsyncSession, record_id: UUID, with_dataset: bool = False, with_suggestions: bool = False
+    db: AsyncSession,
+    record_id: UUID,
+    with_dataset: bool = False,
+    with_suggestions: bool = False,
+    with_vectors: bool = False,
 ) -> "Record":
-    record = await datasets.get_record_by_id(db, record_id, with_dataset, with_suggestions)
+    record = await datasets.get_record_by_id(db, record_id, with_dataset, with_suggestions, with_vectors)
     if not record:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -73,7 +77,7 @@ async def update_record(
     record_update: RecordUpdate,
     current_user: User = Security(auth.get_current_user),
 ):
-    record = await _get_record(db, record_id, with_dataset=True, with_suggestions=True)
+    record = await _get_record(db, record_id, with_dataset=True, with_suggestions=True, with_vectors=True)
 
     await authorize(current_user, RecordPolicyV1.update(record))
 

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -43,6 +43,7 @@ from argilla.server.schemas.v1.datasets import (
     QuestionCreate,
     RecordCreate,
     RecordsCreate,
+    RecordUpdateWithId,
     ResponseValueCreate,
 )
 from argilla.server.schemas.v1.datasets import (
@@ -531,7 +532,7 @@ async def validate_user(db: "AsyncSession", user_id: UUID, users_ids: Optional[S
     return users_ids
 
 
-async def validate_vector(
+async def _validate_vector(
     db: "AsyncSession",
     dataset_id: UUID,
     vector_name: str,
@@ -629,18 +630,21 @@ async def _build_record_vectors(
     db: "AsyncSession",
     dataset: Dataset,
     record_position: int,
-    record_create: "RecordCreate",
+    record_schema: Union["RecordCreate", "RecordUpdateWithId"],
     cache: Dict[str, VectorSettingsSchema] = {},
 ) -> List[Vector]:
     """Create vectors for a record."""
-    if not record_create.vectors:
+    if not record_schema.vectors:
         return []
 
     vectors = []
-    for vector_name, vector_value in record_create.vectors.items():
+    for vector_name, vector_value in record_schema.vectors.items():
         try:
-            await validate_vector(db, dataset.id, vector_name, vector_value, vectors_settings=cache)
-            vectors.append(Vector(value=vector_value, vector_settings_id=cache[vector_name].id))
+            await _validate_vector(db, dataset.id, vector_name, vector_value, vectors_settings=cache)
+            vector = Vector(value=vector_value, vector_settings_id=cache[vector_name].id)
+            if isinstance(record_schema, RecordUpdateWithId):
+                vector.record_id = record_schema.id
+            vectors.append(vector)
         except ValueError as e:
             raise ValueError(
                 f"Provided vector with name={vector_name} of record at position {record_position} is not valid: {e}"
@@ -678,26 +682,30 @@ async def _build_record_responses(
 
 
 async def _build_record_suggestions(
-    db: "AsyncSession", record_position: int, record_create: "RecordCreate", cache: Dict[UUID, Question] = {}
+    db: "AsyncSession",
+    record_position: int,
+    record_schema: Union["RecordCreate", "RecordUpdateWithId"],
+    cache: Dict[UUID, Question] = {},
 ) -> List[Suggestion]:
     """Create suggestions for a record."""
 
-    if not record_create.suggestions:
+    if not record_schema.suggestions:
         return []
 
     suggestions = []
-    for suggestion in record_create.suggestions:
+    for suggestion in record_schema.suggestions:
         try:
             await _validate_suggestion(db, suggestion, questions=cache)
-            suggestions.append(
-                Suggestion(
-                    type=suggestion.type,
-                    score=suggestion.score,
-                    value=suggestion.value,
-                    agent=suggestion.agent,
-                    question_id=suggestion.question_id,
-                )
+            suggestion = Suggestion(
+                type=suggestion.type,
+                score=suggestion.score,
+                value=suggestion.value,
+                agent=suggestion.agent,
+                question_id=suggestion.question_id,
             )
+            if isinstance(record_schema, RecordUpdateWithId):
+                suggestion.record_id = record_schema.id
+            suggestions.append(suggestion)
         except ValueError as e:
             raise ValueError(f"Provided suggestion for record at position {record_position} is not valid: {e}") from e
     return suggestions
@@ -728,18 +736,21 @@ async def update_records(
     records_update_objects: List[Dict[str, Any]] = []
     records_search_engine_update: List[UUID] = []
     records_delete_suggestions: List[UUID] = []
+    records_delete_vectors: List[UUID] = []
 
     # Cache dictionaries to avoid querying the database multiple times
-    metadata_properties: Dict[str, Union[MetadataProperty, Literal["extra"]]] = {}
-    questions: Dict[UUID, Question] = {}
+    metadata_properties_cache: Dict[str, Union[MetadataProperty, Literal["extra"]]] = {}
+    questions_cache: Dict[UUID, Question] = {}
+    vector_settings_cache: Dict[str, VectorSettingsSchema] = {}
 
     suggestions = []
+    vectors = []
     for record_i, record_update in enumerate(records_update.items):
         params = record_update.dict(exclude_unset=True)
 
         if "metadata_" in params and (metadata := params["metadata_"]) is not None:
             try:
-                metadata_properties = await _validate_metadata(db, dataset, metadata, metadata_properties)
+                metadata_properties_cache = await _validate_metadata(db, dataset, metadata, metadata_properties_cache)
             except ValueError as err:
                 raise ValueError(f"Provided metadata for record at position {record_i} is not valid: {err}") from err
             records_search_engine_update.append(record_update.id)
@@ -751,16 +762,16 @@ async def update_records(
             if len(questions_ids) != len(set(questions_ids)):
                 raise ValueError(f"Found duplicate suggestions question IDs for record at position {record_i}")
 
-            for suggestion_i, suggestion in enumerate(record_update.suggestions):
-                try:
-                    questions = await _validate_suggestion(db, suggestion, questions)
-                    suggestions.append(Suggestion(record_id=record_update.id, **suggestion.dict()))
-                except ValueError as err:
-                    raise ValueError(
-                        f"Provided suggestion for record at position {record_i} and suggestion at position "
-                        f"{suggestion_i} is not valid: {err}"
-                    ) from err
+            record_suggestions = await _build_record_suggestions(db, record_i, record_update, questions_cache)
+            suggestions.extend(record_suggestions)
             records_delete_suggestions.append(record_update.id)
+
+        if record_update.vectors is not None:
+            params.pop("vectors")
+
+            record_vectors = await _build_record_vectors(db, dataset, record_i, record_update, vector_settings_cache)
+            vectors.extend(record_vectors)
+            records_delete_vectors.append(record_update.id)
 
         records_update_objects.append(params)
 
@@ -768,6 +779,11 @@ async def update_records(
         params = [Suggestion.record_id.in_(records_delete_suggestions)]
         await Suggestion.delete_many(db, params=params, autocommit=False)
         db.add_all(suggestions)
+
+        params = [Vector.record_id.in_(records_delete_vectors)]
+        await Vector.delete_many(db, params=params, autocommit=False)
+        db.add_all(vectors)
+
         await Record.update_many(db, records_update_objects, autocommit=False)
         records = await get_records_by_ids(db, dataset_id=dataset.id, records_ids=records_search_engine_update)
         await search_engine.index_records(dataset, records)

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -848,8 +848,8 @@ async def update_record(
     async with db.begin_nested():
         record = await record.update(db, **params, replace_dict=True, autocommit=False)
 
-        # If "metadata" has been included in the update, then we need to also update it in the search engine
-        if "metadata_" in params:
+        if "metadata_" in params or "vectors" in params:
+            await record.dataset.awaitable_attrs.vectors_settings
             await search_engine.index_records(record.dataset, [record])
 
     await db.commit()

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -694,9 +694,10 @@ async def _build_record_suggestions(
             suggestions.append(suggestion)
         except ValueError as e:
             err_msg = (
-                f"Provided suggestion for record at position {record_position} is not valid: {e}"
+                f"Provided suggestion for question_id={suggestion.question_id} and record at position {record_position}"
+                f" is not valid: {e}"
                 if record_position is not None
-                else f"Provided suggestion is not valid: {e}"
+                else f"Provided suggestion for question_id={suggestion.question_id} is not valid: {e}"
             )
             raise ValueError(err_msg) from e
     return suggestions

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -423,10 +423,19 @@ class RecordGetterDict(GetterDict):
     def get(self, key: str, default: Any) -> Any:
         if key == "metadata":
             return getattr(self._obj, "metadata_", None)
+
         if key == "responses" and not self._obj.is_relationship_loaded("responses"):
             return default
+
         if key == "suggestions" and not self._obj.is_relationship_loaded("suggestions"):
             return default
+
+        if key == "vectors":
+            if self._obj.is_relationship_loaded("vectors"):
+                return {vector.vector_settings.name: vector.value for vector in self._obj.vectors}
+            else:
+                return default
+
         return super().get(key, default)
 
 
@@ -439,6 +448,7 @@ class Record(BaseModel):
     # response: Optional[Response]
     responses: Optional[List[Response]]
     suggestions: Optional[List[Suggestion]]
+    vectors: Optional[Dict[str, List[float]]]
     inserted_at: datetime
     updated_at: datetime
 

--- a/src/argilla/server/schemas/v1/records.py
+++ b/src/argilla/server/schemas/v1/records.py
@@ -51,3 +51,4 @@ class ResponseCreate(BaseModel):
 class RecordUpdate(UpdateSchema):
     metadata_: Optional[Dict[str, Any]] = Field(None, alias="metadata")
     suggestions: Optional[List[SuggestionCreate]] = None
+    vectors: Optional[Dict[str, List[float]]]

--- a/src/argilla/server/search_engine/commons.py
+++ b/src/argilla/server/search_engine/commons.py
@@ -68,6 +68,13 @@ def _build_metadata_field_payload(dataset: Dataset, metadata: Union[Dict[str, An
     return search_engine_metadata
 
 
+def _build_vectors_field_payload(vectors) -> Dict[str, List[float]]:
+    if vectors is None:
+        return {}
+
+    return {str(vector.vector_settings.id): vector.value for vector in vectors}
+
+
 class SearchDocumentGetter(GetterDict):
     def get(self, key: Any, default: Any = None) -> Any:
         if key == "responses":
@@ -85,6 +92,11 @@ class SearchDocumentGetter(GetterDict):
             }
         elif key == "metadata":
             return _build_metadata_field_payload(self._obj.dataset, self._obj.metadata_)
+        elif key == "vectors":
+            if not self._obj.is_relationship_loaded("vectors"):
+                return default
+
+            return _build_vectors_field_payload(self._obj.vectors)
 
         return super().get(key, default)
 
@@ -95,6 +107,7 @@ class SearchDocument(BaseModel):
 
     metadata: Optional[Dict[str, Any]] = None
     responses: Optional[Dict[str, UserResponse]]
+    vectors: Optional[Dict[str, List[float]]]
 
     inserted_at: datetime.datetime
     updated_at: datetime.datetime

--- a/src/argilla/server/search_engine/commons.py
+++ b/src/argilla/server/search_engine/commons.py
@@ -68,10 +68,7 @@ def _build_metadata_field_payload(dataset: Dataset, metadata: Union[Dict[str, An
     return search_engine_metadata
 
 
-def _build_vectors_field_payload(vectors) -> Dict[str, List[float]]:
-    if vectors is None:
-        return {}
-
+def _build_vectors_field_payload(vectors: List[Vector]) -> Dict[str, List[float]]:
     return {str(vector.vector_settings.id): vector.value for vector in vectors}
 
 
@@ -93,7 +90,7 @@ class SearchDocumentGetter(GetterDict):
         elif key == "metadata":
             return _build_metadata_field_payload(self._obj.dataset, self._obj.metadata_)
         elif key == "vectors":
-            if not self._obj.is_relationship_loaded("vectors"):
+            if not self._obj.is_relationship_loaded("vectors") or not self._obj.vectors:
                 return default
 
             return _build_vectors_field_payload(self._obj.vectors)
@@ -106,8 +103,8 @@ class SearchDocument(BaseModel):
     fields: Dict[str, Any]
 
     metadata: Optional[Dict[str, Any]] = None
-    responses: Optional[Dict[str, UserResponse]]
-    vectors: Optional[Dict[str, List[float]]]
+    responses: Optional[Dict[str, UserResponse]] = None
+    vectors: Optional[Dict[str, List[float]]] = None
 
     inserted_at: datetime.datetime
     updated_at: datetime.datetime
@@ -590,7 +587,7 @@ class BaseElasticAndOpenSearchEngine(SearchEngine):
 
     @abstractmethod
     def _mapping_for_vector_settings(self, vector_settings: VectorSettings) -> dict:
-        """Defines one mapping property configuration for a vector_setting definitio"""
+        """Defines one mapping property configuration for a vector_setting definition"""
         pass
 
     @abstractmethod

--- a/src/argilla/server/settings.py
+++ b/src/argilla/server/settings.py
@@ -77,8 +77,6 @@ class Settings(BaseSettings):
 
     docs_enabled: bool = True
 
-    search_engine: str = "elasticsearch"
-
     namespace: str = Field(default=None, regex=r"^[a-z]+$")
 
     enable_migration: bool = Field(

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -4656,7 +4656,7 @@ class TestSuiteDatasets:
 
         assert response.status_code == 422
         assert response.json() == {
-            "detail": "Provided suggestion for record at position 0 is not valid: "
+            "detail": f"Provided suggestion for question_id={question.id} and record at position 0 is not valid: "
             "'option-a' is not a valid option.\nValid options are: ['option1', 'option2', 'option3']"
         }
 
@@ -4744,7 +4744,7 @@ class TestSuiteDatasets:
 
         assert response.status_code == 422
         assert response.json() == {
-            "detail": f"Provided suggestion for record at position 0 is not valid: question_id={question_id} does not exist"
+            "detail": f"Provided suggestion for question_id={question_id} and record at position 0 is not valid: question_id={question_id} does not exist"
         }
 
     async def test_update_dataset_records_with_nonexistent_vector_settings_name(

--- a/tests/unit/server/api/v1/test_records.py
+++ b/tests/unit/server/api/v1/test_records.py
@@ -40,6 +40,7 @@ from tests.factories import (
     TermsMetadataPropertyFactory,
     TextQuestionFactory,
     UserFactory,
+    VectorSettingsFactory,
     WorkspaceFactory,
 )
 
@@ -128,9 +129,9 @@ class TestSuiteRecords:
     async def test_update_record(self, async_client: "AsyncClient", mock_search_engine: SearchEngine, role: UserRole):
         dataset = await DatasetFactory.create()
         user = await UserFactory.create(workspaces=[dataset.workspace], role=role)
+        question_0 = await TextQuestionFactory.create(dataset=dataset)
         question_1 = await TextQuestionFactory.create(dataset=dataset)
         question_2 = await TextQuestionFactory.create(dataset=dataset)
-        question_3 = await TextQuestionFactory.create(dataset=dataset)
         await TermsMetadataPropertyFactory.create(name="terms-metadata-property", dataset=dataset)
         await IntegerMetadataPropertyFactory.create(name="integer-metadata-property", dataset=dataset)
         await FloatMetadataPropertyFactory.create(name="float-metadata-property", dataset=dataset)
@@ -138,9 +139,12 @@ class TestSuiteRecords:
             dataset=dataset,
             metadata_={"terms-metadata-property": "a", "integer-metadata-property": 1, "float-metadata-property": 1.0},
         )
-        await SuggestionFactory.create(question=question_1, record=record, value="suggestion 1")
-        await SuggestionFactory.create(question=question_2, record=record, value="suggestion 2")
-        await SuggestionFactory.create(question=question_3, record=record, value="suggestion 3")
+        await SuggestionFactory.create(question=question_0, record=record, value="suggestion 1")
+        await SuggestionFactory.create(question=question_1, record=record, value="suggestion 2")
+        await SuggestionFactory.create(question=question_2, record=record, value="suggestion 3")
+        vector_settings_0 = await VectorSettingsFactory.create(dataset=dataset, dimensions=5)
+        vector_settings_1 = await VectorSettingsFactory.create(dataset=dataset, dimensions=5)
+        vector_settings_2 = await VectorSettingsFactory.create(dataset=dataset, dimensions=5)
 
         response = await async_client.patch(
             f"/api/v1/records/{record.id}",
@@ -154,14 +158,19 @@ class TestSuiteRecords:
                 },
                 "suggestions": [
                     {
-                        "question_id": str(question_1.id),
+                        "question_id": str(question_0.id),
                         "value": "suggestion updated 1",
                     },
                     {
-                        "question_id": str(question_2.id),
+                        "question_id": str(question_1.id),
                         "value": "suggestion updated 2",
                     },
                 ],
+                "vectors": {
+                    vector_settings_0.name: [1, 1, 1, 1, 1],
+                    vector_settings_1.name: [2, 2, 2, 2, 2],
+                    vector_settings_2.name: [3, 3, 3, 3, 3],
+                },
             },
         )
 
@@ -179,7 +188,7 @@ class TestSuiteRecords:
             "responses": None,
             "suggestions": [
                 {
-                    "question_id": str(question_1.id),
+                    "question_id": str(question_0.id),
                     "type": None,
                     "score": None,
                     "value": "suggestion updated 1",
@@ -187,7 +196,7 @@ class TestSuiteRecords:
                     "id": str(record.suggestions[0].id),
                 },
                 {
-                    "question_id": str(question_2.id),
+                    "question_id": str(question_1.id),
                     "type": None,
                     "score": None,
                     "value": "suggestion updated 2",
@@ -195,6 +204,7 @@ class TestSuiteRecords:
                     "id": str(record.suggestions[1].id),
                 },
             ],
+            # TODO: add vectors to response
             "inserted_at": record.inserted_at.isoformat(),
             "updated_at": record.updated_at.isoformat(),
         }
@@ -358,7 +368,7 @@ class TestSuiteRecords:
             "detail": f"'extra-metadata' metadata property does not exists for dataset '{dataset.id}' and extra metadata is not allowed for this dataset"
         }
 
-    async def test_update_record_with_not_valid_suggestion(self, async_client: "AsyncClient", owner_auth_header: dict):
+    async def test_update_record_with_invalid_suggestion(self, async_client: "AsyncClient", owner_auth_header: dict):
         dataset = await DatasetFactory.create()
         question = await LabelSelectionQuestionFactory.create(dataset=dataset)
         record = await RecordFactory.create(dataset=dataset)
@@ -376,6 +386,22 @@ class TestSuiteRecords:
         assert response.status_code == 422
         assert response.json() == {
             "detail": f"Provided suggestion for question_id={question.id} is not valid: 'not a valid value' is not a valid option.\nValid options are: ['option1', 'option2', 'option3']"
+        }
+
+    async def test_update_record_with_invalid_vector(self, async_client: "AsyncClient", owner_auth_header: dict):
+        dataset = await DatasetFactory.create()
+        vector_settings = await VectorSettingsFactory.create(dataset=dataset, dimensions=5)
+        record = await RecordFactory.create(dataset=dataset)
+
+        response = await async_client.patch(
+            f"/api/v1/records/{record.id}",
+            headers=owner_auth_header,
+            json={"vectors": {vector_settings.name: [1, 2, 3, 4, 5, 6]}},
+        )
+
+        assert response.status_code == 422
+        assert response.json() == {
+            "detail": f"Provided vector with name={vector_settings.name} is not valid: vector must have 5 elements, got 6 elements"
         }
 
     async def test_update_record_with_suggestion_for_nonexistent_question(
@@ -399,6 +425,23 @@ class TestSuiteRecords:
         assert response.status_code == 422
         assert response.json() == {
             "detail": f"Provided suggestion for question_id={question_id} is not valid: question_id={question_id} does not exist"
+        }
+
+    async def test_update_record_with_nonexistent_vector_settings(
+        self, async_client: "AsyncClient", owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+        record = await RecordFactory.create(dataset=dataset)
+
+        response = await async_client.patch(
+            f"/api/v1/records/{record.id}",
+            headers=owner_auth_header,
+            json={"vectors": {"i-do-not-exist": [1, 2, 3, 4, 5, 6]}},
+        )
+
+        assert response.status_code == 422
+        assert response.json() == {
+            "detail": f"Provided vector with name=i-do-not-exist is not valid: vector with name=i-do-not-exist does not exist for dataset_id={dataset.id}"
         }
 
     async def test_update_record_with_duplicate_suggestions_question_ids(

--- a/tests/unit/server/api/v1/test_records.py
+++ b/tests/unit/server/api/v1/test_records.py
@@ -95,6 +95,7 @@ class TestSuiteRecords:
             "external_id": record.external_id,
             "responses": None,
             "suggestions": [],
+            "vectors": None,
             "inserted_at": record.inserted_at.isoformat(),
             "updated_at": record.updated_at.isoformat(),
         }
@@ -204,7 +205,11 @@ class TestSuiteRecords:
                     "id": str(record.suggestions[1].id),
                 },
             ],
-            # TODO: add vectors to response
+            "vectors": {
+                vector_settings_0.name: [1, 1, 1, 1, 1],
+                vector_settings_1.name: [2, 2, 2, 2, 2],
+                vector_settings_2.name: [3, 3, 3, 3, 3],
+            },
             "inserted_at": record.inserted_at.isoformat(),
             "updated_at": record.updated_at.isoformat(),
         }
@@ -238,6 +243,7 @@ class TestSuiteRecords:
             "external_id": record.external_id,
             "responses": None,
             "suggestions": [],
+            "vectors": {},
             "inserted_at": record.inserted_at.isoformat(),
             "updated_at": record.updated_at.isoformat(),
         }
@@ -263,6 +269,7 @@ class TestSuiteRecords:
             "external_id": record.external_id,
             "responses": None,
             "suggestions": [],
+            "vectors": {},
             "inserted_at": record.inserted_at.isoformat(),
             "updated_at": record.updated_at.isoformat(),
         }
@@ -288,6 +295,7 @@ class TestSuiteRecords:
             "external_id": record.external_id,
             "responses": None,
             "suggestions": [],
+            "vectors": {},
             "inserted_at": record.inserted_at.isoformat(),
             "updated_at": record.updated_at.isoformat(),
         }

--- a/tests/unit/server/search_engine/test_opensearch_engine.py
+++ b/tests/unit/server/search_engine/test_opensearch_engine.py
@@ -260,7 +260,7 @@ async def _refresh_dataset(dataset: Dataset):
 
 
 @pytest.mark.asyncio
-# @pytest.mark.skipif(not server_settings.search_engine == "opensearch", reason="Running on opensearch engine")
+@pytest.mark.skipif(not server_settings.search_engine == "opensearch", reason="Running on opensearch engine")
 class TestSuiteOpenSearchEngine:
     async def test_get_index_or_raise(self, opensearch_engine: OpenSearchEngine):
         dataset = await DatasetFactory.create()


### PR DESCRIPTION
# Description

This PR adds or updates the following:

- Update `BaseElasticAndOpenSearchEngine.index_records` to also index the vectors of the records.
- Update `PATCH /api/v1/dataset/{dataset_id}/records` endpoint to allow updating the `vectors` of the records.
- Update `PATCH /api/v1/records/{record_id}` endpoint to allow updating the `vectors` of the record.

Closes #4069

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
