### PR TITLE
fix: avoid installing `pytest-asyncio==0.22.0`

### DIFF
--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-mock
-  - pytest-asyncio
+  - pytest-asyncio!=0.22.0
   - pytest-env
   - factory_boy~=3.2.1
   # docs, pandoc needs conda ...


### PR DESCRIPTION
# Description

`pytest-asyncio==0.22.0` was released the 31 October causing the following error when running our tests: `RuntimeError: There is no current event loop in thread 'MainThread'`. The version has been yanked in PyPI https://pypi.org/project/pytest-asyncio/0.22.0/, but not yet in conda-forge https://anaconda.org/conda-forge/pytest-asyncio.

This PR updates the conda env to specifically not install `pytest-asyncio==0.22.0`.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**


**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)