### PR TITLE
fix: correct bug on sentence-transformers trainer with a list of values in the records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ These are the section headers that we use:
 
 - Fixed error in `ArgillaTrainer`, with numerical labels use `RatingQuestion` instead of `RankingQuestion` ([#4171](https://github.com/argilla-io/argilla/pull/4171))
 - Fixed error in `ArgillaTrainer`, now we can train for `extractive_question_answering` using a validation sample ([#4204](https://github.com/argilla-io/argilla/pull/4204))
+- Fixed error in `ArgillaTrainer`, when training for `sentence-similarity` it didn't worked with a list of values per record ([#4211](https://github.com/argilla-io/argilla/pull/4211))
 
 ## [1.19.0](https://github.com/argilla-io/argilla/compare/v1.18.0...v1.19.0)
 

--- a/src/argilla/client/feedback/training/schemas.py
+++ b/src/argilla/client/feedback/training/schemas.py
@@ -133,7 +133,6 @@ class TrainingData(ABC):
                         explode_columns.add(pydantic_field_name)
             formatted_data.append(data)
         df = pd.DataFrame(formatted_data)
-
         if explode_columns:
             df = df.explode(list(explode_columns))
         # In cases of MultiLabel datasets the label column contains a list,
@@ -1594,7 +1593,7 @@ class TrainingTaskForSentenceSimilarity(BaseModel, TrainingData):
 
     @requires_dependencies("sentence-transformers")
     def _prepare_for_training_with_sentence_transformers(
-        self, data: List[dict], train_size: float, seed: int
+        self, data: Union[List[dict], List[List[dict]]], train_size: float, seed: int
     ) -> Union["InputExample", Tuple["InputExample", "InputExample"]]:
         from sentence_transformers import InputExample
 
@@ -1615,7 +1614,7 @@ class TrainingTaskForSentenceSimilarity(BaseModel, TrainingData):
             def dataset_fields(sample):
                 return {"texts": [sample["sentence-1"], sample["sentence-2"]], "label": sample["label"]}
 
-        elif sample_keys == sample_keys == {"label", "sentence-1", "sentence-2", "sentence-3"}:
+        elif sample_keys == {"label", "sentence-1", "sentence-2", "sentence-3"}:
 
             def dataset_fields(sample):
                 return {

--- a/src/argilla/client/feedback/training/schemas.py
+++ b/src/argilla/client/feedback/training/schemas.py
@@ -1596,13 +1596,22 @@ class TrainingTaskForSentenceSimilarity(BaseModel, TrainingData):
     def _prepare_for_training_with_sentence_transformers(
         self, data: List[dict], train_size: float, seed: int
     ) -> Union["InputExample", Tuple["InputExample", "InputExample"]]:
+        from types import GeneratorType
+
         from sentence_transformers import InputExample
 
         if not len(data) > 0:
             raise ValueError("The dataset must contain at least one sample to be able to train.")
 
         # Use the first sample to decide what type of dataset to generate:
-        sample_keys = set(data[0].keys())
+        if isinstance(data[0], list):
+            # In case we are returning lists, extract the first element of that list to check the fields.
+            sample_keys = set(data[0][0].keys())
+        elif isinstance(data[0], dict):
+            sample_keys = set(data[0].keys())
+        else:
+            raise ValueError(f"The type is not supported: {type(data[0])}.")
+
         if sample_keys == {"label", "sentence-1", "sentence-2"}:
 
             def dataset_fields(sample):

--- a/src/argilla/client/feedback/training/schemas.py
+++ b/src/argilla/client/feedback/training/schemas.py
@@ -1596,8 +1596,6 @@ class TrainingTaskForSentenceSimilarity(BaseModel, TrainingData):
     def _prepare_for_training_with_sentence_transformers(
         self, data: List[dict], train_size: float, seed: int
     ) -> Union["InputExample", Tuple["InputExample", "InputExample"]]:
-        from types import GeneratorType
-
         from sentence_transformers import InputExample
 
         if not len(data) > 0:

--- a/tests/integration/client/feedback/helpers.py
+++ b/tests/integration/client/feedback/helpers.py
@@ -130,6 +130,20 @@ def formatting_func_sentence_transformers(sample: dict):
             ]
 
 
+def formatting_func_sentence_transformers_all_lists(sample: dict):
+    labels = [
+        annotation["value"]
+        for annotation in sample["question-3"]
+        if annotation["status"] == "submitted" and annotation["value"] is not None
+    ]
+    if labels:
+        # Force to pass always a list of values
+        return [
+            {"sentence-1": sample["text"], "sentence-2": sample["text"], "label": 1},
+            {"sentence-1": sample["text"], "sentence-2": sample["text"], "label": 2},
+        ]
+
+
 # Additional formatting functions used for different sentence transformer cases:
 
 

--- a/tests/integration/client/feedback/training/test_sentence_transformers.py
+++ b/tests/integration/client/feedback/training/test_sentence_transformers.py
@@ -32,6 +32,7 @@ from sentence_transformers import CrossEncoder, InputExample, SentenceTransforme
 
 from tests.integration.client.feedback.helpers import (
     formatting_func_sentence_transformers,
+    formatting_func_sentence_transformers_all_lists,
     formatting_func_sentence_transformers_case_1_b,
     formatting_func_sentence_transformers_case_2,
     formatting_func_sentence_transformers_case_3_a,
@@ -63,6 +64,7 @@ def formatting_func_errored(sample):
     "formatting_func",
     [
         formatting_func_sentence_transformers,
+        formatting_func_sentence_transformers_all_lists,
         formatting_func_sentence_transformers_case_1_b,
         formatting_func_sentence_transformers_case_2,
         formatting_func_sentence_transformers_case_3_b,


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR solves an error in the `ArgillaTrainer` for `sentence-similarity` when the records include nested lists.

Closes #4088

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

Tested locally

**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
