### PR TITLE
feat: Add a general `text_wrapper` to create `repr` methods

### DIFF
--- a/src/argilla/client/feedback/schemas/fields.py
+++ b/src/argilla/client/feedback/schemas/fields.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, Extra, Field, validator
 
 from argilla.client.feedback.schemas.enums import FieldTypes
 from argilla.client.feedback.schemas.validators import title_must_have_value
+from argilla.textwrapping import text_wrapper
 
 
 class FieldSchema(BaseModel, ABC):
@@ -46,6 +47,9 @@ class FieldSchema(BaseModel, ABC):
     type: Optional[FieldTypes] = Field(..., allow_mutation=False)
 
     _title_must_have_value = validator("title", always=True, allow_reuse=True)(title_must_have_value)
+
+    def __repr__(self) -> str:
+        return text_wrapper(self, attr_ignore=["type"])
 
     class Config:
         validate_assignment = True

--- a/src/argilla/client/feedback/schemas/metadata.py
+++ b/src/argilla/client/feedback/schemas/metadata.py
@@ -33,6 +33,7 @@ from argilla.client.feedback.schemas.validators import (
     validate_numeric_metadata_filter_bounds,
     validate_numeric_metadata_property_bounds,
 )
+from argilla.textwrapping import text_wrapper
 
 TERMS_METADATA_PROPERTY_MIN_VALUES = 1
 TERMS_METADATA_FILTER_MIN_VALUES = 1
@@ -61,6 +62,9 @@ class MetadataPropertySchema(BaseModel, ABC):
     title: Optional[str] = None
     visible_for_annotators: Optional[bool] = True
     type: MetadataPropertyTypes = Field(..., allow_mutation=False)
+
+    def __repr__(self) -> str:
+        return text_wrapper(self, attr_ignore=["type"])
 
     class Config:
         validate_assignment = True
@@ -325,6 +329,9 @@ class MetadataFilterSchema(BaseModel, ABC):
 
     name: str = Field(..., regex=r"^(?=.*[a-z0-9])[a-z0-9_-]+$")
     type: MetadataPropertyTypes = Field(..., allow_mutation=False)
+
+    def __repr__(self) -> str:
+        return text_wrapper(self, attr_ignore=["type"])
 
     class Config:
         validate_assignment = True

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel, Extra, Field, conint, conlist, root_validator, v
 from argilla.client.feedback.schemas.enums import QuestionTypes
 from argilla.client.feedback.schemas.utils import LabelMappingMixin
 from argilla.client.feedback.schemas.validators import title_must_have_value
+from argilla.textwrapping import text_wrapper
 
 
 class QuestionSchema(BaseModel, ABC):
@@ -52,6 +53,9 @@ class QuestionSchema(BaseModel, ABC):
     type: Optional[QuestionTypes] = Field(..., allow_mutation=False)
 
     _title_must_have_value = validator("title", always=True, allow_reuse=True)(title_must_have_value)
+
+    def __repr__(self) -> str:
+        return text_wrapper(self, attr_ignore=["type"])
 
     class Config:
         validate_assignment = True

--- a/src/argilla/client/feedback/schemas/records.py
+++ b/src/argilla/client/feedback/schemas/records.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, Extra, Field, PrivateAttr, StrictInt, StrictStr,
 
 from argilla.client.feedback.schemas.enums import RecordSortField, ResponseStatus, SortOrder
 from argilla.textwrapping import text_wrapper
+from argilla.utils.utils import TextWrappedBaseModel
 
 if TYPE_CHECKING:
     from argilla.client.feedback.unification import UnifiedValueSchema
@@ -101,7 +102,7 @@ class ResponseSchema(BaseModel):
         }
 
 
-class SuggestionSchema(BaseModel):
+class SuggestionSchema(TextWrappedBaseModel):
     """Schema for the suggestions for the questions related to the record.
 
     Args:
@@ -123,13 +124,10 @@ class SuggestionSchema(BaseModel):
     """
 
     question_name: str
-    type: Optional[Literal["model", "human"]] = None
+    type: Optional[Literal["model", "human"]] = Field(default="ignore")
     score: Optional[float] = None
     value: Any
     agent: Optional[str] = None
-
-    def __repr__(self):
-        return text_wrapper(self, attr_ignore=["type"])
 
     class Config:
         extra = Extra.forbid

--- a/src/argilla/client/feedback/schemas/records.py
+++ b/src/argilla/client/feedback/schemas/records.py
@@ -19,6 +19,7 @@ from uuid import UUID
 from pydantic import BaseModel, Extra, Field, PrivateAttr, StrictInt, StrictStr, conint, validator
 
 from argilla.client.feedback.schemas.enums import RecordSortField, ResponseStatus, SortOrder
