### PR TITLE
docs: Change `telemetry` section in tutorials to directly executable cells

### DIFF
--- a/docs/_source/tutorials/notebooks/deploying-text2text-dvc-explainability.ipynb
+++ b/docs/_source/tutorials/notebooks/deploying-text2text-dvc-explainability.ipynb
@@ -187,13 +187,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/deploying-textclassification-colab-activelearning.ipynb
+++ b/docs/_source/tutorials/notebooks/deploying-textclassification-colab-activelearning.ipynb
@@ -77,13 +77,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/deploying-texttokenclassification-fastapi.ipynb
+++ b/docs/_source/tutorials/notebooks/deploying-texttokenclassification-fastapi.ipynb
@@ -201,13 +201,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/labelling-spacy-llm.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-spacy-llm.ipynb
@@ -146,13 +146,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/labelling-text2text-disaggregators-explainability.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-text2text-disaggregators-explainability.ipynb
@@ -179,13 +179,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-gpt3-fewshot.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-gpt3-fewshot.ipynb
@@ -180,13 +180,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-sentence-transformers-semantic.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-sentence-transformers-semantic.ipynb
@@ -173,13 +173,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-sentencetransformers-semantic.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-sentencetransformers-semantic.ipynb
@@ -186,13 +186,20 @@
       "source": [
         "### Enable Telemetry\n",
         "\n",
-        "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-        "\n",
-        "```python\n",
-        "from argilla.utils.telemetry import tutorial_running\n",
-        "\n",
-        "tutorial_running()\n",
-        "```"
+        "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "try:\n",
+        "    from argilla.utils.telemetry import tutorial_running\n",
+        "    tutorial_running()\n",
+        "except ImportError:\n",
+        "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
       ]
     },
     {

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-sentencetransformers-weaksupervision.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-sentencetransformers-weaksupervision.ipynb
@@ -219,13 +219,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-setfit-zeroshot.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-setfit-zeroshot.ipynb
@@ -201,13 +201,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-sklearn-weaksupervision.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-sklearn-weaksupervision.ipynb
@@ -192,13 +192,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/labelling-textclassification-snorkel-weaksupervision.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-textclassification-snorkel-weaksupervision.ipynb
@@ -198,13 +198,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/labelling-tokenclassification-basics.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-tokenclassification-basics.ipynb
@@ -162,13 +162,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/labelling-tokenclassification-deletelabels.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-tokenclassification-deletelabels.ipynb
@@ -118,13 +118,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/labelling-tokenclassification-flair-fewshot.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-tokenclassification-flair-fewshot.ipynb
@@ -198,13 +198,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/labelling-tokenclassification-skweak-weaksupervision.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-tokenclassification-skweak-weaksupervision.ipynb
@@ -226,13 +226,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/labelling-tokenclassification-spacy-pretrained.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-tokenclassification-spacy-pretrained.ipynb
@@ -175,13 +175,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/labelling-tokenclassification-using-spacy-llm.ipynb
+++ b/docs/_source/tutorials/notebooks/labelling-tokenclassification-using-spacy-llm.ipynb
@@ -171,13 +171,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/monitoring-textclassification-cleanlab-explainability.ipynb
+++ b/docs/_source/tutorials/notebooks/monitoring-textclassification-cleanlab-explainability.ipynb
@@ -180,13 +180,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/monitoring-textclassification-setfit-explainability.ipynb
+++ b/docs/_source/tutorials/notebooks/monitoring-textclassification-setfit-explainability.ipynb
@@ -254,13 +254,20 @@
       "source": [
         "### Enable Telemetry\n",
         "\n",
-        "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-        "\n",
-        "```python\n",
-        "from argilla.utils.telemetry import tutorial_running\n",
-        "\n",
-        "tutorial_running()\n",
-        "```"
+        "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "try:\n",
+        "    from argilla.utils.telemetry import tutorial_running\n",
+        "    tutorial_running()\n",
+        "except ImportError:\n",
+        "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
       ]
     },
     {

--- a/docs/_source/tutorials/notebooks/monitoring-textclassification-shaptransformersinterpret-explainability.ipynb
+++ b/docs/_source/tutorials/notebooks/monitoring-textclassification-shaptransformersinterpret-explainability.ipynb
@@ -179,13 +179,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/monitoring-textclassification-transformers-explainability.ipynb
+++ b/docs/_source/tutorials/notebooks/monitoring-textclassification-transformers-explainability.ipynb
@@ -199,13 +199,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/ner_fine_tune_bert_beginners.ipynb
+++ b/docs/_source/tutorials/notebooks/ner_fine_tune_bert_beginners.ipynb
@@ -427,13 +427,20 @@
       "source": [
         "### Enable Telemetry\n",
         "\n",
-        "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-        "\n",
-        "```python\n",
-        "from argilla.utils.telemetry import tutorial_running\n",
-        "\n",
-        "tutorial_running()\n",
-        "```"
+        "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "try:\n",
+        "    from argilla.utils.telemetry import tutorial_running\n",
+        "    tutorial_running()\n",
+        "except ImportError:\n",
+        "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
       ]
     },
     {

--- a/docs/_source/tutorials/notebooks/training-textclassification-classyclassification-activelearning.ipynb
+++ b/docs/_source/tutorials/notebooks/training-textclassification-classyclassification-activelearning.ipynb
@@ -171,13 +171,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/training-textclassification-modal-activelearning.ipynb
+++ b/docs/_source/tutorials/notebooks/training-textclassification-modal-activelearning.ipynb
@@ -185,13 +185,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/training-textclassification-setfit-fewshot.ipynb
+++ b/docs/_source/tutorials/notebooks/training-textclassification-setfit-fewshot.ipynb
@@ -178,13 +178,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/training-textclassification-setfit-sentiment.ipynb
+++ b/docs/_source/tutorials/notebooks/training-textclassification-setfit-sentiment.ipynb
@@ -174,13 +174,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/training-textclassification-smalltext-activelearning.ipynb
+++ b/docs/_source/tutorials/notebooks/training-textclassification-smalltext-activelearning.ipynb
@@ -168,18 +168,24 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5be64d5e",
    "metadata": {},
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/training-textclassification-transformers-pretrained.ipynb
+++ b/docs/_source/tutorials/notebooks/training-textclassification-transformers-pretrained.ipynb
@@ -185,13 +185,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials/notebooks/training-textgeneration-unstructured.ipynb
+++ b/docs/_source/tutorials/notebooks/training-textgeneration-unstructured.ipynb
@@ -193,13 +193,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/feedback/curating-feedback-instructiondataset.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/feedback/curating-feedback-instructiondataset.ipynb
@@ -128,13 +128,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/feedback/end2end_examples/add-metadata-003.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/feedback/end2end_examples/add-metadata-003.ipynb
@@ -188,13 +188,21 @@
    "metadata": {},
    "source": [
     "### Enable Telemetry\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the Telemetry page.\n",
     "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {
@@ -1022,7 +1030,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.17"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,

--- a/docs/_source/tutorials_and_integrations/tutorials/feedback/end2end_examples/add-suggestions-and-responses-005.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/feedback/end2end_examples/add-suggestions-and-responses-005.ipynb
@@ -136,13 +136,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the Telemetry page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/feedback/end2end_examples/add-vectors-004.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/feedback/end2end_examples/add-vectors-004.ipynb
@@ -147,13 +147,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Enable Telemetry"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "### Enable Telemetry\n",
+    "\n",
     "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
    ]
   },
