### PR TITLE
feat: change bulk responses items limit from 50 to 100

### DIFF
--- a/src/argilla/server/schemas/v1/responses.py
+++ b/src/argilla/server/schemas/v1/responses.py
@@ -27,7 +27,7 @@ except ImportError:
     from typing_extensions import Annotated
 
 RESPONSES_BULK_CREATE_MIN_ITEMS = 1
-RESPONSES_BULK_CREATE_MAX_ITEMS = 50
+RESPONSES_BULK_CREATE_MAX_ITEMS = 100
 
 
 class ResponseValue(BaseModel):

--- a/tests/unit/server/api/v1/responses/test_create_current_user_responses_bulk.py
+++ b/tests/unit/server/api/v1/responses/test_create_current_user_responses_bulk.py
@@ -41,7 +41,7 @@ class TestCreateCurrentUserResponsesBulk:
         return f"/api/v1/me/responses/bulk"
 
     def bulk_max_items(self) -> int:
-        return 50
+        return 100
 
     async def test_multiple_responses(
         self, async_client: AsyncClient, db: AsyncSession, mock_search_engine: SearchEngine


### PR DESCRIPTION
# Generic Pull Request Template

This PRs include a small change increasing the maximum number of items that can be part of a bulk responses request from `50` to `100`.

Records pagination is expected to be `100` as maximum so it makes sense that the endpoint for bulk annotation/responses also allow to get a maximum of `100` responses to create/update.

Refs #4367 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

- [x] Running tests locally.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] <del>I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)</del>