+from argilla.textwrapping import text_wrapper
 
 if TYPE_CHECKING:
     from argilla.client.feedback.unification import UnifiedValueSchema
@@ -69,6 +70,9 @@ class ResponseSchema(BaseModel):
     user_id: Optional[UUID] = None
     values: Union[Dict[str, ValueSchema], None]
     status: ResponseStatus = ResponseStatus.submitted
+
+    def __repr__(self) -> str:
+        return text_wrapper(self)
 
     class Config:
         extra = Extra.forbid
@@ -123,6 +127,9 @@ class SuggestionSchema(BaseModel):
     score: Optional[float] = None
     value: Any
     agent: Optional[str] = None
+
+    def __repr__(self):
+        return text_wrapper(self, attr_ignore=["type"])
 
     class Config:
         extra = Extra.forbid
@@ -200,6 +207,9 @@ class FeedbackRecord(BaseModel):
     external_id: Optional[str] = None
 
     _unified_responses: Optional[Dict[str, List["UnifiedValueSchema"]]] = PrivateAttr(default_factory=dict)
+
+    def __repr__(self):
+        return text_wrapper(self, attr_multiline=["fields", "metadata"])
 
     class Config:
         extra = Extra.forbid

--- a/src/argilla/client/feedback/schemas/vector_settings.py
+++ b/src/argilla/client/feedback/schemas/vector_settings.py
@@ -17,6 +17,7 @@ from typing import Optional
 from pydantic import BaseModel, Field, PositiveInt, validator
 
 from argilla.client.feedback.schemas.validators import title_must_have_value
+from argilla.textwrapping import text_wrapper
 
 
 class VectorSettings(BaseModel):
@@ -39,5 +40,8 @@ class VectorSettings(BaseModel):
     name: str = Field(..., regex=r"^(?=.*[a-z0-9])[a-z0-9_-]+$")
     title: Optional[str] = None
     dimensions: PositiveInt
+
+    def __repr__(self) -> str:
+        return text_wrapper(self)
 
     _title_must_have_value = validator("title", always=True, allow_reuse=True)(title_must_have_value)

--- a/src/argilla/client/feedback/schemas/vector_settings.py
+++ b/src/argilla/client/feedback/schemas/vector_settings.py
@@ -18,9 +18,10 @@ from pydantic import BaseModel, Field, PositiveInt, validator
 
 from argilla.client.feedback.schemas.validators import title_must_have_value
 from argilla.textwrapping import text_wrapper
