### PR TITLE
fix: Correct naming of the fields for RAG in TaskTemplates

### DIFF
--- a/docs/_source/_common/tabs/task_templates.md
+++ b/docs/_source/_common/tabs/task_templates.md
@@ -291,7 +291,7 @@ ds
 #         TextField(name="retrieved_document_1", use_markdown=False),
 #     ],
 #     questions=[
-#         RatingQuestion(name="question_rating_1", values=[1, 2, 3, 4, 5, 6, 7]),
+#         RatingQuestion(name="rating_retrieved_document_1", values=[1, 2, 3, 4, 5, 6, 7]),
 #         TextQuestion(name="response", use_markdown=False),
 #     ],
 #     guidelines="<Guidelines for the task>",

--- a/docs/_source/tutorials_and_integrations/tutorials/feedback/fine-tuning-sentencesimilarity-rag.ipynb
+++ b/docs/_source/tutorials_and_integrations/tutorials/feedback/fine-tuning-sentencesimilarity-rag.ipynb
@@ -401,7 +401,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -409,14 +409,15 @@
       "text/plain": [
        "FeedbackDataset(\n",
        "   fields=[TextField(name='query', title='Query', required=True, type='text', use_markdown=False), TextField(name='retrieved_document_1', title='Retrieved Document 1', required=True, type='text', use_markdown=False), TextField(name='retrieved_document_2', title='Retrieved Document 2', required=False, type='text', use_markdown=False), TextField(name='retrieved_document_3', title='Retrieved Document 3', required=False, type='text', use_markdown=False)]\n",
-       "   questions=[RatingQuestion(name='question_rating_1', title='Rate the relevance of the user question1', description='Rate the relevance of the retrieved document.', required=True, type='rating', values=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), RatingQuestion(name='question_rating_2', title='Rate the relevance of the user question2', description='Rate the relevance of the retrieved document.', required=False, type='rating', values=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), RatingQuestion(name='question_rating_3', title='Rate the relevance of the user question3', description='Rate the relevance of the retrieved document.', required=False, type='rating', values=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), TextQuestion(name='response', title='Write a helpful, harmless, accurate response to the query.', description='Write the response to the query.', required=False, type='text', use_markdown=False)]\n",
+       "   questions=[RatingQuestion(name='rating_retrieved_document_1', title='Rate the relevance of the Retrieved Document 1 for the query', description='Rate the relevance of the retrieved document.', required=True, type='rating', values=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), RatingQuestion(name='rating_retrieved_document_2', title='Rate the relevance of the Retrieved Document 2 for the query', description='Rate the relevance of the retrieved document.', required=False, type='rating', values=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), RatingQuestion(name='rating_retrieved_document_3', title='Rate the relevance of the Retrieved Document 3 for the query', description='Rate the relevance of the retrieved document.', required=False, type='rating', values=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]), TextQuestion(name='response', title='Write a helpful, harmless, accurate response to the query.', description='Write the response to the query.', required=False, type='text', use_markdown=False)]\n",
        "   guidelines=This is a retrieval augmented generation dataset that contains queries and retrieved documents. Please rate the relevancy of retrieved document and write the response to the query in the response field.)\n",
        "   metadata_properties=[])\n",
        ")"
       ]
      },
+     "execution_count": 2,
      "metadata": {},
-     "output_type": "display_data"
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -654,7 +655,7 @@
     "\n",
     "    for i in range(1, 4):\n",
     "        record = {\"sentence-1\": sample[\"query\"], \"sentence-2\": sample[f\"retrieved_document_{i}\"]}\n",
-    "        values = [resp[\"value\"] for resp in sample[f\"question_rating_{i}\"]]\n",
+    "        values = [resp[\"value\"] for resp in sample[f\"rating_retrieved_document_{i}\"]]\n",
     "        label = int(values[0])\n",
     "        record[\"label\"] = label\n",
     "        records.append(record)\n",

--- a/src/argilla/client/feedback/dataset/local/mixins.py
+++ b/src/argilla/client/feedback/dataset/local/mixins.py
@@ -932,8 +932,8 @@ class TaskTemplateMixin:
 
         rating_questions = [
             RatingQuestion(
-                name="question_rating_" + str(doc + 1),
-                title="Rate the relevance of the user question" + str(doc + 1),
+                name="rating_retrieved_document_" + str(doc + 1),
+                title="Rate the relevance of the Retrieved Document " + str(doc + 1) + " for the query",
                 values=list(range(1, rating_scale + 1)),
                 description="Rate the relevance of the retrieved document.",
                 required=True if doc == 0 else False,


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

As described in the issue, this PR corrects the naming of the RAG fields, appropriate to terminology.

Closes #4410 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
