### PR TITLE
feat: define filters and sort schemas for search

### DIFF
--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -714,8 +714,47 @@ class Query(BaseModel):
         return values
 
 
+# NOTE: Not sure if this filter is useful, if we don't need it we can offer TermsFilter only instead
+class TermFilter(BaseModel):
+    type: Literal["term"]
+    field: str
+    value: Union[str, float]
+
+
+# TODO: Add constraint to field length
+# TODO: Add constraint to values items length
+class TermsFilter(BaseModel):
+    type: Literal["terms"]
+    field: str
+    values: List[Union[str, float]]
+
+
+# TODO: Add constraint to field length
+# TODO: Add validation to have at least one value `gte` or `lte` (or both)
+class RangeFilter(BaseModel):
+    type: Literal["range"]
+    field: str
+    gte: Optional[float]
+    lte: Optional[float]
+
+
+Filter = Annotated[Union[TermFilter, TermsFilter, RangeFilter], PydanticField(..., discriminator="type")]
+
+
+# TODO: Add constraint to and_ items length
+class Filters(BaseModel):
+    and_: Optional[List[Filter]] = PydanticField(None, alias="and")
+
+
+class Order(BaseModel):
+    field: str
+    order: Union[Literal["asc"], Literal["desc"]]
+
+
 class SearchRecordsQuery(BaseModel):
     query: Query
+    filters: Optional[Filters]
+    sort: Optional[List[Order]]
 
 
 class SearchRecord(BaseModel):

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -740,8 +740,20 @@ class TermsFilter(BaseModel):
 class RangeFilter(BaseModel):
     type: Literal["range"]
     field: FilterField
-    gte: float
-    lte: float
+    gte: Optional[float]
+    lte: Optional[float]
+
+    @root_validator
+    def check_gte_and_lte(cls, values: dict) -> dict:
+        gte, lte = values.get("gte"), values.get("lte")
+
+        if gte is None and lte is None:
+            raise ValueError("At least one of 'gte' or 'lte' must be provided")
+
+        if gte is not None and lte is not None and gte > lte:
+            raise ValueError("'gte' must have a value less than or equal to 'lte'")
+
+        return values
 
 
 Filter = Annotated[Union[TermsFilter, RangeFilter], PydanticField(..., discriminator="type")]

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -728,30 +728,30 @@ class Query(BaseModel):
         return values
 
 
-class SuggestionFilterEntity(BaseModel):
-    type: Literal["suggestion"]
+class SuggestionFilterScope(BaseModel):
+    entity: Literal["suggestion"]
     question: QuestionName
     property: Optional[Union[Literal["value"], Literal["agent"], Literal["score"]]] = "value"
 
 
-class ResponseFilterEntity(BaseModel):
-    type: Literal["response"]
+class ResponseFilterScope(BaseModel):
+    entity: Literal["response"]
     question: QuestionName
 
 
-class MetadataFilterEntity(BaseModel):
-    type: Literal["metadata"]
+class MetadataFilterScope(BaseModel):
+    entity: Literal["metadata"]
     metadata_property: MetadataPropertyName
 
 
-FilterEntity = Annotated[
-    Union[SuggestionFilterEntity, ResponseFilterEntity, MetadataFilterEntity], PydanticField(..., discriminator="type")
+FilterScope = Annotated[
+    Union[SuggestionFilterScope, ResponseFilterScope, MetadataFilterScope], PydanticField(..., discriminator="entity")
 ]
 
 
 class TermsFilter(BaseModel):
     type: Literal["terms"]
-    entity: FilterEntity
+    scope: FilterScope
     values: List[str] = PydanticField(
         ..., min_items=TERMS_FILTER_VALUES_MIN_ITEMS, max_items=TERMS_FILTER_VALUES_MAX_ITEMS
     )
@@ -759,7 +759,7 @@ class TermsFilter(BaseModel):
 
 class RangeFilter(BaseModel):
     type: Literal["range"]
-    entity: FilterEntity
+    scope: FilterScope
     gte: Optional[float]
     lte: Optional[float]
 
@@ -786,7 +786,7 @@ class Filters(BaseModel):
 
 
 class Order(BaseModel):
-    entity: FilterEntity
+    scope: FilterScope
     order: Union[Literal["asc"], Literal["desc"]]
 
 


### PR DESCRIPTION
# Description

This is a proposal for adding `filters` and `sort` attributes on the endpoints for search records.

The changes allow us to define the following schema for searching:

```python
from argilla.server.schemas.v1.datasets import SearchRecordsQuery

SearchRecordsQuery.parse_obj({
  "query": {
    "text": {
      "q": "query"
    },
  },
  "filters": {
    "and": [
      {"type": "terms", "scope": {"entity": "suggestion", "question": "sentiment"}, "values": ["positive"]},
      {"type": "terms", "scope": {"entity": "suggestion", "question": "sentiment", "property": "agent"}, "values": ["chat-gpt3.5", "chat-gpt-4.0"]},
      {"type": "terms", "scope": {"entity": "response", "question": "topic"}, "values": ["politics", "news"]},
      {"type": "range", "scope": {"entity": "response", "question": "quality"}, "gte": 0.5, "lte": 0.9},
      {"type": "range", "scope": {"entity": "metadata", "metadata_property": "price"}, "gte": 100.0},
    ]
  },
  "sort": [
    {"scope": {"entity": "suggestion", "question": "sentiment", "property": "score"}, "order": "asc"},
    {"scope": {"entity": "response", "question": "quality"}, "order": "desc"},
  ]
})

# This is an old proposal of the schema leaving it here for reference
SearchRecordsQuery.parse_obj({
  "query": {
    "text": {
      "q": "query"
    },
  },
  "filters": {
    "and": [
      {"type": "terms", "field": "suggestion.sentiment.value", "values": ["positive"]},
      {"type": "terms", "field": "suggestion.sentiment.agent", "values": ["chat-gpt3.5", "chat-gpt-4.0"]},
      {"type": "terms", "field": "response.topic.value", "values": ["politics", "news"]},
      {"type": "range", "field": "response.quality.value", "gte": 0.5, "lte": 0.9},
    ]
  },
  "sort": [
    {"field": "suggestion.sentiment.score", "order": "asc"},
    {"field": "response.quality.value", "order": "desc"},
  ]
})
```

Notice some changes from the Notion documentation:
* I'm using `field` instead of `path` because we are already using `field` in the `query` parameter.
* I have added the possibility of specify `float` in the values in the case that we want to specify numbers.
* <del>I'm adding a new `term` (singular) filter so is more explicit to filter by one specific value (this is optional we can remove it if not needed).</del>

With this PR we should ask several questions:
- [X] Is this functionality enough for the changes that are required on the frontend for filtering responses and suggestions?
  - Reviewed with @damianpumar and feedback applied.
- [ ] Is this format flexible enough so in the future we can add more boolean operators and extend the search without deprecate anything?.
- [x] Do we need additional boolean operators by now or it's enough with `and`?
  - `and` will be enough for the frontend requirements by now.
- [x] What `field`format should we follow?
  - <del>Making the "value" of the field to filter implicit like `suggestion.sentiment` instead of `suggestion.sentiment.value`?</del>
  - Making the "value" of the field to filter explicit like `suggestion.sentiment.value` instead of `suggestion.sentiment`?
    - We choose this solution and we will always use `value` (instead of `values`) at the end. 

@damianpumar should help us to answer the first question of this list.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [x] Running tests locally.

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)