### PR TITLE
fix: Accept draft responses on dataset records creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ These are the section headers that we use:
 - Fixed error in the unification strategy for `RankingQuestion` ([#4295](https://github.com/argilla-io/argilla/pull/4295))
 - Fixed `TextClassificationSettings.labels_schema` order was not being preserved. Closes [#3828](https://github.com/argilla-io/argilla/issues/3828) ([#4332](https://github.com/argilla-io/argilla/pull/4332))
 - Fixed error when requesting non-existing API endpoints. Closes [#4073](https://github.com/argilla-io/argilla/issues/4073) ([#4325](https://github.com/argilla-io/argilla/pull/4325))
+- Fixed error when passing `draft` responses to create records endpoint. ([#4354](https://github.com/argilla-io/argilla/pull/4354))
 
 ### Changed
 

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -491,8 +491,14 @@ class UserDiscardedResponseCreate(BaseModel):
     status: Literal[ResponseStatus.discarded]
 
 
+class UserDraftResponseCreate(BaseModel):
+    user_id: UUID
+    values: Dict[str, ResponseValueCreate]
+    status: Literal[ResponseStatus.draft]
+
+
 UserResponseCreate = Annotated[
-    Union[UserSubmittedResponseCreate, UserDiscardedResponseCreate],
+    Union[UserSubmittedResponseCreate, UserDraftResponseCreate, UserDiscardedResponseCreate],
     PydanticField(discriminator="status"),
 ]
 

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -3088,6 +3088,45 @@ class TestSuiteDatasets:
             await db.execute(select(func.count(Response.id)).filter(Response.status == ResponseStatus.discarded))
         ).scalar() == 1
 
+    async def test_create_dataset_records_with_draft_response(
+        self,
+        async_client: "AsyncClient",
+        db: "AsyncSession",
+        owner: User,
+        owner_auth_header: dict,
+    ):
+        dataset = await DatasetFactory.create(status=DatasetStatus.ready)
+        await TextFieldFactory.create(name="input", dataset=dataset)
+        await TextFieldFactory.create(name="output", dataset=dataset)
+
+        await TextQuestionFactory.create(name="input_ok", dataset=dataset)
+        await TextQuestionFactory.create(name="output_ok", dataset=dataset)
+
+        records_json = {
+            "items": [
+                {
+                    "fields": {"input": "Say Hello", "output": "Hello"},
+                    "responses": [
+                        {
+                            "values": {"input_ok": {"value": "yes"}, "output_ok": {"value": "yes"}},
+                            "status": "draft",
+                            "user_id": str(owner.id),
+                        }
+                    ],
+                },
+            ]
+        }
+
+        response = await async_client.post(
+            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+        )
+
+        assert response.status_code == 204
+        assert (await db.execute(select(func.count(Record.id)))).scalar() == 1
+        assert (
+            await db.execute(select(func.count(Response.id)).filter(Response.status == ResponseStatus.draft))
+        ).scalar() == 1
+
     async def test_create_dataset_records_with_invalid_response_status(
         self,
         async_client: "AsyncClient",


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR fixed the error when passing `draft` responses to the create records endpoint. 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

- [ ] Tested locally

**Checklist**

- [ ] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
