### PR TITLE
feat: Add tests and docs for deprecated `unify_responses` method

### DIFF
--- a/docs/_source/practical_guides/collect_responses.md
+++ b/docs/_source/practical_guides/collect_responses.md
@@ -94,6 +94,10 @@ You can unify responses by using a `FeedbackDataset` in combination with a `Ques
 ```{include} /_common/tabs/unfication_strategies.md
 ```
 
+```{warning}
+Starting from Argilla 1.21.0, `unify_responses` is deprecated. Please use `compute_unified_responses` instead.
+```
+
 Once you have unified your responses, you will have a dataset that's ready for [fine-tuning](fine_tune.md). Remember to save your unified dataset following one of the methods explained in [Export a Feedback Dataset](export_dataset.md).
 
 #### Strategies

--- a/src/argilla/client/feedback/metrics/annotator_metrics.py
+++ b/src/argilla/client/feedback/metrics/annotator_metrics.py
@@ -194,8 +194,8 @@ class UnifiedAnnotationMetric(AnnotatorMetric):
 
     Example:
         >>> import argilla as rg
-        >>> from argilla.client.feedback.metrics import UnifiedAnnotatorMetric
-        >>> metric = UnifiedAnnotatorMetric(dataset=dataset, question_name=question)
+        >>> from argilla.client.feedback.metrics import UnifiedAnnotationMetric
+        >>> metric = UnifiedAnnotationMetric(dataset=dataset, question_name=question)
         >>> metrics_report = metric.compute("accuracy")
     """
 

--- a/tests/integration/client/feedback/metrics/test_annotator_metrics.py
+++ b/tests/integration/client/feedback/metrics/test_annotator_metrics.py
@@ -298,6 +298,9 @@ def test_annotator_metrics_unified(
             assert isinstance(metrics_report, list)
         else:
             assert isinstance(metrics_report, AnnotatorMetricResult)
+            assert str(list(unified_dataset.records[0].unified_responses.values())[0][0].value) in str(
+                dataset.records[0].responses
+            )
             metrics_report = [metrics_report]
             metric_names = [metric_names]
 
@@ -359,6 +362,9 @@ def test_annotator_metrics_unified_from_feedback_dataset(
         assert isinstance(metrics_report, list)
     else:
         assert isinstance(metrics_report, AnnotatorMetricResult)
+        assert str(list(unified_dataset.records[0].unified_responses.values())[0][0].value) in str(
+            dataset.records[0].responses
+        )
         metrics_report = [metrics_report]
         metric_names = [metric_names]
 

--- a/tests/integration/client/feedback/test_unification.py
+++ b/tests/integration/client/feedback/test_unification.py
@@ -32,25 +32,36 @@ from argilla.client.feedback.unification import (
     UnifiedValueSchema,
 )
 
+responses_rating = [
+    {"values": {"rating": {"value": "1"}}},
+    {"values": {"rating": {"value": "2"}}},
+    {"values": {"rating": {"value": "2"}}},
+]
+
+responses_rating_equal = [
+    {"values": {"rating": {"value": "2"}}},
+    {"values": {"rating": {"value": "2"}}},
+]
+
 
 @pytest.mark.parametrize(
-    "strategy, unified_response",
+    "strategy, unified_response, responses",
     [
-        ("mean", [{"value": str(int(5 / 3)), "strategy": "mean"}]),
-        ("majority", [{"value": "2", "strategy": "majority"}]),
-        ("max", [{"value": "2", "strategy": "max"}]),
-        ("min", [{"value": "1", "strategy": "min"}]),
+        ("mean", [{"value": str(int(5 / 3)), "strategy": "mean"}], responses_rating),
+        ("majority", [{"value": "2", "strategy": "majority"}], responses_rating),
+        ("max", [{"value": "2", "strategy": "max"}], responses_rating),
+        ("min", [{"value": "1", "strategy": "min"}], responses_rating),
+        ("mean", [{"value": str(2), "strategy": "mean"}], responses_rating_equal),
+        ("majority", [{"value": "2", "strategy": "majority"}], responses_rating_equal),
+        ("max", [{"value": "2", "strategy": "max"}], responses_rating_equal),
+        ("min", [{"value": "2", "strategy": "min"}], responses_rating_equal),
     ],
 )
-def test_rating_question_strategy(strategy, unified_response):
+def test_rating_question_strategy(strategy, unified_response, responses):
     question_name = "rating"
     records_payload = {
         "fields": {"text": "This is the first record", "label": "positive"},
-        "responses": [
-            {"values": {question_name: {"value": "1"}}},
-            {"values": {question_name: {"value": "2"}}},
-            {"values": {question_name: {"value": "2"}}},
-        ],
+        "responses": responses,
     }
     record = FeedbackRecord(**records_payload)
     question_payload = {
@@ -67,24 +78,68 @@ def test_rating_question_strategy(strategy, unified_response):
     assert RatingQuestionUnification(question=question, strategy=strategy)
 
 
+responses_ranking = [
+    {"values": {"ranking": {"value": [{"rank": 2, "value": "yes"}, {"rank": 3, "value": "no"}]}}},
+    {"values": {"ranking": {"value": [{"rank": 2, "value": "yes"}, {"rank": 1, "value": "no"}]}}},
+    {"values": {"ranking": {"value": [{"rank": 2, "value": "yes"}, {"rank": 3, "value": "no"}]}}},
+]
+
+responses_ranking_equal = [
+    {"values": {"ranking": {"value": [{"rank": 2, "value": "yes"}, {"rank": 3, "value": "no"}]}}},
+    {"values": {"ranking": {"value": [{"rank": 2, "value": "yes"}, {"rank": 3, "value": "no"}]}}},
+]
+
+
 @pytest.mark.parametrize(
-    "strategy, unified_response",
+    "strategy, unified_response, responses",
     [
-        ("majority", [{"value": [{"rank": 2, "value": "yes"}, {"rank": 3, "value": "no"}], "strategy": "majority"}]),
-        ("max", [{"value": [{"rank": 2, "value": "yes"}, {"rank": 3, "value": "no"}], "strategy": "max"}]),
-        ("min", [{"value": [{"rank": 2, "value": "yes"}, {"rank": 1, "value": "no"}], "strategy": "min"}]),
-        ("mean", [{"value": [{"rank": 2, "value": "yes"}, {"rank": 2, "value": "no"}], "strategy": "mean"}]),
+        (
+            "majority",
+            [{"value": [{"rank": 2, "value": "yes"}, {"rank": 3, "value": "no"}], "strategy": "majority"}],
+            responses_ranking,
+        ),
+        (
+            "max",
+            [{"value": [{"rank": 2, "value": "yes"}, {"rank": 3, "value": "no"}], "strategy": "max"}],
+            responses_ranking,
+        ),
+        (
+            "min",
+            [{"value": [{"rank": 2, "value": "yes"}, {"rank": 1, "value": "no"}], "strategy": "min"}],
+            responses_ranking,
+        ),
+        (
+            "mean",
+            [{"value": [{"rank": 2, "value": "yes"}, {"rank": 2, "value": "no"}], "strategy": "mean"}],
+            responses_ranking,
+        ),
+        (
+            "majority",
+            [{"value": [{"rank": 2, "value": "yes"}, {"rank": 3, "value": "no"}], "strategy": "majority"}],
+            responses_ranking_equal,
+        ),
+        (
+            "max",
+            [{"value": [{"rank": 2, "value": "yes"}, {"rank": 3, "value": "no"}], "strategy": "max"}],
+            responses_ranking_equal,
+        ),
+        (
+            "min",
+            [{"value": [{"rank": 2, "value": "yes"}, {"rank": 3, "value": "no"}], "strategy": "min"}],
+            responses_ranking_equal,
+        ),
+        (
+            "mean",
+            [{"value": [{"rank": 2, "value": "yes"}, {"rank": 3, "value": "no"}], "strategy": "mean"}],
+            responses_ranking_equal,
+        ),
     ],
 )
-def test_ranking_question_strategy(strategy, unified_response):
+def test_ranking_question_strategy(strategy, unified_response, responses):
     question_name = "ranking"
     records_payload = {
         "fields": {"text": "This is the first record", "label": "positive"},
-        "responses": [
-            {"values": {question_name: {"value": [{"rank": 2, "value": "yes"}, {"rank": 3, "value": "no"}]}}},
-            {"values": {question_name: {"value": [{"rank": 2, "value": "yes"}, {"rank": 1, "value": "no"}]}}},
-            {"values": {question_name: {"value": [{"rank": 2, "value": "yes"}, {"rank": 3, "value": "no"}]}}},
-        ],
+        "responses": responses,
     }
     record = FeedbackRecord(**records_payload)
     question_payload = {
@@ -101,10 +156,27 @@ def test_ranking_question_strategy(strategy, unified_response):
     assert RankingQuestionUnification(question=question, strategy=strategy)
 
 
+responses_label = [
+    {"values": {"label": {"value": "1"}}},
+    {"values": {"label": {"value": "2"}}},
+    {"values": {"label": {"value": "2"}}},
+]
+
+responses_label_equal = [
+    {"values": {"label": {"value": "2"}}},
+    {"values": {"label": {"value": "2"}}},
+]
+
+responses_label_different = [
+    {"values": {"label": {"value": "1"}}},
+    {"values": {"label": {"value": "2"}}},
+]
+
+
 @pytest.mark.parametrize(
-    "strategy, unified_response",
+    "strategy, unified_response, responses",
     [
-        ("majority", [{"value": "2", "strategy": "majority"}]),
+        ("majority", [{"value": "2", "strategy": "majority"}], responses_label),
         (
             "disagreement",
             [
@@ -112,18 +184,38 @@ def test_ranking_question_strategy(strategy, unified_response):
                 {"value": "2", "strategy": "disagreement"},
                 {"value": "2", "strategy": "disagreement"},
             ],
+            responses_label,
+        ),
+        ("majority", [{"value": "2", "strategy": "majority"}], responses_label_equal),
+        (
+            "disagreement",
+            [
+                {"value": "2", "strategy": "disagreement"},
+                {"value": "2", "strategy": "disagreement"},
+            ],
+            responses_label_equal,
+        ),
+        ("majority", [{"value": "1", "strategy": "majority"}], responses_label_different),
+        (
+            "disagreement",
+            [
+                {"value": "1", "strategy": "disagreement"},
+                {"value": "2", "strategy": "disagreement"},
+            ],
+            responses_label_different,
         ),
     ],
 )
-def test_label_question_strategy(strategy, unified_response):
-    question_name = "rating"
+def test_label_question_strategy(strategy, unified_response, responses):
+    # To ensure reproducibility for the cases that the answer must be chosen randomly
+    import random
+
+    random.seed(42)
+
+    question_name = "label"
     records_payload = {
         "fields": {"text": "This is the first record", "label": "positive"},
-        "responses": [
-            {"values": {question_name: {"value": "1"}}},
-            {"values": {question_name: {"value": "2"}}},
-            {"values": {question_name: {"value": "2"}}},
-        ],
+        "responses": responses,
     }
     record = FeedbackRecord(**records_payload)
     question_payload = {
@@ -140,29 +232,49 @@ def test_label_question_strategy(strategy, unified_response):
     assert LabelQuestionUnification(question=question, strategy=strategy)
 
 
+responses_multilabel = [
+    {"values": {"multilabel": {"value": ["label1"]}}},
+    {"values": {"multilabel": {"value": ["label1", "label2"]}}},
+    {"values": {"multilabel": {"value": ["label1"]}}},
+]
+
+responses_multilabel_equal = [
+    {"values": {"multilabel": {"value": ["label1"]}}},
+    {"values": {"multilabel": {"value": ["label2"]}}},
+]
+
+
 @pytest.mark.parametrize(
-    "strategy, unified_response",
+    "strategy, unified_response, responses",
     [
-        ("majority", [{"value": ["1"], "strategy": "majority"}]),
+        ("majority", [{"value": ["label1"], "strategy": "majority"}], responses_multilabel),
         (
             "disagreement",
             [
-                {"value": ["1"], "strategy": "disagreement"},
-                {"value": ["1", "2"], "strategy": "disagreement"},
-                {"value": ["1"], "strategy": "disagreement"},
+                {"value": ["label1"], "strategy": "disagreement"},
+                {"value": ["label1", "label2"], "strategy": "disagreement"},
+                {"value": ["label1"], "strategy": "disagreement"},
             ],
+            responses_multilabel,
+        ),
+        ("majority", [{"value": ["label1"], "strategy": "majority"}], responses_multilabel_equal),
+        (
+            "disagreement",
+            [{"value": ["label1"], "strategy": "disagreement"}, {"value": ["label2"], "strategy": "disagreement"}],
+            responses_multilabel_equal,
         ),
     ],
 )
-def test_multi_label_question_strategy(strategy, unified_response):
-    question_name = "rating"
+def test_multi_label_question_strategy(strategy, unified_response, responses):
+    # To ensure reproducibility for the cases that the answer must be chosen randomly
+    import random
+
+    random.seed(42)
+
+    question_name = "multilabel"
     records_payload = {
         "fields": {"text": "This is the first record", "label": "positive"},
-        "responses": [
-            {"values": {question_name: {"value": ["1"]}}},
-            {"values": {question_name: {"value": ["1", "2"]}}},
-            {"values": {question_name: {"value": ["1"]}}},
-        ],
+        "responses": responses,
     }
     record = FeedbackRecord(**records_payload)
     question_payload = {
@@ -174,36 +286,6 @@ def test_multi_label_question_strategy(strategy, unified_response):
     question = MultiLabelQuestion(**question_payload)
     strategy = MultiLabelQuestionStrategy(strategy)
     strategy.compute_unified_responses([record], question)
-    unified_response = [UnifiedValueSchema(**resp) for resp in unified_response]
-    assert record._unified_responses[question_name] == unified_response
-    assert MultiLabelQuestionUnification(question=question, strategy=strategy)
-
-
-@pytest.mark.parametrize(
-    "strategy, unified_response",
-    [
-        ("majority", [{"value": ["label1"], "strategy": "majority"}]),
-    ],
-)
-def test_multi_label_question_strategy_without_overlap(strategy, unified_response):
-    question_name = "rating"
-    records_payload = {
-        "fields": {"text": "This is the first record", "label": "positive"},
-        "responses": [
-            {"values": {question_name: {"value": ["label1"]}}},
-            {"values": {question_name: {"value": ["label2"]}}},
-        ],
-    }
-    record = FeedbackRecord(**records_payload)
-    question_payload = {
-        "name": question_name,
-        "description": question_name,
-        "required": True,
-        "labels": ["label1", "label2"],
-    }
-    question = MultiLabelQuestion(**question_payload)
-    strategy = MultiLabelQuestionStrategy(strategy)
-    strategy.unify_responses([record], question)
     unified_response = [UnifiedValueSchema(**resp) for resp in unified_response]
     assert record._unified_responses[question_name] == unified_response
     assert MultiLabelQuestionUnification(question=question, strategy=strategy)


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR adds tests and warning for deprecated `unify_responses` method. All source code seems fine with no reference to the old method. Is there any other part to change (especially in docs)?

Closes #4322 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I added relevant documentation
- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
