### PR TITLE
fix: Use `RatingQuestion` instead of `RankingQuestion` for sentence similarity in the `ArgillaTrainer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ These are the section headers that we use:
 
 - @Racso-3141 Added a progress bar for parsing records process to `from_huggingface()` method with `trange` in `tqdm`.([#4132](https://github.com/argilla-io/argilla/pull/4132)).
 
+### Fixed
+
+- Fixed error in `ArgillaTrainer`, with numerical labels use `RatingQuestion` instead of `RankingQuestion` ([#4171](https://github.com/argilla-io/argilla/pull/4171))
 
 ## [1.19.0]()
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,6 @@ These are the section headers that we use:
 
 ## [Unreleased]()
 
-### Contributors
-
-- @Racso-3141 Added a progress bar for parsing records process to `from_huggingface()` method with `trange` in `tqdm`.([#4132](https://github.com/argilla-io/argilla/pull/4132)).
-
 ### Fixed
 
 - Fixed error in `ArgillaTrainer`, with numerical labels use `RatingQuestion` instead of `RankingQuestion` ([#4171](https://github.com/argilla-io/argilla/pull/4171))

--- a/docs/_source/practical_guides/fine_tune.md
+++ b/docs/_source/practical_guides/fine_tune.md
@@ -545,7 +545,7 @@ label_strategy = RatingQuestionUnification(
 
 task = TrainingTask.for_sentence_similarity(
     texts=[dataset.field_by_name("premise"), dataset.field_by_name("hypothesis")],
-    label=dataset.question_by_name("label"),
+    label=dataset.question_by_name("other-question"),
     label_strategy=label_strategy
 )
 ```

--- a/docs/_source/practical_guides/fine_tune.md
+++ b/docs/_source/practical_guides/fine_tune.md
@@ -533,6 +533,23 @@ task = TrainingTask.for_sentence_similarity(
 )
 ```
 
+For datasets that where annotated with numerical values we could also pass the label strategy we want to use (let's assume we have another question in the dataset named "other-question" that contains values that come from rated answers):
+
+```python
+from argilla.feedback import RatingQuestionUnification
+
+label_strategy = RatingQuestionUnification(
+    question=dataset.question_by_name("other-question"),
+    strategy="majority"
+)
+
+task = TrainingTask.for_sentence_similarity(
+    texts=[dataset.field_by_name("premise"), dataset.field_by_name("hypothesis")],
+    label=dataset.question_by_name("label"),
+    label_strategy=label_strategy
+)
+```
+
 :::
 
 :::{tab-item} formatting_func

--- a/docs/_source/practical_guides/fine_tune.md
+++ b/docs/_source/practical_guides/fine_tune.md
@@ -536,17 +536,10 @@ task = TrainingTask.for_sentence_similarity(
 For datasets that where annotated with numerical values we could also pass the label strategy we want to use (let's assume we have another question in the dataset named "other-question" that contains values that come from rated answers):
 
 ```python
