### PR TITLE
fix: Fix `prepare_dataset_for_annotation_task` to return correct format

### DIFF
--- a/src/argilla/client/feedback/metrics/agreement_metrics.py
+++ b/src/argilla/client/feedback/metrics/agreement_metrics.py
@@ -94,7 +94,10 @@ def prepare_dataset_for_annotation_task(
 
     formatted_responses: FormattedResponses = []
 
+    len_dataset = iter(range(len(hf_dataset[question_name])))
+
     for responses_ in hf_dataset[question_name]:
+        question_text = hf_dataset[next(len_dataset)]["text"]
         for response in responses_:
             user_id = response["user_id"]
             if user_id is None:
@@ -114,7 +117,7 @@ def prepare_dataset_for_annotation_task(
             elif question_type == MultiLabelQuestion:
                 value = frozenset(value)
 
-            formatted_responses.append((user_id, question_name, value))
+            formatted_responses.append((user_id, question_text, value))
 
     return formatted_responses
 

--- a/src/argilla/client/feedback/metrics/agreement_metrics.py
+++ b/src/argilla/client/feedback/metrics/agreement_metrics.py
@@ -94,10 +94,9 @@ def prepare_dataset_for_annotation_task(
 
     formatted_responses: FormattedResponses = []
 
-    len_dataset = iter(range(len(hf_dataset[question_name])))
-
-    for responses_ in hf_dataset[question_name]:
-        question_text = hf_dataset[next(len_dataset)]["text"]
+    for row in hf_dataset:
+        responses_ = row[question_name]
+        question_text = row["text"]
         for response in responses_:
             user_id = response["user_id"]
             if user_id is None:

--- a/tests/integration/client/feedback/metrics/test_agreement_metrics.py
+++ b/tests/integration/client/feedback/metrics/test_agreement_metrics.py
@@ -114,7 +114,7 @@ def test_prepare_dataset_for_annotation_task(
         assert isinstance(item[0], str)
         assert item[0].startswith("00000000-")  # beginning of our uuid for tests
         assert isinstance(item[1], str)
-        assert item[1].startswith("question-")
+        assert item[1] == feedback_dataset_records_with_paired_suggestions[0].fields["text"]
         assert isinstance(item[2], type_of_data)
 
 


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

As described in the issue, the method returns question name for all records. In this PR, the question texts are returned so that the Alpha is correctly corrected. The method can be further improved with a better alternative.

Closes #4396 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
