### PR TITLE
refactor: change filter `and` operator to be mandatory instead of optional

### DIFF
--- a/src/argilla/server/contexts/search.py
+++ b/src/argilla/server/contexts/search.py
@@ -41,7 +41,7 @@ class SearchRecordsQueryValidator:
 
     async def validate(self) -> None:
         if self._query.filters:
-            for filter in self._query.filters.and_ or []:
+            for filter in self._query.filters.and_:
                 await self._validate_filter_scope(filter.scope)
 
         if self._query.sort:

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -787,7 +787,7 @@ Filter = Annotated[Union[TermsFilter, RangeFilter], PydanticField(..., discrimin
 
 
 class Filters(BaseModel):
-    and_: Optional[List[Filter]] = PydanticField(
+    and_: List[Filter] = PydanticField(
         None, alias="and", min_items=FILTERS_AND_MIN_ITEMS, max_items=FILTERS_AND_MAX_ITEMS
     )
 


### PR DESCRIPTION
# Description

A small change so `and_` inside search query filters is non optional.

**Type of change**

- [x] Refactor (change restructuring the codebase without changing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [x] Running tests locally

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)