### PR TITLE
feat: relax `pydantic` constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ These are the section headers that we use:
 - Updated `argilla.load` functions to also work with `FeedbackDataset`s. ([#4347](https://github.com/argilla-io/argilla/pull/4347))
 - [breaking] Updated `argilla.delete` functions to also work with `FeedbackDataset`s. It now raises an error if the dataset does not exist. ([#4347](https://github.com/argilla-io/argilla/pull/4347))
 - Updated `argilla.list_datasets` functions to also work with `FeedbackDataset`s. ([#4347](https://github.com/argilla-io/argilla/pull/4347))
+- Updated `pydantic` dependency constraint to `>=2.0.0`. ([#4450](https://github.com/argilla-io/argilla/pull/4450))
 
 ### Fixed
 

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -44,7 +44,7 @@ dependencies:
       - pgmpy
       - plotly>=4.1.0
       - snorkel>=0.9.7
-      - spacy==3.5.3
+      - spacy>=3.5.3
       - https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.5.0/en_core_web_sm-3.5.0.tar.gz
       - spacy-transformers>=1.2.5
       - spacy-huggingface-hub >= 0.0.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "packaging >= 20.0",
     # pandas -> For data loading
     "pandas >=1.0.0,<2.0.0",
-    "pydantic >=2.0.0",
+    "pydantic >=1.10.7",
     # monitoring
     "wrapt >= 1.13,< 1.15",
     # weaksupervision

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,7 @@ dependencies = [
     "packaging >= 20.0",
     # pandas -> For data loading
     "pandas >=1.0.0,<2.0.0",
-    # Aligned pydantic version with server fastAPI
-    "pydantic >= 1.10.7,< 2.0",
+    "pydantic >=2.0.0",
     # monitoring
     "wrapt >= 1.13,< 1.15",
     # weaksupervision

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ integrations = [
     "pgmpy",
     "plotly >= 4.1.0",
     "snorkel >= 0.9.7",
-    "spacy == 3.5.3",
+    "spacy >= 3.5.3",
     "spacy-transformers >= 1.2.5",
     "spacy-huggingface-hub >= 0.0.10",
     "transformers[torch] >= 4.30.0",

--- a/src/argilla/cli/server/database/users/create.py
+++ b/src/argilla/cli/server/database/users/create.py
@@ -15,7 +15,7 @@
 from typing import List, Optional
 
 import typer
-from pydantic import constr
+from pydantic.v1 import constr
 
 from argilla.cli import typer_ext
 from argilla.cli.server.database.users.utils import get_or_new_workspace

--- a/src/argilla/cli/server/database/users/create.py
+++ b/src/argilla/cli/server/database/users/create.py
@@ -15,7 +15,6 @@
 from typing import List, Optional
 
 import typer
-from pydantic.v1 import constr
 
 from argilla.cli import typer_ext
 from argilla.cli.server.database.users.utils import get_or_new_workspace
@@ -27,6 +26,7 @@ from argilla.server.security.model import (
     UserCreate,
     WorkspaceCreate,
 )
+from argilla.utils.pydantic import constr
 
 USER_API_KEY_MIN_LENGTH = 8
 

--- a/src/argilla/cli/server/database/users/create.py
+++ b/src/argilla/cli/server/database/users/create.py
@@ -26,7 +26,7 @@ from argilla.server.security.model import (
     UserCreate,
     WorkspaceCreate,
 )
-from argilla.utils.pydantic import constr
+from argilla.utils._import_pydantic import constr
 
 USER_API_KEY_MIN_LENGTH = 8
 

--- a/src/argilla/cli/server/database/users/migrate.py
+++ b/src/argilla/cli/server/database/users/migrate.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 import typer
 import yaml
-from pydantic import BaseModel, constr
+from pydantic.v1 import BaseModel, constr
 
 from argilla.cli import typer_ext
 from argilla.cli.server.database.users.utils import get_or_new_workspace

--- a/src/argilla/cli/server/database/users/migrate.py
+++ b/src/argilla/cli/server/database/users/migrate.py
@@ -23,7 +23,7 @@ from argilla.server.database import AsyncSessionLocal
 from argilla.server.models import User, UserRole
 from argilla.server.security.auth_provider.local.settings import settings
 from argilla.server.security.model import USER_USERNAME_REGEX, WORKSPACE_NAME_REGEX
-from argilla.utils.pydantic import BaseModel, constr
+from argilla.utils._import_pydantic import BaseModel, constr
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession

--- a/src/argilla/cli/server/database/users/migrate.py
+++ b/src/argilla/cli/server/database/users/migrate.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING, List, Optional
 
 import typer
 import yaml
-from pydantic.v1 import BaseModel, constr
 
 from argilla.cli import typer_ext
 from argilla.cli.server.database.users.utils import get_or_new_workspace
@@ -24,6 +23,7 @@ from argilla.server.database import AsyncSessionLocal
 from argilla.server.models import User, UserRole
 from argilla.server.security.auth_provider.local.settings import settings
 from argilla.server.security.model import USER_USERNAME_REGEX, WORKSPACE_NAME_REGEX
+from argilla.utils.pydantic import BaseModel, constr
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession

--- a/src/argilla/client/apis/datasets.py
+++ b/src/argilla/client/apis/datasets.py
@@ -27,7 +27,7 @@ from argilla.client.sdk.commons.errors import (
 )
 from argilla.client.sdk.datasets.api import get_dataset
 from argilla.client.sdk.datasets.models import TaskType
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 
 @dataclass

--- a/src/argilla/client/apis/datasets.py
+++ b/src/argilla/client/apis/datasets.py
@@ -18,8 +18,6 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
-from pydantic.v1 import BaseModel, Field
-
 from argilla.client.apis import AbstractApi, api_compatibility
 from argilla.client.sdk.commons.errors import (
     AlreadyExistsApiError,
@@ -29,6 +27,7 @@ from argilla.client.sdk.commons.errors import (
 )
 from argilla.client.sdk.datasets.api import get_dataset
 from argilla.client.sdk.datasets.models import TaskType
+from argilla.utils.pydantic import BaseModel, Field
 
 
 @dataclass

--- a/src/argilla/client/apis/datasets.py
+++ b/src/argilla/client/apis/datasets.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from argilla.client.apis import AbstractApi, api_compatibility
 from argilla.client.sdk.commons.errors import (

--- a/src/argilla/client/apis/status.py
+++ b/src/argilla/client/apis/status.py
@@ -20,7 +20,7 @@ from packaging.version import parse
 from argilla.client.apis import AbstractApi
 from argilla.client.sdk.client import AuthenticatedClient
 from argilla.client.sdk.commons.errors import ApiCompatibilityError
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 class ApiInfo(BaseModel):

--- a/src/argilla/client/apis/status.py
+++ b/src/argilla/client/apis/status.py
@@ -16,7 +16,7 @@ from types import TracebackType
 from typing import Any, ContextManager, Dict, Optional, Type
 
 from packaging.version import parse
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from argilla.client.apis import AbstractApi
 from argilla.client.sdk.client import AuthenticatedClient

--- a/src/argilla/client/apis/status.py
+++ b/src/argilla/client/apis/status.py
@@ -16,11 +16,11 @@ from types import TracebackType
 from typing import Any, ContextManager, Dict, Optional, Type
 
 from packaging.version import parse
-from pydantic.v1 import BaseModel
 
 from argilla.client.apis import AbstractApi
 from argilla.client.sdk.client import AuthenticatedClient
 from argilla.client.sdk.commons.errors import ApiCompatibilityError
+from argilla.utils.pydantic import BaseModel
 
 
 class ApiInfo(BaseModel):

--- a/src/argilla/client/feedback/config.py
+++ b/src/argilla/client/feedback/config.py
@@ -24,7 +24,7 @@ except ImportError:
 
 import json
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 try:
     from yaml import SafeLoader, load, safe_dump

--- a/src/argilla/client/feedback/config.py
+++ b/src/argilla/client/feedback/config.py
@@ -24,7 +24,7 @@ except ImportError:
 
 import json
 
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 try:
     from yaml import SafeLoader, load, safe_dump

--- a/src/argilla/client/feedback/config.py
+++ b/src/argilla/client/feedback/config.py
@@ -24,7 +24,7 @@ except ImportError:
 
 import json
 
-from pydantic.v1 import BaseModel, Field
+from argilla.utils.pydantic import BaseModel, Field
 
 try:
     from yaml import SafeLoader, load, safe_dump

--- a/src/argilla/client/feedback/constants.py
+++ b/src/argilla/client/feedback/constants.py
@@ -14,7 +14,7 @@
 from typing import List, Union
 
 from argilla.client.feedback.schemas.enums import FieldTypes, MetadataPropertyTypes
-from argilla.utils.pydantic import StrictFloat, StrictInt, StrictStr
+from argilla.utils._import_pydantic import StrictFloat, StrictInt, StrictStr
 
 FETCHING_BATCH_SIZE = 250
 PUSHING_BATCH_SIZE = 32

--- a/src/argilla/client/feedback/constants.py
+++ b/src/argilla/client/feedback/constants.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 from typing import List, Union
 
-from pydantic import StrictFloat, StrictInt, StrictStr
+from pydantic.v1 import StrictFloat, StrictInt, StrictStr
 
 from argilla.client.feedback.schemas.enums import FieldTypes, MetadataPropertyTypes
 

--- a/src/argilla/client/feedback/constants.py
+++ b/src/argilla/client/feedback/constants.py
@@ -13,9 +13,8 @@
 #  limitations under the License.
 from typing import List, Union
 
-from pydantic.v1 import StrictFloat, StrictInt, StrictStr
-
 from argilla.client.feedback.schemas.enums import FieldTypes, MetadataPropertyTypes
+from argilla.utils.pydantic import StrictFloat, StrictInt, StrictStr
 
 FETCHING_BATCH_SIZE = 250
 PUSHING_BATCH_SIZE = 32

--- a/src/argilla/client/feedback/dataset/helpers.py
+++ b/src/argilla/client/feedback/dataset/helpers.py
@@ -26,7 +26,7 @@ from argilla.client.sdk.v1.datasets import api as datasets_api_v1
 from argilla.client.sdk.v1.datasets.models import FeedbackDatasetModel
 from argilla.client.singleton import active_client
 from argilla.client.workspaces import Workspace
-from argilla.utils.pydantic import BaseModel, Extra, ValidationError, create_model
+from argilla.utils._import_pydantic import BaseModel, Extra, ValidationError, create_model
 
 if typing.TYPE_CHECKING:
     from argilla.client.feedback.schemas.types import (

--- a/src/argilla/client/feedback/dataset/helpers.py
+++ b/src/argilla/client/feedback/dataset/helpers.py
@@ -16,7 +16,6 @@ import typing
 from typing import Any, Dict, List, Optional, Type, Union
 
 import httpx
-from pydantic.v1 import BaseModel, Extra, ValidationError, create_model
 
 from argilla.client.feedback.constants import FIELD_TYPE_TO_PYTHON_TYPE
 from argilla.client.feedback.dataset.base import FeedbackDatasetBase
@@ -27,6 +26,7 @@ from argilla.client.sdk.v1.datasets import api as datasets_api_v1
 from argilla.client.sdk.v1.datasets.models import FeedbackDatasetModel
 from argilla.client.singleton import active_client
 from argilla.client.workspaces import Workspace
+from argilla.utils.pydantic import BaseModel, Extra, ValidationError, create_model
 
 if typing.TYPE_CHECKING:
     from argilla.client.feedback.schemas.types import (

--- a/src/argilla/client/feedback/dataset/helpers.py
+++ b/src/argilla/client/feedback/dataset/helpers.py
@@ -16,7 +16,7 @@ import typing
 from typing import Any, Dict, List, Optional, Type, Union
 
 import httpx
-from pydantic import BaseModel, Extra, ValidationError, create_model
+from pydantic.v1 import BaseModel, Extra, ValidationError, create_model
 
 from argilla.client.feedback.constants import FIELD_TYPE_TO_PYTHON_TYPE
 from argilla.client.feedback.dataset.base import FeedbackDatasetBase

--- a/src/argilla/client/feedback/schemas/fields.py
+++ b/src/argilla/client/feedback/schemas/fields.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, Literal, Optional
 
 from argilla.client.feedback.schemas.enums import FieldTypes
 from argilla.client.feedback.schemas.validators import title_must_have_value
-from argilla.utils.pydantic import BaseModel, Extra, Field, validator
+from argilla.utils._import_pydantic import BaseModel, Extra, Field, validator
 
 
 class FieldSchema(BaseModel, ABC):

--- a/src/argilla/client/feedback/schemas/fields.py
+++ b/src/argilla/client/feedback/schemas/fields.py
@@ -15,10 +15,9 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Literal, Optional
 
-from pydantic.v1 import BaseModel, Extra, Field, validator
-
 from argilla.client.feedback.schemas.enums import FieldTypes
 from argilla.client.feedback.schemas.validators import title_must_have_value
+from argilla.utils.pydantic import BaseModel, Extra, Field, validator
 
 
 class FieldSchema(BaseModel, ABC):

--- a/src/argilla/client/feedback/schemas/fields.py
+++ b/src/argilla/client/feedback/schemas/fields.py
@@ -15,7 +15,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Literal, Optional
 
-from pydantic import BaseModel, Extra, Field, validator
+from pydantic.v1 import BaseModel, Extra, Field, validator
 
 from argilla.client.feedback.schemas.enums import FieldTypes
 from argilla.client.feedback.schemas.validators import title_must_have_value

--- a/src/argilla/client/feedback/schemas/metadata.py
+++ b/src/argilla/client/feedback/schemas/metadata.py
@@ -21,7 +21,7 @@ from argilla.client.feedback.schemas.validators import (
     validate_numeric_metadata_filter_bounds,
     validate_numeric_metadata_property_bounds,
 )
-from argilla.utils.pydantic import (
+from argilla.utils._import_pydantic import (
     BaseModel,
     Extra,
     Field,

--- a/src/argilla/client/feedback/schemas/metadata.py
+++ b/src/argilla/client/feedback/schemas/metadata.py
@@ -15,7 +15,13 @@
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Union
 
-from pydantic.v1 import (
+from argilla.client.feedback.constants import METADATA_PROPERTY_TYPE_TO_PYDANTIC_TYPE, PYDANTIC_STRICT_TO_PYTHON_TYPE
+from argilla.client.feedback.schemas.enums import MetadataPropertyTypes
+from argilla.client.feedback.schemas.validators import (
+    validate_numeric_metadata_filter_bounds,
+    validate_numeric_metadata_property_bounds,
+)
+from argilla.utils.pydantic import (
     BaseModel,
     Extra,
     Field,
@@ -25,13 +31,6 @@ from pydantic.v1 import (
     ValidationError,
     root_validator,
     validator,
-)
-
-from argilla.client.feedback.constants import METADATA_PROPERTY_TYPE_TO_PYDANTIC_TYPE, PYDANTIC_STRICT_TO_PYTHON_TYPE
-from argilla.client.feedback.schemas.enums import MetadataPropertyTypes
-from argilla.client.feedback.schemas.validators import (
-    validate_numeric_metadata_filter_bounds,
-    validate_numeric_metadata_property_bounds,
 )
 
 TERMS_METADATA_PROPERTY_MIN_VALUES = 1

--- a/src/argilla/client/feedback/schemas/metadata.py
+++ b/src/argilla/client/feedback/schemas/metadata.py
@@ -15,7 +15,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Union
 
-from pydantic import (
+from pydantic.v1 import (
     BaseModel,
     Extra,
     Field,

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -16,7 +16,7 @@ import warnings
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Extra, Field, conint, conlist, root_validator, validator
+from pydantic.v1 import BaseModel, Extra, Field, conint, conlist, root_validator, validator
 
 from argilla.client.feedback.schemas.enums import QuestionTypes
 from argilla.client.feedback.schemas.utils import LabelMappingMixin

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Literal, Optional, Union
 from argilla.client.feedback.schemas.enums import QuestionTypes
 from argilla.client.feedback.schemas.utils import LabelMappingMixin
 from argilla.client.feedback.schemas.validators import title_must_have_value
-from argilla.utils.pydantic import BaseModel, Extra, Field, conint, conlist, root_validator, validator
+from argilla.utils._import_pydantic import BaseModel, Extra, Field, conint, conlist, root_validator, validator
 
 
 class QuestionSchema(BaseModel, ABC):

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -16,11 +16,10 @@ import warnings
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic.v1 import BaseModel, Extra, Field, conint, conlist, root_validator, validator
-
 from argilla.client.feedback.schemas.enums import QuestionTypes
 from argilla.client.feedback.schemas.utils import LabelMappingMixin
 from argilla.client.feedback.schemas.validators import title_must_have_value
+from argilla.utils.pydantic import BaseModel, Extra, Field, conint, conlist, root_validator, validator
 
 
 class QuestionSchema(BaseModel, ABC):

--- a/src/argilla/client/feedback/schemas/records.py
+++ b/src/argilla/client/feedback/schemas/records.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Uni
 from uuid import UUID
 
 from argilla.client.feedback.schemas.enums import RecordSortField, ResponseStatus, SortOrder
-from argilla.utils.pydantic import BaseModel, Extra, Field, PrivateAttr, StrictInt, StrictStr, conint, validator
+from argilla.utils._import_pydantic import BaseModel, Extra, Field, PrivateAttr, StrictInt, StrictStr, conint, validator
 
 if TYPE_CHECKING:
     from argilla.client.feedback.unification import UnifiedValueSchema

--- a/src/argilla/client/feedback/schemas/records.py
+++ b/src/argilla/client/feedback/schemas/records.py
@@ -16,9 +16,8 @@ import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 from uuid import UUID
 
-from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, StrictInt, StrictStr, conint, validator
-
 from argilla.client.feedback.schemas.enums import RecordSortField, ResponseStatus, SortOrder
+from argilla.utils.pydantic import BaseModel, Extra, Field, PrivateAttr, StrictInt, StrictStr, conint, validator
 
 if TYPE_CHECKING:
     from argilla.client.feedback.unification import UnifiedValueSchema

--- a/src/argilla/client/feedback/schemas/records.py
+++ b/src/argilla/client/feedback/schemas/records.py
@@ -16,7 +16,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
 from uuid import UUID
 
-from pydantic import BaseModel, Extra, Field, PrivateAttr, StrictInt, StrictStr, conint, validator
+from pydantic.v1 import BaseModel, Extra, Field, PrivateAttr, StrictInt, StrictStr, conint, validator
 
 from argilla.client.feedback.schemas.enums import RecordSortField, ResponseStatus, SortOrder
 

--- a/src/argilla/client/feedback/schemas/remote/records.py
+++ b/src/argilla/client/feedback/schemas/remote/records.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 from uuid import UUID
 
-from pydantic import Field
+from pydantic.v1 import Field
 
 from argilla.client.feedback.schemas.enums import ResponseStatus
 from argilla.client.feedback.schemas.records import FeedbackRecord, ResponseSchema, SuggestionSchema

--- a/src/argilla/client/feedback/schemas/remote/records.py
+++ b/src/argilla/client/feedback/schemas/remote/records.py
@@ -24,7 +24,7 @@ from argilla.client.sdk.users.models import UserRole
 from argilla.client.sdk.v1.records import api as records_api_v1
 from argilla.client.sdk.v1.suggestions import api as suggestions_api_v1
 from argilla.client.utils import allowed_for_roles
-from argilla.utils.pydantic import Field
+from argilla.utils._import_pydantic import Field
 
 if TYPE_CHECKING:
     import httpx

--- a/src/argilla/client/feedback/schemas/remote/records.py
+++ b/src/argilla/client/feedback/schemas/remote/records.py
@@ -17,8 +17,6 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 from uuid import UUID
 
-from pydantic.v1 import Field
-
 from argilla.client.feedback.schemas.enums import ResponseStatus
 from argilla.client.feedback.schemas.records import FeedbackRecord, ResponseSchema, SuggestionSchema
 from argilla.client.feedback.schemas.remote.shared import RemoteSchema
@@ -26,6 +24,7 @@ from argilla.client.sdk.users.models import UserRole
 from argilla.client.sdk.v1.records import api as records_api_v1
 from argilla.client.sdk.v1.suggestions import api as suggestions_api_v1
 from argilla.client.utils import allowed_for_roles
+from argilla.utils.pydantic import Field
 
 if TYPE_CHECKING:
     import httpx

--- a/src/argilla/client/feedback/schemas/remote/shared.py
+++ b/src/argilla/client/feedback/schemas/remote/shared.py
@@ -17,7 +17,7 @@ from typing import Optional
 from uuid import UUID
 
 import httpx
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class RemoteSchema(BaseModel, ABC):

--- a/src/argilla/client/feedback/schemas/remote/shared.py
+++ b/src/argilla/client/feedback/schemas/remote/shared.py
@@ -17,7 +17,8 @@ from typing import Optional
 from uuid import UUID
 
 import httpx
-from pydantic.v1 import BaseModel, Field
+
+from argilla.utils.pydantic import BaseModel, Field
 
 
 class RemoteSchema(BaseModel, ABC):

--- a/src/argilla/client/feedback/schemas/remote/shared.py
+++ b/src/argilla/client/feedback/schemas/remote/shared.py
@@ -18,7 +18,7 @@ from uuid import UUID
 
 import httpx
 
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 
 class RemoteSchema(BaseModel, ABC):

--- a/src/argilla/client/feedback/schemas/validators.py
+++ b/src/argilla/client/feedback/schemas/validators.py
@@ -15,7 +15,7 @@
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 if TYPE_CHECKING:
-    from pydantic.v1 import BaseModel
+    from argilla.utils.pydantic import BaseModel
 
 
 def title_must_have_value(cls: "BaseModel", v: Optional[str], values: Dict[str, Any]) -> str:

--- a/src/argilla/client/feedback/schemas/validators.py
+++ b/src/argilla/client/feedback/schemas/validators.py
@@ -15,7 +15,7 @@
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 if TYPE_CHECKING:
-    from pydantic import BaseModel
+    from pydantic.v1 import BaseModel
 
 
 def title_must_have_value(cls: "BaseModel", v: Optional[str], values: Dict[str, Any]) -> str:

--- a/src/argilla/client/feedback/schemas/validators.py
+++ b/src/argilla/client/feedback/schemas/validators.py
@@ -15,7 +15,7 @@
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 if TYPE_CHECKING:
-    from argilla.utils.pydantic import BaseModel
+    from argilla.utils._import_pydantic import BaseModel
 
 
 def title_must_have_value(cls: "BaseModel", v: Optional[str], values: Dict[str, Any]) -> str:

--- a/src/argilla/client/feedback/schemas/vector_settings.py
+++ b/src/argilla/client/feedback/schemas/vector_settings.py
@@ -15,7 +15,7 @@
 from typing import Optional
 
 from argilla.client.feedback.schemas.validators import title_must_have_value
-from argilla.utils.pydantic import BaseModel, Field, PositiveInt, validator
+from argilla.utils._import_pydantic import BaseModel, Field, PositiveInt, validator
 
 
 class VectorSettings(BaseModel):

--- a/src/argilla/client/feedback/schemas/vector_settings.py
+++ b/src/argilla/client/feedback/schemas/vector_settings.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 
-from pydantic import BaseModel, Field, PositiveInt, validator
+from pydantic.v1 import BaseModel, Field, PositiveInt, validator
 
 from argilla.client.feedback.schemas.validators import title_must_have_value
 

--- a/src/argilla/client/feedback/schemas/vector_settings.py
+++ b/src/argilla/client/feedback/schemas/vector_settings.py
@@ -14,9 +14,8 @@
 
 from typing import Optional
 
-from pydantic.v1 import BaseModel, Field, PositiveInt, validator
-
 from argilla.client.feedback.schemas.validators import title_must_have_value
+from argilla.utils.pydantic import BaseModel, Field, PositiveInt, validator
 
 
 class VectorSettings(BaseModel):

--- a/src/argilla/client/feedback/training/schemas/base.py
+++ b/src/argilla/client/feedback/training/schemas/base.py
@@ -53,8 +53,8 @@ from argilla.client.feedback.unification import (
     RatingQuestionUnification,
 )
 from argilla.client.models import Framework
+from argilla.utils._import_pydantic import BaseModel
 from argilla.utils.dependency import require_dependencies, requires_dependencies
-from argilla.utils.pydantic import BaseModel
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/argilla/client/feedback/training/schemas/base.py
+++ b/src/argilla/client/feedback/training/schemas/base.py
@@ -54,7 +54,7 @@ from argilla.client.feedback.unification import (
 )
 from argilla.client.models import Framework
 from argilla.utils.dependency import require_dependencies, requires_dependencies
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/argilla/client/feedback/training/schemas/base.py
+++ b/src/argilla/client/feedback/training/schemas/base.py
@@ -54,7 +54,7 @@ from argilla.client.feedback.unification import (
 )
 from argilla.client.models import Framework
 from argilla.utils.dependency import require_dependencies, requires_dependencies
-from pydantic.v1 import BaseModel
+from argilla.utils.pydantic import BaseModel
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/argilla/client/feedback/training/schemas/defaults.py
+++ b/src/argilla/client/feedback/training/schemas/defaults.py
@@ -28,7 +28,7 @@ from argilla.client.feedback.unification import (
     RankingQuestionUnification,
     RatingQuestionUnification,
 )
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class TextClassificationDefaults(BaseModel):

--- a/src/argilla/client/feedback/training/schemas/defaults.py
+++ b/src/argilla/client/feedback/training/schemas/defaults.py
@@ -28,7 +28,7 @@ from argilla.client.feedback.unification import (
     RankingQuestionUnification,
     RatingQuestionUnification,
 )
-from pydantic.v1 import BaseModel
+from argilla.utils.pydantic import BaseModel
 
 
 class TextClassificationDefaults(BaseModel):

--- a/src/argilla/client/feedback/training/schemas/defaults.py
+++ b/src/argilla/client/feedback/training/schemas/defaults.py
@@ -28,7 +28,7 @@ from argilla.client.feedback.unification import (
     RankingQuestionUnification,
     RatingQuestionUnification,
 )
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 class TextClassificationDefaults(BaseModel):

--- a/src/argilla/client/feedback/training/schemas/return_types.py
+++ b/src/argilla/client/feedback/training/schemas/return_types.py
@@ -14,7 +14,7 @@
 
 from typing import Dict, List, Tuple, Union
 
-from pydantic.v1 import BaseModel
+from argilla.utils.pydantic import BaseModel
 
 
 class TextClassificationReturnTypes(BaseModel):

--- a/src/argilla/client/feedback/training/schemas/return_types.py
+++ b/src/argilla/client/feedback/training/schemas/return_types.py
@@ -14,7 +14,7 @@
 
 from typing import Dict, List, Tuple, Union
 
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 class TextClassificationReturnTypes(BaseModel):

--- a/src/argilla/client/feedback/training/schemas/return_types.py
+++ b/src/argilla/client/feedback/training/schemas/return_types.py
@@ -14,7 +14,7 @@
 
 from typing import Dict, List, Tuple, Union
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class TextClassificationReturnTypes(BaseModel):

--- a/src/argilla/client/feedback/unification.py
+++ b/src/argilla/client/feedback/unification.py
@@ -19,7 +19,7 @@ from enum import Enum
 from typing import Any, Dict, List, Union
 
 import pandas as pd
-from pydantic import BaseModel, root_validator, validator
+from pydantic.v1 import BaseModel, root_validator, validator
 
 from argilla.client.feedback.schemas import (
     FeedbackRecord,

--- a/src/argilla/client/feedback/unification.py
+++ b/src/argilla/client/feedback/unification.py
@@ -28,7 +28,7 @@ from argilla.client.feedback.schemas import (
     RatingQuestion,
     ValueSchema,
 )
-from argilla.utils.pydantic import BaseModel, root_validator, validator
+from argilla.utils._import_pydantic import BaseModel, root_validator, validator
 
 
 class UnifiedValueSchema(ValueSchema):

--- a/src/argilla/client/feedback/unification.py
+++ b/src/argilla/client/feedback/unification.py
@@ -19,7 +19,6 @@ from enum import Enum
 from typing import Any, Dict, List, Union
 
 import pandas as pd
-from pydantic.v1 import BaseModel, root_validator, validator
 
 from argilla.client.feedback.schemas import (
     FeedbackRecord,
@@ -29,6 +28,7 @@ from argilla.client.feedback.schemas import (
     RatingQuestion,
     ValueSchema,
 )
+from argilla.utils.pydantic import BaseModel, root_validator, validator
 
 
 class UnifiedValueSchema(ValueSchema):

--- a/src/argilla/client/login.py
+++ b/src/argilla/client/login.py
@@ -17,7 +17,7 @@ from typing import Dict, Optional
 
 from argilla.client.sdk.commons.errors import HttpResponseError, UnauthorizedApiError
 from argilla.client.singleton import init
-from argilla.utils.pydantic import AnyHttpUrl, BaseModel
+from argilla.utils._import_pydantic import AnyHttpUrl, BaseModel
 
 ARGILLA_CACHE_DIR = Path.home() / ".cache" / "argilla"
 ARGILLA_CREDENTIALS_FILE = ARGILLA_CACHE_DIR / "credentials.json"

--- a/src/argilla/client/login.py
+++ b/src/argilla/client/login.py
@@ -15,7 +15,7 @@
 from pathlib import Path
 from typing import Dict, Optional
 
-from pydantic import AnyHttpUrl, BaseModel
+from pydantic.v1 import AnyHttpUrl, BaseModel
 
 from argilla.client.sdk.commons.errors import HttpResponseError, UnauthorizedApiError
 from argilla.client.singleton import init

--- a/src/argilla/client/login.py
+++ b/src/argilla/client/login.py
@@ -15,10 +15,9 @@
 from pathlib import Path
 from typing import Dict, Optional
 
-from pydantic.v1 import AnyHttpUrl, BaseModel
-
 from argilla.client.sdk.commons.errors import HttpResponseError, UnauthorizedApiError
 from argilla.client.singleton import init
+from argilla.utils.pydantic import AnyHttpUrl, BaseModel
 
 ARGILLA_CACHE_DIR = Path.home() / ".cache" / "argilla"
 ARGILLA_CREDENTIALS_FILE = ARGILLA_CACHE_DIR / "credentials.json"

--- a/src/argilla/client/models.py
+++ b/src/argilla/client/models.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 from deprecated import deprecated
-from pydantic import BaseModel, Field, PrivateAttr, root_validator, validator
+from pydantic.v1 import BaseModel, Field, PrivateAttr, root_validator, validator
 
 from argilla import _messages
 from argilla._constants import _JS_MAX_SAFE_INTEGER, DEFAULT_MAX_KEYWORD_LENGTH, PROTECTED_METADATA_FIELD_PREFIX

--- a/src/argilla/client/models.py
+++ b/src/argilla/client/models.py
@@ -25,10 +25,10 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
 from deprecated import deprecated
-from pydantic.v1 import BaseModel, Field, PrivateAttr, root_validator, validator
 
 from argilla import _messages
 from argilla._constants import _JS_MAX_SAFE_INTEGER, DEFAULT_MAX_KEYWORD_LENGTH, PROTECTED_METADATA_FIELD_PREFIX
+from argilla.utils.pydantic import BaseModel, Field, PrivateAttr, root_validator, validator
 from argilla.utils.span_utils import SpanUtils
 
 _LOGGER = logging.getLogger(__name__)

--- a/src/argilla/client/models.py
+++ b/src/argilla/client/models.py
@@ -28,7 +28,7 @@ from deprecated import deprecated
 
 from argilla import _messages
 from argilla._constants import _JS_MAX_SAFE_INTEGER, DEFAULT_MAX_KEYWORD_LENGTH, PROTECTED_METADATA_FIELD_PREFIX
-from argilla.utils.pydantic import BaseModel, Field, PrivateAttr, root_validator, validator
+from argilla.utils._import_pydantic import BaseModel, Field, PrivateAttr, root_validator, validator
 from argilla.utils.span_utils import SpanUtils
 
 _LOGGER = logging.getLogger(__name__)

--- a/src/argilla/client/sdk/commons/models.py
+++ b/src/argilla/client/sdk/commons/models.py
@@ -19,8 +19,7 @@ from typing import TYPE_CHECKING, Any, Dict, Generic, List, MutableMapping, Opti
 from uuid import uuid4
 
 from argilla.client.models import Vectors as ClientVectors
-from argilla.utils.pydantic import BaseModel, Field, validator
-from argilla.utils.pydantic.generics import GenericModel
+from argilla.utils._import_pydantic import BaseModel, Field, GenericModel, validator
 
 if TYPE_CHECKING:
     from httpx import Response as HTTPXResponse

--- a/src/argilla/client/sdk/commons/models.py
+++ b/src/argilla/client/sdk/commons/models.py
@@ -18,8 +18,8 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, Generic, List, MutableMapping, Optional, TypeVar, Union
 from uuid import uuid4
 
-from pydantic import BaseModel, Field, validator
-from pydantic.generics import GenericModel
+from pydantic.v1 import BaseModel, Field, validator
+from pydantic.v1.generics import GenericModel
 
 from argilla.client.models import Vectors as ClientVectors
 

--- a/src/argilla/client/sdk/commons/models.py
+++ b/src/argilla/client/sdk/commons/models.py
@@ -18,10 +18,9 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, Generic, List, MutableMapping, Optional, TypeVar, Union
 from uuid import uuid4
 
-from pydantic.v1 import BaseModel, Field, validator
-from pydantic.v1.generics import GenericModel
-
 from argilla.client.models import Vectors as ClientVectors
+from argilla.utils.pydantic import BaseModel, Field, validator
+from argilla.utils.pydantic.generics import GenericModel
 
 if TYPE_CHECKING:
     from httpx import Response as HTTPXResponse

--- a/src/argilla/client/sdk/datasets/models.py
+++ b/src/argilla/client/sdk/datasets/models.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class TaskType(str, Enum):

--- a/src/argilla/client/sdk/datasets/models.py
+++ b/src/argilla/client/sdk/datasets/models.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Optional
 
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 
 class TaskType(str, Enum):

--- a/src/argilla/client/sdk/datasets/models.py
+++ b/src/argilla/client/sdk/datasets/models.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Optional
 
-from pydantic.v1 import BaseModel, Field
+from argilla.utils.pydantic import BaseModel, Field
 
 
 class TaskType(str, Enum):

--- a/src/argilla/client/sdk/metrics/models.py
+++ b/src/argilla/client/sdk/metrics/models.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 
-from pydantic.v1 import BaseModel, Field
+from argilla.utils.pydantic import BaseModel, Field
 
 
 class MetricInfo(BaseModel):

--- a/src/argilla/client/sdk/metrics/models.py
+++ b/src/argilla/client/sdk/metrics/models.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class MetricInfo(BaseModel):

--- a/src/argilla/client/sdk/metrics/models.py
+++ b/src/argilla/client/sdk/metrics/models.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 
 class MetricInfo(BaseModel):

--- a/src/argilla/client/sdk/text2text/models.py
+++ b/src/argilla/client/sdk/text2text/models.py
@@ -16,7 +16,7 @@
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from argilla.client.models import Text2TextRecord as ClientText2TextRecord
 from argilla.client.sdk.commons.models import (

--- a/src/argilla/client/sdk/text2text/models.py
+++ b/src/argilla/client/sdk/text2text/models.py
@@ -16,8 +16,6 @@
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
-from pydantic.v1 import BaseModel, Field
-
 from argilla.client.models import Text2TextRecord as ClientText2TextRecord
 from argilla.client.sdk.commons.models import (
     MACHINE_NAME,
@@ -29,6 +27,7 @@ from argilla.client.sdk.commons.models import (
     TaskStatus,
     UpdateDatasetRequest,
 )
+from argilla.utils.pydantic import BaseModel, Field
 
 
 class Text2TextPrediction(BaseModel):

--- a/src/argilla/client/sdk/text2text/models.py
+++ b/src/argilla/client/sdk/text2text/models.py
@@ -27,7 +27,7 @@ from argilla.client.sdk.commons.models import (
     TaskStatus,
     UpdateDatasetRequest,
 )
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 
 class Text2TextPrediction(BaseModel):

--- a/src/argilla/client/sdk/text_classification/models.py
+++ b/src/argilla/client/sdk/text_classification/models.py
@@ -15,8 +15,6 @@
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
-from pydantic.v1 import BaseModel, Field
-
 from argilla.client.models import TextClassificationRecord as ClientTextClassificationRecord
 from argilla.client.models import TokenAttributions as ClientTokenAttributions
 from argilla.client.sdk.commons.models import (
@@ -29,6 +27,7 @@ from argilla.client.sdk.commons.models import (
     TaskStatus,
     UpdateDatasetRequest,
 )
+from argilla.utils.pydantic import BaseModel, Field
 
 
 class ClassPrediction(BaseModel):

--- a/src/argilla/client/sdk/text_classification/models.py
+++ b/src/argilla/client/sdk/text_classification/models.py
@@ -27,7 +27,7 @@ from argilla.client.sdk.commons.models import (
     TaskStatus,
     UpdateDatasetRequest,
 )
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 
 class ClassPrediction(BaseModel):

--- a/src/argilla/client/sdk/text_classification/models.py
+++ b/src/argilla/client/sdk/text_classification/models.py
@@ -15,7 +15,7 @@
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from argilla.client.models import TextClassificationRecord as ClientTextClassificationRecord
 from argilla.client.models import TokenAttributions as ClientTokenAttributions

--- a/src/argilla/client/sdk/token_classification/models.py
+++ b/src/argilla/client/sdk/token_classification/models.py
@@ -15,7 +15,7 @@
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 from argilla._constants import DEFAULT_MAX_KEYWORD_LENGTH
 from argilla.client.models import TokenClassificationRecord as ClientTokenClassificationRecord

--- a/src/argilla/client/sdk/token_classification/models.py
+++ b/src/argilla/client/sdk/token_classification/models.py
@@ -15,8 +15,6 @@
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
-from pydantic.v1 import BaseModel, Field, validator
-
 from argilla._constants import DEFAULT_MAX_KEYWORD_LENGTH
 from argilla.client.models import TokenClassificationRecord as ClientTokenClassificationRecord
 from argilla.client.sdk.commons.models import (
@@ -29,6 +27,7 @@ from argilla.client.sdk.commons.models import (
     TaskStatus,
     UpdateDatasetRequest,
 )
+from argilla.utils.pydantic import BaseModel, Field, validator
 
 
 class EntitySpan(BaseModel):

--- a/src/argilla/client/sdk/token_classification/models.py
+++ b/src/argilla/client/sdk/token_classification/models.py
@@ -27,7 +27,7 @@ from argilla.client.sdk.commons.models import (
     TaskStatus,
     UpdateDatasetRequest,
 )
-from argilla.utils.pydantic import BaseModel, Field, validator
+from argilla.utils._import_pydantic import BaseModel, Field, validator
 
 
 class EntitySpan(BaseModel):

--- a/src/argilla/client/sdk/users/models.py
+++ b/src/argilla/client/sdk/users/models.py
@@ -17,7 +17,7 @@ from enum import Enum
 from typing import List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class UserRole(str, Enum):

--- a/src/argilla/client/sdk/users/models.py
+++ b/src/argilla/client/sdk/users/models.py
@@ -17,7 +17,7 @@ from enum import Enum
 from typing import List, Optional
 from uuid import UUID
 
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 
 class UserRole(str, Enum):

--- a/src/argilla/client/sdk/users/models.py
+++ b/src/argilla/client/sdk/users/models.py
@@ -17,7 +17,7 @@ from enum import Enum
 from typing import List, Optional
 from uuid import UUID
 
-from pydantic.v1 import BaseModel, Field
+from argilla.utils.pydantic import BaseModel, Field
 
 
 class UserRole(str, Enum):

--- a/src/argilla/client/sdk/v1/datasets/models.py
+++ b/src/argilla/client/sdk/v1/datasets/models.py
@@ -18,7 +18,7 @@ from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
 
-from argilla.utils.pydantic import BaseModel, Field, StrictInt, StrictStr, conint, root_validator
+from argilla.utils._import_pydantic import BaseModel, Field, StrictInt, StrictStr, conint, root_validator
 
 
 class FeedbackDatasetModel(BaseModel):

--- a/src/argilla/client/sdk/v1/datasets/models.py
+++ b/src/argilla/client/sdk/v1/datasets/models.py
@@ -18,7 +18,7 @@ from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
 
-from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr, conint, root_validator
+from argilla.utils.pydantic import BaseModel, Field, StrictInt, StrictStr, conint, root_validator
 
 
 class FeedbackDatasetModel(BaseModel):

--- a/src/argilla/client/sdk/v1/datasets/models.py
+++ b/src/argilla/client/sdk/v1/datasets/models.py
@@ -18,7 +18,7 @@ from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
 
-from pydantic import BaseModel, Field, StrictInt, StrictStr, conint, root_validator
+from pydantic.v1 import BaseModel, Field, StrictInt, StrictStr, conint, root_validator
 
 
 class FeedbackDatasetModel(BaseModel):

--- a/src/argilla/client/sdk/v1/suggestions/models.py
+++ b/src/argilla/client/sdk/v1/suggestions/models.py
@@ -15,7 +15,7 @@
 from typing import Any, Literal, Optional
 from uuid import UUID
 
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 class SuggestionModel(BaseModel):

--- a/src/argilla/client/sdk/v1/suggestions/models.py
+++ b/src/argilla/client/sdk/v1/suggestions/models.py
@@ -15,7 +15,7 @@
 from typing import Any, Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class SuggestionModel(BaseModel):

--- a/src/argilla/client/sdk/v1/vectors_settings/models.py
+++ b/src/argilla/client/sdk/v1/vectors_settings/models.py
@@ -15,7 +15,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class VectorSettingsModel(BaseModel):

--- a/src/argilla/client/sdk/v1/vectors_settings/models.py
+++ b/src/argilla/client/sdk/v1/vectors_settings/models.py
@@ -15,7 +15,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic.v1 import BaseModel
+from argilla.utils.pydantic import BaseModel
 
 
 class VectorSettingsModel(BaseModel):

--- a/src/argilla/client/sdk/v1/vectors_settings/models.py
+++ b/src/argilla/client/sdk/v1/vectors_settings/models.py
@@ -15,7 +15,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 class VectorSettingsModel(BaseModel):

--- a/src/argilla/client/sdk/v1/workspaces/models.py
+++ b/src/argilla/client/sdk/v1/workspaces/models.py
@@ -15,7 +15,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 class WorkspaceModel(BaseModel):

--- a/src/argilla/client/sdk/v1/workspaces/models.py
+++ b/src/argilla/client/sdk/v1/workspaces/models.py
@@ -15,7 +15,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic.v1 import BaseModel
+from argilla.utils.pydantic import BaseModel
 
 
 class WorkspaceModel(BaseModel):

--- a/src/argilla/client/sdk/v1/workspaces/models.py
+++ b/src/argilla/client/sdk/v1/workspaces/models.py
@@ -15,7 +15,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class WorkspaceModel(BaseModel):

--- a/src/argilla/client/sdk/workspaces/models.py
+++ b/src/argilla/client/sdk/workspaces/models.py
@@ -15,7 +15,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 class WorkspaceModel(BaseModel):

--- a/src/argilla/client/sdk/workspaces/models.py
+++ b/src/argilla/client/sdk/workspaces/models.py
@@ -15,7 +15,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic.v1 import BaseModel
+from argilla.utils.pydantic import BaseModel
 
 
 class WorkspaceModel(BaseModel):

--- a/src/argilla/client/sdk/workspaces/models.py
+++ b/src/argilla/client/sdk/workspaces/models.py
@@ -15,7 +15,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class WorkspaceModel(BaseModel):

--- a/src/argilla/metrics/models.py
+++ b/src/argilla/metrics/models.py
@@ -15,7 +15,7 @@
 import warnings
 from typing import Any, Callable, Dict
 
-from pydantic.v1 import BaseModel, PrivateAttr
+from argilla.utils.pydantic import BaseModel, PrivateAttr
 
 
 # TODO(@frascuchon): Define as dataclasses.dataclass

--- a/src/argilla/metrics/models.py
+++ b/src/argilla/metrics/models.py
@@ -15,7 +15,7 @@
 import warnings
 from typing import Any, Callable, Dict
 
-from argilla.utils.pydantic import BaseModel, PrivateAttr
+from argilla.utils._import_pydantic import BaseModel, PrivateAttr
 
 
 # TODO(@frascuchon): Define as dataclasses.dataclass

--- a/src/argilla/metrics/models.py
+++ b/src/argilla/metrics/models.py
@@ -15,7 +15,7 @@
 import warnings
 from typing import Any, Callable, Dict
 
-from pydantic import BaseModel, PrivateAttr
+from pydantic.v1 import BaseModel, PrivateAttr
 
 
 # TODO(@frascuchon): Define as dataclasses.dataclass

--- a/src/argilla/monitoring/_transformers.py
+++ b/src/argilla/monitoring/_transformers.py
@@ -15,7 +15,7 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from argilla.client.api import Api
 from argilla.client.models import TextClassificationRecord

--- a/src/argilla/monitoring/_transformers.py
+++ b/src/argilla/monitoring/_transformers.py
@@ -19,7 +19,7 @@ from argilla.client.api import Api
 from argilla.client.models import TextClassificationRecord
 from argilla.monitoring.base import BaseMonitor
 from argilla.monitoring.types import MissingType
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 try:
     from transformers import (

--- a/src/argilla/monitoring/_transformers.py
+++ b/src/argilla/monitoring/_transformers.py
@@ -15,12 +15,11 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from pydantic.v1 import BaseModel
-
 from argilla.client.api import Api
 from argilla.client.models import TextClassificationRecord
 from argilla.monitoring.base import BaseMonitor
 from argilla.monitoring.types import MissingType
+from argilla.utils.pydantic import BaseModel
 
 try:
     from transformers import (

--- a/src/argilla/server/apis/v0/handlers/datasets.py
+++ b/src/argilla/server/apis/v0/handlers/datasets.py
@@ -27,7 +27,7 @@ from argilla.server.models import User
 from argilla.server.schemas.v0.datasets import CopyDatasetRequest, CreateDatasetRequest, Dataset, UpdateDatasetRequest
 from argilla.server.security import auth
 from argilla.server.services.datasets import DatasetsService
-from argilla.utils.pydantic import parse_obj_as
+from argilla.utils._import_pydantic import parse_obj_as
 
 router = APIRouter(tags=["datasets"], prefix="/datasets")
 

--- a/src/argilla/server/apis/v0/handlers/datasets.py
+++ b/src/argilla/server/apis/v0/handlers/datasets.py
@@ -16,7 +16,7 @@
 from typing import List
 
 from fastapi import APIRouter, Body, Depends, Security
-from pydantic import parse_obj_as
+from pydantic.v1 import parse_obj_as
 
 from argilla.server.apis.v0.helpers import deprecate_endpoint
 from argilla.server.apis.v0.models.commons.params import (

--- a/src/argilla/server/apis/v0/handlers/datasets.py
+++ b/src/argilla/server/apis/v0/handlers/datasets.py
@@ -16,7 +16,6 @@
 from typing import List
 
 from fastapi import APIRouter, Body, Depends, Security
-from pydantic.v1 import parse_obj_as
 
 from argilla.server.apis.v0.helpers import deprecate_endpoint
 from argilla.server.apis.v0.models.commons.params import (
@@ -28,6 +27,7 @@ from argilla.server.models import User
 from argilla.server.schemas.v0.datasets import CopyDatasetRequest, CreateDatasetRequest, Dataset, UpdateDatasetRequest
 from argilla.server.security import auth
 from argilla.server.services.datasets import DatasetsService
+from argilla.utils.pydantic import parse_obj_as
 
 router = APIRouter(tags=["datasets"], prefix="/datasets")
 

--- a/src/argilla/server/apis/v0/handlers/metrics.py
+++ b/src/argilla/server/apis/v0/handlers/metrics.py
@@ -17,7 +17,6 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, Query, Request, Security
-from pydantic.v1 import BaseModel, Field
 
 from argilla.server.apis.v0.helpers import deprecate_endpoint
 from argilla.server.apis.v0.models.commons.params import CommonTaskHandlerDependencies
@@ -26,6 +25,7 @@ from argilla.server.models import User
 from argilla.server.security import auth
 from argilla.server.services.datasets import DatasetsService
 from argilla.server.services.metrics import MetricsService
+from argilla.utils.pydantic import BaseModel, Field
 
 
 class MetricInfo(BaseModel):

--- a/src/argilla/server/apis/v0/handlers/metrics.py
+++ b/src/argilla/server/apis/v0/handlers/metrics.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, Query, Request, Security
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from argilla.server.apis.v0.helpers import deprecate_endpoint
 from argilla.server.apis.v0.models.commons.params import CommonTaskHandlerDependencies

--- a/src/argilla/server/apis/v0/handlers/metrics.py
+++ b/src/argilla/server/apis/v0/handlers/metrics.py
@@ -25,7 +25,7 @@ from argilla.server.models import User
 from argilla.server.security import auth
 from argilla.server.services.datasets import DatasetsService
 from argilla.server.services.metrics import MetricsService
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 
 class MetricInfo(BaseModel):

--- a/src/argilla/server/apis/v0/handlers/records.py
+++ b/src/argilla/server/apis/v0/handlers/records.py
@@ -15,7 +15,7 @@
 from typing import Optional, Union
 
 from fastapi import APIRouter, Depends, Query, Security
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from argilla.client.sdk.token_classification.models import TokenClassificationQuery
 from argilla.server.apis.v0.models.commons.params import CommonTaskHandlerDependencies

--- a/src/argilla/server/apis/v0/handlers/records.py
+++ b/src/argilla/server/apis/v0/handlers/records.py
@@ -15,7 +15,6 @@
 from typing import Optional, Union
 
 from fastapi import APIRouter, Depends, Query, Security
-from pydantic.v1 import BaseModel
 
 from argilla.client.sdk.token_classification.models import TokenClassificationQuery
 from argilla.server.apis.v0.models.commons.params import CommonTaskHandlerDependencies
@@ -28,6 +27,7 @@ from argilla.server.security import auth
 from argilla.server.services.datasets import DatasetsService
 from argilla.server.services.search.service import SearchRecordsService
 from argilla.server.services.storage.service import RecordsStorageService
+from argilla.utils.pydantic import BaseModel
 
 
 def configure_router(router: APIRouter):

--- a/src/argilla/server/apis/v0/handlers/records.py
+++ b/src/argilla/server/apis/v0/handlers/records.py
@@ -27,7 +27,7 @@ from argilla.server.security import auth
 from argilla.server.services.datasets import DatasetsService
 from argilla.server.services.search.service import SearchRecordsService
 from argilla.server.services.storage.service import RecordsStorageService
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 def configure_router(router: APIRouter):

--- a/src/argilla/server/apis/v0/handlers/records_search.py
+++ b/src/argilla/server/apis/v0/handlers/records_search.py
@@ -15,7 +15,6 @@ import json
 from typing import List, Optional, Union
 
 from fastapi import APIRouter, Depends, Query, Security
-from pydantic.v1 import BaseModel, Field
 
 from argilla.client.sdk.token_classification.models import TokenClassificationQuery
 from argilla.server.apis.v0.models.commons.model import SortableField
@@ -27,6 +26,7 @@ from argilla.server.daos.backend.generic_elastic import PaginatedSortInfo
 from argilla.server.models import User
 from argilla.server.security import auth
 from argilla.server.services.datasets import DatasetsService
+from argilla.utils.pydantic import BaseModel, Field
 
 # TODO(@frascuchon): This will be merged with `records.py`
 #  once the similarity search feature is merged into develop

--- a/src/argilla/server/apis/v0/handlers/records_search.py
+++ b/src/argilla/server/apis/v0/handlers/records_search.py
@@ -26,7 +26,7 @@ from argilla.server.daos.backend.generic_elastic import PaginatedSortInfo
 from argilla.server.models import User
 from argilla.server.security import auth
 from argilla.server.services.datasets import DatasetsService
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 # TODO(@frascuchon): This will be merged with `records.py`
 #  once the similarity search feature is merged into develop

--- a/src/argilla/server/apis/v0/handlers/records_search.py
+++ b/src/argilla/server/apis/v0/handlers/records_search.py
@@ -15,7 +15,7 @@ import json
 from typing import List, Optional, Union
 
 from fastapi import APIRouter, Depends, Query, Security
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from argilla.client.sdk.token_classification.models import TokenClassificationQuery
 from argilla.server.apis.v0.models.commons.model import SortableField

--- a/src/argilla/server/apis/v0/handlers/records_update.py
+++ b/src/argilla/server/apis/v0/handlers/records_update.py
@@ -15,7 +15,7 @@
 from typing import Any, Dict, Optional, Union
 
 from fastapi import APIRouter, Depends, Security
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from argilla.server.apis.v0.models.commons.params import CommonTaskHandlerDependencies
 from argilla.server.apis.v0.models.text2text import Text2TextRecord

--- a/src/argilla/server/apis/v0/handlers/records_update.py
+++ b/src/argilla/server/apis/v0/handlers/records_update.py
@@ -27,7 +27,7 @@ from argilla.server.security import auth
 from argilla.server.services.datasets import DatasetsService
 from argilla.server.services.search.service import SearchRecordsService
 from argilla.server.services.storage.service import RecordsStorageService
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 def configure_router(router: APIRouter):

--- a/src/argilla/server/apis/v0/handlers/records_update.py
+++ b/src/argilla/server/apis/v0/handlers/records_update.py
@@ -15,7 +15,6 @@
 from typing import Any, Dict, Optional, Union
 
 from fastapi import APIRouter, Depends, Security
-from pydantic.v1 import BaseModel
 
 from argilla.server.apis.v0.models.commons.params import CommonTaskHandlerDependencies
 from argilla.server.apis.v0.models.text2text import Text2TextRecord
@@ -28,6 +27,7 @@ from argilla.server.security import auth
 from argilla.server.services.datasets import DatasetsService
 from argilla.server.services.search.service import SearchRecordsService
 from argilla.server.services.storage.service import RecordsStorageService
+from argilla.utils.pydantic import BaseModel
 
 
 def configure_router(router: APIRouter):

--- a/src/argilla/server/apis/v0/handlers/users.py
+++ b/src/argilla/server/apis/v0/handlers/users.py
@@ -17,7 +17,7 @@ from typing import List
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Security, status
-from pydantic import parse_obj_as
+from pydantic.v1 import parse_obj_as
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from argilla.server import models

--- a/src/argilla/server/apis/v0/handlers/users.py
+++ b/src/argilla/server/apis/v0/handlers/users.py
@@ -17,7 +17,6 @@ from typing import List
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Security, status
-from pydantic.v1 import parse_obj_as
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from argilla.server import models
@@ -28,6 +27,7 @@ from argilla.server.policies import UserPolicy, authorize
 from argilla.server.security import auth
 from argilla.server.security.model import User, UserCreate
 from argilla.utils import telemetry
+from argilla.utils.pydantic import parse_obj_as
 
 router = APIRouter(tags=["users"])
 

--- a/src/argilla/server/apis/v0/handlers/users.py
+++ b/src/argilla/server/apis/v0/handlers/users.py
@@ -27,7 +27,7 @@ from argilla.server.policies import UserPolicy, authorize
 from argilla.server.security import auth
 from argilla.server.security.model import User, UserCreate
 from argilla.utils import telemetry
-from argilla.utils.pydantic import parse_obj_as
+from argilla.utils._import_pydantic import parse_obj_as
 
 router = APIRouter(tags=["users"])
 

--- a/src/argilla/server/apis/v0/handlers/workspaces.py
+++ b/src/argilla/server/apis/v0/handlers/workspaces.py
@@ -16,7 +16,7 @@ from typing import List
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Security
-from pydantic import parse_obj_as
+from pydantic.v1 import parse_obj_as
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from argilla.server.contexts import accounts

--- a/src/argilla/server/apis/v0/handlers/workspaces.py
+++ b/src/argilla/server/apis/v0/handlers/workspaces.py
@@ -16,7 +16,6 @@ from typing import List
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Security
-from pydantic.v1 import parse_obj_as
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from argilla.server.contexts import accounts
@@ -25,6 +24,7 @@ from argilla.server.errors import EntityAlreadyExistsError, EntityNotFoundError
 from argilla.server.policies import WorkspacePolicy, WorkspaceUserPolicy, authorize
 from argilla.server.security import auth
 from argilla.server.security.model import User, Workspace, WorkspaceCreate, WorkspaceUserCreate
+from argilla.utils.pydantic import parse_obj_as
 
 router = APIRouter(tags=["workspaces"])
 

--- a/src/argilla/server/apis/v0/handlers/workspaces.py
+++ b/src/argilla/server/apis/v0/handlers/workspaces.py
@@ -24,7 +24,7 @@ from argilla.server.errors import EntityAlreadyExistsError, EntityNotFoundError
 from argilla.server.policies import WorkspacePolicy, WorkspaceUserPolicy, authorize
 from argilla.server.security import auth
 from argilla.server.security.model import User, Workspace, WorkspaceCreate, WorkspaceUserCreate
-from argilla.utils.pydantic import parse_obj_as
+from argilla.utils._import_pydantic import parse_obj_as
 
 router = APIRouter(tags=["workspaces"])
 

--- a/src/argilla/server/apis/v0/models/commons/model.py
+++ b/src/argilla/server/apis/v0/models/commons/model.py
@@ -19,8 +19,8 @@ Common model for task definitions
 
 from typing import Any, Dict, Generic, List, TypeVar
 
-from pydantic import BaseModel, Field
-from pydantic.generics import GenericModel
+from pydantic.v1 import BaseModel, Field
+from pydantic.v1.generics import GenericModel
 
 from argilla.server.services.search.model import (
     ServiceQueryRange,

--- a/src/argilla/server/apis/v0/models/commons/model.py
+++ b/src/argilla/server/apis/v0/models/commons/model.py
@@ -19,15 +19,14 @@ Common model for task definitions
 
 from typing import Any, Dict, Generic, List, TypeVar
 
-from pydantic.v1 import BaseModel, Field
-from pydantic.v1.generics import GenericModel
-
 from argilla.server.services.search.model import (
     ServiceQueryRange,
     ServiceSearchResultsAggregations,
     ServiceSortableField,
 )
 from argilla.server.services.tasks.commons import ServiceBaseAnnotation, ServiceBaseRecord, ServiceBaseRecordInputs
+from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils.pydantic.generics import GenericModel
 
 
 class SortableField(ServiceSortableField):

--- a/src/argilla/server/apis/v0/models/commons/model.py
+++ b/src/argilla/server/apis/v0/models/commons/model.py
@@ -25,8 +25,7 @@ from argilla.server.services.search.model import (
     ServiceSortableField,
 )
 from argilla.server.services.tasks.commons import ServiceBaseAnnotation, ServiceBaseRecord, ServiceBaseRecordInputs
-from argilla.utils.pydantic import BaseModel, Field
-from argilla.utils.pydantic.generics import GenericModel
+from argilla.utils._import_pydantic import BaseModel, Field, GenericModel
 
 
 class SortableField(ServiceSortableField):

--- a/src/argilla/server/apis/v0/models/dataset_settings.py
+++ b/src/argilla/server/apis/v0/models/dataset_settings.py
@@ -14,9 +14,8 @@
 
 from typing import Dict, List, Optional, Union
 
-from pydantic.v1 import BaseModel, Field, validator
-
 from argilla.server.daos.models.datasets import EmbeddingsConfig
+from argilla.utils.pydantic import BaseModel, Field, validator
 
 
 class AbstractDatasetSettings(BaseModel):

--- a/src/argilla/server/apis/v0/models/dataset_settings.py
+++ b/src/argilla/server/apis/v0/models/dataset_settings.py
@@ -15,7 +15,7 @@
 from typing import Dict, List, Optional, Union
 
 from argilla.server.daos.models.datasets import EmbeddingsConfig
-from argilla.utils.pydantic import BaseModel, Field, validator
+from argilla.utils._import_pydantic import BaseModel, Field, validator
 
 
 class AbstractDatasetSettings(BaseModel):

--- a/src/argilla/server/apis/v0/models/dataset_settings.py
+++ b/src/argilla/server/apis/v0/models/dataset_settings.py
@@ -14,7 +14,7 @@
 
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 from argilla.server.daos.models.datasets import EmbeddingsConfig
 

--- a/src/argilla/server/apis/v0/models/text2text.py
+++ b/src/argilla/server/apis/v0/models/text2text.py
@@ -27,7 +27,7 @@ from argilla.server.commons.models import PredictionStatus
 from argilla.server.schemas.v0.datasets import UpdateDatasetRequest
 from argilla.server.services.metrics.models import CommonTasksMetrics
 from argilla.server.services.search.model import ServiceBaseRecordsQuery, ServiceBaseSearchResultsAggregations
-from argilla.utils.pydantic import BaseModel, Field, validator
+from argilla.utils._import_pydantic import BaseModel, Field, validator
 
 
 class Text2TextPrediction(BaseModel):

--- a/src/argilla/server/apis/v0/models/text2text.py
+++ b/src/argilla/server/apis/v0/models/text2text.py
@@ -15,7 +15,7 @@
 
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 from argilla.server.apis.v0.models.commons.model import (
     BaseAnnotation,

--- a/src/argilla/server/apis/v0/models/text2text.py
+++ b/src/argilla/server/apis/v0/models/text2text.py
@@ -15,8 +15,6 @@
 
 from typing import Dict, List, Optional
 
-from pydantic.v1 import BaseModel, Field, validator
-
 from argilla.server.apis.v0.models.commons.model import (
     BaseAnnotation,
     BaseRecord,
@@ -29,6 +27,7 @@ from argilla.server.commons.models import PredictionStatus
 from argilla.server.schemas.v0.datasets import UpdateDatasetRequest
 from argilla.server.services.metrics.models import CommonTasksMetrics
 from argilla.server.services.search.model import ServiceBaseRecordsQuery, ServiceBaseSearchResultsAggregations
+from argilla.utils.pydantic import BaseModel, Field, validator
 
 
 class Text2TextPrediction(BaseModel):

--- a/src/argilla/server/apis/v0/models/text_classification.py
+++ b/src/argilla/server/apis/v0/models/text_classification.py
@@ -36,7 +36,7 @@ from argilla.server.services.tasks.text_classification.model import ServiceTextC
 from argilla.server.services.tasks.text_classification.model import (
     TextClassificationAnnotation as _TextClassificationAnnotation,
 )
-from argilla.utils.pydantic import BaseModel, Field, root_validator, validator
+from argilla.utils._import_pydantic import BaseModel, Field, root_validator, validator
 
 
 class UpdateLabelingRule(BaseModel):

--- a/src/argilla/server/apis/v0/models/text_classification.py
+++ b/src/argilla/server/apis/v0/models/text_classification.py
@@ -16,8 +16,6 @@
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
-from pydantic.v1 import BaseModel, Field, root_validator, validator
-
 from argilla.server.apis.v0.models.commons.model import (
     BaseRecord,
     BaseRecordInputs,
@@ -38,6 +36,7 @@ from argilla.server.services.tasks.text_classification.model import ServiceTextC
 from argilla.server.services.tasks.text_classification.model import (
     TextClassificationAnnotation as _TextClassificationAnnotation,
 )
+from argilla.utils.pydantic import BaseModel, Field, root_validator, validator
 
 
 class UpdateLabelingRule(BaseModel):

--- a/src/argilla/server/apis/v0/models/text_classification.py
+++ b/src/argilla/server/apis/v0/models/text_classification.py
@@ -16,7 +16,7 @@
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field, root_validator, validator
+from pydantic.v1 import BaseModel, Field, root_validator, validator
 
 from argilla.server.apis.v0.models.commons.model import (
     BaseRecord,

--- a/src/argilla/server/apis/v0/models/token_classification.py
+++ b/src/argilla/server/apis/v0/models/token_classification.py
@@ -22,7 +22,7 @@ from argilla.server.services.search.model import ServiceBaseRecordsQuery, Servic
 from argilla.server.services.tasks.token_classification.model import (
     ServiceTokenClassificationAnnotation as _TokenClassificationAnnotation,
 )
-from argilla.utils.pydantic import BaseModel, Field, root_validator, validator
+from argilla.utils._import_pydantic import BaseModel, Field, root_validator, validator
 
 
 class TokenClassificationAnnotation(_TokenClassificationAnnotation):

--- a/src/argilla/server/apis/v0/models/token_classification.py
+++ b/src/argilla/server/apis/v0/models/token_classification.py
@@ -14,8 +14,6 @@
 #  limitations under the License.
 from typing import Dict, List, Optional
 
-from pydantic.v1 import BaseModel, Field, root_validator, validator
-
 from argilla.server.apis.v0.models.commons.model import BaseRecord, BaseRecordInputs, BaseSearchResults, ScoreRange
 from argilla.server.commons.models import PredictionStatus
 from argilla.server.daos.backend.search.model import SortableField
@@ -24,6 +22,7 @@ from argilla.server.services.search.model import ServiceBaseRecordsQuery, Servic
 from argilla.server.services.tasks.token_classification.model import (
     ServiceTokenClassificationAnnotation as _TokenClassificationAnnotation,
 )
+from argilla.utils.pydantic import BaseModel, Field, root_validator, validator
 
 
 class TokenClassificationAnnotation(_TokenClassificationAnnotation):

--- a/src/argilla/server/apis/v0/models/token_classification.py
+++ b/src/argilla/server/apis/v0/models/token_classification.py
@@ -14,7 +14,7 @@
 #  limitations under the License.
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel, Field, root_validator, validator
+from pydantic.v1 import BaseModel, Field, root_validator, validator
 
 from argilla.server.apis.v0.models.commons.model import BaseRecord, BaseRecordInputs, BaseSearchResults, ScoreRange
 from argilla.server.commons.models import PredictionStatus

--- a/src/argilla/server/commons/config.py
+++ b/src/argilla/server/commons/config.py
@@ -14,8 +14,6 @@
 
 from typing import List, Optional, Set, Type
 
-from pydantic.v1 import BaseModel
-
 from argilla.server.commons.models import TaskType
 from argilla.server.errors import EntityNotFoundError, WrongTaskError
 from argilla.server.services.datasets import ServiceBaseDataset, ServiceDataset
@@ -23,6 +21,7 @@ from argilla.server.services.metrics import ServiceBaseMetric
 from argilla.server.services.metrics.models import ServiceBaseTaskMetrics
 from argilla.server.services.search.model import ServiceRecordsQuery
 from argilla.server.services.tasks.commons import ServiceRecord
+from argilla.utils.pydantic import BaseModel
 
 
 class TaskConfig(BaseModel):

--- a/src/argilla/server/commons/config.py
+++ b/src/argilla/server/commons/config.py
@@ -14,7 +14,7 @@
 
 from typing import List, Optional, Set, Type
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from argilla.server.commons.models import TaskType
 from argilla.server.errors import EntityNotFoundError, WrongTaskError

--- a/src/argilla/server/commons/config.py
+++ b/src/argilla/server/commons/config.py
@@ -21,7 +21,7 @@ from argilla.server.services.metrics import ServiceBaseMetric
 from argilla.server.services.metrics.models import ServiceBaseTaskMetrics
 from argilla.server.services.search.model import ServiceRecordsQuery
 from argilla.server.services.tasks.commons import ServiceRecord
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 class TaskConfig(BaseModel):

--- a/src/argilla/server/daos/backend/base.py
+++ b/src/argilla/server/daos/backend/base.py
@@ -17,7 +17,7 @@ import warnings
 from abc import ABC
 from typing import Any, List, Optional, Type
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from argilla.server.errors import InvalidTextSearchError
 

--- a/src/argilla/server/daos/backend/base.py
+++ b/src/argilla/server/daos/backend/base.py
@@ -17,9 +17,8 @@ import warnings
 from abc import ABC
 from typing import Any, List, Optional, Type
 
-from pydantic.v1 import BaseModel
-
 from argilla.server.errors import InvalidTextSearchError
+from argilla.utils.pydantic import BaseModel
 
 
 class ClosedIndexError(Exception):

--- a/src/argilla/server/daos/backend/base.py
+++ b/src/argilla/server/daos/backend/base.py
@@ -18,7 +18,7 @@ from abc import ABC
 from typing import Any, List, Optional, Type
 
 from argilla.server.errors import InvalidTextSearchError
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 class ClosedIndexError(Exception):

--- a/src/argilla/server/daos/backend/generic_elastic.py
+++ b/src/argilla/server/daos/backend/generic_elastic.py
@@ -14,8 +14,6 @@
 
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-from pydantic.v1 import BaseModel, Field
-
 from argilla._constants import PROTECTED_METADATA_FIELD_PREFIX
 from argilla.logging import LoggingMixin
 from argilla.server.commons.models import TaskType
@@ -40,6 +38,7 @@ from argilla.server.daos.backend.search.model import (
 from argilla.server.errors import BadRequestError, EntityNotFoundError
 from argilla.server.errors.task_errors import MetadataLimitExceededError
 from argilla.server.settings import settings
+from argilla.utils.pydantic import BaseModel, Field
 
 
 def dataset_records_index(dataset_id: str) -> str:

--- a/src/argilla/server/daos/backend/generic_elastic.py
+++ b/src/argilla/server/daos/backend/generic_elastic.py
@@ -38,7 +38,7 @@ from argilla.server.daos.backend.search.model import (
 from argilla.server.errors import BadRequestError, EntityNotFoundError
 from argilla.server.errors.task_errors import MetadataLimitExceededError
 from argilla.server.settings import settings
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 
 def dataset_records_index(dataset_id: str) -> str:

--- a/src/argilla/server/daos/backend/generic_elastic.py
+++ b/src/argilla/server/daos/backend/generic_elastic.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from argilla._constants import PROTECTED_METADATA_FIELD_PREFIX
 from argilla.logging import LoggingMixin

--- a/src/argilla/server/daos/backend/mappings/token_classification.py
+++ b/src/argilla/server/daos/backend/mappings/token_classification.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from argilla.server.daos.backend.mappings.helpers import mappings
 from argilla.server.daos.backend.query_helpers import nested_mappings_from_base_model

--- a/src/argilla/server/daos/backend/mappings/token_classification.py
+++ b/src/argilla/server/daos/backend/mappings/token_classification.py
@@ -14,10 +14,9 @@
 
 from typing import Optional
 
-from pydantic.v1 import BaseModel, Field
-
 from argilla.server.daos.backend.mappings.helpers import mappings
 from argilla.server.daos.backend.query_helpers import nested_mappings_from_base_model
+from argilla.utils.pydantic import BaseModel, Field
 
 
 class MentionMetrics(BaseModel):

--- a/src/argilla/server/daos/backend/mappings/token_classification.py
+++ b/src/argilla/server/daos/backend/mappings/token_classification.py
@@ -16,7 +16,7 @@ from typing import Optional
 
 from argilla.server.daos.backend.mappings.helpers import mappings
 from argilla.server.daos.backend.query_helpers import nested_mappings_from_base_model
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 
 class MentionMetrics(BaseModel):

--- a/src/argilla/server/daos/backend/query_helpers.py
+++ b/src/argilla/server/daos/backend/query_helpers.py
@@ -16,7 +16,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional, Type, Union
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from argilla.server.commons.models import TaskStatus
 from argilla.server.daos.backend.mappings.helpers import mappings

--- a/src/argilla/server/daos/backend/query_helpers.py
+++ b/src/argilla/server/daos/backend/query_helpers.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional, Type, Union
 
 from argilla.server.commons.models import TaskStatus
 from argilla.server.daos.backend.mappings.helpers import mappings
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 def nested_mappings_from_base_model(model_class: Type[BaseModel]) -> Dict[str, Any]:

--- a/src/argilla/server/daos/backend/query_helpers.py
+++ b/src/argilla/server/daos/backend/query_helpers.py
@@ -16,10 +16,9 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional, Type, Union
 
-from pydantic.v1 import BaseModel
-
 from argilla.server.commons.models import TaskStatus
 from argilla.server.daos.backend.mappings.helpers import mappings
+from argilla.utils.pydantic import BaseModel
 
 
 def nested_mappings_from_base_model(model_class: Type[BaseModel]) -> Dict[str, Any]:

--- a/src/argilla/server/daos/backend/search/model.py
+++ b/src/argilla/server/daos/backend/search/model.py
@@ -15,7 +15,7 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional, TypeVar, Union
 
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 from argilla.server.commons.models import TaskStatus
 

--- a/src/argilla/server/daos/backend/search/model.py
+++ b/src/argilla/server/daos/backend/search/model.py
@@ -15,9 +15,8 @@
 from enum import Enum
 from typing import Any, Dict, List, Optional, TypeVar, Union
 
-from pydantic.v1 import BaseModel, Field, validator
-
 from argilla.server.commons.models import TaskStatus
+from argilla.utils.pydantic import BaseModel, Field, validator
 
 
 class SortOrder(str, Enum):

--- a/src/argilla/server/daos/backend/search/model.py
+++ b/src/argilla/server/daos/backend/search/model.py
@@ -16,7 +16,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, TypeVar, Union
 
 from argilla.server.commons.models import TaskStatus
-from argilla.utils.pydantic import BaseModel, Field, validator
+from argilla.utils._import_pydantic import BaseModel, Field, validator
 
 
 class SortOrder(str, Enum):

--- a/src/argilla/server/daos/models/datasets.py
+++ b/src/argilla/server/daos/models/datasets.py
@@ -15,7 +15,7 @@
 from datetime import datetime
 from typing import Any, Dict, Optional, TypeVar, Union
 
-from pydantic import BaseModel, Field, root_validator
+from pydantic.v1 import BaseModel, Field, root_validator
 
 from argilla._constants import ES_INDEX_REGEX_PATTERN
 from argilla.server.commons.models import TaskType

--- a/src/argilla/server/daos/models/datasets.py
+++ b/src/argilla/server/daos/models/datasets.py
@@ -15,10 +15,9 @@
 from datetime import datetime
 from typing import Any, Dict, Optional, TypeVar, Union
 
-from pydantic.v1 import BaseModel, Field, root_validator
-
 from argilla._constants import ES_INDEX_REGEX_PATTERN
 from argilla.server.commons.models import TaskType
+from argilla.utils.pydantic import BaseModel, Field, root_validator
 
 
 class BaseDatasetDB(BaseModel):

--- a/src/argilla/server/daos/models/datasets.py
+++ b/src/argilla/server/daos/models/datasets.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, Optional, TypeVar, Union
 
 from argilla._constants import ES_INDEX_REGEX_PATTERN
 from argilla.server.commons.models import TaskType
-from argilla.utils.pydantic import BaseModel, Field, root_validator
+from argilla.utils._import_pydantic import BaseModel, Field, root_validator
 
 
 class BaseDatasetDB(BaseModel):

--- a/src/argilla/server/daos/models/records.py
+++ b/src/argilla/server/daos/models/records.py
@@ -18,9 +18,6 @@ import warnings
 from datetime import datetime
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
 
-from pydantic.v1 import BaseModel, Field, conint, constr, root_validator, validator
-from pydantic.v1.generics import GenericModel
-
 from argilla import _messages
 from argilla._constants import _JS_MAX_SAFE_INTEGER, PROTECTED_METADATA_FIELD_PREFIX
 from argilla.server.commons.models import PredictionStatus, TaskStatus, TaskType
@@ -28,6 +25,8 @@ from argilla.server.daos.backend.search.model import BaseRecordsQuery, SortConfi
 from argilla.server.helpers import flatten_dict
 from argilla.server.settings import settings
 from argilla.utils import limit_value_length
+from argilla.utils.pydantic import BaseModel, Field, conint, constr, root_validator, validator
+from argilla.utils.pydantic.generics import GenericModel
 
 
 class DaoRecordsSearch(BaseModel):

--- a/src/argilla/server/daos/models/records.py
+++ b/src/argilla/server/daos/models/records.py
@@ -25,8 +25,7 @@ from argilla.server.daos.backend.search.model import BaseRecordsQuery, SortConfi
 from argilla.server.helpers import flatten_dict
 from argilla.server.settings import settings
 from argilla.utils import limit_value_length
-from argilla.utils.pydantic import BaseModel, Field, conint, constr, root_validator, validator
-from argilla.utils.pydantic.generics import GenericModel
+from argilla.utils._import_pydantic import BaseModel, Field, GenericModel, conint, constr, root_validator, validator
 
 
 class DaoRecordsSearch(BaseModel):

--- a/src/argilla/server/daos/models/records.py
+++ b/src/argilla/server/daos/models/records.py
@@ -18,8 +18,8 @@ import warnings
 from datetime import datetime
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
 
-from pydantic import BaseModel, Field, conint, constr, root_validator, validator
-from pydantic.generics import GenericModel
+from pydantic.v1 import BaseModel, Field, conint, constr, root_validator, validator
+from pydantic.v1.generics import GenericModel
 
 from argilla import _messages
 from argilla._constants import _JS_MAX_SAFE_INTEGER, PROTECTED_METADATA_FIELD_PREFIX

--- a/src/argilla/server/errors/adapter.py
+++ b/src/argilla/server/errors/adapter.py
@@ -14,7 +14,6 @@
 
 import logging
 
-import pydantic.v1 as pydantic
 from fastapi.exceptions import RequestValidationError
 
 from argilla.server.errors.base_errors import BadRequestError, GenericServerError, ServerError, ValidationError

--- a/src/argilla/server/errors/adapter.py
+++ b/src/argilla/server/errors/adapter.py
@@ -14,7 +14,7 @@
 
 import logging
 
-import pydantic
+import pydantic.v1 as pydantic
 from fastapi.exceptions import RequestValidationError
 
 from argilla.server.errors.base_errors import BadRequestError, GenericServerError, ServerError, ValidationError

--- a/src/argilla/server/errors/api_errors.py
+++ b/src/argilla/server/errors/api_errors.py
@@ -25,7 +25,7 @@ from argilla.server.errors.base_errors import (
     ServerError,
 )
 from argilla.utils import telemetry
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 class ErrorDetail(BaseModel):

--- a/src/argilla/server/errors/api_errors.py
+++ b/src/argilla/server/errors/api_errors.py
@@ -16,7 +16,7 @@ from typing import Any, Dict
 
 from fastapi import HTTPException, Request
 from fastapi.exception_handlers import http_exception_handler
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from argilla.server.errors.adapter import exception_to_argilla_error
 from argilla.server.errors.base_errors import (

--- a/src/argilla/server/errors/api_errors.py
+++ b/src/argilla/server/errors/api_errors.py
@@ -16,7 +16,6 @@ from typing import Any, Dict
 
 from fastapi import HTTPException, Request
 from fastapi.exception_handlers import http_exception_handler
-from pydantic.v1 import BaseModel
 
 from argilla.server.errors.adapter import exception_to_argilla_error
 from argilla.server.errors.base_errors import (
@@ -26,6 +25,7 @@ from argilla.server.errors.base_errors import (
     ServerError,
 )
 from argilla.utils import telemetry
+from argilla.utils.pydantic import BaseModel
 
 
 class ErrorDetail(BaseModel):

--- a/src/argilla/server/errors/base_errors.py
+++ b/src/argilla/server/errors/base_errors.py
@@ -14,8 +14,9 @@
 
 from typing import Any, Optional, Type, Union
 
-import pydantic.v1 as pydantic
 from starlette import status
+
+from argilla.utils.pydantic import ValidationError
 
 
 class ServerError(Exception):
@@ -59,7 +60,7 @@ class ValidationError(ServerError):
 
     HTTP_STATUS = status.HTTP_422_UNPROCESSABLE_ENTITY
 
-    def __init__(self, error: pydantic.ValidationError):
+    def __init__(self, error: ValidationError):
         self.errors = error.errors()
 
 

--- a/src/argilla/server/errors/base_errors.py
+++ b/src/argilla/server/errors/base_errors.py
@@ -16,7 +16,7 @@ from typing import Any, Optional, Type, Union
 
 from starlette import status
 
-from argilla.utils.pydantic import ValidationError
+from argilla.utils._import_pydantic import ValidationError
 
 
 class ServerError(Exception):

--- a/src/argilla/server/errors/base_errors.py
+++ b/src/argilla/server/errors/base_errors.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Optional, Type, Union
 
-import pydantic
+import pydantic.v1 as pydantic
 from starlette import status
 
 

--- a/src/argilla/server/models/database.py
+++ b/src/argilla/server/models/database.py
@@ -17,7 +17,6 @@ from datetime import datetime
 from typing import Any, List, Optional, Union
 from uuid import UUID
 
-from pydantic.v1 import parse_obj_as
 from sqlalchemy import JSON, ForeignKey, String, Text, UniqueConstraint, and_, sql
 from sqlalchemy import Enum as SAEnum
 from sqlalchemy.engine.default import DefaultExecutionContext
@@ -36,6 +35,7 @@ from argilla.server.models.base import DatabaseModel
 from argilla.server.models.metadata_properties import MetadataPropertySettings
 from argilla.server.models.mixins import inserted_at_current_value
 from argilla.server.models.questions import QuestionSettings
+from argilla.utils.pydantic import parse_obj_as
 
 # Include here the data model ref to be accessible for automatic alembic migration scripts
 __all__ = [

--- a/src/argilla/server/models/database.py
+++ b/src/argilla/server/models/database.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from typing import Any, List, Optional, Union
 from uuid import UUID
 
-from pydantic import parse_obj_as
+from pydantic.v1 import parse_obj_as
 from sqlalchemy import JSON, ForeignKey, String, Text, UniqueConstraint, and_, sql
 from sqlalchemy import Enum as SAEnum
 from sqlalchemy.engine.default import DefaultExecutionContext

--- a/src/argilla/server/models/database.py
+++ b/src/argilla/server/models/database.py
@@ -35,7 +35,7 @@ from argilla.server.models.base import DatabaseModel
 from argilla.server.models.metadata_properties import MetadataPropertySettings
 from argilla.server.models.mixins import inserted_at_current_value
 from argilla.server.models.questions import QuestionSettings
-from argilla.utils.pydantic import parse_obj_as
+from argilla.utils._import_pydantic import parse_obj_as
 
 # Include here the data model ref to be accessible for automatic alembic migration scripts
 __all__ = [

--- a/src/argilla/server/models/metadata_properties.py
+++ b/src/argilla/server/models/metadata_properties.py
@@ -15,10 +15,9 @@
 from abc import ABC, abstractmethod
 from typing import Any, Generic, List, Literal, Optional, TypeVar, Union
 
-from pydantic.v1 import BaseModel, Field
-from pydantic.v1.generics import GenericModel
-
 from argilla.server.enums import MetadataPropertyType
+from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils.pydantic.generics import GenericModel
 
 __all__ = [
     "MetadataPropertySettings",

--- a/src/argilla/server/models/metadata_properties.py
+++ b/src/argilla/server/models/metadata_properties.py
@@ -16,8 +16,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Generic, List, Literal, Optional, TypeVar, Union
 
 from argilla.server.enums import MetadataPropertyType
-from argilla.utils.pydantic import BaseModel, Field
-from argilla.utils.pydantic.generics import GenericModel
+from argilla.utils._import_pydantic import BaseModel, Field, GenericModel
 
 __all__ = [
     "MetadataPropertySettings",

--- a/src/argilla/server/models/metadata_properties.py
+++ b/src/argilla/server/models/metadata_properties.py
@@ -15,8 +15,8 @@
 from abc import ABC, abstractmethod
 from typing import Any, Generic, List, Literal, Optional, TypeVar, Union
 
-from pydantic import BaseModel, Field
-from pydantic.generics import GenericModel
+from pydantic.v1 import BaseModel, Field
+from pydantic.v1.generics import GenericModel
 
 from argilla.server.enums import MetadataPropertyType
 

--- a/src/argilla/server/models/mixins.py
+++ b/src/argilla/server/models/mixins.py
@@ -15,7 +15,6 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Set, TypeVar, Union
 
-from pydantic.v1 import BaseModel
 from sqlalchemy import sql
 from sqlalchemy.dialects.mysql import insert as mysql_insert
 from sqlalchemy.dialects.postgresql import insert as postgres_insert
@@ -23,6 +22,8 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.engine.default import DefaultExecutionContext
 from sqlalchemy.orm import Mapped, mapped_column
 from typing_extensions import Self
+
+from argilla.utils.pydantic import BaseModel
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession

--- a/src/argilla/server/models/mixins.py
+++ b/src/argilla/server/models/mixins.py
@@ -23,7 +23,7 @@ from sqlalchemy.engine.default import DefaultExecutionContext
 from sqlalchemy.orm import Mapped, mapped_column
 from typing_extensions import Self
 
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession

--- a/src/argilla/server/models/mixins.py
+++ b/src/argilla/server/models/mixins.py
@@ -15,7 +15,7 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Set, TypeVar, Union
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from sqlalchemy import sql
 from sqlalchemy.dialects.mysql import insert as mysql_insert
 from sqlalchemy.dialects.postgresql import insert as postgres_insert

--- a/src/argilla/server/models/questions.py
+++ b/src/argilla/server/models/questions.py
@@ -15,7 +15,7 @@
 from typing import Any, Generic, List, Literal, Optional, Protocol, TypeVar, Union
 
 from argilla.server.enums import QuestionType, ResponseStatus
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 try:
     from typing import Annotated

--- a/src/argilla/server/models/questions.py
+++ b/src/argilla/server/models/questions.py
@@ -14,9 +14,8 @@
 
 from typing import Any, Generic, List, Literal, Optional, Protocol, TypeVar, Union
 
-from pydantic.v1 import BaseModel, Field
-
 from argilla.server.enums import QuestionType, ResponseStatus
+from argilla.utils.pydantic import BaseModel, Field
 
 try:
     from typing import Annotated

--- a/src/argilla/server/models/questions.py
+++ b/src/argilla/server/models/questions.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Generic, List, Literal, Optional, Protocol, TypeVar, Union
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from argilla.server.enums import QuestionType, ResponseStatus
 

--- a/src/argilla/server/schemas/base.py
+++ b/src/argilla/server/schemas/base.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, Set, Union
 
-from argilla.utils.pydantic import BaseModel, root_validator
+from argilla.utils._import_pydantic import BaseModel, root_validator
 
 
 class UpdateSchema(BaseModel):

--- a/src/argilla/server/schemas/base.py
+++ b/src/argilla/server/schemas/base.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, Set, Union
 
-from pydantic import BaseModel, root_validator
+from pydantic.v1 import BaseModel, root_validator
 
 
 class UpdateSchema(BaseModel):

--- a/src/argilla/server/schemas/base.py
+++ b/src/argilla/server/schemas/base.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, Set, Union
 
-from pydantic.v1 import BaseModel, root_validator
+from argilla.utils.pydantic import BaseModel, root_validator
 
 
 class UpdateSchema(BaseModel):

--- a/src/argilla/server/schemas/v0/datasets.py
+++ b/src/argilla/server/schemas/v0/datasets.py
@@ -20,7 +20,7 @@ from datetime import datetime
 from typing import Any, Dict, Optional, Union
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from argilla._constants import ES_INDEX_REGEX_PATTERN
 from argilla.server.commons.models import TaskType

--- a/src/argilla/server/schemas/v0/datasets.py
+++ b/src/argilla/server/schemas/v0/datasets.py
@@ -20,10 +20,9 @@ from datetime import datetime
 from typing import Any, Dict, Optional, Union
 from uuid import UUID
 
-from pydantic.v1 import BaseModel, Field
-
 from argilla._constants import ES_INDEX_REGEX_PATTERN
 from argilla.server.commons.models import TaskType
+from argilla.utils.pydantic import BaseModel, Field
 
 
 class UpdateDatasetRequest(BaseModel):

--- a/src/argilla/server/schemas/v0/datasets.py
+++ b/src/argilla/server/schemas/v0/datasets.py
@@ -22,7 +22,7 @@ from uuid import UUID
 
 from argilla._constants import ES_INDEX_REGEX_PATTERN
 from argilla.server.commons.models import TaskType
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 
 class UpdateDatasetRequest(BaseModel):

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -23,10 +23,17 @@ from argilla.server.schemas.base import UpdateSchema
 from argilla.server.schemas.v1.records import RecordUpdate
 from argilla.server.schemas.v1.suggestions import Suggestion, SuggestionCreate
 from argilla.server.search_engine import TextQuery
-from argilla.utils.pydantic import BaseModel, PositiveInt, conlist, constr, root_validator, validator
-from argilla.utils.pydantic import Field as PydanticField
-from argilla.utils.pydantic.generics import GenericModel
-from argilla.utils.pydantic.utils import GetterDict
+from argilla.utils._import_pydantic import (
+    BaseModel,
+    GenericModel,
+    GetterDict,
+    PositiveInt,
+    conlist,
+    constr,
+    root_validator,
+    validator,
+)
+from argilla.utils._import_pydantic import Field as PydanticField
 
 try:
     from typing import Annotated

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -17,10 +17,10 @@ from typing import Any, Dict, Generic, List, Literal, Optional, TypeVar, Union
 from uuid import UUID
 
 from fastapi import HTTPException, Query
-from pydantic import BaseModel, PositiveInt, conlist, constr, root_validator, validator
-from pydantic import Field as PydanticField
-from pydantic.generics import GenericModel
-from pydantic.utils import GetterDict
+from pydantic.v1 import BaseModel, PositiveInt, conlist, constr, root_validator, validator
+from pydantic.v1 import Field as PydanticField
+from pydantic.v1.generics import GenericModel
+from pydantic.v1.utils import GetterDict
 
 from argilla.server.enums import RecordInclude, RecordSortField, SimilarityOrder, SortOrder
 from argilla.server.schemas.base import UpdateSchema

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -17,16 +17,16 @@ from typing import Any, Dict, Generic, List, Literal, Optional, TypeVar, Union
 from uuid import UUID
 
 from fastapi import HTTPException, Query
-from pydantic.v1 import BaseModel, PositiveInt, conlist, constr, root_validator, validator
-from pydantic.v1 import Field as PydanticField
-from pydantic.v1.generics import GenericModel
-from pydantic.v1.utils import GetterDict
 
 from argilla.server.enums import RecordInclude, RecordSortField, SimilarityOrder, SortOrder
 from argilla.server.schemas.base import UpdateSchema
 from argilla.server.schemas.v1.records import RecordUpdate
 from argilla.server.schemas.v1.suggestions import Suggestion, SuggestionCreate
 from argilla.server.search_engine import TextQuery
+from argilla.utils.pydantic import BaseModel, PositiveInt, conlist, constr, root_validator, validator
+from argilla.utils.pydantic import Field as PydanticField
+from argilla.utils.pydantic.generics import GenericModel
+from argilla.utils.pydantic.utils import GetterDict
 
 try:
     from typing import Annotated

--- a/src/argilla/server/schemas/v1/fields.py
+++ b/src/argilla/server/schemas/v1/fields.py
@@ -16,11 +16,10 @@ from datetime import datetime
 from typing import Literal, Optional
 from uuid import UUID
 
-from pydantic.v1 import BaseModel
-
 from argilla.server.enums import FieldType
 from argilla.server.schemas.base import UpdateSchema
 from argilla.server.schemas.v1.datasets import FieldTitle
+from argilla.utils.pydantic import BaseModel
 
 
 class TextFieldSettings(BaseModel):

--- a/src/argilla/server/schemas/v1/fields.py
+++ b/src/argilla/server/schemas/v1/fields.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from typing import Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from argilla.server.enums import FieldType
 from argilla.server.schemas.base import UpdateSchema

--- a/src/argilla/server/schemas/v1/fields.py
+++ b/src/argilla/server/schemas/v1/fields.py
@@ -19,7 +19,7 @@ from uuid import UUID
 from argilla.server.enums import FieldType
 from argilla.server.schemas.base import UpdateSchema
 from argilla.server.schemas.v1.datasets import FieldTitle
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 class TextFieldSettings(BaseModel):

--- a/src/argilla/server/schemas/v1/metadata_properties.py
+++ b/src/argilla/server/schemas/v1/metadata_properties.py
@@ -16,12 +16,11 @@ from datetime import datetime
 from typing import Generic, List, Literal, Optional, TypeVar, Union
 from uuid import UUID
 
-from pydantic.v1 import BaseModel, Field, validator
-from pydantic.v1.generics import GenericModel
-
 from argilla.server.enums import MetadataPropertyType
 from argilla.server.schemas.base import UpdateSchema
 from argilla.server.schemas.v1.datasets import MetadataPropertySettings, MetadataPropertyTitle
+from argilla.utils.pydantic import BaseModel, Field, validator
+from argilla.utils.pydantic.generics import GenericModel
 
 FLOAT_METADATA_METRICS_PRECISION = 5
 

--- a/src/argilla/server/schemas/v1/metadata_properties.py
+++ b/src/argilla/server/schemas/v1/metadata_properties.py
@@ -16,8 +16,8 @@ from datetime import datetime
 from typing import Generic, List, Literal, Optional, TypeVar, Union
 from uuid import UUID
 
-from pydantic import BaseModel, Field, validator
-from pydantic.generics import GenericModel
+from pydantic.v1 import BaseModel, Field, validator
+from pydantic.v1.generics import GenericModel
 
 from argilla.server.enums import MetadataPropertyType
 from argilla.server.schemas.base import UpdateSchema

--- a/src/argilla/server/schemas/v1/metadata_properties.py
+++ b/src/argilla/server/schemas/v1/metadata_properties.py
@@ -19,8 +19,7 @@ from uuid import UUID
 from argilla.server.enums import MetadataPropertyType
 from argilla.server.schemas.base import UpdateSchema
 from argilla.server.schemas.v1.datasets import MetadataPropertySettings, MetadataPropertyTitle
-from argilla.utils.pydantic import BaseModel, Field, validator
-from argilla.utils.pydantic.generics import GenericModel
+from argilla.utils._import_pydantic import BaseModel, Field, GenericModel, validator
 
 FLOAT_METADATA_METRICS_PRECISION = 5
 

--- a/src/argilla/server/schemas/v1/questions.py
+++ b/src/argilla/server/schemas/v1/questions.py
@@ -16,10 +16,9 @@ from datetime import datetime
 from typing import Literal, Optional, Union
 from uuid import UUID
 
-from pydantic.v1 import BaseModel, Field, PositiveInt, conlist
-
 from argilla.server.schemas.base import UpdateSchema
 from argilla.server.schemas.v1.datasets import QuestionDescription, QuestionTitle
+from argilla.utils.pydantic import BaseModel, Field, PositiveInt, conlist
 
 try:
     from typing import Annotated

--- a/src/argilla/server/schemas/v1/questions.py
+++ b/src/argilla/server/schemas/v1/questions.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from typing import Literal, Optional, Union
 from uuid import UUID
 
-from pydantic import BaseModel, Field, PositiveInt, conlist
+from pydantic.v1 import BaseModel, Field, PositiveInt, conlist
 
 from argilla.server.schemas.base import UpdateSchema
 from argilla.server.schemas.v1.datasets import QuestionDescription, QuestionTitle

--- a/src/argilla/server/schemas/v1/questions.py
+++ b/src/argilla/server/schemas/v1/questions.py
@@ -18,7 +18,7 @@ from uuid import UUID
 
 from argilla.server.schemas.base import UpdateSchema
 from argilla.server.schemas.v1.datasets import QuestionDescription, QuestionTitle
-from argilla.utils.pydantic import BaseModel, Field, PositiveInt, conlist
+from argilla.utils._import_pydantic import BaseModel, Field, PositiveInt, conlist
 
 try:
     from typing import Annotated

--- a/src/argilla/server/schemas/v1/records.py
+++ b/src/argilla/server/schemas/v1/records.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from argilla.server.models import ResponseStatus
 from argilla.server.schemas.base import UpdateSchema

--- a/src/argilla/server/schemas/v1/records.py
+++ b/src/argilla/server/schemas/v1/records.py
@@ -16,11 +16,10 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from pydantic.v1 import BaseModel, Field
-
 from argilla.server.models import ResponseStatus
 from argilla.server.schemas.base import UpdateSchema
 from argilla.server.schemas.v1.suggestions import SuggestionCreate
+from argilla.utils.pydantic import BaseModel, Field
 
 
 class ResponseValue(BaseModel):

--- a/src/argilla/server/schemas/v1/records.py
+++ b/src/argilla/server/schemas/v1/records.py
@@ -19,7 +19,7 @@ from uuid import UUID
 from argilla.server.models import ResponseStatus
 from argilla.server.schemas.base import UpdateSchema
 from argilla.server.schemas.v1.suggestions import SuggestionCreate
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 
 class ResponseValue(BaseModel):

--- a/src/argilla/server/schemas/v1/responses.py
+++ b/src/argilla/server/schemas/v1/responses.py
@@ -17,9 +17,9 @@ from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
 
 from fastapi import Body
-from pydantic.v1 import BaseModel, Field
 
 from argilla.server.models import ResponseStatus
+from argilla.utils.pydantic import BaseModel, Field
 
 try:
     from typing import Annotated

--- a/src/argilla/server/schemas/v1/responses.py
+++ b/src/argilla/server/schemas/v1/responses.py
@@ -19,7 +19,7 @@ from uuid import UUID
 from fastapi import Body
 
 from argilla.server.models import ResponseStatus
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 try:
     from typing import Annotated

--- a/src/argilla/server/schemas/v1/responses.py
+++ b/src/argilla/server/schemas/v1/responses.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
 
 from fastapi import Body
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from argilla.server.models import ResponseStatus
 

--- a/src/argilla/server/schemas/v1/suggestions.py
+++ b/src/argilla/server/schemas/v1/suggestions.py
@@ -15,9 +15,8 @@
 from typing import Any, List, Optional
 from uuid import UUID
 
-from pydantic.v1 import BaseModel, Field
-
 from argilla.server.models import SuggestionType
+from argilla.utils.pydantic import BaseModel, Field
 
 AGENT_REGEX = r"^(?=.*[a-zA-Z0-9])[a-zA-Z0-9-_:\.\/\s]+$"
 AGENT_MIN_LENGTH = 1

--- a/src/argilla/server/schemas/v1/suggestions.py
+++ b/src/argilla/server/schemas/v1/suggestions.py
@@ -15,7 +15,7 @@
 from typing import Any, List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from argilla.server.models import SuggestionType
 

--- a/src/argilla/server/schemas/v1/suggestions.py
+++ b/src/argilla/server/schemas/v1/suggestions.py
@@ -16,7 +16,7 @@ from typing import Any, List, Optional
 from uuid import UUID
 
 from argilla.server.models import SuggestionType
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 AGENT_REGEX = r"^(?=.*[a-zA-Z0-9])[a-zA-Z0-9-_:\.\/\s]+$"
 AGENT_MIN_LENGTH = 1

--- a/src/argilla/server/schemas/v1/vector_settings.py
+++ b/src/argilla/server/schemas/v1/vector_settings.py
@@ -16,10 +16,9 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
-from pydantic.v1 import BaseModel
-
 from argilla.server.schemas.base import UpdateSchema
 from argilla.server.schemas.v1.datasets import VectorSettingsTitle
+from argilla.utils.pydantic import BaseModel
 
 
 class VectorSettings(BaseModel):

--- a/src/argilla/server/schemas/v1/vector_settings.py
+++ b/src/argilla/server/schemas/v1/vector_settings.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from argilla.server.schemas.base import UpdateSchema
 from argilla.server.schemas.v1.datasets import VectorSettingsTitle

--- a/src/argilla/server/schemas/v1/vector_settings.py
+++ b/src/argilla/server/schemas/v1/vector_settings.py
@@ -18,7 +18,7 @@ from uuid import UUID
 
 from argilla.server.schemas.base import UpdateSchema
 from argilla.server.schemas.v1.datasets import VectorSettingsTitle
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 class VectorSettings(BaseModel):

--- a/src/argilla/server/schemas/v1/workspaces.py
+++ b/src/argilla/server/schemas/v1/workspaces.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from typing import List
 from uuid import UUID
 
-from pydantic.v1 import BaseModel
+from argilla.utils.pydantic import BaseModel
 
 
 class Workspace(BaseModel):

--- a/src/argilla/server/schemas/v1/workspaces.py
+++ b/src/argilla/server/schemas/v1/workspaces.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from typing import List
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class Workspace(BaseModel):

--- a/src/argilla/server/schemas/v1/workspaces.py
+++ b/src/argilla/server/schemas/v1/workspaces.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from typing import List
 from uuid import UUID
 
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 class Workspace(BaseModel):

--- a/src/argilla/server/search_engine/base.py
+++ b/src/argilla/server/search_engine/base.py
@@ -29,9 +29,6 @@ from typing import (
 )
 from uuid import UUID
 
-from pydantic.v1 import BaseModel, Field, root_validator
-from pydantic.v1.generics import GenericModel
-
 from argilla.server.enums import (
     MetadataPropertyType,
     RecordSortField,
@@ -40,6 +37,8 @@ from argilla.server.enums import (
     SortOrder,
 )
 from argilla.server.models import Dataset, MetadataProperty, Record, Response, Suggestion, User, Vector, VectorSettings
+from argilla.utils.pydantic import BaseModel, Field, root_validator
+from argilla.utils.pydantic.generics import GenericModel
 
 __all__ = [
     "SearchEngine",

--- a/src/argilla/server/search_engine/base.py
+++ b/src/argilla/server/search_engine/base.py
@@ -29,8 +29,8 @@ from typing import (
 )
 from uuid import UUID
 
-from pydantic import BaseModel, Field, root_validator
-from pydantic.generics import GenericModel
+from pydantic.v1 import BaseModel, Field, root_validator
+from pydantic.v1.generics import GenericModel
 
 from argilla.server.enums import (
     MetadataPropertyType,

--- a/src/argilla/server/search_engine/base.py
+++ b/src/argilla/server/search_engine/base.py
@@ -37,8 +37,7 @@ from argilla.server.enums import (
     SortOrder,
 )
 from argilla.server.models import Dataset, MetadataProperty, Record, Response, Suggestion, User, Vector, VectorSettings
-from argilla.utils.pydantic import BaseModel, Field, root_validator
-from argilla.utils.pydantic.generics import GenericModel
+from argilla.utils._import_pydantic import BaseModel, Field, GenericModel, root_validator
 
 __all__ = [
     "SearchEngine",

--- a/src/argilla/server/security/auth_provider/local/settings.py
+++ b/src/argilla/server/security/auth_provider/local/settings.py
@@ -13,7 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from pydantic import BaseSettings
+from pydantic.v1 import BaseSettings
 
 from argilla.server import helpers
 from argilla.server.settings import settings as server_settings

--- a/src/argilla/server/security/auth_provider/local/settings.py
+++ b/src/argilla/server/security/auth_provider/local/settings.py
@@ -13,10 +13,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from pydantic.v1 import BaseSettings
-
 from argilla.server import helpers
 from argilla.server.settings import settings as server_settings
+from argilla.utils.pydantic import BaseSettings
 
 
 class Settings(BaseSettings):

--- a/src/argilla/server/security/auth_provider/local/settings.py
+++ b/src/argilla/server/security/auth_provider/local/settings.py
@@ -15,7 +15,7 @@
 
 from argilla.server import helpers
 from argilla.server.settings import settings as server_settings
-from argilla.utils.pydantic import BaseSettings
+from argilla.utils._import_pydantic import BaseSettings
 
 
 class Settings(BaseSettings):

--- a/src/argilla/server/security/model.py
+++ b/src/argilla/server/security/model.py
@@ -18,8 +18,8 @@ from datetime import datetime
 from typing import Any, List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field, constr, root_validator, validator
-from pydantic.utils import GetterDict
+from pydantic.v1 import BaseModel, Field, constr, root_validator, validator
+from pydantic.v1.utils import GetterDict
 
 from argilla._constants import ES_INDEX_REGEX_PATTERN
 from argilla.server.errors import BadRequestError, EntityNotFoundError

--- a/src/argilla/server/security/model.py
+++ b/src/argilla/server/security/model.py
@@ -12,17 +12,13 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import re
-import uuid
 from datetime import datetime
 from typing import Any, List, Optional
 from uuid import UUID
 
 from argilla._constants import ES_INDEX_REGEX_PATTERN
-from argilla.server.errors import BadRequestError, EntityNotFoundError
 from argilla.server.models import UserRole
-from argilla.utils.pydantic import BaseModel, Field, constr, root_validator, validator
-from argilla.utils.pydantic.utils import GetterDict
+from argilla.utils._import_pydantic import BaseModel, Field, GetterDict, constr
 
 WORKSPACE_NAME_REGEX = ES_INDEX_REGEX_PATTERN
 

--- a/src/argilla/server/security/model.py
+++ b/src/argilla/server/security/model.py
@@ -18,12 +18,11 @@ from datetime import datetime
 from typing import Any, List, Optional
 from uuid import UUID
 
-from pydantic.v1 import BaseModel, Field, constr, root_validator, validator
-from pydantic.v1.utils import GetterDict
-
 from argilla._constants import ES_INDEX_REGEX_PATTERN
 from argilla.server.errors import BadRequestError, EntityNotFoundError
 from argilla.server.models import UserRole
+from argilla.utils.pydantic import BaseModel, Field, constr, root_validator, validator
+from argilla.utils.pydantic.utils import GetterDict
 
 WORKSPACE_NAME_REGEX = ES_INDEX_REGEX_PATTERN
 

--- a/src/argilla/server/server.py
+++ b/src/argilla/server/server.py
@@ -31,7 +31,7 @@ from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
-from pydantic import ConfigError, ValidationError
+from pydantic.v1 import ConfigError, ValidationError
 
 from argilla import __version__ as argilla_version
 from argilla._constants import DEFAULT_API_KEY, DEFAULT_PASSWORD, DEFAULT_USERNAME

--- a/src/argilla/server/server.py
+++ b/src/argilla/server/server.py
@@ -59,7 +59,7 @@ from argilla.server.routes import api_router
 from argilla.server.security import auth
 from argilla.server.settings import settings
 from argilla.server.static_rewrite import RewriteStaticFiles
-from argilla.utils.pydantic import ConfigError, ValidationError
+from argilla.utils._import_pydantic import ConfigError, ValidationError
 
 _LOGGER = logging.getLogger("argilla")
 

--- a/src/argilla/server/server.py
+++ b/src/argilla/server/server.py
@@ -31,7 +31,6 @@ from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
-from pydantic.v1 import ConfigError, ValidationError
 
 from argilla import __version__ as argilla_version
 from argilla._constants import DEFAULT_API_KEY, DEFAULT_PASSWORD, DEFAULT_USERNAME
@@ -60,6 +59,7 @@ from argilla.server.routes import api_router
 from argilla.server.security import auth
 from argilla.server.settings import settings
 from argilla.server.static_rewrite import RewriteStaticFiles
+from argilla.utils.pydantic import ConfigError, ValidationError
 
 _LOGGER = logging.getLogger("argilla")
 

--- a/src/argilla/server/services/info.py
+++ b/src/argilla/server/services/info.py
@@ -18,10 +18,10 @@ from typing import Any, Dict
 
 import psutil
 from fastapi import Depends
-from pydantic.v1 import BaseModel
 
 from argilla import __version__ as version
 from argilla.server.daos.backend import GenericElasticEngineBackend
+from argilla.utils.pydantic import BaseModel
 
 
 def size(bytes):

--- a/src/argilla/server/services/info.py
+++ b/src/argilla/server/services/info.py
@@ -18,7 +18,7 @@ from typing import Any, Dict
 
 import psutil
 from fastapi import Depends
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from argilla import __version__ as version
 from argilla.server.daos.backend import GenericElasticEngineBackend

--- a/src/argilla/server/services/info.py
+++ b/src/argilla/server/services/info.py
@@ -21,7 +21,7 @@ from fastapi import Depends
 
 from argilla import __version__ as version
 from argilla.server.daos.backend import GenericElasticEngineBackend
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 def size(bytes):

--- a/src/argilla/server/services/metrics/models.py
+++ b/src/argilla/server/services/metrics/models.py
@@ -14,10 +14,9 @@
 
 from typing import Any, ClassVar, Dict, Generic, Iterable, List, Optional, TypeVar, Union
 
-from pydantic.v1 import BaseModel, Field
-
 from argilla.server.services.search.model import ServiceRecordsQuery
 from argilla.server.services.tasks.commons import ServiceRecord
+from argilla.utils.pydantic import BaseModel, Field
 
 
 class ServiceBaseMetric(BaseModel):

--- a/src/argilla/server/services/metrics/models.py
+++ b/src/argilla/server/services/metrics/models.py
@@ -14,7 +14,7 @@
 
 from typing import Any, ClassVar, Dict, Generic, Iterable, List, Optional, TypeVar, Union
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from argilla.server.services.search.model import ServiceRecordsQuery
 from argilla.server.services.tasks.commons import ServiceRecord

--- a/src/argilla/server/services/metrics/models.py
+++ b/src/argilla/server/services/metrics/models.py
@@ -16,7 +16,7 @@ from typing import Any, ClassVar, Dict, Generic, Iterable, List, Optional, TypeV
 
 from argilla.server.services.search.model import ServiceRecordsQuery
 from argilla.server.services.tasks.commons import ServiceRecord
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 
 class ServiceBaseMetric(BaseModel):

--- a/src/argilla/server/services/search/model.py
+++ b/src/argilla/server/services/search/model.py
@@ -14,10 +14,9 @@
 
 from typing import Any, Dict, List, TypeVar
 
-from pydantic.v1 import BaseModel, Field
-
 from argilla.server.daos.backend.search.model import BaseRecordsQuery, QueryRange, SortableField, SortConfig
 from argilla.server.services.tasks.commons import ServiceRecord
+from argilla.utils.pydantic import BaseModel, Field
 
 
 class ServiceBaseRecordsQuery(BaseRecordsQuery):

--- a/src/argilla/server/services/search/model.py
+++ b/src/argilla/server/services/search/model.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from argilla.server.daos.backend.search.model import BaseRecordsQuery, QueryRange, SortableField, SortConfig
 from argilla.server.services.tasks.commons import ServiceRecord

--- a/src/argilla/server/services/search/model.py
+++ b/src/argilla/server/services/search/model.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, TypeVar
 
 from argilla.server.daos.backend.search.model import BaseRecordsQuery, QueryRange, SortableField, SortConfig
 from argilla.server.services.tasks.commons import ServiceRecord
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 
 class ServiceBaseRecordsQuery(BaseRecordsQuery):

--- a/src/argilla/server/services/tasks/commons/models.py
+++ b/src/argilla/server/services/tasks/commons/models.py
@@ -14,7 +14,7 @@
 
 from typing import Generic, TypeVar
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from argilla.server.daos.models.records import BaseAnnotationDB, BaseRecordDB, BaseRecordInDB
 

--- a/src/argilla/server/services/tasks/commons/models.py
+++ b/src/argilla/server/services/tasks/commons/models.py
@@ -14,9 +14,8 @@
 
 from typing import Generic, TypeVar
 
-from pydantic.v1 import BaseModel
-
 from argilla.server.daos.models.records import BaseAnnotationDB, BaseRecordDB, BaseRecordInDB
+from argilla.utils.pydantic import BaseModel
 
 
 class ServiceBaseAnnotation(BaseAnnotationDB):

--- a/src/argilla/server/services/tasks/commons/models.py
+++ b/src/argilla/server/services/tasks/commons/models.py
@@ -15,7 +15,7 @@
 from typing import Generic, TypeVar
 
 from argilla.server.daos.models.records import BaseAnnotationDB, BaseRecordDB, BaseRecordInDB
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 class ServiceBaseAnnotation(BaseAnnotationDB):

--- a/src/argilla/server/services/tasks/text2text/models.py
+++ b/src/argilla/server/services/tasks/text2text/models.py
@@ -14,7 +14,7 @@
 
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from argilla.server.commons.models import PredictionStatus, TaskType
 from argilla.server.services.search.model import ServiceBaseRecordsQuery, ServiceScoreRange

--- a/src/argilla/server/services/tasks/text2text/models.py
+++ b/src/argilla/server/services/tasks/text2text/models.py
@@ -14,11 +14,10 @@
 
 from typing import Any, Dict, List, Optional
 
-from pydantic.v1 import BaseModel, Field
-
 from argilla.server.commons.models import PredictionStatus, TaskType
 from argilla.server.services.search.model import ServiceBaseRecordsQuery, ServiceScoreRange
 from argilla.server.services.tasks.commons import ServiceBaseAnnotation, ServiceBaseRecord
+from argilla.utils.pydantic import BaseModel, Field
 
 
 class ServiceText2TextPrediction(BaseModel):

--- a/src/argilla/server/services/tasks/text2text/models.py
+++ b/src/argilla/server/services/tasks/text2text/models.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Optional
 from argilla.server.commons.models import PredictionStatus, TaskType
 from argilla.server.services.search.model import ServiceBaseRecordsQuery, ServiceScoreRange
 from argilla.server.services.tasks.commons import ServiceBaseAnnotation, ServiceBaseRecord
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 
 class ServiceText2TextPrediction(BaseModel):

--- a/src/argilla/server/services/tasks/text_classification/metrics.py
+++ b/src/argilla/server/services/tasks/text_classification/metrics.py
@@ -14,13 +14,12 @@
 
 from typing import Any, ClassVar, Dict, Iterable, List
 
-from pydantic.v1 import Field
-
 from argilla.server.services.metrics import ServiceBaseMetric, ServicePythonMetric
 from argilla.server.services.metrics.models import CommonTasksMetrics
 from argilla.server.services.search.model import ServiceRecordsQuery
 from argilla.server.services.tasks.text_classification.model import ServiceTextClassificationRecord
 from argilla.utils.dependency import requires_dependencies
+from argilla.utils.pydantic import Field
 
 
 class F1Metric(ServicePythonMetric):

--- a/src/argilla/server/services/tasks/text_classification/metrics.py
+++ b/src/argilla/server/services/tasks/text_classification/metrics.py
@@ -18,8 +18,8 @@ from argilla.server.services.metrics import ServiceBaseMetric, ServicePythonMetr
 from argilla.server.services.metrics.models import CommonTasksMetrics
 from argilla.server.services.search.model import ServiceRecordsQuery
 from argilla.server.services.tasks.text_classification.model import ServiceTextClassificationRecord
+from argilla.utils._import_pydantic import Field
 from argilla.utils.dependency import requires_dependencies
-from argilla.utils.pydantic import Field
 
 
 class F1Metric(ServicePythonMetric):

--- a/src/argilla/server/services/tasks/text_classification/metrics.py
+++ b/src/argilla/server/services/tasks/text_classification/metrics.py
@@ -14,7 +14,7 @@
 
 from typing import Any, ClassVar, Dict, Iterable, List
 
-from pydantic import Field
+from pydantic.v1 import Field
 
 from argilla.server.services.metrics import ServiceBaseMetric, ServicePythonMetric
 from argilla.server.services.metrics.models import CommonTasksMetrics

--- a/src/argilla/server/services/tasks/text_classification/model.py
+++ b/src/argilla/server/services/tasks/text_classification/model.py
@@ -16,7 +16,7 @@
 from datetime import datetime
 from typing import Any, ClassVar, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field, root_validator, validator
+from pydantic.v1 import BaseModel, Field, root_validator, validator
 
 from argilla._constants import DEFAULT_MAX_KEYWORD_LENGTH
 from argilla.server.commons.models import PredictionStatus, TaskStatus, TaskType

--- a/src/argilla/server/services/tasks/text_classification/model.py
+++ b/src/argilla/server/services/tasks/text_classification/model.py
@@ -16,14 +16,13 @@
 from datetime import datetime
 from typing import Any, ClassVar, Dict, List, Optional, Union
 
-from pydantic.v1 import BaseModel, Field, root_validator, validator
-
 from argilla._constants import DEFAULT_MAX_KEYWORD_LENGTH
 from argilla.server.commons.models import PredictionStatus, TaskStatus, TaskType
 from argilla.server.helpers import flatten_dict
 from argilla.server.services.datasets import ServiceBaseDataset
 from argilla.server.services.search.model import ServiceBaseRecordsQuery, ServiceScoreRange
 from argilla.server.services.tasks.commons import ServiceBaseAnnotation, ServiceBaseRecord
+from argilla.utils.pydantic import BaseModel, Field, root_validator, validator
 
 
 class ServiceLabelingRule(BaseModel):

--- a/src/argilla/server/services/tasks/text_classification/model.py
+++ b/src/argilla/server/services/tasks/text_classification/model.py
@@ -22,7 +22,7 @@ from argilla.server.helpers import flatten_dict
 from argilla.server.services.datasets import ServiceBaseDataset
 from argilla.server.services.search.model import ServiceBaseRecordsQuery, ServiceScoreRange
 from argilla.server.services.tasks.commons import ServiceBaseAnnotation, ServiceBaseRecord
-from argilla.utils.pydantic import BaseModel, Field, root_validator, validator
+from argilla.utils._import_pydantic import BaseModel, Field, root_validator, validator
 
 
 class ServiceLabelingRule(BaseModel):

--- a/src/argilla/server/services/tasks/token_classification/metrics.py
+++ b/src/argilla/server/services/tasks/token_classification/metrics.py
@@ -23,7 +23,7 @@ from argilla.server.services.tasks.token_classification.model import (
     ServiceTokenClassificationRecord,
 )
 from argilla.utils import SpanUtils
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 
 class F1Metric(ServicePythonMetric[ServiceTokenClassificationRecord]):

--- a/src/argilla/server/services/tasks/token_classification/metrics.py
+++ b/src/argilla/server/services/tasks/token_classification/metrics.py
@@ -14,8 +14,6 @@
 
 from typing import Any, ClassVar, Dict, Iterable, List, Optional, Set, Tuple
 
-from pydantic.v1 import BaseModel, Field
-
 from argilla.server.services.metrics import ServiceBaseMetric, ServicePythonMetric
 from argilla.server.services.metrics.models import CommonTasksMetrics
 from argilla.server.services.search.model import ServiceRecordsQuery
@@ -25,6 +23,7 @@ from argilla.server.services.tasks.token_classification.model import (
     ServiceTokenClassificationRecord,
 )
 from argilla.utils import SpanUtils
+from argilla.utils.pydantic import BaseModel, Field
 
 
 class F1Metric(ServicePythonMetric[ServiceTokenClassificationRecord]):

--- a/src/argilla/server/services/tasks/token_classification/metrics.py
+++ b/src/argilla/server/services/tasks/token_classification/metrics.py
@@ -14,7 +14,7 @@
 
 from typing import Any, ClassVar, Dict, Iterable, List, Optional, Set, Tuple
 
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from argilla.server.services.metrics import ServiceBaseMetric, ServicePythonMetric
 from argilla.server.services.metrics.models import CommonTasksMetrics

--- a/src/argilla/server/services/tasks/token_classification/model.py
+++ b/src/argilla/server/services/tasks/token_classification/model.py
@@ -15,13 +15,12 @@
 
 from typing import Dict, List, Optional, Set, Tuple
 
-from pydantic.v1 import BaseModel, Field, validator
-
 from argilla._constants import DEFAULT_MAX_KEYWORD_LENGTH
 from argilla.server.commons.models import PredictionStatus, TaskType
 from argilla.server.services.search.model import ServiceBaseRecordsQuery, ServiceScoreRange
 from argilla.server.services.tasks.commons import ServiceBaseAnnotation, ServiceBaseRecord
 from argilla.utils import SpanUtils
+from argilla.utils.pydantic import BaseModel, Field, validator
 
 PREDICTED_MENTIONS_ES_FIELD_NAME = "predicted_mentions"
 MENTIONS_ES_FIELD_NAME = "mentions"

--- a/src/argilla/server/services/tasks/token_classification/model.py
+++ b/src/argilla/server/services/tasks/token_classification/model.py
@@ -15,7 +15,7 @@
 
 from typing import Dict, List, Optional, Set, Tuple
 
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 from argilla._constants import DEFAULT_MAX_KEYWORD_LENGTH
 from argilla.server.commons.models import PredictionStatus, TaskType

--- a/src/argilla/server/services/tasks/token_classification/model.py
+++ b/src/argilla/server/services/tasks/token_classification/model.py
@@ -20,7 +20,7 @@ from argilla.server.commons.models import PredictionStatus, TaskType
 from argilla.server.services.search.model import ServiceBaseRecordsQuery, ServiceScoreRange
 from argilla.server.services.tasks.commons import ServiceBaseAnnotation, ServiceBaseRecord
 from argilla.utils import SpanUtils
-from argilla.utils.pydantic import BaseModel, Field, validator
+from argilla.utils._import_pydantic import BaseModel, Field, validator
 
 PREDICTED_MENTIONS_ES_FIELD_NAME = "predicted_mentions"
 MENTIONS_ES_FIELD_NAME = "mentions"

--- a/src/argilla/server/settings.py
+++ b/src/argilla/server/settings.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import List, Optional
 from urllib.parse import urlparse
 
-from pydantic import BaseSettings, Field, root_validator, validator
+from pydantic.v1 import BaseSettings, Field, root_validator, validator
 
 from argilla._constants import DEFAULT_MAX_KEYWORD_LENGTH, DEFAULT_TELEMETRY_KEY
 

--- a/src/argilla/server/settings.py
+++ b/src/argilla/server/settings.py
@@ -25,7 +25,7 @@ from typing import List, Optional
 from urllib.parse import urlparse
 
 from argilla._constants import DEFAULT_MAX_KEYWORD_LENGTH, DEFAULT_TELEMETRY_KEY
-from argilla.utils.pydantic import BaseSettings, Field, root_validator, validator
+from argilla.utils._import_pydantic import BaseSettings, Field, root_validator, validator
 
 
 class Settings(BaseSettings):

--- a/src/argilla/server/settings.py
+++ b/src/argilla/server/settings.py
@@ -24,9 +24,8 @@ from pathlib import Path
 from typing import List, Optional
 from urllib.parse import urlparse
 
-from pydantic.v1 import BaseSettings, Field, root_validator, validator
-
 from argilla._constants import DEFAULT_MAX_KEYWORD_LENGTH, DEFAULT_TELEMETRY_KEY
+from argilla.utils.pydantic import BaseSettings, Field, root_validator, validator
 
 
 class Settings(BaseSettings):

--- a/src/argilla/server/utils.py
+++ b/src/argilla/server/utils.py
@@ -18,7 +18,8 @@ from typing import Any, Callable, Dict, List, Optional, Set, Type, TypeVar, Unio
 from uuid import UUID
 
 from fastapi import HTTPException, Query
-from pydantic.v1 import BaseModel
+
+from argilla.utils.pydantic import BaseModel
 
 
 # TODO: remove this function at some point
@@ -81,7 +82,7 @@ def parse_query_param(
     In addition, if a `pydantic.BaseModel` is provided, the dictionary is parsed into an instance of that model:
 
         ```python
-        from pydantic.v1 import BaseModel, Field
+        from argilla.utils.pydantic import BaseModel, Field
 
 
         class Params(BaseModel):

--- a/src/argilla/server/utils.py
+++ b/src/argilla/server/utils.py
@@ -19,7 +19,7 @@ from uuid import UUID
 
 from fastapi import HTTPException, Query
 
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 
 
 # TODO: remove this function at some point
@@ -82,7 +82,7 @@ def parse_query_param(
     In addition, if a `pydantic.BaseModel` is provided, the dictionary is parsed into an instance of that model:
 
         ```python
-        from argilla.utils.pydantic import BaseModel, Field
+        from pydantic import BaseModel, Field
 
 
         class Params(BaseModel):

--- a/src/argilla/server/utils.py
+++ b/src/argilla/server/utils.py
@@ -18,7 +18,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Type, TypeVar, Unio
 from uuid import UUID
 
 from fastapi import HTTPException, Query
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 # TODO: remove this function at some point
@@ -81,7 +81,7 @@ def parse_query_param(
     In addition, if a `pydantic.BaseModel` is provided, the dictionary is parsed into an instance of that model:
 
         ```python
-        from pydantic import BaseModel, Field
+        from pydantic.v1 import BaseModel, Field
 
 
         class Params(BaseModel):

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -19,8 +19,8 @@ from typing import Any, Dict, List, Literal, Optional, Union
 
 from argilla.client.models import TextClassificationRecord, TokenClassificationRecord
 from argilla.training.base import ArgillaTrainerSkeleton
+from argilla.utils._import_pydantic import BaseModel
 from argilla.utils.dependency import require_dependencies
-from argilla.utils.pydantic import BaseModel
 
 __all__ = ["ArgillaSpaCyTrainer", "ArgillaSpaCyTransformersTrainer"]
 

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -17,7 +17,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 from argilla.client.models import TextClassificationRecord, TokenClassificationRecord
 from argilla.training.base import ArgillaTrainerSkeleton

--- a/src/argilla/training/spacy.py
+++ b/src/argilla/training/spacy.py
@@ -17,11 +17,10 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic.v1 import BaseModel
-
 from argilla.client.models import TextClassificationRecord, TokenClassificationRecord
 from argilla.training.base import ArgillaTrainerSkeleton
 from argilla.utils.dependency import require_dependencies
+from argilla.utils.pydantic import BaseModel
 
 __all__ = ["ArgillaSpaCyTrainer", "ArgillaSpaCyTransformersTrainer"]
 

--- a/src/argilla/utils/_import_pydantic.py
+++ b/src/argilla/utils/_import_pydantic.py
@@ -14,5 +14,9 @@
 
 try:
     from pydantic.v1 import *  # noqa: F403
+    from pydantic.v1.generics import *  # noqa: F403
+    from pydantic.v1.utils import *  # noqa: F403
 except ImportError:
     from pydantic import *  # noqa: F403
+    from pydantic.generics import *  # noqa: F403
+    from pydantic.utils import *  # noqa: F403

--- a/src/argilla/utils/pydantic.py
+++ b/src/argilla/utils/pydantic.py
@@ -12,16 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Any, Literal, Optional
-from uuid import UUID
-
-from argilla.utils.pydantic import BaseModel
-
-
-class SuggestionModel(BaseModel):
-    id: UUID
-    question_id: UUID
-    value: Any
-    type: Optional[Literal["model", "human"]] = None
-    score: Optional[float] = None
-    agent: Optional[str] = None
+try:
+    from pydantic.v1 import *  # noqa: F403
+except ImportError:
+    from pydantic import *  # noqa: F403

--- a/tests/integration/client/feedback/dataset/remote/test_dataset.py
+++ b/tests/integration/client/feedback/dataset/remote/test_dataset.py
@@ -49,6 +49,7 @@ from argilla.client.sdk.commons.errors import ValidationApiError
 from argilla.client.sdk.users.models import UserRole
 from argilla.client.workspaces import Workspace
 from argilla.server.models import User as ServerUser
+from argilla.server.settings import settings
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tests.factories import (

--- a/tests/integration/client/test_models.py
+++ b/tests/integration/client/test_models.py
@@ -26,7 +26,7 @@ from argilla.client.models import (
     TokenClassificationRecord,
     _Validators,
 )
-from argilla.utils.pydantic import ValidationError
+from argilla.utils._import_pydantic import ValidationError
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/client/test_models.py
+++ b/tests/integration/client/test_models.py
@@ -26,7 +26,7 @@ from argilla.client.models import (
     TokenClassificationRecord,
     _Validators,
 )
-from pydantic.v1 import ValidationError
+from argilla.utils.pydantic import ValidationError
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/client/test_models.py
+++ b/tests/integration/client/test_models.py
@@ -26,7 +26,7 @@ from argilla.client.models import (
     TokenClassificationRecord,
     _Validators,
 )
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -34,9 +34,9 @@ from argilla.server.models import User, UserRole, Workspace
 from argilla.server.server import app
 from argilla.server.settings import settings
 from argilla.utils import telemetry
+from argilla.utils.pydantic import BaseModel
 from argilla.utils.telemetry import TelemetryClient
 from fastapi.testclient import TestClient
-from pydantic.v1 import BaseModel
 from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -36,7 +36,7 @@ from argilla.server.settings import settings
 from argilla.utils import telemetry
 from argilla.utils.telemetry import TelemetryClient
 from fastapi.testclient import TestClient
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -34,7 +34,7 @@ from argilla.server.models import User, UserRole, Workspace
 from argilla.server.server import app
 from argilla.server.settings import settings
 from argilla.utils import telemetry
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 from argilla.utils.telemetry import TelemetryClient
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine

--- a/tests/unit/client/feedback/dataset/test_helpers.py
+++ b/tests/unit/client/feedback/dataset/test_helpers.py
@@ -26,7 +26,7 @@ from argilla.client.feedback.schemas.remote.metadata import (
     RemoteIntegerMetadataProperty,
     RemoteTermsMetadataProperty,
 )
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 if TYPE_CHECKING:
     from argilla.client.feedback.schemas.types import AllowedMetadataPropertyTypes, AllowedRemoteMetadataPropertyTypes

--- a/tests/unit/client/feedback/dataset/test_helpers.py
+++ b/tests/unit/client/feedback/dataset/test_helpers.py
@@ -26,7 +26,7 @@ from argilla.client.feedback.schemas.remote.metadata import (
     RemoteIntegerMetadataProperty,
     RemoteTermsMetadataProperty,
 )
-from pydantic.v1 import ValidationError
+from argilla.utils.pydantic import ValidationError
 
 if TYPE_CHECKING:
     from argilla.client.feedback.schemas.types import AllowedMetadataPropertyTypes, AllowedRemoteMetadataPropertyTypes

--- a/tests/unit/client/feedback/dataset/test_helpers.py
+++ b/tests/unit/client/feedback/dataset/test_helpers.py
@@ -26,7 +26,7 @@ from argilla.client.feedback.schemas.remote.metadata import (
     RemoteIntegerMetadataProperty,
     RemoteTermsMetadataProperty,
 )
-from argilla.utils.pydantic import ValidationError
+from argilla.utils._import_pydantic import ValidationError
 
 if TYPE_CHECKING:
     from argilla.client.feedback.schemas.types import AllowedMetadataPropertyTypes, AllowedRemoteMetadataPropertyTypes

--- a/tests/unit/client/feedback/schemas/test_fields.py
+++ b/tests/unit/client/feedback/schemas/test_fields.py
@@ -17,7 +17,7 @@ from typing import Any, Dict
 import pytest
 from argilla.client.feedback.schemas.enums import FieldTypes
 from argilla.client.feedback.schemas.fields import TextField
-from argilla.utils.pydantic import ValidationError
+from argilla.utils._import_pydantic import ValidationError
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/client/feedback/schemas/test_fields.py
+++ b/tests/unit/client/feedback/schemas/test_fields.py
@@ -17,7 +17,7 @@ from typing import Any, Dict
 import pytest
 from argilla.client.feedback.schemas.enums import FieldTypes
 from argilla.client.feedback.schemas.fields import TextField
-from pydantic.v1 import ValidationError
+from argilla.utils.pydantic import ValidationError
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/client/feedback/schemas/test_fields.py
+++ b/tests/unit/client/feedback/schemas/test_fields.py
@@ -17,7 +17,7 @@ from typing import Any, Dict
 import pytest
 from argilla.client.feedback.schemas.enums import FieldTypes
 from argilla.client.feedback.schemas.fields import TextField
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/client/feedback/schemas/test_metadata.py
+++ b/tests/unit/client/feedback/schemas/test_metadata.py
@@ -24,7 +24,7 @@ from argilla.client.feedback.schemas.metadata import (
     TermsMetadataFilter,
     TermsMetadataProperty,
 )
-from pydantic.v1 import ValidationError, create_model
+from argilla.utils.pydantic import ValidationError, create_model
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/client/feedback/schemas/test_metadata.py
+++ b/tests/unit/client/feedback/schemas/test_metadata.py
@@ -24,7 +24,7 @@ from argilla.client.feedback.schemas.metadata import (
     TermsMetadataFilter,
     TermsMetadataProperty,
 )
-from pydantic import ValidationError, create_model
+from pydantic.v1 import ValidationError, create_model
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/client/feedback/schemas/test_metadata.py
+++ b/tests/unit/client/feedback/schemas/test_metadata.py
@@ -24,7 +24,7 @@ from argilla.client.feedback.schemas.metadata import (
     TermsMetadataFilter,
     TermsMetadataProperty,
 )
-from argilla.utils.pydantic import ValidationError, create_model
+from argilla.utils._import_pydantic import ValidationError, create_model
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/client/feedback/schemas/test_questions.py
+++ b/tests/unit/client/feedback/schemas/test_questions.py
@@ -24,7 +24,7 @@ from argilla.client.feedback.schemas.questions import (
     TextQuestion,
     _LabelQuestion,
 )
-from argilla.utils.pydantic import ValidationError
+from argilla.utils._import_pydantic import ValidationError
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/client/feedback/schemas/test_questions.py
+++ b/tests/unit/client/feedback/schemas/test_questions.py
@@ -24,7 +24,7 @@ from argilla.client.feedback.schemas.questions import (
     TextQuestion,
     _LabelQuestion,
 )
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/client/feedback/schemas/test_questions.py
+++ b/tests/unit/client/feedback/schemas/test_questions.py
@@ -24,7 +24,7 @@ from argilla.client.feedback.schemas.questions import (
     TextQuestion,
     _LabelQuestion,
 )
-from pydantic.v1 import ValidationError
+from argilla.utils.pydantic import ValidationError
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/client/feedback/schemas/test_records.py
+++ b/tests/unit/client/feedback/schemas/test_records.py
@@ -23,7 +23,7 @@ from argilla.client.feedback.schemas.records import (
     SuggestionSchema,
     ValueSchema,
 )
-from argilla.utils.pydantic import ValidationError
+from argilla.utils._import_pydantic import ValidationError
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/client/feedback/schemas/test_records.py
+++ b/tests/unit/client/feedback/schemas/test_records.py
@@ -23,7 +23,7 @@ from argilla.client.feedback.schemas.records import (
     SuggestionSchema,
     ValueSchema,
 )
-from pydantic.v1 import ValidationError
+from argilla.utils.pydantic import ValidationError
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/client/feedback/schemas/test_records.py
+++ b/tests/unit/client/feedback/schemas/test_records.py
@@ -23,7 +23,7 @@ from argilla.client.feedback.schemas.records import (
     SuggestionSchema,
     ValueSchema,
 )
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/client/feedback/schemas/test_utils.py
+++ b/tests/unit/client/feedback/schemas/test_utils.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from argilla.client.feedback.schemas.utils import LabelMappingMixin
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 
 
 def test_label_mapping_mixin() -> None:

--- a/tests/unit/client/feedback/schemas/test_utils.py
+++ b/tests/unit/client/feedback/schemas/test_utils.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from argilla.client.feedback.schemas.utils import LabelMappingMixin
-from pydantic.v1 import BaseModel, Field
+from argilla.utils.pydantic import BaseModel, Field
 
 
 def test_label_mapping_mixin() -> None:

--- a/tests/unit/client/feedback/schemas/test_utils.py
+++ b/tests/unit/client/feedback/schemas/test_utils.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 from argilla.client.feedback.schemas.utils import LabelMappingMixin
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 def test_label_mapping_mixin() -> None:

--- a/tests/unit/server/commons/test_settings.py
+++ b/tests/unit/server/commons/test_settings.py
@@ -14,7 +14,7 @@
 
 import pytest
 from argilla.server.settings import Settings
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 
 @pytest.mark.parametrize("bad_namespace", ["Badns", "bad-ns", "12-bad-ns", "@bad"])

--- a/tests/unit/server/commons/test_settings.py
+++ b/tests/unit/server/commons/test_settings.py
@@ -14,7 +14,7 @@
 
 import pytest
 from argilla.server.settings import Settings
-from argilla.utils.pydantic import ValidationError
+from argilla.utils._import_pydantic import ValidationError
 
 
 @pytest.mark.parametrize("bad_namespace", ["Badns", "bad-ns", "12-bad-ns", "@bad"])

--- a/tests/unit/server/commons/test_settings.py
+++ b/tests/unit/server/commons/test_settings.py
@@ -14,7 +14,7 @@
 
 import pytest
 from argilla.server.settings import Settings
-from pydantic.v1 import ValidationError
+from argilla.utils.pydantic import ValidationError
 
 
 @pytest.mark.parametrize("bad_namespace", ["Badns", "bad-ns", "12-bad-ns", "@bad"])

--- a/tests/unit/server/models/old_models/test_datasets.py
+++ b/tests/unit/server/models/old_models/test_datasets.py
@@ -19,7 +19,7 @@ import pytest
 from argilla.server.commons.models import TaskType
 from argilla.server.daos.models.datasets import BaseDatasetDB
 from argilla.server.schemas.v0.datasets import CreateDatasetRequest, Dataset
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/server/models/old_models/test_datasets.py
+++ b/tests/unit/server/models/old_models/test_datasets.py
@@ -19,7 +19,7 @@ import pytest
 from argilla.server.commons.models import TaskType
 from argilla.server.daos.models.datasets import BaseDatasetDB
 from argilla.server.schemas.v0.datasets import CreateDatasetRequest, Dataset
-from argilla.utils.pydantic import ValidationError
+from argilla.utils._import_pydantic import ValidationError
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/server/models/old_models/test_datasets.py
+++ b/tests/unit/server/models/old_models/test_datasets.py
@@ -19,7 +19,7 @@ import pytest
 from argilla.server.commons.models import TaskType
 from argilla.server.daos.models.datasets import BaseDatasetDB
 from argilla.server.schemas.v0.datasets import CreateDatasetRequest, Dataset
-from pydantic.v1 import ValidationError
+from argilla.utils.pydantic import ValidationError
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/server/models/old_models/test_text_classification.py
+++ b/tests/unit/server/models/old_models/test_text_classification.py
@@ -25,7 +25,7 @@ from argilla.server.services.tasks.text_classification.model import (
     ClassPrediction,
     ServiceTextClassificationRecord,
 )
-from pydantic.v1 import ValidationError
+from argilla.utils.pydantic import ValidationError
 
 
 def test_flatten_metadata():

--- a/tests/unit/server/models/old_models/test_text_classification.py
+++ b/tests/unit/server/models/old_models/test_text_classification.py
@@ -25,7 +25,7 @@ from argilla.server.services.tasks.text_classification.model import (
     ClassPrediction,
     ServiceTextClassificationRecord,
 )
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 
 def test_flatten_metadata():

--- a/tests/unit/server/models/old_models/test_text_classification.py
+++ b/tests/unit/server/models/old_models/test_text_classification.py
@@ -25,7 +25,7 @@ from argilla.server.services.tasks.text_classification.model import (
     ClassPrediction,
     ServiceTextClassificationRecord,
 )
-from argilla.utils.pydantic import ValidationError
+from argilla.utils._import_pydantic import ValidationError
 
 
 def test_flatten_metadata():

--- a/tests/unit/server/models/old_models/test_token_classification.py
+++ b/tests/unit/server/models/old_models/test_token_classification.py
@@ -26,7 +26,7 @@ from argilla.server.services.tasks.token_classification.model import (
     EntitySpan,
     ServiceTokenClassificationRecord,
 )
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 
 def test_char_position():

--- a/tests/unit/server/models/old_models/test_token_classification.py
+++ b/tests/unit/server/models/old_models/test_token_classification.py
@@ -26,7 +26,7 @@ from argilla.server.services.tasks.token_classification.model import (
     EntitySpan,
     ServiceTokenClassificationRecord,
 )
-from pydantic.v1 import ValidationError
+from argilla.utils.pydantic import ValidationError
 
 
 def test_char_position():

--- a/tests/unit/server/models/old_models/test_token_classification.py
+++ b/tests/unit/server/models/old_models/test_token_classification.py
@@ -26,7 +26,7 @@ from argilla.server.services.tasks.token_classification.model import (
     EntitySpan,
     ServiceTokenClassificationRecord,
 )
-from argilla.utils.pydantic import ValidationError
+from argilla.utils._import_pydantic import ValidationError
 
 
 def test_char_position():

--- a/tests/unit/server/models/test_base.py
+++ b/tests/unit/server/models/test_base.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 import pytest
 import pytest_asyncio
 from argilla.server.models.base import DatabaseModel
-from argilla.utils.pydantic import BaseModel
+from argilla.utils._import_pydantic import BaseModel
 from sqlalchemy import JSON, inspect, select
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column

--- a/tests/unit/server/models/test_base.py
+++ b/tests/unit/server/models/test_base.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 import pytest
 import pytest_asyncio
 from argilla.server.models.base import DatabaseModel
-from pydantic.v1 import BaseModel
+from argilla.utils.pydantic import BaseModel
 from sqlalchemy import JSON, inspect, select
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column

--- a/tests/unit/server/models/test_base.py
+++ b/tests/unit/server/models/test_base.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 import pytest
 import pytest_asyncio
 from argilla.server.models.base import DatabaseModel
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 from sqlalchemy import JSON, inspect, select
 from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import Mapped, mapped_column

--- a/tests/unit/server/security/test_model.py
+++ b/tests/unit/server/security/test_model.py
@@ -16,7 +16,7 @@ from typing import Union
 
 import pytest
 from argilla.server.security.model import User, UserCreate, WorkspaceCreate
-from pydantic.v1 import ValidationError
+from argilla.utils.pydantic import ValidationError
 
 from tests.factories import UserFactory, WorkspaceFactory
 

--- a/tests/unit/server/security/test_model.py
+++ b/tests/unit/server/security/test_model.py
@@ -16,7 +16,7 @@ from typing import Union
 
 import pytest
 from argilla.server.security.model import User, UserCreate, WorkspaceCreate
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 from tests.factories import UserFactory, WorkspaceFactory
 

--- a/tests/unit/server/security/test_model.py
+++ b/tests/unit/server/security/test_model.py
@@ -16,7 +16,7 @@ from typing import Union
 
 import pytest
 from argilla.server.security.model import User, UserCreate, WorkspaceCreate
-from argilla.utils.pydantic import ValidationError
+from argilla.utils._import_pydantic import ValidationError
 
 from tests.factories import UserFactory, WorkspaceFactory
 

--- a/tests/unit/server/test_utils.py
+++ b/tests/unit/server/test_utils.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Set
 import pytest
 from argilla.server.utils import parse_query_param
 from fastapi import HTTPException
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/server/test_utils.py
+++ b/tests/unit/server/test_utils.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Set
 
 import pytest
 from argilla.server.utils import parse_query_param
-from argilla.utils.pydantic import BaseModel, Field
+from argilla.utils._import_pydantic import BaseModel, Field
 from fastapi import HTTPException
 
 

--- a/tests/unit/server/test_utils.py
+++ b/tests/unit/server/test_utils.py
@@ -16,8 +16,8 @@ from typing import Any, Dict, List, Set
 
 import pytest
 from argilla.server.utils import parse_query_param
+from argilla.utils.pydantic import BaseModel, Field
 from fastapi import HTTPException
-from pydantic.v1 import BaseModel, Field
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

This PR relax the `pydantic` constraint so `pydantic>=2.0.0` works also. In order to make `argilla` work with both pydantic versions:

1. Create `argilla.utils.pydantic` module that tries to import everything from `pydantic.v1`. If it fails imports everything from `pydantic`.
2. Update all the imports `from pydantic import ...` -> `from argilla.utils.pydantic import ...`
3. Relax `spacy` constraint that hardly depended on `pydantic<2.0.0`

We would still need to update the code to use the V2, but with this we allow users to have `pydantic>=2.0.0` and `argilla` installed in the same virtual environment.

Closes #3369

**Type of change**

- [x] New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
