### PR TITLE
feat: add a maximum limit of 5 vectors settings that can be created per dataset

### DIFF
--- a/src/argilla/server/apis/v1/handlers/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets.py
@@ -661,7 +661,7 @@ async def create_dataset_vector_settings(
     count_vectors_settings_by_dataset_id = await datasets.count_vectors_settings_by_dataset_id(db, dataset_id)
     if count_vectors_settings_by_dataset_id >= CREATE_DATASET_VECTOR_SETTINGS_MAX_COUNT:
         raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=f"The maximum number of vector settings has been reached for dataset with id `{dataset_id}`",
         )
 

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -312,6 +312,12 @@ async def delete_question(db: "AsyncSession", question: Question) -> Question:
     return await question.delete(db)
 
 
+async def count_vectors_settings_by_dataset_id(db: "AsyncSession", dataset_id: UUID) -> int:
+    result = await db.execute(select(func.count(VectorSettings.id)).filter_by(dataset_id=dataset_id))
+
+    return result.scalar()
+
+
 async def get_vector_settings_by_id(db: "AsyncSession", vector_settings_id: UUID) -> Union[VectorSettings, None]:
     result = await db.execute(
         select(VectorSettings).filter_by(id=vector_settings_id).options(selectinload(VectorSettings.dataset))

--- a/tests/unit/server/api/v1/datasets/test_create_dataset_vector_settings.py
+++ b/tests/unit/server/api/v1/datasets/test_create_dataset_vector_settings.py
@@ -1,0 +1,49 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from uuid import UUID
+
+import pytest
+from argilla.server.apis.v1.handlers.datasets import CREATE_DATASET_VECTOR_SETTINGS_MAX_COUNT
+from httpx import AsyncClient
+
+from tests.factories import DatasetFactory, VectorSettingsFactory
+
+
+@pytest.mark.asyncio
+class TestCreateDatasetVectorSettings:
+    def url(self, dataset_id: UUID) -> str:
+        return f"/api/v1/datasets/{dataset_id}/vectors-settings"
+
+    async def test_with_maximum_number_of_vector_settings_reached(
+        self, async_client: AsyncClient, owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+
+        await VectorSettingsFactory.create_batch(CREATE_DATASET_VECTOR_SETTINGS_MAX_COUNT, dataset=dataset)
+
+        response = await async_client.post(
+            self.url(dataset.id),
+            headers=owner_auth_header,
+            json={
+                "name": "name",
+                "title": "title",
+                "dimensions": 3,
+            },
+        )
+
+        assert response.status_code == 403
+        assert response.json() == {
+            "detail": f"The maximum number of vector settings has been reached for dataset with id `{dataset.id}`"
+        }

--- a/tests/unit/server/api/v1/datasets/test_create_dataset_vector_settings.py
+++ b/tests/unit/server/api/v1/datasets/test_create_dataset_vector_settings.py
@@ -43,7 +43,7 @@ class TestCreateDatasetVectorSettings:
             },
         )
 
-        assert response.status_code == 403
+        assert response.status_code == 422
         assert response.json() == {
             "detail": f"The maximum number of vector settings has been reached for dataset with id `{dataset.id}`"
         }


### PR DESCRIPTION
# Description

This PR add changes to the endpoint `POST /api/v1/datasets/:dataset_id/vectors-settings` only allowing a maximum of `5` vector settings to be created by dataset. 

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [x] Adding unit tests.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)