### PR TITLE
fix: sets `use_enum_values` to `True` to avoid problems with client `DatasetConfig` serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ These are the section headers that we use:
 - Update `GET /api/v1/me/datasets/:dataset_id/records` endpoint to fetch record using the search engine. ([#4142](https://github.com/argilla-io/argilla/pull/4142))
 - [breaking] `limit` query parameter for `GET /api/v1/datasets/:dataset_id/records` endpoint is now only accepting values greater or equal than `1` and less or equal than `1000`. ([#4143](https://github.com/argilla-io/argilla/pull/4143))
 - [breaking] `limit` query parameter for `GET /api/v1/me/datasets/:dataset_id/records` endpoint is now only accepting values greater or equal than `1` and less or equal than `1000`. ([#4143](https://github.com/argilla-io/argilla/pull/4143))
+- Now client class `DatasetConfig` is setting `use_enum_values` config value to `True`. ([#4172](https://github.com/argilla-io/argilla/pull/4172))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ These are the section headers that we use:
 - Update `GET /api/v1/me/datasets/:dataset_id/records` endpoint to fetch record using the search engine. ([#4142](https://github.com/argilla-io/argilla/pull/4142))
 - [breaking] `limit` query parameter for `GET /api/v1/datasets/:dataset_id/records` endpoint is now only accepting values greater or equal than `1` and less or equal than `1000`. ([#4143](https://github.com/argilla-io/argilla/pull/4143))
 - [breaking] `limit` query parameter for `GET /api/v1/me/datasets/:dataset_id/records` endpoint is now only accepting values greater or equal than `1` and less or equal than `1000`. ([#4143](https://github.com/argilla-io/argilla/pull/4143))
-- Now client class `DatasetConfig` is setting `use_enum_values` config value to `True`. ([#4172](https://github.com/argilla-io/argilla/pull/4172))
+- Now client class `DatasetConfig` is setting `use_enum_values` config value to `True`. Closes [#4089](https://github.com/argilla-io/argilla/issues/4089) ([#4172](https://github.com/argilla-io/argilla/pull/4172))
 
 ### Fixed
 

--- a/src/argilla/client/feedback/config.py
+++ b/src/argilla/client/feedback/config.py
@@ -46,6 +46,9 @@ class DatasetConfig(BaseModel):
     allow_extra_metadata: bool = True
     vectors_settings: Optional[List[VectorSettings]] = None
 
+    class Config:
+        use_enum_values = True
+
     def to_yaml(self) -> str:
         return dump(self.dict())
 


### PR DESCRIPTION
# Description

I couldn't reproduce the error locally but looks like `use_enum_values` could potentially solve the problem:

```python
In [17]: class Response(BaseModel):
    ...:     status: ResponseStatus
    ...:

In [18]: Response(status=ResponseStatus.draft)
Out[18]: Response(status=<ResponseStatus.draft: 'draft'>)

In [19]: class Response(BaseModel):
    ...:     status: ResponseStatus
    ...:     class Config:
    ...:         use_enum_values = True
    ...:

In [20]: Response(status=ResponseStatus.draft)
Out[20]: Response(status='draft')
```

Closes #4089 

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

If it's really difficult to test because it was happening only in some specific environments. Even when environments with the same dependencies and configuration.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)