### PR TITLE
feat: delete suggestion from record on search engine

### DIFF
--- a/src/argilla/server/apis/v1/handlers/records.py
+++ b/src/argilla/server/apis/v1/handlers/records.py
@@ -174,6 +174,7 @@ async def upsert_suggestion(
 async def delete_record_suggestions(
     *,
     db: AsyncSession = Depends(get_async_db),
+    search_engine: SearchEngine = Depends(get_search_engine),
     record_id: UUID,
     current_user: User = Security(auth.get_current_user),
     ids: str = Query(..., description="A comma separated list with the IDs of the suggestions to be removed"),
@@ -194,7 +195,7 @@ async def delete_record_suggestions(
             detail=f"Cannot delete more than {DELETE_RECORD_SUGGESTIONS_LIMIT} suggestions at once",
         )
 
-    await datasets.delete_suggestions(db, record, suggestion_ids)
+    await datasets.delete_suggestions(db, search_engine, record, suggestion_ids)
 
 
 @router.delete("/records/{record_id}", response_model=RecordSchema, response_model_exclude_unset=True)

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -1112,7 +1112,6 @@ async def get_suggestion_by_id(db: "AsyncSession", suggestion_id: "UUID") -> Uni
 async def delete_suggestion(db: "AsyncSession", search_engine: SearchEngine, suggestion: Suggestion) -> Suggestion:
     async with db.begin_nested():
         suggestion = await suggestion.delete(db, autocommit=False)
-        # TODO: Should we touch here dataset last_activity?
         await search_engine.delete_record_suggestion(suggestion)
 
     await db.commit()

--- a/src/argilla/server/search_engine/base.py
+++ b/src/argilla/server/search_engine/base.py
@@ -22,7 +22,6 @@ from typing import (
     Generic,
     Iterable,
     List,
-    Literal,
     Optional,
     Type,
     TypeVar,
@@ -36,12 +35,11 @@ from pydantic.generics import GenericModel
 from argilla.server.enums import (
     MetadataPropertyType,
     RecordSortField,
-    ResponseStatus,
     ResponseStatusFilter,
     SimilarityOrder,
     SortOrder,
 )
-from argilla.server.models import Dataset, MetadataProperty, Record, Response, User, Vector, VectorSettings
+from argilla.server.models import Dataset, MetadataProperty, Record, Response, Suggestion, User, Vector, VectorSettings
 
 __all__ = [
     "SearchEngine",
@@ -309,6 +307,10 @@ class SearchEngine(metaclass=ABCMeta):
 
     @abstractmethod
     async def delete_record_response(self, response: Response):
+        pass
+
+    @abstractmethod
+    async def delete_record_suggestion(self, suggestion: Suggestion):
         pass
 
     @abstractmethod

--- a/src/argilla/server/search_engine/commons.py
+++ b/src/argilla/server/search_engine/commons.py
@@ -319,6 +319,15 @@ class BaseElasticAndOpenSearchEngine(SearchEngine):
             index_name, id=record.id, body={"script": f'ctx._source["responses"].remove("{response.user.username}")'}
         )
 
+    async def delete_record_suggestion(self, suggestion: Suggestion):
+        index_name = await self._get_index_or_raise(suggestion.record.dataset)
+
+        await self._update_document_request(
+            index_name,
+            id=suggestion.record_id,
+            body={"script": f'ctx._source["suggestions"].remove("{suggestion.question.name}")'},
+        )
+
     async def set_records_vectors(self, dataset: Dataset, vectors: Iterable[Vector]):
         index_name = await self._get_index_or_raise(dataset)
 


### PR DESCRIPTION
# Description

Delete a suggestion from the record document on search engine when the suggestion is deleted using it's deletion endpoint.

Ref #4230 

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [x] Running tests locally.
- [x] Checking manually that deleting a suggestion is affecting filters later on the UI.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)