@@ -163,9 +158,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()"
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/feedback/end2end_examples/assign-records-002.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/feedback/end2end_examples/assign-records-002.ipynb
@@ -145,13 +145,21 @@
    "metadata": {},
    "source": [
     "### Enable Telemetry\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the Telemetry page.\n",
     "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/feedback/end2end_examples/configure-users-and-workspaces-000.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/feedback/end2end_examples/configure-users-and-workspaces-000.ipynb
@@ -399,30 +399,24 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fa470f0b",
    "metadata": {},
    "source": [
-    "### Enable Telemetry"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "95e3ca39",
-   "metadata": {},
-   "source": [
+    "### Enable Telemetry\n",
+    "\n",
     "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7671fbb5",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()"
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/feedback/end2end_examples/create-dataset-001.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/feedback/end2end_examples/create-dataset-001.ipynb
@@ -304,36 +304,24 @@
         },
         {
             "cell_type": "markdown",
-            "id": "fa470f0b",
             "metadata": {},
             "source": [
-                "### Enable Telemetry"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "95e3ca39",
-            "metadata": {},
-            "source": [
+                "### Enable Telemetry\n",
+                "\n",
                 "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
             ]
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "id": "7671fbb5",
-            "metadata": {
-                "editable": true,
-                "slideshow": {
-                    "slide_type": ""
-                },
-                "tags": []
-            },
+            "metadata": {},
             "outputs": [],
             "source": [
-                "from argilla.utils.telemetry import tutorial_running\n",
-                "\n",
-                "tutorial_running()"
+                "try:\n",
+                "    from argilla.utils.telemetry import tutorial_running\n",
+                "    tutorial_running()\n",
+                "except ImportError:\n",
+                "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
             ]
         },
         {

--- a/docs/_source/tutorials_and_integrations/tutorials/feedback/end2end_examples/filter-and-query-008.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/feedback/end2end_examples/filter-and-query-008.ipynb
@@ -136,13 +136,21 @@
    "metadata": {},
    "source": [
     "### Enable Telemetry\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the Telemetry page.\n",
     "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/feedback/end2end_examples/train-model-006.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/feedback/end2end_examples/train-model-006.ipynb
@@ -136,13 +136,21 @@
    "metadata": {},
    "source": [
     "### Enable Telemetry\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the Telemetry page.\n",
     "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/feedback/fine-tuning-sentencesimilarity-rag.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/feedback/fine-tuning-sentencesimilarity-rag.ipynb
@@ -177,7 +177,7 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../../reference/telemetry.md) page."
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
    ]
   },
   {
@@ -186,9 +186,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()"
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/feedback/labelling-feedback-langchain-syntethic.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/feedback/labelling-feedback-langchain-syntethic.ipynb
@@ -145,13 +145,20 @@
       "source": [
         "### Enable Telemetry\n",
         "\n",
-        "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../../reference/telemetry.md) page.\n",
-        "\n",
-        "```python\n",
-        "from argilla.utils.telemetry import tutorial_running\n",
-        "\n",
-        "tutorial_running()\n",
-        "```"
+        "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "try:\n",
+        "    from argilla.utils.telemetry import tutorial_running\n",
+        "    tutorial_running()\n",
+        "except ImportError:\n",
+        "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
       ]
     },
     {

--- a/docs/_source/tutorials_and_integrations/tutorials/feedback/labelling-feedback-setfit.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/feedback/labelling-feedback-setfit.ipynb
@@ -123,13 +123,20 @@
       "source": [
         "### Enable Telemetry\n",
         "\n",
-        "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../../reference/telemetry.md) page.\n",
-        "\n",
-        "```python\n",
-        "from argilla.utils.telemetry import tutorial_running\n",
-        "\n",
-        "tutorial_running()\n",
-        "```"
+        "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "try:\n",
+        "    from argilla.utils.telemetry import tutorial_running\n",
+        "    tutorial_running()\n",
+        "except ImportError:\n",
+        "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
       ]
     },
     {

--- a/docs/_source/tutorials_and_integrations/tutorials/feedback/labelling-spacy-llm.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/feedback/labelling-spacy-llm.ipynb
@@ -146,13 +146,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/feedback/train-reward-model-rlhf.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/feedback/train-reward-model-rlhf.ipynb
@@ -145,13 +145,20 @@
       "source": [
         "### Enable Telemetry\n",
         "\n",
-        "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../../reference/telemetry.md) page.\n",
-        "\n",
-        "```python\n",
-        "from argilla.utils.telemetry import tutorial_running\n",
-        "\n",
-        "tutorial_running()\n",
-        "```"
+        "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "try:\n",
+        "    from argilla.utils.telemetry import tutorial_running\n",
+        "    tutorial_running()\n",
+        "except ImportError:\n",
+        "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
       ]
     },
     {

--- a/docs/_source/tutorials_and_integrations/tutorials/feedback/trainer-feedback-setfit.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/feedback/trainer-feedback-setfit.ipynb
@@ -142,13 +142,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/feedback/training-llm-mistral-sft.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/feedback/training-llm-mistral-sft.ipynb
@@ -148,13 +148,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/feedback/training-qa-transformers.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/feedback/training-qa-transformers.ipynb
@@ -156,13 +156,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/other_datasets/few_shot_learning_with_setfit.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/other_datasets/few_shot_learning_with_setfit.ipynb
@@ -178,13 +178,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/other_datasets/few_shot_text_classification_with_active_learning.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/other_datasets/few_shot_text_classification_with_active_learning.ipynb
@@ -168,19 +168,25 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/other_datasets/label_data_with_semantic_search.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/other_datasets/label_data_with_semantic_search.ipynb
@@ -176,13 +176,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/other_datasets/label_errors_cleanlab.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/other_datasets/label_errors_cleanlab.ipynb
@@ -180,13 +180,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/other_datasets/labelling-tokenclassification-using-spacy-llm.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/other_datasets/labelling-tokenclassification-using-spacy-llm.ipynb
@@ -171,13 +171,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/other_datasets/weak_supervision_ner.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/other_datasets/weak_supervision_ner.ipynb
@@ -226,13 +226,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {

--- a/docs/_source/tutorials_and_integrations/tutorials/other_datasets/weak_supervision_text_classification_semantic_search.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/other_datasets/weak_supervision_text_classification_semantic_search.ipynb
@@ -224,13 +224,20 @@
    "source": [
     "### Enable Telemetry\n",
     "\n",
-    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../../reference/telemetry.md) page.\n",
-    "\n",
-    "```python\n",
-    "from argilla.utils.telemetry import tutorial_running\n",
-    "\n",
-    "tutorial_running()\n",
-    "```"
+    "We gain valuable insights from how you interact with our tutorials. To improve ourselves in offering you the most suitable content, using the following lines of code will help us understand that this tutorial is serving you effectively. Though this is entirely anonymous, you can choose to skip this step if you prefer. For more info, please check out the [Telemetry](../../reference/telemetry.md) page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from argilla.utils.telemetry import tutorial_running\n",
+    "    tutorial_running()\n",
+    "except ImportError:\n",
+    "    print(\"Telemetry is introduced in Argilla 1.20.0 and not found in the current installation. Skipping telemetry.\")"
    ]
   },
   {


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

In tutorials, telemetry section was a markdown that included python code, which was not executable but required copy&paste first. This PR changes all telemetry sections to exectuable python cells.

Closes #4386 

**Type of change**

(Remember to title the PR according to the type of change)

- [ ] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes.)

- [ ] `sphinx-autobuild` (read [Developer Documentation](https://docs.argilla.io/en/latest/community/developer_docs.html#building-the-documentation) for more details)

**Checklist**

- [ ] I added relevant documentation
- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
