### PR TITLE
fix: safer dump of `vectors` in the HuggingFace Hub

### DIFF
--- a/src/argilla/client/feedback/integrations/huggingface/dataset.py
+++ b/src/argilla/client/feedback/integrations/huggingface/dataset.py
@@ -443,10 +443,7 @@ class HuggingFaceDatasetMixin:
             vectors = {}
             if "vectors" in hfds[index] and hfds[index]["vectors"]:
                 for vector_settings in dataset.vectors_settings:
-                    if (
-                        vector_settings.name in hfds[index]["vectors"]
-                        and hfds[index]["vectors"][vector_settings.name] is not None
-                    ):
+                    if hfds[index]["vectors"].get(vector_settings.name, None) is not None:
                         vectors.update({vector_settings.name: hfds[index]["vectors"][vector_settings.name]})
 
             records.append(

--- a/tests/integration/client/feedback/integrations/huggingface/test_dataset.py
+++ b/tests/integration/client/feedback/integrations/huggingface/test_dataset.py
@@ -24,7 +24,7 @@ import pytest
 class TestSuiteHuggingFaceDatasetMixin:
     @classmethod
     def setup_class(cls: "TestSuiteHuggingFaceDatasetMixin") -> None:
-        github_ref_name = re.sub(r"[^a-zA-Z0-9-]", "-", os.getenv("GITHUB_REF_NAME", "fix/hello-world"))
+        github_ref_name = re.sub(r"[^a-zA-Z0-9-]", "-", os.getenv("GITHUB_REF_NAME", "test"))
         cls.repo_id = "argilla/test-integration-{}-{}".format(github_ref_name, uuid4())
         cls.dataset = rg.FeedbackDataset(
             fields=[
@@ -44,9 +44,7 @@ class TestSuiteHuggingFaceDatasetMixin:
                 rg.FloatMetadataProperty(name="float-metadata-property", min=0.0, max=100.0),
             ],
             vectors_settings=[
-                # Named `text-field` to ensure that even if name is duplicated with a field/question, the
-                # vector is properly serialized under the `vectors` column in the `datasets.Dataset`
-                rg.VectorSettings(name="text-field", dimensions=2),
+                rg.VectorSettings(name="float-vector", dimensions=2),
             ],
             guidelines="These are the guidelines",
         )
@@ -89,3 +87,49 @@ class TestSuiteHuggingFaceDatasetMixin:
         assert dataset.vectors_settings == self.dataset.vectors_settings
         assert dataset.guidelines == self.dataset.guidelines
         assert dataset.records == self.dataset.records
+
+
+# Separate edge cases for integration tests
+@pytest.mark.skipif(os.getenv("HF_HUB_ACCESS_TOKEN") is None, reason="`HF_HUB_ACCESS_TOKEN` is not set")
+def test_push_to_huggingface_duplicated_vectors_name() -> None:
+    """Ensure that even if a field in the `FeedbackDataset` is named as a vector within the same dataset,
+    the dataset can still be pushed and pulled to/from HuggingFace Hub, respectively.
+    """
+    dataset = rg.FeedbackDataset(
+        fields=[
+            rg.TextField(name="text-field", required=True),
+        ],
+        questions=[
+            rg.TextQuestion(name="text-question", required=True),
+        ],
+        vectors_settings=[
+            # Named `text-field` to ensure that even if name is duplicated with a field/question, the
+            # vector is properly serialized under the `vectors` column in the `datasets.Dataset`
+            rg.VectorSettings(name="float-vector", dimensions=2),
+        ],
+    )
+
+    dataset.add_records(
+        [
+            rg.FeedbackRecord(
+                fields={
+                    "text-field": "This is a text field",
+                },
+                vectors={"text-field": [1.0, 2.0]},
+            )
+        ]
+    )
+
+    github_ref_name = re.sub(r"[^a-zA-Z0-9-]", "-", os.getenv("GITHUB_REF_NAME", "test"))
+    repo_id = "argilla/test-integration-{}-{}".format(github_ref_name, uuid4())
+    dataset.push_to_huggingface(repo_id=repo_id, private=True, token=os.getenv("HF_HUB_ACCESS_TOKEN"))
+
+    try:
+        hf_dataset = rg.FeedbackDataset.from_huggingface(repo_id=repo_id, token=os.getenv("HF_HUB_ACCESS_TOKEN"))
+        assert isinstance(hf_dataset, rg.FeedbackDataset)
+        assert hf_dataset.records == dataset.records
+    except Exception as e:
+        from huggingface_hub import HfApi
+
+        HfApi().delete_repo(repo_id, repo_type="dataset", token=os.getenv("HF_HUB_ACCESS_TOKEN"))
+        raise e

--- a/tests/integration/client/feedback/integrations/huggingface/test_dataset.py
+++ b/tests/integration/client/feedback/integrations/huggingface/test_dataset.py
@@ -63,7 +63,7 @@ class TestSuiteHuggingFaceDatasetMixin:
                         "integer-metadata-property": 1,
                         "float-metadata-property": 1.0,
                     },
