### PR TITLE
feat: add helper function to keep track of the tutorial usage

### DIFF
--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -58,5 +58,6 @@ dependencies:
       - trl>=0.5.0
       - sentence-transformers
       - rich!=13.1.0
+      - ipynbname>=2023.2.0.0
       # install Argilla in editable mode
       - -e .[server,listeners]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,8 @@ integrations = [
     "openai>=0.27.10,<1.0.0",
     "peft",
     "trl>=0.5.0",
+    # To find the a notebook name from within a notebook
+    "ipynbname"
 ]
 tests = [
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ integrations = [
     "openai>=0.27.10,<1.0.0",
     "peft",
     "trl>=0.5.0",
-    # To find the a notebook name from within a notebook
+    # To find the notebook name from within a notebook
     "ipynbname"
 ]
 tests = [

--- a/src/argilla/utils/telemetry.py
+++ b/src/argilla/utils/telemetry.py
@@ -103,5 +103,14 @@ async def track_login(request: "Request", username: str):
     )
 
 
+def tutorial_running(tutorial_id: int) -> None:
+    """Can be called when a tutorial is executed so that the tutorial_id is used to identify the tutorial and send an event.
+
+    Args:
+        tutorial_id: ID number of the tutorial.
+    """
+    _CLIENT.track_data(action="TutorialRunning", data={"tutorial_id": tutorial_id})
+
+
 def get_telemetry_client() -> TelemetryClient:
     return _CLIENT

--- a/src/argilla/utils/telemetry.py
+++ b/src/argilla/utils/telemetry.py
@@ -103,11 +103,11 @@ async def track_login(request: "Request", username: str):
     )
 
 
-def tutorial_running(tutorial_id: int) -> None:
+def tutorial_running(tutorial_id: str) -> None:
     """Can be called when a tutorial is executed so that the tutorial_id is used to identify the tutorial and send an event.
 
     Args:
-        tutorial_id: ID number of the tutorial.
+        tutorial_id: ID number of the tutorial, use the filename of the file without the extension.
     """
     _CLIENT.track_data(action="TutorialRunning", data={"tutorial_id": tutorial_id})
 

--- a/src/argilla/utils/telemetry.py
+++ b/src/argilla/utils/telemetry.py
@@ -103,13 +103,43 @@ async def track_login(request: "Request", username: str):
     )
 
 
-def tutorial_running(tutorial_id: str) -> None:
-    """Can be called when a tutorial is executed so that the tutorial_id is used to identify the tutorial and send an event.
+def get_current_filename() -> Optional[str]:
+    """Returns the filename of the current file.
 
-    Args:
-        tutorial_id: ID number of the tutorial, use the filename of the file without the extension.
+    It will try to get the filename from the following sources:
+    - __file__ variable (only works when running from python)
+    - __vsc_ipynb_file__ variable (only works when running from vscode)
+    - ipynbname.name() (only works when running from a notebook/gooble colab)
+    - None if it can't be determined
     """
-    _CLIENT.track_data(action="TutorialRunning", data={"tutorial_id": tutorial_id})
+    from pathlib import Path
+
+    try:
+        try:
+            # Should work if we are running from python
+            return Path(__file__).stem
+        except NameError as e:
+            # This should work if we are running a notebook from vscode
+            globals_ = globals()
+            return Path(globals_["__vsc_ipynb_file__"]).stem
+    except KeyError as e:
+        # This should work for notebooks running locally or using google colab
+        import urllib.parse
+
+        import ipynbname
+
+        return Path(urllib.parse.unquote_plus(ipynbname.name())).stem
+    except Exception as e:
+        import warnings
+
+        warnings.warn("Couldn't determine the filename.")
+        return
+
+
+def tutorial_running() -> None:
+    """Can be called when a tutorial is executed so that the tutorial_id is used to identify the tutorial and send an event."""
+    if tutorial_id := get_current_filename():
+        _CLIENT.track_data(action="TutorialRunning", data={"tutorial_id": tutorial_id})
 
 
 def get_telemetry_client() -> TelemetryClient:

--- a/src/argilla/utils/telemetry.py
+++ b/src/argilla/utils/telemetry.py
@@ -129,11 +129,6 @@ def get_current_filename() -> Optional[str]:
         import ipynbname
 
         return Path(urllib.parse.unquote_plus(ipynbname.name())).stem
-    except Exception as e:
-        import warnings
-
-        warnings.warn("Couldn't determine the filename.")
-        return
 
 
 def tutorial_running() -> None:


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR includes a function to keep track of the tutorials running, similar to the format used in haystack:

```python
from argilla.utils.telemetry import tutorial_running

tutorial_running("tutorial_filename")
```

Closes #4189

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
