### PR TITLE
Token Classification epochs parameter trainer changed

### DIFF
--- a/docs/_source/practical_guides/fine_tune.md
+++ b/docs/_source/practical_guides/fine_tune.md
@@ -1471,7 +1471,7 @@ trainer = ArgillaTrainer(
     framework="spacy",
     train_size=0.8
 )
-trainer.update_config(max_epochs=2)
+trainer.update_config(num_train_epochs=2)
 trainer.train(output_dir="my_spacy_model")
 records = trainer.predict("The ArgillaTrainer is great!", as_argilla_records=True)
 rg.log(records=records, name="conll2003", workspace="admin")


### PR DESCRIPTION


Closes #4373 

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [X] Documentation update

**How Has This Been Tested**

This feature was tested while working on the SpanMarker tutorial, as I realised the number of training epochs only changed with `trainer.update_config(num_train_epochs=2)`, not with `trainer.update_config(max_epochs=2) `