### PR TITLE
feat: add validations to suggestions agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ These are the section headers that we use:
 ### Changed
 
 - Updated `push_to_argilla` to print `repr` of the pushed `RemoteFeedbackDataset` after push and changed `show_progress` to True by default. ([#4223](https://github.com/argilla-io/argilla/pull/4223))
+- Suggestions `agent` field is now validated when created or updated using a regular expression and an specific length. ([#4265](https://github.com/argilla-io/argilla/pull/4265))
 
 ## [1.19.0](https://github.com/argilla-io/argilla/compare/v1.18.0...v1.19.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ These are the section headers that we use:
 
 ### Changed
 
+- [breaking] Suggestions `agent` field only accepts now some specific characters and a limited length. ([#4265](https://github.com/argilla-io/argilla/pull/4265))
 - Updated `push_to_argilla` to print `repr` of the pushed `RemoteFeedbackDataset` after push and changed `show_progress` to True by default. ([#4223](https://github.com/argilla-io/argilla/pull/4223))
-- Suggestions `agent` field is now validated when created or updated using a regular expression and an specific length. ([#4265](https://github.com/argilla-io/argilla/pull/4265))
 
 ## [1.19.0](https://github.com/argilla-io/argilla/compare/v1.18.0...v1.19.0)
 

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -1046,6 +1046,7 @@ async def upsert_suggestion(
     db: "AsyncSession", record: Record, question: Question, suggestion_create: "SuggestionCreate"
 ) -> Suggestion:
     question.parsed_settings.check_response(suggestion_create)
+
     return await Suggestion.upsert(
         db,
         schema=SuggestionCreateWithRecordId(record_id=record.id, **suggestion_create.dict()),

--- a/src/argilla/server/schemas/v1/suggestions.py
+++ b/src/argilla/server/schemas/v1/suggestions.py
@@ -15,22 +15,32 @@
 from typing import Any, List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from argilla.server.models import SuggestionType
+
+AGENT_REGEX = r"^(?=.*[a-zA-Z0-9])[a-zA-Z0-9-_:\.\/\s]+$"
+AGENT_MIN_LENGTH = 1
+AGENT_MAX_LENGTH = 200
 
 
 class BaseSuggestion(BaseModel):
     question_id: UUID
     type: Optional[SuggestionType]
-    # TODO: we should add a validation to score only allowing values between 0 and 1
-    score: Optional[float]
     value: Any
     agent: Optional[str]
+    # TODO: we should add a validation to score only allowing values between 0 and 1
+    score: Optional[float]
 
 
 class SuggestionCreate(BaseSuggestion):
-    pass
+    agent: Optional[str] = Field(
+        None,
+        regex=AGENT_REGEX,
+        min_length=AGENT_MIN_LENGTH,
+        max_length=AGENT_MAX_LENGTH,
+        description="Agent used to generate the suggestion",
+    )
 
 
 class Suggestion(BaseSuggestion):

--- a/tests/unit/server/api/v1/records/__init__.py
+++ b/tests/unit/server/api/v1/records/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/tests/unit/server/api/v1/records/test_upsert_suggestion.py
+++ b/tests/unit/server/api/v1/records/test_upsert_suggestion.py
@@ -1,0 +1,94 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from uuid import UUID, uuid4
+
+import pytest
+from argilla.server.enums import SuggestionType
+from httpx import AsyncClient
+
+from tests.factories import RecordFactory, TextQuestionFactory
+
+
+@pytest.mark.asyncio
+class TestUpsertSuggestion:
+    def url(self, record_id: UUID) -> str:
+        return f"/api/v1/records/{record_id}/suggestions"
+
+    @pytest.mark.parametrize(
+        "agent", ["a", "A", "0", "gpt 3.5", "gpt-3.5-turbo", "argilla/zephyr-7b", "ft:gpt-3.5-turbo"]
+    )
+    async def test_with_valid_agent(self, async_client: AsyncClient, owner_auth_header: dict, agent: str):
+        record = await RecordFactory.create()
+        question = await TextQuestionFactory.create(dataset=record.dataset)
+
+        response = await async_client.put(
+            self.url(record.id),
+            headers=owner_auth_header,
+            json={
+                "question_id": str(question.id),
+                "type": SuggestionType.model,
+                "value": "value",
+                "agent": agent,
+                "score": 1.0,
+            },
+        )
+
+        assert response.status_code == 201
+
+    @pytest.mark.parametrize("agent", ["", " ", "  ", "-", "_", ":", ".", "/", ","])
+    async def test_with_invalid_agent(self, async_client: AsyncClient, owner_auth_header: dict, agent: str):
+        response = await async_client.put(
+            self.url(uuid4()),
+            headers=owner_auth_header,
+            json={
+                "question_id": str(uuid4()),
+                "type": SuggestionType.model,
+                "value": "value",
+                "agent": agent,
+                "score": 1.0,
+            },
+        )
+
+        assert response.status_code == 422
+
+    async def test_with_invalid_min_length_agent(self, async_client: AsyncClient, owner_auth_header: dict):
+        response = await async_client.put(
+            self.url(uuid4()),
+            headers=owner_auth_header,
+            json={
+                "question_id": str(uuid4()),
+                "type": SuggestionType.model,
+                "value": "value",
+                "agent": "",
+                "score": 1.0,
+            },
+        )
+
+        assert response.status_code == 422
+
+    async def test_with_invalid_max_length_agent(self, async_client: AsyncClient, owner_auth_header: dict):
+        response = await async_client.put(
+            self.url(uuid4()),
+            headers=owner_auth_header,
+            json={
+                "question_id": str(uuid4()),
+                "type": SuggestionType.model,
+                "value": "value",
+                "agent": "a" * 201,
+                "score": 1.0,
+            },
+        )
+
+        assert response.status_code == 422


### PR DESCRIPTION
# Description

This PR adds some validations to suggestions agent field:
* The agent must have at least one letter or numeric character.
* Additionally only the following symbols are allowed (apart from numbers and letters): `-`, `_`, `:`, `.`, `/`, and spaces.
* The agent needs to have a length between 1 and 200 (both included) to be valid.

Closes #4237

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [x] Running tests locally.

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)