### PR TITLE
feat: add search records suggestions options new endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ These are the section headers that we use:
 ### Added
 
 - Added `metadata_properties` to the `__repr__` method of the `FeedbackDataset` and `RemoteFeedbackDataset`.([#4192](https://github.com/argilla-io/argilla/pull/4192)).
+- Added `GET /api/v1/datasets/:dataset_id/records/search/suggestions/options` endpoint to return suggestion available options for searching. ([#4260](https://github.com/argilla-io/argilla/pull/4260))
 
 ### Fixed
 

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -18,11 +18,11 @@ from uuid import UUID
 
 import sqlalchemy
 from fastapi.encoders import jsonable_encoder
-from sqlalchemy import Select, and_, func, or_, select
+from sqlalchemy import Select, and_, func, select
 from sqlalchemy.orm import contains_eager, joinedload, selectinload
 
 from argilla.server.contexts import accounts
-from argilla.server.enums import DatasetStatus, RecordInclude, ResponseStatusFilter, UserRole
+from argilla.server.enums import DatasetStatus, RecordInclude, UserRole
 from argilla.server.models import (
     Dataset,
     Field,

--- a/src/argilla/server/contexts/search.py
+++ b/src/argilla/server/contexts/search.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+from typing import Mapping, List, Any
 from uuid import UUID
 
 from sqlalchemy import func, select
@@ -21,14 +21,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from argilla.server.models import Question, Suggestion
 
 
-async def get_dataset_suggestion_agents_by_question(db: AsyncSession, dataset_id: UUID):
+async def get_dataset_suggestion_agents_by_question(db: AsyncSession, dataset_id: UUID) -> List[Mapping[str, Any]]:
     if db.bind.dialect.name == postgresql.dialect.name:
         return await _get_dataset_suggestion_agents_by_question_postgresql(db, dataset_id)
     else:
         return await _get_dataset_suggestion_agents_by_question_sqlite(db, dataset_id)
 
 
-async def _get_dataset_suggestion_agents_by_question_postgresql(db: AsyncSession, dataset_id: UUID):
+async def _get_dataset_suggestion_agents_by_question_postgresql(db: AsyncSession, dataset_id: UUID) -> List[Mapping[str, Any]]:
     result = await db.execute(
         select(
             Question.id.label("question_id"),
@@ -44,7 +44,7 @@ async def _get_dataset_suggestion_agents_by_question_postgresql(db: AsyncSession
     return result.mappings().all()
 
 
-async def _get_dataset_suggestion_agents_by_question_sqlite(db: AsyncSession, dataset_id: UUID):
+async def _get_dataset_suggestion_agents_by_question_sqlite(db: AsyncSession, dataset_id: UUID) -> List[Mapping[str, Any]]:
     result = await db.execute(
         select(
             Question.id.label("question_id"),

--- a/src/argilla/server/contexts/search.py
+++ b/src/argilla/server/contexts/search.py
@@ -11,7 +11,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from typing import Mapping, List, Any
+from typing import Any, List, Mapping
 from uuid import UUID
 
 from sqlalchemy import func, select
@@ -28,7 +28,9 @@ async def get_dataset_suggestion_agents_by_question(db: AsyncSession, dataset_id
         return await _get_dataset_suggestion_agents_by_question_sqlite(db, dataset_id)
 
 
-async def _get_dataset_suggestion_agents_by_question_postgresql(db: AsyncSession, dataset_id: UUID) -> List[Mapping[str, Any]]:
+async def _get_dataset_suggestion_agents_by_question_postgresql(
+    db: AsyncSession, dataset_id: UUID
+) -> List[Mapping[str, Any]]:
     result = await db.execute(
         select(
             Question.id.label("question_id"),
@@ -44,7 +46,9 @@ async def _get_dataset_suggestion_agents_by_question_postgresql(db: AsyncSession
     return result.mappings().all()
 
 
-async def _get_dataset_suggestion_agents_by_question_sqlite(db: AsyncSession, dataset_id: UUID) -> List[Mapping[str, Any]]:
+async def _get_dataset_suggestion_agents_by_question_sqlite(
+    db: AsyncSession, dataset_id: UUID
+) -> List[Mapping[str, Any]]:
     result = await db.execute(
         select(
             Question.id.label("question_id"),

--- a/src/argilla/server/contexts/search.py
+++ b/src/argilla/server/contexts/search.py
@@ -1,0 +1,69 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from argilla.server.models import Question, Suggestion
+
+
+async def get_dataset_suggestion_agents_by_question(db: AsyncSession, dataset_id: UUID):
+    if db.bind.dialect.name == postgresql.dialect.name:
+        return await _get_dataset_suggestion_agents_by_question_postgresql(db, dataset_id)
+    else:
+        return await _get_dataset_suggestion_agents_by_question_sqlite(db, dataset_id)
+
+
+async def _get_dataset_suggestion_agents_by_question_postgresql(db: AsyncSession, dataset_id: UUID):
+    result = await db.execute(
+        select(
+            Question.id.label("question_id"),
+            Question.name.label("question_name"),
+            func.array_remove(func.array_agg(Suggestion.agent.distinct()), None).label("suggestion_agents"),
+        )
+        .join(Suggestion)
+        .where(Question.dataset_id == dataset_id)
+        .group_by(Question.id)
+        .order_by(Question.inserted_at)
+    )
+
+    return result.mappings().all()
+
+
+async def _get_dataset_suggestion_agents_by_question_sqlite(db: AsyncSession, dataset_id: UUID):
+    result = await db.execute(
+        select(
+            Question.id.label("question_id"),
+            Question.name.label("question_name"),
+            func.group_concat(Suggestion.agent.distinct()).label("suggestion_agents"),
+        )
+        .join(Suggestion)
+        .where(Question.dataset_id == dataset_id)
+        .group_by(Question.id)
+        .order_by(Question.inserted_at)
+    )
+
+    rows = result.mappings().all()
+
+    return [
+        {
+            "question_id": row["question_id"],
+            "question_name": row["question_name"],
+            "suggestion_agents": row["suggestion_agents"].split(",") if row["suggestion_agents"] else [],
+        }
+        for row in rows
+    ]

--- a/src/argilla/server/contexts/search.py
+++ b/src/argilla/server/contexts/search.py
@@ -35,7 +35,7 @@ async def _get_dataset_suggestion_agents_by_question_postgresql(db: AsyncSession
             Question.name.label("question_name"),
             func.array_remove(func.array_agg(Suggestion.agent.distinct()), None).label("suggestion_agents"),
         )
-        .join(Suggestion)
+        .outerjoin(Suggestion)
         .where(Question.dataset_id == dataset_id)
         .group_by(Question.id)
         .order_by(Question.inserted_at)
@@ -51,7 +51,7 @@ async def _get_dataset_suggestion_agents_by_question_sqlite(db: AsyncSession, da
             Question.name.label("question_name"),
             func.group_concat(Suggestion.agent.distinct()).label("suggestion_agents"),
         )
-        .join(Suggestion)
+        .outerjoin(Suggestion)
         .where(Question.dataset_id == dataset_id)
         .group_by(Question.id)
         .order_by(Question.inserted_at)

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -726,3 +726,17 @@ class SearchRecord(BaseModel):
 class SearchRecordsResult(BaseModel):
     items: List[SearchRecord]
     total: int = 0
+
+
+class SearchSuggestionOptionsQuestion(BaseModel):
+    id: UUID
+    name: str
+
+
+class SearchSuggestionOptions(BaseModel):
+    question: SearchSuggestionOptionsQuestion
+    agents: List[str]
+
+
+class SearchSuggestionsOptions(BaseModel):
+    items: List[SearchSuggestionOptions]

--- a/tests/unit/server/api/v1/datasets/test_list_dataset_records_search_suggestions_options.py
+++ b/tests/unit/server/api/v1/datasets/test_list_dataset_records_search_suggestions_options.py
@@ -1,0 +1,140 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from uuid import UUID, uuid4
+
+import pytest
+from argilla._constants import API_KEY_HEADER_NAME
+from httpx import AsyncClient
+
+from tests.factories import (
+    AdminFactory,
+    AnnotatorFactory,
+    DatasetFactory,
+    OwnerFactory,
+    QuestionFactory,
+    SuggestionFactory,
+)
+
+
+@pytest.mark.asyncio
+class TestListDatasetRecordsSearchSuggestionsOptions:
+    def url(self, dataset_id: UUID) -> str:
+        return f"/api/v1/datasets/{dataset_id}/records/search/suggestions/options"
+
+    async def test(self, async_client: AsyncClient, owner_auth_header: dict):
+        dataset = await DatasetFactory.create()
+        question_a = await QuestionFactory.create(name="question-a", dataset=dataset)
+        question_b = await QuestionFactory.create(name="question-b", dataset=dataset)
+        question_c = await QuestionFactory.create(name="question-c", dataset=dataset)
+
+        await SuggestionFactory.create(question=question_a)
+        await SuggestionFactory.create(question=question_b, agent="agent-a")
+        await SuggestionFactory.create(question=question_b, agent="agent-a")
+        await SuggestionFactory.create(question=question_c, agent="agent-a")
+        await SuggestionFactory.create(question=question_c, agent="agent-b")
+        await SuggestionFactory.create(question=question_c, agent="agent-c")
+        await SuggestionFactory.create(question=question_c, agent="agent-c")
+
+        extra_dataset = await DatasetFactory.create()
+        extra_question_a = await QuestionFactory.create(name="extra-question-a", dataset=extra_dataset)
+        extra_question_b = await QuestionFactory.create(name="extra-question-b", dataset=extra_dataset)
+
+        await SuggestionFactory.create(question=extra_question_a, agent="extra-agent-a")
+        await SuggestionFactory.create(question=extra_question_b, agent="extra-agent-b")
+
+        response = await async_client.get(self.url(dataset.id), headers=owner_auth_header)
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "items": [
+                {
+                    "question": {
+                        "id": str(question_a.id),
+                        "name": "question-a",
+                    },
+                    "agents": [],
+                },
+                {
+                    "question": {
+                        "id": str(question_b.id),
+                        "name": "question-b",
+                    },
+                    "agents": ["agent-a"],
+                },
+                {
+                    "question": {
+                        "id": str(question_c.id),
+                        "name": "question-c",
+                    },
+                    "agents": ["agent-a", "agent-b", "agent-c"],
+                },
+            ]
+        }
+
+    async def test_with_dataset_without_questions(self, async_client: AsyncClient, owner_auth_header: dict):
+        dataset = await DatasetFactory.create()
+
+        response = await async_client.get(self.url(dataset.id), headers=owner_auth_header)
+
+        assert response.status_code == 200
+        assert response.json() == {"items": []}
+
+    async def test_with_dataset_without_suggestions(self, async_client: AsyncClient, owner_auth_header: dict):
+        dataset = await DatasetFactory.create()
+        await QuestionFactory.create(name="question-a", dataset=dataset)
+        await QuestionFactory.create(name="question-b", dataset=dataset)
+        await QuestionFactory.create(name="question-c", dataset=dataset)
+
+        response = await async_client.get(self.url(dataset.id), headers=owner_auth_header)
+
+        assert response.status_code == 200
+        assert response.json() == {"items": []}
+
+    async def test_as_owner(self, async_client: AsyncClient):
+        dataset = await DatasetFactory.create()
+        owner = await OwnerFactory.create(workspaces=[dataset.workspace])
+
+        response = await async_client.get(self.url(dataset.id), headers={API_KEY_HEADER_NAME: owner.api_key})
+
+        assert response.status_code == 200
+
+    async def test_as_admin(self, async_client: AsyncClient):
+        dataset = await DatasetFactory.create()
+        admin = await AdminFactory.create(workspaces=[dataset.workspace])
+
+        response = await async_client.get(self.url(dataset.id), headers={API_KEY_HEADER_NAME: admin.api_key})
+
+        assert response.status_code == 200
+
+    async def test_as_annotator(self, async_client: AsyncClient):
+        dataset = await DatasetFactory.create()
+        annotator = await AnnotatorFactory.create(workspaces=[dataset.workspace])
+
+        response = await async_client.get(self.url(dataset.id), headers={API_KEY_HEADER_NAME: annotator.api_key})
+
+        assert response.status_code == 200
+
+    async def test_as_user_from_different_workspace(self, async_client: AsyncClient):
+        dataset = await DatasetFactory.create()
+        annotator = await AnnotatorFactory.create()
+
+        response = await async_client.get(self.url(dataset.id), headers={API_KEY_HEADER_NAME: annotator.api_key})
+
+        assert response.status_code == 403
+
+    async def test_with_non_existent_dataset(self, async_client: AsyncClient, owner_auth_header: dict):
+        response = await async_client.get(self.url(uuid4()), headers=owner_auth_header)
+
+        assert response.status_code == 404


### PR DESCRIPTION
# Description

This PR adds a new `GET /datasets/:dataset_id/records/search/suggestions/options` endpoint that will return information about the options that are allowed to search records with suggestions.

Right now we are returning the list of different agents that are defined for a question suggestions inside the dataset.

The response is in the form:

```json
{
    "items": [
        {
            "question": {
                "id": "5d87c0e7-9eaf-4b92-ba0d-6cf50a4176e6",
                "name": "question-a",
            },
            "agents": [],
        },
        {
            "question": {
                "id": "bd68eec1-cace-4df8-b239-9da081ac41b3",
                "name": "question-b",
            },
            "agents": [
                "agent-a"
            ],
        },
        {
            "question": {
                "id": "30ccbe15-8e9a-4893-8fce-e713a1c32ea1",
                "name": "question-c",
            },
            "agents": [
                "agent-a",
                "agent-b",
                "agent-c"
            ],
        },
    ]
}
```

Details about the endpoint behavior and code changes:
* All the questions of the dataset will have an entry in the response, event those that doesn't have questions or have questions but without suggestions.
* In the list of `agents` we will only include different agent strings so you should not see any repetition.
* We have included two implementations of the function that return the results one for SQLite and another one for PostgreSQL, this is related with the lack of support from SQLite to arrays and the impossibility of aggregating elements as arrays with this database.
  * The SQLite implementation is using `group_concat` specifically, this is doing a string concatenation using a `,` character as delimiter. This is open to errors if the agent is using that character inside the agent string. We will add a validation for this on issue #4237 to avoid possible errors.
* We have added a new `server/contexts/search.py` file, where we want to add domain functions associated with the search functionality or argilla.

Closes #4224 

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [x] Running locally unit tests using SQLite database.
- [x] Running locally unit tests using PostgreSQL database.

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)