### PR TITLE
feat: retrieve vectors when fetching records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ These are the section headers that we use:
 - Added `GET /api/v1/records/:record_id` endpoint to get a specific record. ([#4039](https://github.com/argilla-io/argilla/pull/4039))
 - Added support to include vectors for `GET /api/v1/datasets/:dataset_id/records` endpoint response using `include` query param. ([#4063](https://github.com/argilla-io/argilla/pull/4063))
 - Added support to include vectors for `GET /api/v1/me/datasets/:dataset_id/records` endpoint response using `include` query param. ([#4063](https://github.com/argilla-io/argilla/pull/4063))
-- Added support to include vectors for `GET /api/v1/me/datasets/:dataset_id/records/search` endpoint response using `include` query param. ([#4063](https://github.com/argilla-io/argilla/pull/4063))
+- Added support to include vectors for `POST /api/v1/me/datasets/:dataset_id/records/search` endpoint response using `include` query param. ([#4063](https://github.com/argilla-io/argilla/pull/4063))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ These are the section headers that we use:
 - Added `GET /api/v1/datasets/:dataset_id/vectors-settings` endpoint for listing the vectors settings for a dataset. ([#3776](https://github.com/argilla-io/argilla/pull/3776))
 - Added `DELETE /api/v1/vectors-settings/:vector_settings_id` endpoint for deleting a vector settings. ([#3776](https://github.com/argilla-io/argilla/pull/3776))
 - Added `GET /api/v1/records/:record_id` endpoint to get a specific record. ([#4039](https://github.com/argilla-io/argilla/pull/4039))
+- Added support to include vectors for `GET /api/v1/datasets/:dataset_id/records` endpoint response using `include` query param. ([#4063](https://github.com/argilla-io/argilla/pull/4063))
+- Added support to include vectors for `GET /api/v1/me/datasets/:dataset_id/records` endpoint response using `include` query param. ([#4063](https://github.com/argilla-io/argilla/pull/4063))
+- Added support to include vectors for `GET /api/v1/me/datasets/:dataset_id/records/search` endpoint response using `include` query param. ([#4063](https://github.com/argilla-io/argilla/pull/4063))
 
 ### Changed
 

--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -22,7 +22,7 @@ from typing_extensions import Annotated
 
 from argilla.server.contexts import accounts, datasets
 from argilla.server.database import get_async_db
-from argilla.server.enums import MetadataPropertyType, RecordInclude, RecordSortField, ResponseStatusFilter, SortOrder
+from argilla.server.enums import MetadataPropertyType, RecordSortField, ResponseStatusFilter, SortOrder
 from argilla.server.models import Dataset as DatasetModel
 from argilla.server.models import ResponseStatus, User
 from argilla.server.policies import DatasetPolicyV1, MetadataPropertyPolicyV1, authorize, is_authorized
@@ -43,6 +43,7 @@ from argilla.server.schemas.v1.datasets import (
     Question,
     QuestionCreate,
     Questions,
+    RecordIncludeParam,
     Records,
     RecordsCreate,
     RecordsUpdate,
@@ -78,6 +79,10 @@ LIST_DATASET_RECORDS_LIMIT_LTE = 1000
 DELETE_DATASET_RECORDS_LIMIT = 100
 
 router = APIRouter(tags=["datasets"])
+
+parse_record_include_param = parse_query_param(
+    name="include", help="Relationships to include in the response", model=RecordIncludeParam
+)
 
 
 async def _get_dataset(
@@ -234,7 +239,7 @@ async def _filter_records_using_search_engine(
     offset: int,
     user: Optional[User] = None,
     response_statuses: Optional[List[ResponseStatusFilter]] = None,
-    include: Optional[List[RecordInclude]] = None,
+    include: Optional[RecordIncludeParam] = None,
     sort_by_query_param: Optional[Dict[str, str]] = None,
 ) -> Tuple[List["Record"], int]:
     search_responses = await _get_search_responses(
@@ -289,6 +294,7 @@ async def list_current_user_datasets(
             dataset_list = current_user.datasets
     else:
         dataset_list = await datasets.list_datasets_by_workspace_id(db, workspace_id)
+
     return Datasets(items=dataset_list)
 
 
@@ -364,7 +370,7 @@ async def list_current_user_dataset_records(
     dataset_id: UUID,
     metadata: MetadataQueryParams = Depends(),
     sort_by_query_param: SortByQueryParamParsed,
-    include: List[RecordInclude] = Query([], description="Relationships to include in the response"),
+    include: Optional[RecordIncludeParam] = Depends(parse_record_include_param),
     response_statuses: List[ResponseStatusFilter] = Query([], alias="response_status"),
     offset: int = 0,
     limit: int = Query(default=LIST_DATASET_RECORDS_LIMIT_DEFAULT, lte=LIST_DATASET_RECORDS_LIMIT_LTE),
@@ -409,7 +415,7 @@ async def list_dataset_records(
     dataset_id: UUID,
     metadata: MetadataQueryParams = Depends(),
     sort_by_query_param: SortByQueryParamParsed,
-    include: List[RecordInclude] = Query([], description="Relationships to include in the response"),
+    include: Optional[RecordIncludeParam] = Depends(parse_record_include_param),
     response_statuses: List[ResponseStatusFilter] = Query([], alias="response_status"),
     offset: int = 0,
     limit: int = Query(default=LIST_DATASET_RECORDS_LIMIT_DEFAULT, lte=LIST_DATASET_RECORDS_LIMIT_LTE),
@@ -709,7 +715,7 @@ async def search_dataset_records(
     query: SearchRecordsQuery,
     metadata: MetadataQueryParams = Depends(),
     sort_by_query_param: SortByQueryParamParsed,
-    include: List[RecordInclude] = Query([]),
+    include: Optional[RecordIncludeParam] = Depends(parse_record_include_param),
     response_statuses: List[ResponseStatusFilter] = Query([], alias="response_status"),
     offset: int = Query(0, ge=0),
     limit: int = Query(default=LIST_DATASET_RECORDS_LIMIT_DEFAULT, lte=LIST_DATASET_RECORDS_LIMIT_LTE),

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -18,7 +18,7 @@ from uuid import UUID
 
 import sqlalchemy
 from fastapi.encoders import jsonable_encoder
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import Select, and_, func, or_, select
 from sqlalchemy.orm import contains_eager, joinedload, selectinload
 
 from argilla.server.contexts import accounts
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
 
     from argilla.server.schemas.v1.datasets import (
         DatasetUpdate,
+        RecordIncludeParam,
         RecordsUpdate,
         VectorSettingsCreate,
     )
@@ -357,9 +358,12 @@ async def get_record_by_id(
             selectinload(Record.dataset).selectinload(Dataset.questions),
             selectinload(Record.dataset).selectinload(Dataset.metadata_properties),
         )
+
     if with_suggestions:
         query = query.options(selectinload(Record.suggestions))
+
     result = await db.execute(query)
+
     return result.scalar_one_or_none()
 
 
@@ -367,24 +371,20 @@ async def get_records_by_ids(
     db: "AsyncSession",
     dataset_id: UUID,
     records_ids: List[UUID],
-    include: Optional[List[RecordInclude]] = None,
+    include: Optional["RecordIncludeParam"] = None,
     user_id: Optional[UUID] = None,
 ) -> List[Record]:
-    if include is None:
-        include = []
-
     query = select(Record).filter(Record.dataset_id == dataset_id, Record.id.in_(records_ids))
 
-    if RecordInclude.responses in include:
-        if user_id:
+    if include and include.with_responses:
+        if not user_id:
+            query = query.options(joinedload(Record.responses))
+        else:
             query = query.outerjoin(
                 Response, and_(Response.record_id == Record.id, Response.user_id == user_id)
             ).options(contains_eager(Record.responses))
-        else:
-            query = query.options(joinedload(Record.responses))
 
-    if RecordInclude.suggestions in include:
-        query = query.options(joinedload(Record.suggestions))
+    query = await _configure_query_relationships(query, include_params=include)
 
     result = await db.execute(query)
     records = result.unique().scalars().all()
@@ -396,11 +396,31 @@ async def get_records_by_ids(
     return ordered_records
 
 
+async def _configure_query_relationships(
+    query: "Select", include_params: Optional["RecordIncludeParam"] = None
+) -> "Select":
+    if not include_params:
+        return query
+
+    if include_params.with_suggestions:
+        query = query.options(joinedload(Record.suggestions))
+
+    if include_params.with_all_vectors:
+        query = query.options(joinedload(Record.vectors))
+
+    elif include_params.with_some_vector:
+        query = query.outerjoin(
+            Vector, and_(Vector.record_id == Record.id, Vector.vector_settings_id.in_(include_params.vectors))
+        ).options(contains_eager(Record.vectors))
+
+    return query
+
+
 async def list_records_by_dataset_id(
     db: "AsyncSession",
     dataset_id: UUID,
     user_id: Optional[UUID] = None,
-    include: List[RecordInclude] = [],
+    include: Optional["RecordIncludeParam"] = None,
     response_statuses: List[ResponseStatusFilter] = [],
     offset: int = 0,
     limit: int = LIST_RECORDS_LIMIT,
@@ -433,12 +453,10 @@ async def list_records_by_dataset_id(
     if response_status_filter_expressions:
         records_query = records_query.filter(or_(*response_status_filter_expressions))
 
-    if RecordInclude.responses in include:
+    if include and include.with_responses:
         records_query = records_query.options(contains_eager(Record.responses))
 
-    if RecordInclude.suggestions in include:
-        records_query = records_query.options(joinedload(Record.suggestions))
-
+    records_query = await _configure_query_relationships(query=records_query, include_params=include)
     records_query = records_query.order_by(Record.inserted_at.asc()).offset(offset).limit(limit)
     result_records = await db.execute(records_query)
 

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -410,7 +410,11 @@ async def _configure_query_relationships(
 
     elif include_params.with_some_vector:
         query = query.outerjoin(
-            Vector, and_(Vector.record_id == Record.id, Vector.vector_settings_id.in_(include_params.vectors))
+            Vector,
+            and_(
+                Vector.record_id == Record.id,
+                Vector.vector_settings_id.in_(include_params.vectors),
+            ),
         ).options(contains_eager(Record.vectors))
 
     return query

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -409,12 +409,11 @@ async def _configure_query_relationships(
         query = query.options(joinedload(Record.vectors))
 
     elif include_params.with_some_vector:
+        vector_settings_ids_subquery = (
+            select(VectorSettings.id).filter(VectorSettings.name.in_(include_params.vectors)).subquery()
+        )
         query = query.outerjoin(
-            Vector,
-            and_(
-                Vector.record_id == Record.id,
-                Vector.vector_settings_id.in_(include_params.vectors),
-            ),
+            Vector, and_(Vector.record_id == Record.id, Vector.vector_settings_id.in_(vector_settings_ids_subquery))
         ).options(contains_eager(Record.vectors))
 
     return query

--- a/src/argilla/server/enums.py
+++ b/src/argilla/server/enums.py
@@ -51,6 +51,7 @@ class UserRole(str, Enum):
 class RecordInclude(str, Enum):
     responses = "responses"
     suggestions = "suggestions"
+    vectors = "vectors"
 
 
 class QuestionType(str, Enum):

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -399,14 +399,6 @@ class VectorSettingsCreate(BaseModel):
     )
 
 
-class Vector(BaseModel):
-    value: List[float]
-    vector_settings_id: UUID
-
-    class Config:
-        orm_mode = True
-
-
 class ResponseValue(BaseModel):
     value: Any
 

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -520,7 +520,7 @@ class RecordsUpdate(BaseModel):
 
 class RecordIncludeParam(BaseModel):
     relationships: Optional[List[RecordInclude]] = PydanticField(None, alias="keys")
-    vectors: Optional[List[UUID]] = PydanticField(None, alias="vectors")
+    vectors: Optional[List[str]] = PydanticField(None, alias="vectors")
 
     @root_validator
     def check(cls, values: Dict[str, Any]) -> Dict[str, Any]:
@@ -534,7 +534,7 @@ class RecordIncludeParam(BaseModel):
             # raise ValueError("Cannot include both 'vectors' and 'relationships' in the same request")
             raise HTTPException(
                 status_code=422,
-                detail="'include' query param cannot have both 'vectors' and 'vectors:vector_settings_id_1,vectors_settings_id_2,...'",
+                detail="'include' query param cannot have both 'vectors' and 'vectors:vector_settings_name_1,vectors_settings_name_2,...'",
             )
 
         return values

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -5555,6 +5555,184 @@ class TestSuiteDatasets:
             limit=LIST_DATASET_RECORDS_LIMIT_DEFAULT,
         )
 
+    async def test_search_dataset_records_with_include_vectors(
+        self, async_client: "AsyncClient", mock_search_engine: SearchEngine, owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+        record_a = await RecordFactory.create(dataset=dataset)
+        record_b = await RecordFactory.create(dataset=dataset)
+        record_c = await RecordFactory.create(dataset=dataset)
+        vector_settings_a = await VectorSettingsFactory.create(name="vector-a", dimensions=3, dataset=dataset)
+        vector_settings_b = await VectorSettingsFactory.create(name="vector-b", dimensions=2, dataset=dataset)
+
+        await VectorFactory.create(value=[1.0, 2.0, 3.0], vector_settings=vector_settings_a, record=record_a)
+        await VectorFactory.create(value=[4.0, 5.0], vector_settings=vector_settings_b, record=record_a)
+        await VectorFactory.create(value=[1.0, 2.0], vector_settings=vector_settings_b, record=record_b)
+
+        await TextFieldFactory.create(name="input", dataset=dataset)
+
+        mock_search_engine.search.return_value = SearchResponses(
+            items=[
+                SearchResponseItem(record_id=record_a.id, score=10.0),
+                SearchResponseItem(record_id=record_b.id, score=9.0),
+                SearchResponseItem(record_id=record_c.id, score=8.0),
+            ],
+            total=3,
+        )
+
+        response = await async_client.post(
+            f"/api/v1/me/datasets/{dataset.id}/records/search",
+            headers=owner_auth_header,
+            params={"include": RecordInclude.vectors.value},
+            json={
+                "query": {
+                    "text": {
+                        "q": "query",
+                        "field": "input",
+                    }
+                }
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json() == {
+            "items": [
+                {
+                    "record": {
+                        "id": str(record_a.id),
+                        "fields": {"text": "This is a text", "sentiment": "neutral"},
+                        "metadata": None,
+                        "external_id": record_a.external_id,
+                        "vectors": {
+                            "vector-a": [1.0, 2.0, 3.0],
+                            "vector-b": [4.0, 5.0],
+                        },
+                        "inserted_at": record_a.inserted_at.isoformat(),
+                        "updated_at": record_a.updated_at.isoformat(),
+                    },
+                    "query_score": 10.0,
+                },
+                {
+                    "record": {
+                        "id": str(record_b.id),
+                        "fields": {"text": "This is a text", "sentiment": "neutral"},
+                        "metadata": None,
+                        "external_id": record_b.external_id,
+                        "vectors": {
+                            "vector-b": [1.0, 2.0],
+                        },
+                        "inserted_at": record_b.inserted_at.isoformat(),
+                        "updated_at": record_b.updated_at.isoformat(),
+                    },
+                    "query_score": 9.0,
+                },
+                {
+                    "record": {
+                        "id": str(record_c.id),
+                        "fields": {"text": "This is a text", "sentiment": "neutral"},
+                        "metadata": None,
+                        "external_id": record_c.external_id,
+                        "vectors": {},
+                        "inserted_at": record_c.inserted_at.isoformat(),
+                        "updated_at": record_c.updated_at.isoformat(),
+                    },
+                    "query_score": 8.0,
+                },
+            ],
+            "total": 3,
+        }
+
+    async def test_search_dataset_records_with_include_specific_vectors(
+        self, async_client: "AsyncClient", mock_search_engine: SearchEngine, owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+        record_a = await RecordFactory.create(dataset=dataset)
+        record_b = await RecordFactory.create(dataset=dataset)
+        record_c = await RecordFactory.create(dataset=dataset)
+        vector_settings_a = await VectorSettingsFactory.create(name="vector-a", dimensions=3, dataset=dataset)
+        vector_settings_b = await VectorSettingsFactory.create(name="vector-b", dimensions=2, dataset=dataset)
+        vector_settings_c = await VectorSettingsFactory.create(name="vector-c", dimensions=4, dataset=dataset)
+
+        await VectorFactory.create(value=[1.0, 2.0, 3.0], vector_settings=vector_settings_a, record=record_a)
+        await VectorFactory.create(value=[4.0, 5.0], vector_settings=vector_settings_b, record=record_a)
+        await VectorFactory.create(value=[6.0, 7.0, 8.0, 9.0], vector_settings=vector_settings_c, record=record_a)
+        await VectorFactory.create(value=[1.0, 2.0], vector_settings=vector_settings_b, record=record_b)
+        await VectorFactory.create(value=[10.0, 11.0, 12.0, 13.0], vector_settings=vector_settings_c, record=record_b)
+        await VectorFactory.create(value=[14.0, 15.0, 16.0, 17.0], vector_settings=vector_settings_c, record=record_c)
+
+        await TextFieldFactory.create(name="input", dataset=dataset)
+
+        mock_search_engine.search.return_value = SearchResponses(
+            items=[
+                SearchResponseItem(record_id=record_a.id, score=10.0),
+                SearchResponseItem(record_id=record_b.id, score=9.0),
+                SearchResponseItem(record_id=record_c.id, score=8.0),
+            ],
+            total=3,
+        )
+
+        response = await async_client.post(
+            f"/api/v1/me/datasets/{dataset.id}/records/search",
+            headers=owner_auth_header,
+            params={"include": f"{RecordInclude.vectors.value}:{vector_settings_a.name},{vector_settings_b.name}"},
+            json={
+                "query": {
+                    "text": {
+                        "q": "query",
+                        "field": "input",
+                    }
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "items": [
+                {
+                    "record": {
+                        "id": str(record_a.id),
+                        "fields": {"text": "This is a text", "sentiment": "neutral"},
+                        "metadata": None,
+                        "external_id": record_a.external_id,
+                        "vectors": {
+                            "vector-a": [1.0, 2.0, 3.0],
+                            "vector-b": [4.0, 5.0],
+                        },
+                        "inserted_at": record_a.inserted_at.isoformat(),
+                        "updated_at": record_a.updated_at.isoformat(),
+                    },
+                    "query_score": 10.0,
+                },
+                {
+                    "record": {
+                        "id": str(record_b.id),
+                        "fields": {"text": "This is a text", "sentiment": "neutral"},
+                        "metadata": None,
+                        "external_id": record_b.external_id,
+                        "vectors": {
+                            "vector-b": [1.0, 2.0],
+                        },
+                        "inserted_at": record_b.inserted_at.isoformat(),
+                        "updated_at": record_b.updated_at.isoformat(),
+                    },
+                    "query_score": 9.0,
+                },
+                {
+                    "record": {
+                        "id": str(record_c.id),
+                        "fields": {"text": "This is a text", "sentiment": "neutral"},
+                        "metadata": None,
+                        "external_id": record_c.external_id,
+                        "vectors": {},
+                        "inserted_at": record_c.inserted_at.isoformat(),
+                        "updated_at": record_c.updated_at.isoformat(),
+                    },
+                    "query_score": 8.0,
+                },
+            ],
+            "total": 3,
+        }
+
     async def test_search_dataset_records_with_response_status_filter(
         self, async_client: "AsyncClient", mock_search_engine: SearchEngine, owner: User, owner_auth_header: dict
     ):

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -857,7 +857,7 @@ class TestSuiteDatasets:
 
         response = await async_client.get(
             f"/api/v1/datasets/{dataset.id}/records",
-            params={"include": f"{RecordInclude.vectors.value}:{vector_settings_a.id},{vector_settings_b.id}"},
+            params={"include": f"{RecordInclude.vectors.value}:{vector_settings_a.name},{vector_settings_b.name}"},
             headers=owner_auth_header,
         )
 
@@ -1591,7 +1591,7 @@ class TestSuiteDatasets:
 
         response = await async_client.get(
             f"/api/v1/me/datasets/{dataset.id}/records",
-            params={"include": f"{RecordInclude.vectors.value}:{vector_settings_a.id},{vector_settings_b.id}"},
+            params={"include": f"{RecordInclude.vectors.value}:{vector_settings_a.name},{vector_settings_b.name}"},
             headers=owner_auth_header,
         )
 

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -91,6 +91,7 @@ from tests.factories import (
     TextFieldFactory,
     TextQuestionFactory,
     UserFactory,
+    VectorFactory,
     VectorSettingsFactory,
     WorkspaceFactory,
 )
@@ -777,6 +778,128 @@ class TestSuiteDatasets:
 
         assert response.status_code == 200
 
+    async def test_list_dataset_records_with_include_vectors(
+        self, async_client: "AsyncClient", owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+        record_a = await RecordFactory.create(dataset=dataset)
+        record_b = await RecordFactory.create(dataset=dataset)
+        record_c = await RecordFactory.create(dataset=dataset)
+        vector_settings_a = await VectorSettingsFactory.create(name="vector-a", dimensions=3, dataset=dataset)
+        vector_settings_b = await VectorSettingsFactory.create(name="vector-b", dimensions=2, dataset=dataset)
+
+        await VectorFactory.create(value=[1.0, 2.0, 3.0], vector_settings=vector_settings_a, record=record_a)
+        await VectorFactory.create(value=[4.0, 5.0], vector_settings=vector_settings_b, record=record_a)
+        await VectorFactory.create(value=[1.0, 2.0], vector_settings=vector_settings_b, record=record_b)
+
+        response = await async_client.get(
+            f"/api/v1/datasets/{dataset.id}/records",
+            params={"include": RecordInclude.vectors.value},
+            headers=owner_auth_header,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "items": [
+                {
+                    "id": str(record_a.id),
+                    "fields": {"text": "This is a text", "sentiment": "neutral"},
+                    "metadata": None,
+                    "external_id": record_a.external_id,
+                    "vectors": {
+                        "vector-a": [1.0, 2.0, 3.0],
+                        "vector-b": [4.0, 5.0],
+                    },
+                    "inserted_at": record_a.inserted_at.isoformat(),
+                    "updated_at": record_a.updated_at.isoformat(),
+                },
+                {
+                    "id": str(record_b.id),
+                    "fields": {"text": "This is a text", "sentiment": "neutral"},
+                    "metadata": None,
+                    "external_id": record_b.external_id,
+                    "vectors": {
+                        "vector-b": [1.0, 2.0],
+                    },
+                    "inserted_at": record_b.inserted_at.isoformat(),
+                    "updated_at": record_b.updated_at.isoformat(),
+                },
+                {
+                    "id": str(record_c.id),
+                    "fields": {"text": "This is a text", "sentiment": "neutral"},
+                    "metadata": None,
+                    "external_id": record_c.external_id,
+                    "vectors": {},
+                    "inserted_at": record_c.inserted_at.isoformat(),
+                    "updated_at": record_c.updated_at.isoformat(),
+                },
+            ],
+            "total": 3,
+        }
+
+    async def test_list_dataset_records_with_include_specific_vectors(
+        self, async_client: "AsyncClient", owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+        record_a = await RecordFactory.create(dataset=dataset)
+        record_b = await RecordFactory.create(dataset=dataset)
+        record_c = await RecordFactory.create(dataset=dataset)
+        vector_settings_a = await VectorSettingsFactory.create(name="vector-a", dimensions=3, dataset=dataset)
+        vector_settings_b = await VectorSettingsFactory.create(name="vector-b", dimensions=2, dataset=dataset)
+        vector_settings_c = await VectorSettingsFactory.create(name="vector-c", dimensions=4, dataset=dataset)
+
+        await VectorFactory.create(value=[1.0, 2.0, 3.0], vector_settings=vector_settings_a, record=record_a)
+        await VectorFactory.create(value=[4.0, 5.0], vector_settings=vector_settings_b, record=record_a)
+        await VectorFactory.create(value=[6.0, 7.0, 8.0, 9.0], vector_settings=vector_settings_c, record=record_a)
+        await VectorFactory.create(value=[1.0, 2.0], vector_settings=vector_settings_b, record=record_b)
+        await VectorFactory.create(value=[10.0, 11.0, 12.0, 13.0], vector_settings=vector_settings_c, record=record_b)
+        await VectorFactory.create(value=[14.0, 15.0, 16.0, 17.0], vector_settings=vector_settings_c, record=record_c)
+
+        response = await async_client.get(
+            f"/api/v1/datasets/{dataset.id}/records",
+            params={"include": f"{RecordInclude.vectors.value}:{vector_settings_a.id},{vector_settings_b.id}"},
+            headers=owner_auth_header,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "items": [
+                {
+                    "id": str(record_a.id),
+                    "fields": {"text": "This is a text", "sentiment": "neutral"},
+                    "metadata": None,
+                    "external_id": record_a.external_id,
+                    "vectors": {
+                        "vector-a": [1.0, 2.0, 3.0],
+                        "vector-b": [4.0, 5.0],
+                    },
+                    "inserted_at": record_a.inserted_at.isoformat(),
+                    "updated_at": record_a.updated_at.isoformat(),
+                },
+                {
+                    "id": str(record_b.id),
+                    "fields": {"text": "This is a text", "sentiment": "neutral"},
+                    "metadata": None,
+                    "external_id": record_b.external_id,
+                    "vectors": {
+                        "vector-b": [1.0, 2.0],
+                    },
+                    "inserted_at": record_b.inserted_at.isoformat(),
+                    "updated_at": record_b.updated_at.isoformat(),
+                },
+                {
+                    "id": str(record_c.id),
+                    "fields": {"text": "This is a text", "sentiment": "neutral"},
+                    "metadata": None,
+                    "external_id": record_c.external_id,
+                    "vectors": {},
+                    "inserted_at": record_c.inserted_at.isoformat(),
+                    "updated_at": record_c.updated_at.isoformat(),
+                },
+            ],
+            "total": 3,
+        }
+
     async def test_list_dataset_records_with_offset(self, async_client: "AsyncClient", owner_auth_header: dict):
         dataset = await DatasetFactory.create()
         await RecordFactory.create(fields={"record_a": "value_a"}, dataset=dataset)
@@ -1388,6 +1511,128 @@ class TestSuiteDatasets:
 
         assert response.status_code == 200
         assert response.json() == expected
+
+    async def test_list_current_user_dataset_records_with_include_vectors(
+        self, async_client: "AsyncClient", owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+        record_a = await RecordFactory.create(dataset=dataset)
+        record_b = await RecordFactory.create(dataset=dataset)
+        record_c = await RecordFactory.create(dataset=dataset)
+        vector_settings_a = await VectorSettingsFactory.create(name="vector-a", dimensions=3, dataset=dataset)
+        vector_settings_b = await VectorSettingsFactory.create(name="vector-b", dimensions=2, dataset=dataset)
+
+        await VectorFactory.create(value=[1.0, 2.0, 3.0], vector_settings=vector_settings_a, record=record_a)
+        await VectorFactory.create(value=[4.0, 5.0], vector_settings=vector_settings_b, record=record_a)
+        await VectorFactory.create(value=[1.0, 2.0], vector_settings=vector_settings_b, record=record_b)
+
+        response = await async_client.get(
+            f"/api/v1/me/datasets/{dataset.id}/records",
+            params={"include": RecordInclude.vectors.value},
+            headers=owner_auth_header,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "items": [
+                {
+                    "id": str(record_a.id),
+                    "fields": {"text": "This is a text", "sentiment": "neutral"},
+                    "metadata": None,
+                    "external_id": record_a.external_id,
+                    "vectors": {
+                        "vector-a": [1.0, 2.0, 3.0],
+                        "vector-b": [4.0, 5.0],
+                    },
+                    "inserted_at": record_a.inserted_at.isoformat(),
+                    "updated_at": record_a.updated_at.isoformat(),
+                },
+                {
+                    "id": str(record_b.id),
+                    "fields": {"text": "This is a text", "sentiment": "neutral"},
+                    "metadata": None,
+                    "external_id": record_b.external_id,
+                    "vectors": {
+                        "vector-b": [1.0, 2.0],
+                    },
+                    "inserted_at": record_b.inserted_at.isoformat(),
+                    "updated_at": record_b.updated_at.isoformat(),
+                },
+                {
+                    "id": str(record_c.id),
+                    "fields": {"text": "This is a text", "sentiment": "neutral"},
+                    "metadata": None,
+                    "external_id": record_c.external_id,
+                    "vectors": {},
+                    "inserted_at": record_c.inserted_at.isoformat(),
+                    "updated_at": record_c.updated_at.isoformat(),
+                },
+            ],
+            "total": 3,
+        }
+
+    async def test_list_current_user_dataset_records_with_include_specific_vectors(
+        self, async_client: "AsyncClient", owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+        record_a = await RecordFactory.create(dataset=dataset)
+        record_b = await RecordFactory.create(dataset=dataset)
+        record_c = await RecordFactory.create(dataset=dataset)
+        vector_settings_a = await VectorSettingsFactory.create(name="vector-a", dimensions=3, dataset=dataset)
+        vector_settings_b = await VectorSettingsFactory.create(name="vector-b", dimensions=2, dataset=dataset)
+        vector_settings_c = await VectorSettingsFactory.create(name="vector-c", dimensions=4, dataset=dataset)
+
+        await VectorFactory.create(value=[1.0, 2.0, 3.0], vector_settings=vector_settings_a, record=record_a)
+        await VectorFactory.create(value=[4.0, 5.0], vector_settings=vector_settings_b, record=record_a)
+        await VectorFactory.create(value=[6.0, 7.0, 8.0, 9.0], vector_settings=vector_settings_c, record=record_a)
+        await VectorFactory.create(value=[1.0, 2.0], vector_settings=vector_settings_b, record=record_b)
+        await VectorFactory.create(value=[10.0, 11.0, 12.0, 13.0], vector_settings=vector_settings_c, record=record_b)
+        await VectorFactory.create(value=[14.0, 15.0, 16.0, 17.0], vector_settings=vector_settings_c, record=record_c)
+
+        response = await async_client.get(
+            f"/api/v1/me/datasets/{dataset.id}/records",
+            params={"include": f"{RecordInclude.vectors.value}:{vector_settings_a.id},{vector_settings_b.id}"},
+            headers=owner_auth_header,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "items": [
+                {
+                    "id": str(record_a.id),
+                    "fields": {"text": "This is a text", "sentiment": "neutral"},
+                    "metadata": None,
+                    "external_id": record_a.external_id,
+                    "vectors": {
+                        "vector-a": [1.0, 2.0, 3.0],
+                        "vector-b": [4.0, 5.0],
+                    },
+                    "inserted_at": record_a.inserted_at.isoformat(),
+                    "updated_at": record_a.updated_at.isoformat(),
+                },
+                {
+                    "id": str(record_b.id),
+                    "fields": {"text": "This is a text", "sentiment": "neutral"},
+                    "metadata": None,
+                    "external_id": record_b.external_id,
+                    "vectors": {
+                        "vector-b": [1.0, 2.0],
+                    },
+                    "inserted_at": record_b.inserted_at.isoformat(),
+                    "updated_at": record_b.updated_at.isoformat(),
+                },
+                {
+                    "id": str(record_c.id),
+                    "fields": {"text": "This is a text", "sentiment": "neutral"},
+                    "metadata": None,
+                    "external_id": record_c.external_id,
+                    "vectors": {},
+                    "inserted_at": record_c.inserted_at.isoformat(),
+                    "updated_at": record_c.updated_at.isoformat(),
+                },
+            ],
+            "total": 3,
+        }
 
     async def test_list_current_user_dataset_records_with_offset(
         self, async_client: "AsyncClient", owner_auth_header: dict

--- a/tests/unit/server/api/v1/test_records.py
+++ b/tests/unit/server/api/v1/test_records.py
@@ -94,6 +94,7 @@ class TestSuiteRecords:
             "external_id": record.external_id,
             "responses": None,
             "suggestions": [],
+            "vectors": None,
             "inserted_at": record.inserted_at.isoformat(),
             "updated_at": record.updated_at.isoformat(),
         }
@@ -195,6 +196,7 @@ class TestSuiteRecords:
                     "id": str(record.suggestions[1].id),
                 },
             ],
+            "vectors": None,
             "inserted_at": record.inserted_at.isoformat(),
             "updated_at": record.updated_at.isoformat(),
         }
@@ -228,6 +230,7 @@ class TestSuiteRecords:
             "external_id": record.external_id,
             "responses": None,
             "suggestions": [],
+            "vectors": None,
             "inserted_at": record.inserted_at.isoformat(),
             "updated_at": record.updated_at.isoformat(),
         }
@@ -253,6 +256,7 @@ class TestSuiteRecords:
             "external_id": record.external_id,
             "responses": None,
             "suggestions": [],
+            "vectors": None,
             "inserted_at": record.inserted_at.isoformat(),
             "updated_at": record.updated_at.isoformat(),
         }
@@ -278,6 +282,7 @@ class TestSuiteRecords:
             "external_id": record.external_id,
             "responses": None,
             "suggestions": [],
+            "vectors": None,
             "inserted_at": record.inserted_at.isoformat(),
             "updated_at": record.updated_at.isoformat(),
         }


### PR DESCRIPTION
# Description

This PR add support to `include=vectors` and `include=vectors:vector_settings_id_01,vector_settings_id_02` parameters in the following endpoints:
* `GET /api/v1/datasets/:dataset_id/records`
* `GET /api/v1/me/datasets/:dataset_id/records`
* `GET /api/v1/me/datasets/:dataset_id/records/search`

Possible improvements to this PR:
- [x] Use vector names instead of vector settings ids for `include` like `include=vectors:vector_name_01,vector_name_02`.
- [ ] Add support for `include` parameter to `GET /api/v1/records/:record_id` endpoint.

Closes #4051 

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [x] Running tests locally.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)