### PR TITLE
feat: increase timeout minutes for python tests

### DIFF
--- a/.github/workflows/run-python-tests.yml
+++ b/.github/workflows/run-python-tests.yml
@@ -94,6 +94,7 @@ jobs:
         run: |
           pip install -e ".[server,listeners]"
           pytest --cov=argilla --cov-report=xml:${{ env.COVERAGE_REPORT }}.xml ${{ inputs.pytestArgs }} -vs
+        timeout-minutes: 30
       - name: Upload coverage report artifact
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

We face some problems with the integration tests with code that works fine locally:
- https://github.com/argilla-io/argilla/actions/runs/6933507625/job/18930941495

There are similar issues opened:
- https://github.com/actions/runner/issues/2323
- https://github.com/david-thrower/cerebros-core-algorithm-alpha/pull/83

There is no clear reason but it seems to be related to a timeout.

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