+from argilla.utils.utils import TextWrappedBaseModel
 
 
-class VectorSettings(BaseModel):
+class VectorSettings(TextWrappedBaseModel):
     """Schema for the `FeedbackDataset` vectors settings. The vectors setttings are used
     to define the configuration of the vectors associated to the records of a `FeedbackDataset`
     that will be used to perform the vector search.
@@ -40,8 +41,5 @@ class VectorSettings(BaseModel):
     name: str = Field(..., regex=r"^(?=.*[a-z0-9])[a-z0-9_-]+$")
     title: Optional[str] = None
     dimensions: PositiveInt
-
-    def __repr__(self) -> str:
-        return text_wrapper(self)
 
     _title_must_have_value = validator("title", always=True, allow_reuse=True)(title_must_have_value)

--- a/src/argilla/client/users.py
+++ b/src/argilla/client/users.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import textwrap
 import warnings
 from datetime import datetime
 from typing import TYPE_CHECKING, Iterator, List, Optional, Union
@@ -149,11 +150,19 @@ class User:
         return self.role == UserRole.annotator
 
     def __repr__(self) -> str:
+        indent = "   "
+        first_name = self.first_name or None
         return (
-            f"User(id={self.id}, username={self.username}, role={self.role},"
-            f" api_key={self.api_key}, first_name={self.first_name},"
-            f" last_name={self.last_name}, inserted_at={self.inserted_at},"
-            f" updated_at={self.updated_at})"
+            "User("
+            + textwrap.indent(f"\nid={self.id}", indent)
+            + textwrap.indent(f"\nusername={self.username}", indent)
+            + textwrap.indent(f"\nrole={self.role}", indent)
+            + textwrap.indent(f"\napi_key={self.api_key}", indent)
+            + textwrap.indent(f"\nfirst_name={first_name}", indent)
+            + textwrap.indent(f"\nlast_name={self.last_name}", indent)
+            + textwrap.indent(f"\ninserted_at={self.inserted_at}", indent)
+            + textwrap.indent(f"\nupdated_at={self.updated_at}", indent)
+            + "\n)"
         )
 
     @staticmethod

--- a/src/argilla/client/workspaces.py
+++ b/src/argilla/client/workspaces.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import textwrap
 import warnings
 from datetime import datetime
 from typing import TYPE_CHECKING, Iterator, List, Optional, Union
@@ -119,9 +120,14 @@ class Workspace:
         return workspaces_api.list_workspace_users(self._client, self.id).parsed
 
     def __repr__(self) -> str:
+        indent = "   "
         return (
-            f"Workspace(id={self.id}, name={self.name},"
-            f" inserted_at={self.inserted_at}, updated_at={self.updated_at})"
+            "Workspace("
+            + textwrap.indent(f"\id={self.id}", indent)
+            + textwrap.indent(f"\nname={self.name}", indent)
+            + textwrap.indent(f"\ninserted_at={self.inserted_at}", indent)
+            + textwrap.indent(f"\nupdated_at={self.updated_at}", indent)
+            + "\n)"
         )
 
     @allowed_for_roles(roles=[UserRole.owner])

--- a/src/argilla/listeners/models.py
+++ b/src/argilla/listeners/models.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import dataclasses
+import textwrap
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from prodict import Prodict
@@ -35,6 +36,15 @@ class Search:
 
     total: int
     query_params: Optional[Dict[str, Any]] = None
+
+    def __repr__(self) -> str:
+        indent = "   "
+        return (
+            "Search("
+            + textwrap.indent(f"\ntotal={self.total}", indent)
+            + textwrap.indent(f"\nquery_params={self.query_params}", indent)
+            + "\n)"
+        )
 
 
 class Metrics(Prodict):
@@ -66,6 +76,16 @@ class RGListenerContext:
     search: Optional[Search] = None
     metrics: Optional[Metrics] = None
     query_params: Optional[Dict[str, Any]] = None
+
+    def __repr__(self) -> str:
+        indent = "   "
+        return (
+            "RGListenerContext("
+            + textwrap.indent(f"\nsearch={self.search}", indent)
+            + textwrap.indent(f"\ntitle={self.metrics}", indent)
+            + textwrap.indent(f"\nrequired={self.query_params}", indent)
+            + "\n)"
+        )
 
     def __post_init__(self):
         self.__listener__ = self.listener

--- a/src/argilla/textwrapping.py
+++ b/src/argilla/textwrapping.py
@@ -1,0 +1,59 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import textwrap
+
+
+def text_wrapper(self, attr_ignore: list = None, attr_multiline: list = None):
+    """
+    This is a general function that creates __repr__ methods for classes that inherit from pydantic.BaseModel.
+
+    Args:
+        self: The class that inherits from pydantic.BaseModel.
+        attr_ignore: A list of attributes that should be ignored in the __repr__ method.
+        attr_multiline: A list of attributes that should be printed in multiple lines in the __repr__ method. The attribute given should be a dictionary.
+
+    Returns:
+        A string for the __repr__ method of the class that inherits from pydantic.BaseModel.
+    """
+
+    if attr_ignore == None:
+        attr_ignore = []
+    if attr_multiline == None:
+        attr_multiline = []
+
+    def create_wrapped_list(self, attr_ignore=None, attr_multiline=None):
+        attribute_list = []
+        for field in self.__fields__:
+            if field not in attr_ignore:
+                value = str(getattr(self, field)).replace("\n", " ").replace("\t", " ")
+                if field in attr_multiline:
+                    pre_indent = " " * (len(field) - 4)
+                    value = f"\n\t{pre_indent}".join(
+                        f"'{item[0]}': '{item[1]}'" for item in getattr(self, field).items()
+                    )
+                attribute_list.append(f"{field}={value}")
+        else:
+            indent = "   "
+            indented_elements = [textwrap.indent(element, prefix=indent) for element in attribute_list]
+            return indented_elements
+
+    return_text = ""
+    return_text += self.__class__.__name__ + "("
+    for attribute in create_wrapped_list(self, attr_ignore=attr_ignore, attr_multiline=attr_multiline):
+        return_text += "\n" + attribute
+    else:
+        return_text += "\n)"
+
+    return return_text


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR adds a `text_wrapper` method that creates object representations automatically for classes that inherits from pydantic `BaseModel`. It also includes changes in repr methods of some other classes that are not inheriting from BaseModel.

Closes #2259 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I added relevant documentation
- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
