### PR TITLE
refactor: Remove support for unsupported versions for feedback datasets

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -76,17 +76,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - searchEngineDockerImage: docker.elastic.co/elasticsearch/elasticsearch:8.0.1
+          - searchEngineDockerImage: docker.elastic.co/elasticsearch/elasticsearch:8.8.0
             searchEngineDockerEnv: '{"discovery.type": "single-node", "xpack.security.enabled": "false"}'
-            coverageReport: coverage-elasticsearch-8.0.1
+            coverageReport: coverage-elasticsearch-8.8.0
             runsOn: extended-runner
-          - searchEngineDockerImage: docker.elastic.co/elasticsearch/elasticsearch:7.17.11
+          - searchEngineDockerImage: docker.elastic.co/elasticsearch/elasticsearch:8.6.0
             searchEngineDockerEnv: '{"discovery.type": "single-node", "xpack.security.enabled": "false"}'
-            coverageReport: coverage-elasticsearch-7.17.11
+            coverageReport: coverage-elasticsearch-8.6.0
             runsOn: extended-runner
-          - searchEngineDockerImage: opensearchproject/opensearch:1.3.11
+          - searchEngineDockerImage: opensearchproject/opensearch:2.8.0
             searchEngineDockerEnv: '{"discovery.type": "single-node", "plugins.security.disabled": "true"}'