-                    vectors={"text-field": [1.0, 2.0]},
+                    vectors={"float-vector": [1.0, 2.0]},
                     external_id="external-id-1",
                 )
             ]
@@ -91,7 +91,7 @@ class TestSuiteHuggingFaceDatasetMixin:
 
 # Separate edge cases for integration tests
 @pytest.mark.skipif(os.getenv("HF_HUB_ACCESS_TOKEN") is None, reason="`HF_HUB_ACCESS_TOKEN` is not set")
-def test_push_to_huggingface_duplicated_vectors_name() -> None:
+def test_push_to_huggingface_with_vectors_with_field_names() -> None:
     """Ensure that even if a field in the `FeedbackDataset` is named as a vector within the same dataset,
     the dataset can still be pushed and pulled to/from HuggingFace Hub, respectively.
     """
@@ -105,7 +105,7 @@ def test_push_to_huggingface_duplicated_vectors_name() -> None:
         vectors_settings=[
             # Named `text-field` to ensure that even if name is duplicated with a field/question, the
             # vector is properly serialized under the `vectors` column in the `datasets.Dataset`
-            rg.VectorSettings(name="float-vector", dimensions=2),
+            rg.VectorSettings(name="text-field", dimensions=2),
         ],
     )
 

--- a/tests/integration/client/feedback/integrations/huggingface/test_dataset.py
+++ b/tests/integration/client/feedback/integrations/huggingface/test_dataset.py
@@ -44,7 +44,9 @@ class TestSuiteHuggingFaceDatasetMixin:
                 rg.FloatMetadataProperty(name="float-metadata-property", min=0.0, max=100.0),
             ],
             vectors_settings=[
-                rg.VectorSettings(name="float-vector", dimensions=2),
+                # Named `text-field` to ensure that even if name is duplicated with a field/question, the
+                # vector is properly serialized under the `vectors` column in the `datasets.Dataset`
+                rg.VectorSettings(name="text-field", dimensions=2),
             ],
             guidelines="These are the guidelines",
         )
@@ -63,7 +65,7 @@ class TestSuiteHuggingFaceDatasetMixin:
                         "integer-metadata-property": 1,
                         "float-metadata-property": 1.0,
                     },
-                    vectors={"float-vector": [1.0, 2.0]},
+                    vectors={"text-field": [1.0, 2.0]},
                     external_id="external-id-1",
                 )
             ]


### PR DESCRIPTION
# Description

This PR solves an issue that was happening (and is still happening) related to the naming we're using for the columns in the HuggingFace Hub dataset, as we're exporting each of the fields and responses using their names in Argilla, and appending `-suggestion` or whatever feels necessary, but we can run into conflicts in any `field` is name as any other `question`, named `metadata` or named `external_id`, as well as the other way around for `question`.

So on, this PR fixes that for the upcoming `vectors`, as those are usually named after the field that those refer to, so instead of dumping those under the same name, we're dumping a Python dict in a column named `vectors` where each key-value pair is a vector name and its value. Similarly to what was done previously for the former Argilla datasets.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

- [x] Add integration tests for duplicated name on `vectors_settings` for a given vector and ensured that it's dumped and restored properly

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)