### PR TITLE
feat(integration): add support for `vectors` and `vectors_settings` in `{push_to,from)_huggingface`

### DIFF
--- a/src/argilla/client/feedback/config.py
+++ b/src/argilla/client/feedback/config.py
@@ -33,6 +33,7 @@ except ImportError:
     )
 
 from argilla.client.feedback.schemas.types import AllowedFieldTypes, AllowedMetadataPropertyTypes, AllowedQuestionTypes
+from argilla.client.feedback.schemas.vector_settings import VectorSettings
 
 
 class DatasetConfig(BaseModel):
@@ -43,6 +44,7 @@ class DatasetConfig(BaseModel):
         List[Annotated[AllowedMetadataPropertyTypes, Field(..., discriminator="type")]]
     ] = None
     allow_extra_metadata: bool = True
+    vectors_settings: Optional[List[VectorSettings]] = None
 
     def to_yaml(self) -> str:
         return dump(self.dict())

--- a/src/argilla/client/feedback/integrations/huggingface/card/argilla_template.md
+++ b/src/argilla/client/feedback/integrations/huggingface/card/argilla_template.md
@@ -62,7 +62,7 @@ There are no leaderboards associated with this dataset.
 
 ### Data in Argilla
 
-The dataset is created in Argilla with: **fields**, **questions**, **suggestions**, **metadata**, and **guidelines**.
+The dataset is created in Argilla with: **fields**, **questions**, **suggestions**, **metadata**, **vectors**, and **guidelines**.
 
 The **fields** are the dataset records themselves, for the moment just text fields are supported. These are the ones that will be used to provide responses to the questions.
 
@@ -80,7 +80,16 @@ The **questions** are the questions that will be asked to the annotators. They c
 
 The **suggestions** are human or machine generated recommendations for each question to assist the annotator during the annotation process, so those are always linked to the existing questions, and named appending "-suggestion" and "-suggestion-metadata" to those, containing the value/s of the suggestion and its metadata, respectively. So on, the possible values are the same as in the table above, but the column name is appended with "-suggestion" and the metadata is appended with "-suggestion-metadata".
 
