### PR TITLE
fix: Dump dataset config from json serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,6 @@ These are the section headers that we use:
 - Update `GET /api/v1/me/datasets/:dataset_id/records` endpoint to fetch record using the search engine. ([#4142](https://github.com/argilla-io/argilla/pull/4142))
 - [breaking] `limit` query parameter for `GET /api/v1/datasets/:dataset_id/records` endpoint is now only accepting values greater or equal than `1` and less or equal than `1000`. ([#4143](https://github.com/argilla-io/argilla/pull/4143))
 - [breaking] `limit` query parameter for `GET /api/v1/me/datasets/:dataset_id/records` endpoint is now only accepting values greater or equal than `1` and less or equal than `1000`. ([#4143](https://github.com/argilla-io/argilla/pull/4143))
-- Now client class `DatasetConfig` is setting `use_enum_values` config value to `True`. Closes [#4089](https://github.com/argilla-io/argilla/issues/4089) ([#4172](https://github.com/argilla-io/argilla/pull/4172))
 - [breaking] Remove support for Elasticsearch < 8.5 and OpenSearch < 2.4. ()
 
 ### Fixed
@@ -76,6 +75,7 @@ These are the section headers that we use:
 - Fixed creating records with responses from multiple users. Closes [#3746](https://github.com/argilla-io/argilla/issues/3746) and [#3808](https://github.com/argilla-io/argilla/issues/3808) ([#4142](https://github.com/argilla-io/argilla/pull/4142))
 - Fixed deleting or updating responses as an owner for annotators. (Commit [403a66d](https://github.com/argilla-io/argilla/commit/403a66d16d816fa8a62e3f76314ccc90e0073297))
 - Fixed passing user_id when getting records by id. (Commit [98c7927](https://github.com/argilla-io/argilla/commit/98c792757a21da05bac89b7f625e7e5792ad59f9))
+- Fixed non-basic tags serialized when pushing a dataset to the Hugging Face Hub. Closes [#4089](https://github.com/argilla-io/argilla/issues/4089) ([#4200](https://github.com/argilla-io/argilla/pull/4200))
 
 ## [1.18.0](https://github.com/argilla-io/argilla/compare/v1.17.0...v1.18.0)
 

--- a/src/argilla/client/feedback/config.py
+++ b/src/argilla/client/feedback/config.py
@@ -24,8 +24,11 @@ except ImportError:
 
 from pydantic import BaseModel, Field
 
+import json
+
 try:
-    from yaml import SafeLoader, dump, load
+    from yaml import SafeLoader, safe_dump, load
+
 except ImportError:
     raise ImportError(
         "Please make sure to install `PyYAML` in order to use `DatasetConfig`. To do"
@@ -46,11 +49,13 @@ class DatasetConfig(BaseModel):
     allow_extra_metadata: bool = True
     vectors_settings: Optional[List[VectorSettings]] = None
 
-    class Config:
-        use_enum_values = True
-
     def to_yaml(self) -> str:
-        return dump(self.dict())
+        # THIS DOUBLE SERIALIZATION IS DONE TO AVOID GENERATING YAMLs WITH CUSTOM ENUM TYPES.
+        # SEE https://github.com/argilla-io/argilla/issues/4089
+        # A better solution must be applied. We must review all defined enums in Pydantic models and set up the
+        # `use_enum_values = True` flag.
+        # See also https://github.com/yaml/pyyaml/issues/722
+        return safe_dump(json.loads(self.json()))
 
     @classmethod
     def from_yaml(cls, yaml_str: str) -> "DatasetConfig":

--- a/src/argilla/client/feedback/config.py
+++ b/src/argilla/client/feedback/config.py
@@ -22,12 +22,12 @@ try:
 except ImportError:
     from typing_extensions import Annotated
 
-from pydantic import BaseModel, Field
-
 import json
 
+from pydantic import BaseModel, Field
+
 try:
-    from yaml import SafeLoader, safe_dump, load
+    from yaml import SafeLoader, load, safe_dump
 
 except ImportError:
     raise ImportError(


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

Using the `use_enum_values = True` works only at the root level. We should review all sub-models used by the `DatasetConfig` class to properly serialize enums. 

As a simple (but not efficient) workaround, a double serialization-deserialization using json is applied. This will ensure that extra tags are not serialized as part of the resultant file. 

Also, the `safe_dump` function is used, which prevents and raises errors when a non-basic tags is detected.

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
