### PR TITLE
fix: add ranking question type explicit properties to search engine mapping

### DIFF
--- a/src/argilla/server/search_engine/commons.py
+++ b/src/argilla/server/search_engine/commons.py
@@ -169,7 +169,7 @@ def es_mapping_for_question(question: Question) -> dict:
     elif question_type in [QuestionType.label_selection, QuestionType.multi_label_selection]:
         return {"type": "keyword"}
     elif question_type == QuestionType.ranking:
-        return {"type": "nested"}  # TODO: Disable indexing rating for now
+        return {"type": "nested", "properties": {"rank": {"type": "integer"}, "value": {"type": "keyword"}}}
     else:
         raise Exception(f"ElasticSearch mappings for Question of type {question_type} cannot be generated")
 


### PR DESCRIPTION
# Description

After testing suggestions creation and indexing we found an error creating suggestions using ranking questions types. Specifying an explicit set of properties fix the problem.

This is the script used to test the suggestions index:

```python
import argilla as rg

dataset = rg.FeedbackDataset(
  fields=[rg.TextField(name="text")],
  questions=[
    rg.RatingQuestion(name="rating-question", values=[1, 2, 3, 4]),
    rg.TextQuestion(name="text-question"),
    rg.LabelQuestion(name="label-question", labels=["one", "two"]),
    rg.MultiLabelQuestion(name="multi-label-question", labels=["one", "two", "three"]),
    rg.RankingQuestion(name="ranking-question", values=["ranking-1", "ranking-2", "ranking-3"]),
  ],
)

dataset.add_records(
  records=[
    rg.FeedbackRecord(
      fields={"text": "record-1"},
      suggestions=[
        {"question_name": "rating-question", "value": 1},
        {"question_name": "text-question", "value": "suggestion-1",}
      ]
    ),
    rg.FeedbackRecord(
      fields={"text": "record-2"},
      suggestions=[
        {"question_name": "label-question", "value": "one"},
        {"question_name": "multi-label-question", "value": ["one", "two"]},
        {
          "question_name": "ranking-question",
          "value": [
            {"rank": 1, "value": "ranking-1"},
            {"rank": 2, "value": "ranking-2"},
            {"rank": 3, "value": "ranking-3"}
          ]
        }
      ]
    ),
  ],
)

dataset.push_to_argilla(name="test-dataset")
```

Refs #4230

Kudos to @gabrielmbmb for helping me doing the manual testing using the SDK.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [x] Manually creating suggestions using SDK and checking integration with the search engine.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)