### PR TITLE
fix: correct unification implementation for `RankingQuestionStrategy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ These are the section headers that we use:
 - Fixed error in `ArgillaTrainer`, with numerical labels, using `RatingQuestion` instead of `RankingQuestion` ([#4171](https://github.com/argilla-io/argilla/pull/4171))
 - Fixed error in `ArgillaTrainer`, now we can train for `extractive_question_answering` using a validation sample ([#4204](https://github.com/argilla-io/argilla/pull/4204))
 - Fixed error in `ArgillaTrainer`, when training for `sentence-similarity` it didn't work with a list of values per record ([#4211](https://github.com/argilla-io/argilla/pull/4211))
+- Fixed error in the unification strategy for `RankingQuestion` ([#4295](https://github.com/argilla-io/argilla/pull/4295))
 
 ### Changed
 

--- a/src/argilla/client/feedback/unification.py
+++ b/src/argilla/client/feedback/unification.py
@@ -557,6 +557,9 @@ class MultiLabelQuestionStrategy(LabelQuestionStrategyMixin, Enum):
                 if count >= majority:
                     majority_value.append(value)
 
+            if not majority_value:
+                majority_value = [random.choice(list(counter.keys()))]
+
             rec._unified_responses[question] = [UnifiedValueSchema(value=majority_value, strategy=self.value)]
         return records
 

--- a/tests/integration/client/feedback/test_unification.py
+++ b/tests/integration/client/feedback/test_unification.py
@@ -73,6 +73,7 @@ def test_rating_question_strategy(strategy, unified_response):
         ("majority", [{"value": [{"rank": 2, "value": "yes"}, {"rank": 3, "value": "no"}], "strategy": "majority"}]),
         ("max", [{"value": [{"rank": 2, "value": "yes"}, {"rank": 3, "value": "no"}], "strategy": "max"}]),
         ("min", [{"value": [{"rank": 2, "value": "yes"}, {"rank": 1, "value": "no"}], "strategy": "min"}]),
+        ("mean", [{"value": [{"rank": 2, "value": "yes"}, {"rank": 2, "value": "no"}], "strategy": "mean"}]),
     ],
 )
 def test_ranking_question_strategy(strategy, unified_response):

--- a/tests/integration/client/feedback/test_unification.py
+++ b/tests/integration/client/feedback/test_unification.py
@@ -70,10 +70,9 @@ def test_rating_question_strategy(strategy, unified_response):
 @pytest.mark.parametrize(
     "strategy, unified_response",
     [
-        ("mean", [{"value": "yes", "strategy": "mean"}]),
-        ("majority", [{"value": "yes", "strategy": "majority"}]),
-        ("max", [{"value": "no", "strategy": "max"}]),
-        ("min", [{"value": "yes", "strategy": "min"}]),
+        ("majority", [{"value": [{"rank": 2, "value": "yes"}, {"rank": 3, "value": "no"}], "strategy": "majority"}]),
+        ("max", [{"value": [{"rank": 2, "value": "yes"}, {"rank": 3, "value": "no"}], "strategy": "max"}]),
+        ("min", [{"value": [{"rank": 2, "value": "yes"}, {"rank": 1, "value": "no"}], "strategy": "min"}]),
     ],
 )
 def test_ranking_question_strategy(strategy, unified_response):

--- a/tests/integration/client/feedback/test_unification.py
+++ b/tests/integration/client/feedback/test_unification.py
@@ -179,6 +179,36 @@ def test_multi_label_question_strategy(strategy, unified_response):
     assert MultiLabelQuestionUnification(question=question, strategy=strategy)
 
 
+@pytest.mark.parametrize(
+    "strategy, unified_response",
+    [
+        ("majority", [{"value": ["label1"], "strategy": "majority"}]),
+    ],
+)
+def test_multi_label_question_strategy_without_overlap(strategy, unified_response):
+    question_name = "rating"
+    records_payload = {
+        "fields": {"text": "This is the first record", "label": "positive"},
+        "responses": [
+            {"values": {question_name: {"value": ["label1"]}}},
+            {"values": {question_name: {"value": ["label2"]}}},
+        ],
+    }
+    record = FeedbackRecord(**records_payload)
+    question_payload = {
+        "name": question_name,
+        "description": question_name,
+        "required": True,
+        "labels": ["label1", "label2"],
+    }
+    question = MultiLabelQuestion(**question_payload)
+    strategy = MultiLabelQuestionStrategy(strategy)
+    strategy.unify_responses([record], question)
+    unified_response = [UnifiedValueSchema(**resp) for resp in unified_response]
+    assert record._unified_responses[question_name] == unified_response
+    assert MultiLabelQuestionUnification(question=question, strategy=strategy)
+
+
 def test_label_question_strategy_not_implemented():
     with pytest.raises(NotImplementedError, match="'majority_weighted'-strategy not implemented yet"):
         LabelQuestionStrategy._majority_weighted("mock", "mock")


### PR DESCRIPTION


<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

Currently we have the following behaviour for :

```python
## FeedbackRecord.responses
[
    ResponseSchema(
        user_id=None,
        values={
            'ranking': ValueSchema(
                value=[
                    RankingValueSchema(value='yes', rank=2),
                    RankingValueSchema(value='no', rank=3)
                ]
            )
        },
        status=<ResponseStatus.submitted: 'submitted'>
    ),
    ResponseSchema(
        user_id=None,
        values={
            'ranking': ValueSchema(
                value=[
                    RankingValueSchema(value='yes', rank=2),
                    RankingValueSchema(value='no', rank=1)
                ]
            )
        },
        status=<ResponseStatus.submitted: 'submitted'>
    )
]

## Unified responses:

[UnifiedValueSchema(value='yes', strategy=<RatingQuestionStrategy.MIN: 'min'>)]
```

Where we should have:

```python
[UnifiedValueSchema(value=[{'value': 'yes', 'rank': 2}, {'value': 'no', 'rank': 1}], strategy=<RatingQuestionStrategy.MIN: 'min'>)]
```

This PR fixes the issue

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [x] `tests/integration/client/feedback/test_unification.py`


**Checklist**

- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
