### PR TITLE
chore: Upgrade minimal OpenSearch version to 2.6.0

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -56,9 +56,9 @@ jobs:
             searchEngineDockerEnv: '{"discovery.type": "single-node", "xpack.security.enabled": "false"}'
             coverageReport: coverage-elasticsearch-8.8.2
             runsOn: extended-runner
-          - searchEngineDockerImage: opensearchproject/opensearch:2.5.0
+          - searchEngineDockerImage: opensearchproject/opensearch:2.6.0
             searchEngineDockerEnv: '{"discovery.type": "single-node", "plugins.security.disabled": "true"}'
-            coverageReport: coverage-opensearch-2.5.0
+            coverageReport: coverage-opensearch-2.6.0
             runsOn: ubuntu-latest
     name: Run unit tests
     uses: ./.github/workflows/run-python-tests.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ These are the section headers that we use:
 - Update `FeedbackDataset.push_to_argilla` to also push vector settings. ([#4055](https://github.com/argilla-io/argilla/pull/4055))
 - Update `FeedbackDatasetRecord` to support the creation of records with vectors. ([#4043](https://github.com/argilla-io/argilla/pull/4043))
 - Update `POST /api/v1/me/datasets/:dataset_id/records/search` endpoint to allow to search records with vectors. ([#4019](https://github.com/argilla-io/argilla/pull/4019))
-- [breaking] Users working with OpenSearch engines must use version >=2.5 and set `ARGILLA_SEARCH_ENGINE=opensearch`. ([#4019](https://github.com/argilla-io/argilla/pull/4019))
+- [breaking] Users working with OpenSearch engines must use version >=2.6 and set `ARGILLA_SEARCH_ENGINE=opensearch`. ([#4019](https://github.com/argilla-io/argilla/pull/4019) and [#4109](https://github.com/argilla-io/argilla/pull/4109)))
 
 ## [1.18.0](https://github.com/argilla-io/argilla/compare/v1.17.0...v1.18.0)
 

--- a/docker/docker-compose.elasticsearch.yaml
+++ b/docker/docker-compose.elasticsearch.yaml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.8.2
     ports:
       - "9200:9200"
       - "9300:9300"
@@ -23,7 +23,7 @@ services:
     volumes:
       - elasticsearch-data-8:/usr/share/elasticsearch/data/
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.5.3
+    image: docker.elastic.co/kibana/kibana:8.8.2
     ports:
       - "5601:5601"
     environment:

--- a/docker/docker-compose.opensearch.yaml
+++ b/docker/docker-compose.opensearch.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   opensearch:
-    image: opensearchproject/opensearch:2.5.0
+    image: opensearchproject/opensearch:2.6.0
     container_name: opensearch-node1
     environment:
       - cluster.name=opensearch-cluster
@@ -23,15 +23,15 @@ services:
     volumes:
       - opensearch-data:/usr/share/opensearch/data
   opensearch-dashboards:
-    image: opensearchproject/opensearch-dashboards:2.5.0
+    image: opensearchproject/opensearch-dashboards:2.6.0
     container_name: opensearch-dashboards
     ports:
       - 5601:5601 # Map host port 5601 to container port 5601
     expose:
       - "5601" # Expose port 5601 for web access to OpenSearch Dashboards
     environment:
-      DISABLE_SECURITY_DASHBOARDS_PLUGIN: 1
-      OPENSEARCH_HOSTS: '["http://opensearch-node1:9200"]'
+      - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true"
+      - 'OPENSEARCH_HOSTS=["http://opensearch-node1:9200"]'
     networks:
       - argilla
 

--- a/src/argilla/server/search_engine/opensearch.py
+++ b/src/argilla/server/search_engine/opensearch.py
@@ -90,8 +90,10 @@ class OpenSearchEngine(BaseElasticAndOpenSearchEngine):
             bool_filter_query["must_not"] = [{"ids": {"values": [str(excluded_id)]}}]
 
         if bool_filter_query:
+            # This will work only for lucene versions >= 9.5.0 (OpenSearch >= 2.6.0)
+            # Otherwise, knn + filter can raise a "failed to create query: Rewrite first" query shard exception
+            # See https://github.com/apache/lucene/pull/12072
             # See https://opensearch.org/docs/latest/search-plugins/knn/filter-search-knn/#efficient-k-nn-filtering
-            # Will work from Opensearch >= v2.5
             knn_query["filter"] = {"bool": bool_filter_query}
 
         body = {"query": {"knn": {field_name_for_vector_settings(vector_settings): knn_query}}}

--- a/tests/unit/server/search_engine/test_opensearch_engine.py
+++ b/tests/unit/server/search_engine/test_opensearch_engine.py
@@ -1154,20 +1154,33 @@ class TestSuiteOpenSearchEngine:
         assert responses.total == 1
         assert responses.items[0].record_id != selected_record.id
 
-    async def test_similarity_search_by_record(
+    @pytest.mark.parametrize(
+        "user_response_status_filter",
+        [
+            None,
+            UserResponseStatusFilter(statuses=[ResponseStatusFilter.draft, ResponseStatusFilter.missing]),
+        ],
+    )
+    async def test_similarity_search_by_record_and_user_response_filter(
         self,
         opensearch_engine: OpenSearchEngine,
         opensearch: OpenSearch,
         test_banking_sentiment_dataset_with_vectors: Dataset,
+        user_response_status_filter: UserResponseStatusFilter,
     ):
         selected_record: Record = test_banking_sentiment_dataset_with_vectors.records[0]
         vector_settings: VectorSettings = test_banking_sentiment_dataset_with_vectors.vectors_settings[0]
+
+        if user_response_status_filter:
+            test_user = await UserFactory.create()
+            user_response_status_filter.user = test_user
 
         responses = await opensearch_engine.similarity_search(
             dataset=test_banking_sentiment_dataset_with_vectors,
             vector_settings=vector_settings,
             record=selected_record,
             max_results=1,
+            user_response_status_filter=user_response_status_filter,
         )
 
         assert responses.total == 1


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

Doing some tests with OpenSearch 2.5 I realized some cases where similarity search fails when adding as part of the `knn` filter an existing field clause (for user responses). This is documented and fixed in the Lucene 9.5.0 version (See here: https://github.com/apache/lucene/pull/12072). So the minimal required OpenSearch version must use the Lucene 9.5.0, which is 2.6.0.

Using versions under  2.6.0 an error `"failed to create query: Rewrite first"` using similarity search can be potentially raised.


**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

Local tests 

**Checklist**

- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
