### PR TITLE
fix: solved bug from `ArgillaTrainer` with extractive QA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ These are the section headers that we use:
 ### Fixed
 
 - Fixed error in `ArgillaTrainer`, with numerical labels use `RatingQuestion` instead of `RankingQuestion` ([#4171](https://github.com/argilla-io/argilla/pull/4171))
+- Fixed error in `ArgillaTrainer`, now we can train for `extractive_question_answering` using a validation sample ([#4204](https://github.com/argilla-io/argilla/pull/4204))
 
 ## [1.19.0]()
 

--- a/src/argilla/client/feedback/training/schemas.py
+++ b/src/argilla/client/feedback/training/schemas.py
@@ -1302,6 +1302,7 @@ class TrainingTaskForQuestionAnswering(BaseModel, TrainingData):
             "question": [],
             "context": [],
             "answer": [],
+            "id": [],
         }
         for entry in data:
             if any([entry.get("question") is None, entry.get("context") is None, entry.get("answer") is None]):
@@ -1316,6 +1317,8 @@ class TrainingTaskForQuestionAnswering(BaseModel, TrainingData):
             datasets_dict["context"].append(entry["context"])
             datasets_dict["answer"].append({"answer_start": [answer_start], "text": [entry["answer"]]})
 
+        datasets_dict["id"] = list(range(len(data)))
+
         feature_dict = {
             "question": datasets.Value("string"),
             "context": datasets.Value("string"),
@@ -1327,6 +1330,7 @@ class TrainingTaskForQuestionAnswering(BaseModel, TrainingData):
                 length=-1,
                 id=None,
             ),
+            "id": datasets.Value(dtype="int32"),
         }
 
         ds = datasets.Dataset.from_dict(datasets_dict, features=datasets.Features(feature_dict))

--- a/src/argilla/training/transformers.py
+++ b/src/argilla/training/transformers.py
@@ -366,6 +366,8 @@ class ArgillaTransformersTrainer(ArgillaTrainerSkeleton):
             self._tokenized_eval_dataset = None
 
     def compute_metrics(self):
+        import collections
+
         import evaluate
         import numpy as np
         from transformers import AutoModelForQuestionAnswering
@@ -426,8 +428,6 @@ class ArgillaTransformersTrainer(ArgillaTrainerSkeleton):
             func = compute_metrics
         elif AutoModelForQuestionAnswering:
             squad = evaluate.load("squad")
-
-            import collections
 
             # Copy from https://huggingface.co/learn/nlp-course/chapter7/7?fw=pt#fine-tuning-the-model-with-the-trainer-api
             n_best = 20

--- a/tests/integration/client/feedback/training/test_trainer.py
+++ b/tests/integration/client/feedback/training/test_trainer.py
@@ -312,9 +312,9 @@ def test_question_answering_without_formatting_func(
         context=dataset.field_by_name("text"),
         answer=dataset.question_by_name("question-1"),
     )
-    trainer = ArgillaTrainer(dataset=dataset, task=task, framework="transformers")
+    trainer = ArgillaTrainer(dataset=dataset, task=task, framework="transformers", train_size=0.8)
     trainer.update_config(num_iterations=1)
-    trainer.train(__OUTPUT_DIR__)
+    train_with_cleanup(trainer, __OUTPUT_DIR__)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

Fixed the error that appeared when training for extractive question answering.

In order to compute the metrics with the evaluation data the format expected by squad dataset works with an extra field in the dataset to locate the answers during the validation pass:


```diff
feature_dict = {
    "question": datasets.Value("string"),
    "context": datasets.Value("string"),
    "answer": datasets.Sequence(
        feature={
            "text": datasets.Value(dtype="string", id=None),
            "answer_start": datasets.Value(dtype="int32", id=None),
        },
        length=-1,
        id=None,
    ),
+ "id": datasets.Value(dtype="int32"),
}
```

Closes #4158

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

The previous tests now include test sample to force the metrics computation

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