-from argilla.feedback import RatingQuestionUnification
-
-label_strategy = RatingQuestionUnification(
-    question=dataset.question_by_name("other-question"),
-    strategy="majority"
-)
-
 task = TrainingTask.for_sentence_similarity(
     texts=[dataset.field_by_name("premise"), dataset.field_by_name("hypothesis")],
     label=dataset.question_by_name("other-question"),
-    label_strategy=label_strategy
+    label_strategy="majority" # or "mean" for RankingQuestion
 )
 ```
 

--- a/src/argilla/client/feedback/training/schemas.py
+++ b/src/argilla/client/feedback/training/schemas.py
@@ -1561,14 +1561,16 @@ class TrainingTaskForSentenceSimilarity(BaseModel, TrainingData):
             for example in formatted_data:
                 record = {}
                 for k, v in new_keys.items():
-                    value = example[k]
                     if v == "label":
+                        value = example[v]
                         # At this point the label must be either an int or a float, determine which one is it.
                         if isinstance(value, str):
                             if value.lstrip("-").isdigit():
                                 value = int(value)
                             else:
                                 value = float(value)
+                    else:
+                        value = example[k]
 
                     record[v] = value
                 outputs.append(record)

--- a/tests/integration/client/feedback/helpers.py
+++ b/tests/integration/client/feedback/helpers.py
@@ -288,7 +288,7 @@ def formatting_func_sentence_transformers(sample: dict):
         elif labels[0] == "c":
             return [
                 {"sentence-1": sample["text"], "sentence-2": sample["text"], "label": 1},
-                {"sentence-1": sample["text"], "sentence-2": sample["text"], "label": 0},
+                {"sentence-1": sample["text"], "sentence-2": sample["text"], "label": 2},
             ]
 
 task = TrainingTask.for_sentence_similarity(formatting_func=formatting_func_sentence_transformers)

--- a/tests/integration/client/feedback/helpers.py
+++ b/tests/integration/client/feedback/helpers.py
@@ -126,7 +126,7 @@ def formatting_func_sentence_transformers(sample: dict):
         elif labels[0] == "c":
             return [
                 {"sentence-1": sample["text"], "sentence-2": sample["text"], "label": 1},
-                {"sentence-1": sample["text"], "sentence-2": sample["text"], "label": 0},
+                {"sentence-1": sample["text"], "sentence-2": sample["text"], "label": 2},
             ]
 
 
@@ -180,7 +180,7 @@ def formatting_func_sentence_transformers_case_3_a(sample):
         elif labels[0] == "b":
             return {"sentence": sample["text"], "label": 1}
         elif labels[0] == "c":
-            return [{"sentence": sample["text"], "label": 1}, {"sentence": sample["text"], "label": 0}]
+            return [{"sentence": sample["text"], "label": 1}, {"sentence": sample["text"], "label": 2}]
 
 
 def formatting_func_sentence_transformers_case_3_b(sample):
@@ -202,7 +202,7 @@ def formatting_func_sentence_transformers_case_3_b(sample):
         elif labels[0] == "c":
             return [
                 {"sentence-1": sample["text"], "sentence-2": sample["text"], "sentence-3": sample["text"], "label": 1},
-                {"sentence-1": sample["text"], "sentence-2": sample["text"], "sentence-3": sample["text"], "label": 0},
+                {"sentence-1": sample["text"], "sentence-2": sample["text"], "sentence-3": sample["text"], "label": 2},
             ]
 
 
@@ -219,6 +219,17 @@ def formatting_func_sentence_transformers_case_4(sample):
             return {"sentence-1": sample["text"], "sentence-2": sample["text"], "sentence-3": sample["text"]}
         elif labels[0] == "c":
             return [{"sentence-1": sample["text"], "sentence-2": sample["text"], "sentence-3": sample["text"]}] * 2
+
+
+def formatting_func_sentence_transformers_rating_question(sample: dict):
+    # Formatting function to test the RatingQuestion
+    labels = [
+        annotation["value"]
+        for annotation in sample["question-2"]
+        if annotation["status"] == "submitted" and annotation["value"] is not None
+    ]
+    if labels:
+        return {"sentence-1": sample["text"], "sentence-2": sample["text"], "label": labels[0]}
 
 
 def model_card_pattern(framework: Framework, training_task: Any) -> str:

--- a/tests/integration/client/feedback/training/test_sentence_transformers.py
+++ b/tests/integration/client/feedback/training/test_sentence_transformers.py
@@ -20,6 +20,10 @@ from argilla.client.feedback.dataset import FeedbackDataset
 from argilla.client.feedback.schemas.records import FeedbackRecord
 from argilla.client.feedback.training.base import ArgillaTrainer
 from argilla.client.feedback.training.schemas import (
+    LabelQuestion,
+    LabelQuestionUnification,
+    RatingQuestion,
+    RatingQuestionUnification,
     TrainingTask,
 )
 from sentence_transformers import CrossEncoder, InputExample, SentenceTransformer
@@ -31,6 +35,7 @@ from tests.integration.client.feedback.helpers import (
     formatting_func_sentence_transformers_case_3_a,
     formatting_func_sentence_transformers_case_3_b,
     formatting_func_sentence_transformers_case_4,
+    formatting_func_sentence_transformers_rating_question,
 )
 from tests.integration.training.helpers import train_with_cleanup
 
@@ -60,6 +65,7 @@ def formatting_func_errored(sample):
         formatting_func_sentence_transformers_case_2,
         formatting_func_sentence_transformers_case_3_b,
         formatting_func_sentence_transformers_case_4,
+        formatting_func_sentence_transformers_rating_question,
     ],
 )
 @pytest.mark.usefixtures(
@@ -84,7 +90,14 @@ def test_prepare_for_training_sentence_transformers(
     )
     dataset.add_records(records=feedback_dataset_records * 2)
 
-    task = TrainingTask.for_sentence_similarity(formatting_func=formatting_func)
+    if formatting_func.__name__ == "formatting_func_sentence_transformers_rating_question":
+        label_strategy = RatingQuestionUnification(
+            question=RatingQuestion(name="label", values=[1, 2]), strategy="majority"
+        )
+        task = TrainingTask.for_sentence_similarity(formatting_func=formatting_func, label_strategy=label_strategy)
+    else:
+        task = TrainingTask.for_sentence_similarity(formatting_func=formatting_func)
+
     train_dataset = dataset.prepare_for_training(framework=__FRAMEWORK__, task=task)
 
     assert isinstance(train_dataset, list)

--- a/tests/integration/client/feedback/training/test_sentence_transformers.py
+++ b/tests/integration/client/feedback/training/test_sentence_transformers.py
@@ -93,9 +93,7 @@ def test_prepare_for_training_sentence_transformers(
     dataset.add_records(records=feedback_dataset_records * 2)
 
     if formatting_func.__name__ == "formatting_func_sentence_transformers_rating_question":
-        label_strategy = RatingQuestionUnification(
-            question=RatingQuestion(name="label", values=[1, 2]), strategy="majority"
-        )
+        label_strategy = RatingQuestionUnification(question=dataset.question_by_name("question-2"), strategy="majority")
         task = TrainingTask.for_sentence_similarity(formatting_func=formatting_func, label_strategy=label_strategy)
     else:
         task = TrainingTask.for_sentence_similarity(formatting_func=formatting_func)


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

Update the `ArgillaTrainer` to use `RatingQuestion` instead of `RankingQuestion` when training for `sentence-similarity` with numerical labels.

Closes #4049 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [x] `test/integration/client/feedback/training/test_sentence_transformers.py`

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