-            coverageReport: coverage-opensearch-1.3.11
+            coverageReport: coverage-opensearch-2.8.0
             runsOn: extended-runner
     name: Run unit tests with extra engines
     uses: ./.github/workflows/run-python-tests.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ These are the section headers that we use:
 - [breaking] `limit` query parameter for `GET /api/v1/datasets/:dataset_id/records` endpoint is now only accepting values greater or equal than `1` and less or equal than `1000`. ([#4143](https://github.com/argilla-io/argilla/pull/4143))
 - [breaking] `limit` query parameter for `GET /api/v1/me/datasets/:dataset_id/records` endpoint is now only accepting values greater or equal than `1` and less or equal than `1000`. ([#4143](https://github.com/argilla-io/argilla/pull/4143))
 - Now client class `DatasetConfig` is setting `use_enum_values` config value to `True`. Closes [#4089](https://github.com/argilla-io/argilla/issues/4089) ([#4172](https://github.com/argilla-io/argilla/pull/4172))
+- [breaking] Remove support for Elasticsearch < 8.5 and OpenSearch < 2.4. ()
 
 ### Fixed
 

--- a/src/argilla/server/daos/backend/client_adapters/base.py
+++ b/src/argilla/server/daos/backend/client_adapters/base.py
@@ -22,8 +22,6 @@ from argilla.server.daos.backend.search.model import BaseQuery, SortConfig
 
 @dataclasses.dataclass
 class IClientAdapter(metaclass=ABCMeta):
-    vector_search_supported: bool
-
     @abstractmethod
     def get_cluster_info(self) -> Dict[str, Any]:
         """Returns basic about es cluster"""

--- a/src/argilla/server/daos/backend/client_adapters/elasticsearch.py
+++ b/src/argilla/server/daos/backend/client_adapters/elasticsearch.py
@@ -49,8 +49,6 @@ class ElasticsearchClient(OpenSearchClient):
         vectors: Dict[str, int],
         similarity_metric: str = "l2_norm",
     ):
-        self._check_vector_supported()
-
         vector_mappings = {}
         for vector_name, vector_dimension in vectors.items():
             index_mapping = {
@@ -106,7 +104,6 @@ class ElasticsearchClient(OpenSearchClient):
     ):
         knn = es_query.pop("knn", None)
         if knn:
-            self._check_vector_supported()
             results = self.__client__.search(
                 index=index,
                 knn=knn,

--- a/src/argilla/server/daos/backend/client_adapters/factory.py
+++ b/src/argilla/server/daos/backend/client_adapters/factory.py
@@ -12,11 +12,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import logging
-from typing import Tuple, Type
+from typing import Tuple
 
-import httpx
 from opensearchpy import OpenSearch
 from packaging.version import parse
+
+from argilla.server.settings import settings as server_settings
 
 from argilla.server.daos.backend.base import GenericSearchError
 from argilla.server.daos.backend.client_adapters import ElasticsearchClient, IClientAdapter, OpenSearchClient
@@ -45,34 +46,25 @@ class ClientAdapterFactory:
 
         version, distribution = cls._fetch_cluster_version_info(client_config)
 
-        (client_class, support_vector_search) = cls._resolve_client_class_with_vector_support(version, distribution)
+        if distribution != server_settings.search_engine:
+            _LOGGER.warning(
+                f"The search engine distribution is not the same as the one configured in the server. "
+                f"The configuration will be automatically updated with ARGILLA_SEARCH_ENGINE={distribution}."
+            )
+            server_settings.search_engine = distribution
 
-        return client_class(
-            index_shards=index_shards, vector_search_supported=support_vector_search, config_backend=client_config
-        )
-
-    @classmethod
-    def _resolve_client_class_with_vector_support(cls, version: str, distribution: str) -> Tuple[Type, bool]:
-        support_vector_search = True
-
-        if distribution == "elasticsearch" and parse("8.5") <= parse(version):
-            if parse("8.5") <= parse(ElasticsearchClient.ES_CLIENT_VERSION):
-                client_class = ElasticsearchClient
-            else:
-                _LOGGER.warning(
-                    "Elasticsearch 8.5 backend found but installed\n"
-                    "client does not support vectors. Please upgrade your elasticsearch client\n"
-                    "if you want to support similarity search in argilla."
-                )
-                client_class = OpenSearchClient
-                support_vector_search = False
-        elif distribution == "opensearch" and parse("2.2") <= parse(version):
+        if distribution == "elasticsearch" and parse("8.5.0") <= parse(version):
+            client_class = ElasticsearchClient
+        elif distribution == "opensearch" and parse("2.4.0") <= parse(version):
             client_class = OpenSearchClient
         else:
-            client_class = OpenSearchClient
-            support_vector_search = False
+            raise ValueError(
+                f"Unsupported ElasticSearch/OpenSearch backend version :{version}. "
+                f"Minimal supported version are `8.5.0` for Elasticsearch and `2.4.0` for OpenSearch. "
+                "Please, upgrade the backend to a supported version."
+            )
 
-        return client_class, support_vector_search
+        return client_class(index_shards=index_shards, config_backend=client_config)
 
     @classmethod
     def _fetch_cluster_version_info(cls, client_config: dict) -> Tuple[str, str]:

--- a/src/argilla/server/daos/backend/client_adapters/factory.py
+++ b/src/argilla/server/daos/backend/client_adapters/factory.py
@@ -17,10 +17,9 @@ from typing import Tuple
 from opensearchpy import OpenSearch
 from packaging.version import parse
 
-from argilla.server.settings import settings as server_settings
-
 from argilla.server.daos.backend.base import GenericSearchError
 from argilla.server.daos.backend.client_adapters import ElasticsearchClient, IClientAdapter, OpenSearchClient
+from argilla.server.settings import settings as server_settings
 
 _LOGGER = logging.getLogger("argilla")
 

--- a/src/argilla/server/daos/backend/client_adapters/opensearch.py
+++ b/src/argilla/server/daos/backend/client_adapters/opensearch.py
@@ -52,12 +52,8 @@ class OpenSearchClient(IClientAdapter):
         index: str,
         vectors: Dict[str, int],
     ):
-        self._check_vector_supported()
+        self.set_index_settings(index=index, settings={"index.knn": False})
 
-        self.set_index_settings(
-            index=index,
-            settings={"index.knn": False},
-        )
         vector_mappings = {}
         for vector_name, vector_dimension in vectors.items():
             index_mapping = {
@@ -77,13 +73,6 @@ class OpenSearchClient(IClientAdapter):
             index=index,
             properties=vector_mappings,
         )
-
-    def _check_vector_supported(self):
-        if not self.vector_search_supported:
-            raise ValueError(
-                "The vector search is not supported for this elasticsearch version. "
-                "Please, update the server to use this feature"
-            )
 
     def search_docs(
         self,
@@ -742,9 +731,6 @@ class OpenSearchClient(IClientAdapter):
         size: int,
         routing: Optional[str] = None,
     ):
-        if "knn" in es_query["query"]:
-            self._check_vector_supported()
-
         results = self.__client__.search(
             index=index,
             body=es_query,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -27,15 +27,3 @@ os.environ.update(
     NUMEXPR_NUM_THREADS="1",
     MKL_NUM_THREADS="1",
 )
-
-try:
-    client = ClientAdapterFactory.get(
-        hosts=settings.elasticsearch,
-        index_shards=settings.es_records_index_shards,
-        ssl_verify=settings.elasticsearch_ssl_verify,
-        ca_path=settings.elasticsearch_ca_path,
-    )
-
-    SUPPORTED_VECTOR_SEARCH = client.vector_search_supported
-except Exception:
-    SUPPORTED_VECTOR_SEARCH = False

--- a/tests/integration/client/test_api.py
+++ b/tests/integration/client/test_api.py
@@ -76,7 +76,6 @@ from argilla.server.commons.models import TaskStatus
 from argilla.server.models import User, UserRole
 from httpx import ConnectError
 
-from tests import SUPPORTED_VECTOR_SEARCH
 from tests.factories import DatasetFactory, UserFactory, WorkspaceFactory
 
 
@@ -375,7 +374,7 @@ def test_load_limits(argilla_user: User):
     api = Argilla(api_key=argilla_user.api_key)
     api.delete(dataset)
 
-    create_some_data_for_text_classification(api.http_client, dataset, n=50, with_vectors=SUPPORTED_VECTOR_SEARCH)
+    create_some_data_for_text_classification(api.http_client, dataset, n=50)
 
     limit_data_to = 10
     ds = api.load(name=dataset, limit=limit_data_to)
@@ -763,7 +762,7 @@ def test_load_with_ids_list(api: Argilla):
     api.delete(name=dataset)
 
     expected_data = 100
-    create_some_data_for_text_classification(api.client, dataset, n=expected_data, with_vectors=SUPPORTED_VECTOR_SEARCH)
+    create_some_data_for_text_classification(api.client, dataset, n=expected_data)
     ds = api.load(name=dataset, ids=[3, 5])
     assert len(ds) == 2
 
@@ -778,7 +777,6 @@ def test_load_with_query(api: Argilla):
         api.client,
         dataset,
         n=expected_data,
-        with_vectors=SUPPORTED_VECTOR_SEARCH,
     )
     ds = api.load(name=dataset, query="id:1")
     ds = ds.to_pandas()
@@ -815,17 +813,16 @@ def test_load_as_pandas(api: Argilla):
         api.client,
         dataset,
         n=expected_data,
-        with_vectors=SUPPORTED_VECTOR_SEARCH,
     )
 
     records = api.load(name=dataset)
     assert isinstance(records, DatasetForTextClassification)
     assert isinstance(records[0], TextClassificationRecord)
 
-    if SUPPORTED_VECTOR_SEARCH:
-        for record in records:
-            for vector in record.vectors:
-                assert server_vectors_cfg[vector]["value"] == record.vectors[vector]
+
+    for record in records:
+        for vector in record.vectors:
+            assert server_vectors_cfg[vector]["value"] == record.vectors[vector]
 
 
 @pytest.mark.parametrize(
@@ -874,8 +871,7 @@ def test_load_text2text(api: Argilla):
             status="Default",
             event_timestamp=datetime.datetime(2000, 1, 1),
         )
-        if SUPPORTED_VECTOR_SEARCH:
-            record.vectors = vectors
+        record.vectors = vectors
         records.append(record)
 
     dataset = "test_load_text2text"
@@ -884,9 +880,8 @@ def test_load_text2text(api: Argilla):
 
     df = api.load(name=dataset)
     assert len(df) == 2
-    if SUPPORTED_VECTOR_SEARCH:
-        for record in df:
-            assert record.vectors["bert_uncased"] == vectors["bert_uncased"]
+    for record in df:
+        assert record.vectors["bert_uncased"] == vectors["bert_uncased"]
 
 
 def test_client_workspace(api: Argilla, argilla_user: User):

--- a/tests/integration/client/test_api.py
+++ b/tests/integration/client/test_api.py
@@ -819,7 +819,6 @@ def test_load_as_pandas(api: Argilla):
     assert isinstance(records, DatasetForTextClassification)
     assert isinstance(records[0], TextClassificationRecord)
 
-
     for record in records:
         for vector in record.vectors:
             assert server_vectors_cfg[vector]["value"] == record.vectors[vector]

--- a/tests/integration/test_log_for_text_classification.py
+++ b/tests/integration/test_log_for_text_classification.py
@@ -14,8 +14,9 @@
 
 from typing import TYPE_CHECKING
 
-import argilla as rg
 import pytest
+
+import argilla as rg
 from argilla.client.api import delete, init, load, log
 from argilla.client.client import Argilla
 from argilla.client.datasets import read_datasets
@@ -27,7 +28,6 @@ from argilla.client.sdk.commons.errors import (
 )
 from argilla.server.settings import settings
 
-from tests import SUPPORTED_VECTOR_SEARCH
 from tests.factories import WorkspaceFactory
 
 if TYPE_CHECKING:
@@ -76,10 +76,6 @@ def test_delete_and_create_for_different_task(api: Argilla):
     api.load(dataset)
 
 
-@pytest.mark.skipif(
-    condition=not SUPPORTED_VECTOR_SEARCH,
-    reason="Vector search not supported",
-)
 def test_similarity_search_in_python_client(api: Argilla):
     dataset = "test_similarity_search_in_python_client"
     text = "This is a text"
@@ -107,10 +103,6 @@ def test_similarity_search_in_python_client(api: Argilla):
         )
 
 
-@pytest.mark.skipif(
-    condition=not SUPPORTED_VECTOR_SEARCH,
-    reason="Vector search not supported",
-)
 def test_log_data_with_vectors_and_update_ok(api: Argilla):
     dataset = "test_log_data_with_vectors_and_update_ok"
     text = "This is a text"
@@ -139,7 +131,6 @@ def test_log_data_with_vectors_and_update_ok(api: Argilla):
     assert ds[0].id == 3
 
 
-@pytest.mark.skipif(condition=not SUPPORTED_VECTOR_SEARCH, reason="Vector search not supported")
 def test_log_data_with_vectors_and_update_ko(argilla_user: "User"):
     dataset = "test_log_data_with_vectors_and_update_ko"
     text = "This is a text"

--- a/tests/integration/test_log_for_text_classification.py
+++ b/tests/integration/test_log_for_text_classification.py
@@ -14,9 +14,8 @@
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 import argilla as rg
+import pytest
 from argilla.client.api import delete, init, load, log
 from argilla.client.client import Argilla
 from argilla.client.datasets import read_datasets

--- a/tests/integration/test_log_for_token_classification.py
+++ b/tests/integration/test_log_for_token_classification.py
@@ -22,7 +22,6 @@ from argilla.metrics import __all__ as ALL_METRICS
 from argilla.metrics import entity_consistency
 
 
-
 def test_log_with_empty_text(api: Argilla):
     dataset = "test_log_with_empty_text"
     text = " "

--- a/tests/integration/test_log_for_token_classification.py
+++ b/tests/integration/test_log_for_token_classification.py
@@ -21,7 +21,6 @@ from argilla.client.sdk.commons.errors import NotFoundApiError
 from argilla.metrics import __all__ as ALL_METRICS
 from argilla.metrics import entity_consistency
 
-from tests import SUPPORTED_VECTOR_SEARCH
 
 
 def test_log_with_empty_text(api: Argilla):
@@ -184,7 +183,6 @@ def test_search_keywords(api: Argilla):
     assert {"listened", "listen"} == top_keywords, top_keywords
 
 
-@pytest.mark.skipif(condition=not SUPPORTED_VECTOR_SEARCH, reason="Vector search not supported")
 def test_log_data_with_vectors_and_update_ok(api: Argilla):
     dataset = "test_log_data_with_vectors_and_update_ok"
     text = "This is a text"
@@ -217,10 +215,6 @@ def test_log_data_with_vectors_and_update_ok(api: Argilla):
     assert ds[0].id == 3
 
 
-@pytest.mark.skipif(
-    condition=not SUPPORTED_VECTOR_SEARCH,
-    reason="Vector search not supported",
-)
 def test_log_data_with_vectors_and_partial_update_ok(api: Argilla):
     dataset = "test_log_data_and_partial_update_ok"
     text = "This is a text"

--- a/tests/unit/server/api/v0/test_text2text.py
+++ b/tests/unit/server/api/v0/test_text2text.py
@@ -24,8 +24,6 @@ from argilla.server.apis.v0.models.text2text import (
 from argilla.server.commons.models import TaskType
 from argilla.server.models import User
 
-from tests import SUPPORTED_VECTOR_SEARCH
-
 if TYPE_CHECKING:
     from httpx import AsyncClient
 
@@ -116,10 +114,6 @@ async def search_data(
             assert vector_name in record.vectors
 
 
-@pytest.mark.skipif(
-    condition=not SUPPORTED_VECTOR_SEARCH,
-    reason="Vector search not supported",
-)
 @pytest.mark.asyncio
 async def test_search_with_vectors(async_client: "AsyncClient", argilla_user: User):
     async_client.headers.update({API_KEY_HEADER_NAME: argilla_user.api_key})

--- a/tests/unit/server/api/v0/test_text_classification.py
+++ b/tests/unit/server/api/v0/test_text_classification.py
@@ -31,8 +31,6 @@ from argilla.server.commons.models import PredictionStatus, TaskType
 from argilla.server.models import User
 from argilla.server.schemas.v0.datasets import Dataset
 
-from tests import SUPPORTED_VECTOR_SEARCH
-
 if TYPE_CHECKING:
     from httpx import AsyncClient
 
@@ -229,7 +227,6 @@ async def test_create_records_for_text_classification(async_client: "AsyncClient
     test_telemetry.assert_called()
 
 
-@pytest.mark.skipif(condition=not SUPPORTED_VECTOR_SEARCH, reason="Vector search not supported")
 @pytest.mark.asyncio
 async def test_create_records_for_text_classification_vector_search(
     async_client: "AsyncClient", argilla_user: User, test_telemetry

--- a/tests/unit/server/api/v0/test_token_classification.py
+++ b/tests/unit/server/api/v0/test_token_classification.py
@@ -27,9 +27,6 @@ from argilla.server.apis.v0.models.token_classification import (
 )
 from argilla.server.commons.models import TaskType
 
-from tests import SUPPORTED_VECTOR_SEARCH
-
-
 @pytest.mark.asyncio
 async def test_load_as_different_task(async_client: "AsyncClient", argilla_user: User):
     async_client.headers.update({API_KEY_HEADER_NAME: argilla_user.api_key})
@@ -262,10 +259,6 @@ async def test_create_records_for_token_classification(
         assert metrics_validator(record)
 
 
-@pytest.mark.skipif(
-    condition=not SUPPORTED_VECTOR_SEARCH,
-    reason="Vector search not supported",
-)
 @pytest.mark.parametrize(
     ("include_metrics", "metrics_validator"),
     [

--- a/tests/unit/server/api/v0/test_token_classification.py
+++ b/tests/unit/server/api/v0/test_token_classification.py
@@ -27,6 +27,7 @@ from argilla.server.apis.v0.models.token_classification import (
 )
 from argilla.server.commons.models import TaskType
 
+
 @pytest.mark.asyncio
 async def test_load_as_different_task(async_client: "AsyncClient", argilla_user: User):
     async_client.headers.update({API_KEY_HEADER_NAME: argilla_user.api_key})


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR aligns required versions for Elastic and OpenSearch between the Feedback dataset and other tasks. Now, Argilla will support Elasticsearch >= 8.5 and OpenSearch >= 2.4


