### PR TITLE
docs: extend using proxy section

### DIFF
--- a/docker/nginx/docker-compose.yaml
+++ b/docker/nginx/docker-compose.yaml
@@ -1,0 +1,18 @@
+version: "3.8"
+
+services:
+  nginx:
+    image: nginx:latest
+    container_name: "nginx_proxy"
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+
+  argilla:
+    image: argilla/argilla-quickstart:v1.20.0
+    environment:
+      ARGILLA_ENABLE_TELEMETRY: 0
+      ARGILLA_BASE_URL: /argilla
+    ports:
+      - "6900:6900"

--- a/docker/nginx/docker-compose.yaml
+++ b/docker/nginx/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
 
   argilla:
-    image: argilla/argilla-quickstart:v1.20.0
+    image: argilla/argilla-quickstart:latest
     environment:
       ARGILLA_ENABLE_TELEMETRY: 0
       ARGILLA_BASE_URL: /argilla

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,0 +1,15 @@
+events {}
+
+http {
+  server {
+      listen 80;
+
+      location /argilla/ {
+          proxy_pass http://argilla:6900/;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+      }
+  }
+}

--- a/docker/traefik/docker-compose.yaml
+++ b/docker/traefik/docker-compose.yaml
@@ -1,0 +1,31 @@
+version: "3.8"
+
+services:
+  traefik:
+    image: "traefik:v2.10"
+    container_name: "traefik"
+    command:
+      #- "--log.level=DEBUG"
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+    ports:
+      - "80:80"
+      - "8080:8080"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+
+  argilla:
+    image: argilla/argilla-quickstart:v1.20.0
+    environment:
+      ARGILLA_ENABLE_TELEMETRY: 0
+      ARGILLA_BASE_URL: /argilla
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.argilla.rule=PathPrefix(`/argilla/`)"
+      - "traefik.http.routers.argilla.entrypoints=web"
+      - "traefik.http.services.argilla.loadbalancer.server.port=6900"
+      - "traefik.http.middlewares.argilla-stripprefix.stripprefix.prefixes=/argilla"
+      - "traefik.http.middlewares.argilla-stripprefix.stripprefix.forceSlash=false"
+      - "traefik.http.routers.argilla.middlewares=argilla-stripprefix"

--- a/docker/traefik/docker-compose.yaml
+++ b/docker/traefik/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
 
   argilla:
-    image: argilla/argilla-quickstart:v1.20.0
+    image: argilla/argilla-quickstart:latest
     environment:
       ARGILLA_ENABLE_TELEMETRY: 0
       ARGILLA_BASE_URL: /argilla

--- a/docs/_source/getting_started/installation/configurations/server_configuration.md
+++ b/docs/_source/getting_started/installation/configurations/server_configuration.md
@@ -17,13 +17,19 @@ This may result in unexpected results when combining filtering with vector searc
 :::
 
 ## Launching
+
 ### Using a proxy
 
 If you run Argilla behind a proxy by adding some extra prefix to expose the service, you should set the `ARGILLA_BASE_URL`
 environment variable to properly route requests to the server application.
 
-For example, if your proxy exposes Argilla in the URL `https://my-proxy/custom-path-for-argilla`,  you should launch the
+For example, if your proxy exposes Argilla in the URL `https://my-proxy/custom-path-for-argilla`, you should launch the
 Argilla server with `ARGILLA_BASE_URL=/custom-path-for-argilla`.
+
+NGINX and Traefik have been tested and are known to work with Argilla:
+
+- [NGINX example](https://github.com/argilla-io/argilla/tree/main/docker/nginx)
+- [Traefik example](https://github.com/argilla-io/argilla/tree/main/docker/traefik)
 
 ### with `uvicorn`
 


### PR DESCRIPTION
# Description

This PR adds examples to the docs on how to use `NGINX` and `Traefik` as reverse proxy for Argilla server.

Closes #3706

**Type of change**

- [x] Documentation update

**How Has This Been Tested**

- [x] `sphinx-autobuild` (read [Developer Documentation](https://docs.argilla.io/en/latest/community/developer_docs.html#building-the-documentation) for more details)

**Checklist**

- [x] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