-**✨ NEW** The **metadata** is a dictionary that can be used to provide additional information about the dataset record. This can be useful to provide additional context to the annotators, or to provide additional information about the dataset record itself. For example, you can use this to provide a link to the original source of the dataset record, or to provide additional information about the dataset record itself, such as the author, the date, or the source. The metadata is always optional, and can be potentially linked to the `metadata_properties` defined in the dataset configuration file in `argilla.yaml`.
+The **metadata** is a dictionary that can be used to provide additional information about the dataset record. This can be useful to provide additional context to the annotators, or to provide additional information about the dataset record itself. For example, you can use this to provide a link to the original source of the dataset record, or to provide additional information about the dataset record itself, such as the author, the date, or the source. The metadata is always optional, and can be potentially linked to the `metadata_properties` defined in the dataset configuration file in `argilla.yaml`.
+
+{% if argilla_vectors_settings %}
+**✨ NEW** The **vectors** are different columns that contain a vector in floating point, which is constraint to the pre-defined dimensions in the **vectors_settings** when configuring the vectors within the dataset itself, also the dimensions will always be 1-dimensional. The **vectors** are optional and identified by the pre-defined vector name in the dataset configuration file in `argilla.yaml`.
+
+| Vector Name | Title | Dimensions |
+|-------------|-------|------------|
+{% for vector in argilla_vectors_settings %}| {{ vector.name }} | {{ vector.title }} | [1, {{ vector.dimensions }}] |
+{% endfor %}
+{% endif %}
 
 The **guidelines**, are optional as well, and are just a plain string that can be used to provide instructions to the annotators. Find those in the [annotation guidelines](#annotation-guidelines) section.
 
@@ -114,9 +123,13 @@ Among the dataset fields, we differentiate between the following:
     {% for question in argilla_questions %}
     * (optional) **{{ question.name }}-suggestion** is of type `{{ question.type }}`{% if question.type in ["rating", "label_selection", "multi_label_selection", "ranking"] %} with the following allowed values {% if question.type in ["rating", "ranking"] %}{{ question.values | list }}{% else %}{{ question.labels | list }}{% endif %}{% endif %}.{% endfor %}
 
+* **✨ NEW** **Vectors**: As of Argilla 1.19.0, the vectors have been included in order to add support for similarity search to explore similar records based on vector search powered by the search engine defined. The vectors are optional and cannot be seen within the UI, those are uploaded and internally used. Also the vectors will always be optional, and only the dimensions previously defined in their settings.
+    {% for vector in argilla_vectors_settings %}
+    * (optional) **{{ vector.name }}** is of type `float32` and has a dimension of (1, `{{ vector.dimensions }}`).{% endfor %}
+
 Additionally, we also have two more fields that are optional and are the following:
 
-* **✨ NEW** **metadata:** This is an optional field that can be used to provide additional information about the dataset record. This can be useful to provide additional context to the annotators, or to provide additional information about the dataset record itself. For example, you can use this to provide a link to the original source of the dataset record, or to provide additional information about the dataset record itself, such as the author, the date, or the source. The metadata is always optional, and can be potentially linked to the `metadata_properties` defined in the dataset configuration file in `argilla.yaml`.
+* **metadata:** This is an optional field that can be used to provide additional information about the dataset record. This can be useful to provide additional context to the annotators, or to provide additional information about the dataset record itself. For example, you can use this to provide a link to the original source of the dataset record, or to provide additional information about the dataset record itself, such as the author, the date, or the source. The metadata is always optional, and can be potentially linked to the `metadata_properties` defined in the dataset configuration file in `argilla.yaml`.
 * **external_id:** This is an optional field that can be used to provide an external ID for the dataset record. This can be useful if you want to link the dataset record to an external resource, such as a database or a file.
 
 ### Data Splits

--- a/src/argilla/client/feedback/integrations/huggingface/card/argilla_template.md
+++ b/src/argilla/client/feedback/integrations/huggingface/card/argilla_template.md
@@ -123,9 +123,11 @@ Among the dataset fields, we differentiate between the following:
     {% for question in argilla_questions %}
     * (optional) **{{ question.name }}-suggestion** is of type `{{ question.type }}`{% if question.type in ["rating", "label_selection", "multi_label_selection", "ranking"] %} with the following allowed values {% if question.type in ["rating", "ranking"] %}{{ question.values | list }}{% else %}{{ question.labels | list }}{% endif %}{% endif %}.{% endfor %}
 
+{% if argilla_vectors_settings %}
 * **✨ NEW** **Vectors**: As of Argilla 1.19.0, the vectors have been included in order to add support for similarity search to explore similar records based on vector search powered by the search engine defined. The vectors are optional and cannot be seen within the UI, those are uploaded and internally used. Also the vectors will always be optional, and only the dimensions previously defined in their settings.
     {% for vector in argilla_vectors_settings %}
     * (optional) **{{ vector.name }}** is of type `float32` and has a dimension of (1, `{{ vector.dimensions }}`).{% endfor %}
+{% endif %}
 
 Additionally, we also have two more fields that are optional and are the following:
 

--- a/src/argilla/client/feedback/integrations/huggingface/dataset.py
+++ b/src/argilla/client/feedback/integrations/huggingface/dataset.py
@@ -205,6 +205,7 @@ class HuggingFaceDatasetMixin:
                     guidelines=self.guidelines,
                     metadata_properties=self.metadata_properties or None,
                     allow_extra_metadata=self.allow_extra_metadata,
+                    vectors_settings=self.vectors_settings or None,
                 ).to_yaml()
             )
             f.flush()
@@ -306,6 +307,7 @@ class HuggingFaceDatasetMixin:
                     guidelines=config.guidelines,
                     metadata_properties=config.metadata_properties,
                     allow_extra_metadata=config.allow_extra_metadata,
+                    vectors_settings=config.vectors_settings,
                 )
         except EntryNotFoundError:
             # TODO(alvarobartt): here for backwards compatibility, last used in 1.12.0

--- a/tests/integration/client/feedback/integrations/huggingface/test_dataset.py
+++ b/tests/integration/client/feedback/integrations/huggingface/test_dataset.py
@@ -43,6 +43,9 @@ class TestSuiteHuggingFaceDatasetMixin:
                 rg.IntegerMetadataProperty(name="integer-metadata-property", min=0, max=100),
                 rg.FloatMetadataProperty(name="float-metadata-property", min=0.0, max=100.0),
             ],
