### PR TITLE
fix: pinning `pytest-asyncio` to version `0.21.1` to avoid problems running unit tests on GitHub workflows

### DIFF
--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-mock
-  - pytest-asyncio!=0.22.0
+  - pytest-asyncio==0.21.1 # Pinning version 0.21.1, version 0.23.2 is causing problems with GitHub workflows
   - pytest-env
   - factory_boy~=3.2.1
   # docs, pandoc needs conda ...


### PR DESCRIPTION
# Description

Looks like `pytest-asyncio` latest version (`0.23.2`) was causing some problems running unit tests returning multiple errors with the following message:

```
RuntimeError: There is no current event loop in thread 'MainThread'.
```

Pinning `pytest-asyncio` to version `0.21.1` is fixing these problems.

We should take a look to it in the future and update to a next version where these problems have been addressed.

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Tests should be successfully executed for this PR.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)