+            vectors_settings=[
+                rg.VectorSettings(name="float-vector", dimensions=2),
+            ],
             guidelines="These are the guidelines",
         )
 
@@ -60,6 +63,7 @@ class TestSuiteHuggingFaceDatasetMixin:
                         "integer-metadata-property": 1,
                         "float-metadata-property": 1.0,
                     },
+                    vectors={"float-vector": [1.0, 2.0]},
                     external_id="external-id-1",
                 )
             ]
@@ -80,5 +84,6 @@ class TestSuiteHuggingFaceDatasetMixin:
         assert dataset.fields == self.dataset.fields
         assert dataset.questions == self.dataset.questions
         assert dataset.metadata_properties == self.dataset.metadata_properties
+        assert dataset.vectors_settings == self.dataset.vectors_settings
         assert dataset.guidelines == self.dataset.guidelines
         assert dataset.records == self.dataset.records

--- a/tests/unit/client/feedback/integrations/huggingface/card/test__dataset_card.py
+++ b/tests/unit/client/feedback/integrations/huggingface/card/test__dataset_card.py
@@ -27,6 +27,7 @@ from argilla.client.feedback.schemas.questions import (
     TextQuestion,
 )
 from argilla.client.feedback.schemas.records import FeedbackRecord
+from argilla.client.feedback.schemas.vector_settings import VectorSettings
 from huggingface_hub import DatasetCardData
 
 if TYPE_CHECKING:
@@ -36,7 +37,7 @@ if TYPE_CHECKING:
 
 class TestSuiteArgillaDatasetCard:
     @pytest.mark.parametrize(
-        "repo_id,fields,questions,guidelines,record",
+        "repo_id,fields,questions,guidelines,vectors_settings,record",
         [
             (
                 f"argilla/dataset-card-{uuid4()}",
@@ -49,6 +50,7 @@ class TestSuiteArgillaDatasetCard:
                     RankingQuestion(name="ranking-question", values=["a", "b", "c"]),
                 ],
                 "## Guidelines",
+                [VectorSettings(name="float-vector", dimensions=2)],
                 FeedbackRecord(
                     fields={"text-field": "text"},
                     responses=[
@@ -86,6 +88,7 @@ class TestSuiteArgillaDatasetCard:
                             "value": ["a", "b", "c"],
                         },
                     ],
+                    vectors={"float-vector": [1.0, 2.0]},
                     external_id="external-id-1",
                 ),
             )
@@ -97,6 +100,7 @@ class TestSuiteArgillaDatasetCard:
         fields: List["AllowedFieldTypes"],
         questions: List["AllowedQuestionTypes"],
         guidelines: str,
+        vectors_settings: List[VectorSettings],
         record: FeedbackRecord,
     ) -> None:
         card = ArgillaDatasetCard.from_template(
@@ -108,6 +112,7 @@ class TestSuiteArgillaDatasetCard:
             argilla_fields=fields,
             argilla_questions=questions,
             argilla_guidelines=guidelines,
+            argilla_vectors_settings=vectors_settings,
             argilla_record=json.loads(record.json()),
             huggingface_record=record.json(),
         )
@@ -117,4 +122,5 @@ class TestSuiteArgillaDatasetCard:
         assert card.content.__contains__(f"# Dataset Card for {repo_id.split('/')[1]}")
         assert all(field.name in card.content for field in fields)
         assert all(question.name in card.content for question in questions)
+        assert all(vector_settings.name in card.content for vector_settings in vectors_settings)
         assert guidelines in card.content


### PR DESCRIPTION
# Description

This PR adds support for the recently included `vectors` and `vectors_settings` at `FeedbackRecord` and `FeedbackDataset` level respectively. This means that the `vectors` can be stored and restored using `format_as("datasets")` via a `FeedbackDataset`, but also that the `vectors_settings` can be stored and restored as part of the `FeedbackDataset` settings when calling `push_to_huggingface` and `from_huggingface`, respectively.

Besides that also the `ArgillaDatasetCard` has been updated so as to include information about what's new!

Closes #4119

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [x] Add unit tests for the `DatasetConfig`
- [x] Add unit/integration tests for `push_to_huggingface` and `from_huggingface` methods from `HuggingFaceDatasetMixin`

**Checklist**

- [x] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
