### PR TITLE
refactor: move Question schemas to his own file and unify canonical Question schema adding dataset_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ These are the section headers that we use:
 - Added pydantic v2 support using the python SDK ([#4459](https://github.com/argilla-io/argilla/pull/4459))
 - API v1 responses returning `Record` schema now always include `dataset_id` as attribute. ([#4482](https://github.com/argilla-io/argilla/pull/4482))
 - API v1 responses returning `Response` schema now always include `record_id` as attribute. ([#4482](https://github.com/argilla-io/argilla/pull/4482))
+- API v1 responses returning `Question` schema now always include `dataset_id` attribute. ([]())
 
 ### Changed
 
@@ -35,7 +36,6 @@ These are the section headers that we use:
 ## Removed
 
 - The deprecated `python -m argilla database` command has been removed. ([#4472](https://github.com/argilla-io/argilla/pull/4472))
-
 
 ## [1.21.0](https://github.com/argilla-io/argilla/compare/v1.20.0...v1.21.0)
 
@@ -50,7 +50,6 @@ These are the section headers that we use:
 - Added new CLI task to reindex datasets and records into the search engine. ([#4404](https://github.com/argilla-io/argilla/pull/4404))
 - Added `httpx_extra_kwargs` argument to `rg.init` and `Argilla` to allow passing extra arguments to `httpx.Client` used by `Argilla`. ([#4440](https://github.com/argilla-io/argilla/pull/4441))
 - Added `ResponseStatusFilter` enum in `__init__` imports of Argilla ([#4118](https://github.com/argilla-io/argilla/pull/4463)). Contributed by @Piyush-Kumar-Ghosh.
-
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ These are the section headers that we use:
 - Added pydantic v2 support using the python SDK ([#4459](https://github.com/argilla-io/argilla/pull/4459))
 - API v1 responses returning `Record` schema now always include `dataset_id` as attribute. ([#4482](https://github.com/argilla-io/argilla/pull/4482))
 - API v1 responses returning `Response` schema now always include `record_id` as attribute. ([#4482](https://github.com/argilla-io/argilla/pull/4482))
-- API v1 responses returning `Question` schema now always include `dataset_id` attribute. ([]())
+- API v1 responses returning `Question` schema now always include `dataset_id` attribute. ([#4487](https://github.com/argilla-io/argilla/pull/4487))
 
 ### Changed
 

--- a/src/argilla/server/apis/v1/handlers/datasets/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets/datasets.py
@@ -36,13 +36,11 @@ from argilla.server.schemas.v1.datasets import (
     MetadataProperties,
     MetadataProperty,
     MetadataPropertyCreate,
-    Question,
-    QuestionCreate,
-    Questions,
     VectorSettings,
     VectorSettingsCreate,
     VectorsSettings,
 )
+from argilla.server.schemas.v1.questions import Question, QuestionCreate, Questions
 from argilla.server.search_engine import (
     SearchEngine,
     get_search_engine,

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -55,12 +55,12 @@ from argilla.server.schemas.v1.datasets import (
     DatasetCreate,
     FieldCreate,
     MetadataPropertyCreate,
-    QuestionCreate,
 )
 from argilla.server.schemas.v1.datasets import (
     VectorSettings as VectorSettingsSchema,
 )
 from argilla.server.schemas.v1.metadata_properties import MetadataPropertyUpdate
+from argilla.server.schemas.v1.questions import QuestionCreate
 from argilla.server.schemas.v1.records import (
     RecordCreate,
     RecordIncludeParam,

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -18,12 +18,12 @@ from uuid import UUID
 
 from fastapi import Query
 
-from argilla.server.enums import SimilarityOrder, SortOrder
-from argilla.server.pydantic_v1 import BaseModel, PositiveInt, conlist, constr, root_validator, validator
+from argilla.server.enums import DatasetStatus, FieldType, MetadataPropertyType, SimilarityOrder, SortOrder
+from argilla.server.pydantic_v1 import BaseModel, PositiveInt, constr, root_validator
 from argilla.server.pydantic_v1 import Field as PydanticField
 from argilla.server.pydantic_v1.generics import GenericModel
 from argilla.server.schemas.base import UpdateSchema
-from argilla.server.schemas.v1.questions import QuestionDescription, QuestionName, QuestionTitle
+from argilla.server.schemas.v1.questions import QuestionName
 from argilla.server.schemas.v1.records import Record, RecordFilterScope
 from argilla.server.schemas.v1.responses import ResponseFilterScope
 from argilla.server.search_engine import TextQuery
@@ -32,9 +32,6 @@ try:
     from typing import Annotated
 except ImportError:
     from typing_extensions import Annotated
-
-from argilla.server.enums import DatasetStatus, FieldType, MetadataPropertyType
-from argilla.server.models import QuestionSettings, QuestionType
 
 DATASET_NAME_REGEX = r"^(?!-|_)[a-zA-Z0-9-_ ]+$"
 DATASET_NAME_MIN_LENGTH = 1
@@ -59,26 +56,6 @@ VECTOR_SETTINGS_CREATE_NAME_MIN_LENGTH = 1
 VECTOR_SETTINGS_CREATE_NAME_MAX_LENGTH = 200
 VECTOR_SETTINGS_CREATE_TITLE_MIN_LENGTH = 1
 VECTOR_SETTINGS_CREATE_TITLE_MAX_LENGTH = 500
-
-RATING_OPTIONS_MIN_ITEMS = 2
-RATING_OPTIONS_MAX_ITEMS = 10
-
-RATING_LOWER_VALUE_ALLOWED = 1
-RATING_UPPER_VALUE_ALLOWED = 10
-
-VALUE_TEXT_OPTION_VALUE_MIN_LENGTH = 1
-VALUE_TEXT_OPTION_VALUE_MAX_LENGTH = 200
-VALUE_TEXT_OPTION_TEXT_MIN_LENGTH = 1
-VALUE_TEXT_OPTION_TEXT_MAX_LENGTH = 500
-VALUE_TEXT_OPTION_DESCRIPTION_MIN_LENGTH = 1
-VALUE_TEXT_OPTION_DESCRIPTION_MAX_LENGTH = 1000
-
-LABEL_SELECTION_OPTIONS_MIN_ITEMS = 2
-LABEL_SELECTION_OPTIONS_MAX_ITEMS = 250
-LABEL_SELECTION_MIN_VISIBLE_OPTIONS = 3
-
-RANKING_OPTIONS_MIN_ITEMS = 2
-RANKING_OPTIONS_MAX_ITEMS = 50
 
 TERMS_METADATA_PROPERTY_VALUES_MIN_ITEMS = 1
 TERMS_METADATA_PROPERTY_VALUES_MAX_ITEMS = 250
@@ -196,141 +173,6 @@ class FieldCreate(BaseModel):
     title: FieldTitle
     required: Optional[bool]
     settings: TextFieldSettings
-
-
-class TextQuestionSettingsCreate(BaseModel):
-    type: Literal[QuestionType.text]
-    use_markdown: bool = False
-
-
-class UniqueValuesCheckerMixin(BaseModel):
-    @root_validator(skip_on_failure=True)
-    def check_unique_values(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        options = values.get("options", [])
-        seen = set()
-        duplicates = set()
-        for option in options:
-            if option.value in seen:
-                duplicates.add(option.value)
-            else:
-                seen.add(option.value)
-        if duplicates:
-            raise ValueError(f"Option values must be unique, found duplicates: {duplicates}")
-        return values
-
-
-class RatingQuestionSettingsOption(BaseModel):
-    value: int
-
-
-class RatingQuestionSettingsCreate(UniqueValuesCheckerMixin):
-    type: Literal[QuestionType.rating]
-    options: conlist(
-        item_type=RatingQuestionSettingsOption,
-        min_items=RATING_OPTIONS_MIN_ITEMS,
-        max_items=RATING_OPTIONS_MAX_ITEMS,
-    )
-
-    @validator("options")
-    def check_option_value_range(cls, options: List[RatingQuestionSettingsOption]):
-        """Validator to control all values are in allowed range 1 <= x <= 10"""
-        for option in options:
-            if not RATING_LOWER_VALUE_ALLOWED <= option.value <= RATING_UPPER_VALUE_ALLOWED:
-                raise ValueError(
-                    f"Option value {option.value!r} out of range "
-                    f"[{RATING_LOWER_VALUE_ALLOWED!r}, {RATING_UPPER_VALUE_ALLOWED!r}]"
-                )
-        return options
-
-
-class ValueTextQuestionSettingsOption(BaseModel):
-    value: constr(
-        min_length=VALUE_TEXT_OPTION_VALUE_MIN_LENGTH,
-        max_length=VALUE_TEXT_OPTION_VALUE_MAX_LENGTH,
-    )
-    text: constr(
-        min_length=VALUE_TEXT_OPTION_TEXT_MIN_LENGTH,
-        max_length=VALUE_TEXT_OPTION_TEXT_MAX_LENGTH,
-    )
-    description: Optional[
-        constr(
-            min_length=VALUE_TEXT_OPTION_DESCRIPTION_MIN_LENGTH,
-            max_length=VALUE_TEXT_OPTION_DESCRIPTION_MAX_LENGTH,
-        )
-    ] = None
-
-
-class LabelSelectionQuestionSettingsCreate(UniqueValuesCheckerMixin):
-    type: Literal[QuestionType.label_selection]
-    options: conlist(
-        item_type=ValueTextQuestionSettingsOption,
-        min_items=LABEL_SELECTION_OPTIONS_MIN_ITEMS,
-        max_items=LABEL_SELECTION_OPTIONS_MAX_ITEMS,
-    )
-    visible_options: Optional[int] = PydanticField(None, ge=LABEL_SELECTION_MIN_VISIBLE_OPTIONS)
-
-    @root_validator(skip_on_failure=True)
-    def check_visible_options_value(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        visible_options = values.get("visible_options")
-        if visible_options is not None:
-            num_options = len(values["options"])
-            if visible_options > num_options:
-                raise ValueError(
-                    "The value for 'visible_options' must be less or equal to the number of items in 'options'"
-                    f" ({num_options})"
-                )
-        return values
-
-
-class MultiLabelSelectionQuestionSettingsCreate(LabelSelectionQuestionSettingsCreate):
-    type: Literal[QuestionType.multi_label_selection]
-
-
-class RankingQuestionSettingsCreate(UniqueValuesCheckerMixin):
-    type: Literal[QuestionType.ranking]
-    options: conlist(
-        item_type=ValueTextQuestionSettingsOption,
-        min_items=RANKING_OPTIONS_MIN_ITEMS,
-        max_items=RANKING_OPTIONS_MAX_ITEMS,
-    )
-
-
-QuestionSettingsCreate = Annotated[
-    Union[
-        TextQuestionSettingsCreate,
-        RatingQuestionSettingsCreate,
-        LabelSelectionQuestionSettingsCreate,
-        MultiLabelSelectionQuestionSettingsCreate,
-        RankingQuestionSettingsCreate,
-    ],
-    PydanticField(discriminator="type"),
-]
-
-
-class Question(BaseModel):
-    id: UUID
-    name: str
-    title: str
-    description: Optional[str]
-    required: bool
-    settings: QuestionSettings
-    inserted_at: datetime
-    updated_at: datetime
-
-    class Config:
-        orm_mode = True
-
-
-class Questions(BaseModel):
-    items: List[Question]
-
-
-class QuestionCreate(BaseModel):
-    name: QuestionName
-    title: QuestionTitle
-    description: Optional[QuestionDescription]
-    required: Optional[bool]
-    settings: QuestionSettingsCreate
 
 
 class VectorSettings(BaseModel):

--- a/src/argilla/server/schemas/v1/questions.py
+++ b/src/argilla/server/schemas/v1/questions.py
@@ -13,12 +13,13 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import Annotated, Literal, Optional, Union
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
 
 from typing_extensions import Annotated
 
-from argilla.server.pydantic_v1 import BaseModel, Field, PositiveInt, conlist, constr
+from argilla.server.models import QuestionType
+from argilla.server.pydantic_v1 import BaseModel, Field, PositiveInt, conlist, constr, root_validator, validator
 from argilla.server.schemas.base import UpdateSchema
 
 try:
@@ -26,7 +27,6 @@ try:
 except ImportError:
     from typing_extensions import Annotated
 
-from argilla.server.models import QuestionType
 
 QUESTION_CREATE_NAME_REGEX = r"^(?=.*[a-z0-9])[a-z0-9_-]+$"
 QUESTION_CREATE_NAME_MIN_LENGTH = 1
@@ -37,6 +37,25 @@ QUESTION_CREATE_TITLE_MAX_LENGTH = 500
 
 QUESTION_CREATE_DESCRIPTION_MIN_LENGTH = 1
 QUESTION_CREATE_DESCRIPTION_MAX_LENGTH = 1000
+
+VALUE_TEXT_OPTION_VALUE_MIN_LENGTH = 1
+VALUE_TEXT_OPTION_VALUE_MAX_LENGTH = 200
+VALUE_TEXT_OPTION_TEXT_MIN_LENGTH = 1
+VALUE_TEXT_OPTION_TEXT_MAX_LENGTH = 500
+VALUE_TEXT_OPTION_DESCRIPTION_MIN_LENGTH = 1
+VALUE_TEXT_OPTION_DESCRIPTION_MAX_LENGTH = 1000
+
+LABEL_SELECTION_OPTIONS_MIN_ITEMS = 2
+LABEL_SELECTION_OPTIONS_MAX_ITEMS = 250
+LABEL_SELECTION_MIN_VISIBLE_OPTIONS = 3
+
+RANKING_OPTIONS_MIN_ITEMS = 2
+RANKING_OPTIONS_MAX_ITEMS = 50
+
+RATING_OPTIONS_MIN_ITEMS = 2
+RATING_OPTIONS_MAX_ITEMS = 10
+RATING_LOWER_VALUE_ALLOWED = 1
+RATING_UPPER_VALUE_ALLOWED = 10
 
 
 class TextQuestionSettings(BaseModel):
@@ -84,21 +103,6 @@ QuestionSettings = Annotated[
     ],
     Field(..., discriminator="type"),
 ]
-
-
-class Question(BaseModel):
-    id: UUID
-    name: str
-    title: str
-    description: Optional[str]
-    required: bool
-    settings: QuestionSettings
-    dataset_id: UUID
-    inserted_at: datetime
-    updated_at: datetime
-
-    class Config:
-        orm_mode = True
 
 
 class TextQuestionSettingsUpdate(UpdateSchema):
@@ -163,6 +167,138 @@ QuestionDescription = Annotated[
     ),
     Field(..., description="The description of the question"),
 ]
+
+
+class UniqueValuesCheckerMixin(BaseModel):
+    @root_validator(skip_on_failure=True)
+    def check_unique_values(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        options = values.get("options", [])
+        seen = set()
+        duplicates = set()
+        for option in options:
+            if option.value in seen:
+                duplicates.add(option.value)
+            else:
+                seen.add(option.value)
+        if duplicates:
+            raise ValueError(f"Option values must be unique, found duplicates: {duplicates}")
+        return values
+
+
+class TextQuestionSettingsCreate(BaseModel):
+    type: Literal[QuestionType.text]
+    use_markdown: bool = False
+
+
+class RatingQuestionSettingsCreate(UniqueValuesCheckerMixin):
+    type: Literal[QuestionType.rating]
+    options: conlist(
+        item_type=RatingQuestionSettingsOption,
+        min_items=RATING_OPTIONS_MIN_ITEMS,
+        max_items=RATING_OPTIONS_MAX_ITEMS,
+    )
+
+    @validator("options")
+    def check_option_value_range(cls, options: List[RatingQuestionSettingsOption]):
+        """Validator to control all values are in allowed range 1 <= x <= 10"""
+        for option in options:
+            if not RATING_LOWER_VALUE_ALLOWED <= option.value <= RATING_UPPER_VALUE_ALLOWED:
+                raise ValueError(
+                    f"Option value {option.value!r} out of range "
+                    f"[{RATING_LOWER_VALUE_ALLOWED!r}, {RATING_UPPER_VALUE_ALLOWED!r}]"
+                )
+        return options
+
+
+class ValueTextQuestionSettingsOptionCreate(BaseModel):
+    value: constr(
+        min_length=VALUE_TEXT_OPTION_VALUE_MIN_LENGTH,
+        max_length=VALUE_TEXT_OPTION_VALUE_MAX_LENGTH,
+    )
+    text: constr(
+        min_length=VALUE_TEXT_OPTION_TEXT_MIN_LENGTH,
+        max_length=VALUE_TEXT_OPTION_TEXT_MAX_LENGTH,
+    )
+    description: Optional[
+        constr(
+            min_length=VALUE_TEXT_OPTION_DESCRIPTION_MIN_LENGTH,
+            max_length=VALUE_TEXT_OPTION_DESCRIPTION_MAX_LENGTH,
+        )
+    ] = None
+
+
+class LabelSelectionQuestionSettingsCreate(UniqueValuesCheckerMixin):
+    type: Literal[QuestionType.label_selection]
+    options: conlist(
+        item_type=ValueTextQuestionSettingsOptionCreate,
+        min_items=LABEL_SELECTION_OPTIONS_MIN_ITEMS,
+        max_items=LABEL_SELECTION_OPTIONS_MAX_ITEMS,
+    )
+    visible_options: Optional[int] = Field(None, ge=LABEL_SELECTION_MIN_VISIBLE_OPTIONS)
+
+    @root_validator(skip_on_failure=True)
+    def check_visible_options_value(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        visible_options = values.get("visible_options")
+        if visible_options is not None:
+            num_options = len(values["options"])
+            if visible_options > num_options:
+                raise ValueError(
+                    "The value for 'visible_options' must be less or equal to the number of items in 'options'"
+                    f" ({num_options})"
+                )
+        return values
+
+
+class MultiLabelSelectionQuestionSettingsCreate(LabelSelectionQuestionSettingsCreate):
+    type: Literal[QuestionType.multi_label_selection]
+
+
+class RankingQuestionSettingsCreate(UniqueValuesCheckerMixin):
+    type: Literal[QuestionType.ranking]
+    options: conlist(
+        item_type=ValueTextQuestionSettingsOptionCreate,
+        min_items=RANKING_OPTIONS_MIN_ITEMS,
+        max_items=RANKING_OPTIONS_MAX_ITEMS,
+    )
+
+
+QuestionSettingsCreate = Annotated[
+    Union[
+        TextQuestionSettingsCreate,
+        RatingQuestionSettingsCreate,
+        LabelSelectionQuestionSettingsCreate,
+        MultiLabelSelectionQuestionSettingsCreate,
+        RankingQuestionSettingsCreate,
+    ],
+    Field(discriminator="type"),
+]
+
+
+class Question(BaseModel):
+    id: UUID
+    name: str
+    title: str
+    description: Optional[str]
+    required: bool
+    settings: QuestionSettings
+    dataset_id: UUID
+    inserted_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class Questions(BaseModel):
+    items: List[Question]
+
+
+class QuestionCreate(BaseModel):
+    name: QuestionName
+    title: QuestionTitle
+    description: Optional[QuestionDescription]
+    required: Optional[bool]
+    settings: QuestionSettingsCreate
 
 
 class QuestionUpdate(UpdateSchema):

--- a/tests/unit/client/sdk/models/v1/test_datasets.py
+++ b/tests/unit/client/sdk/models/v1/test_datasets.py
@@ -15,7 +15,7 @@
 from argilla.client.sdk.v1.datasets.models import FeedbackDatasetModel as ClientSchema
 from argilla.client.sdk.v1.datasets.models import FeedbackQuestionModel as ClientQuestionSchema
 from argilla.server.schemas.v1.datasets import Dataset as ServerSchema
-from argilla.server.schemas.v1.datasets import Question as ServerQuestionSchema
+from argilla.server.schemas.v1.questions import Question as ServerQuestionSchema
 
 
 def test_feedback_dataset_schema(helpers) -> None:

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -47,13 +47,7 @@ from argilla.server.schemas.v1.datasets import (
     FIELD_CREATE_TITLE_MAX_LENGTH,
     METADATA_PROPERTY_CREATE_NAME_MAX_LENGTH,
     METADATA_PROPERTY_CREATE_TITLE_MAX_LENGTH,
-    RANKING_OPTIONS_MAX_ITEMS,
-    RATING_OPTIONS_MAX_ITEMS,
-    RATING_OPTIONS_MIN_ITEMS,
     TERMS_METADATA_PROPERTY_VALUES_MAX_ITEMS,
-    VALUE_TEXT_OPTION_DESCRIPTION_MAX_LENGTH,
-    VALUE_TEXT_OPTION_TEXT_MAX_LENGTH,
-    VALUE_TEXT_OPTION_VALUE_MAX_LENGTH,
     VECTOR_SETTINGS_CREATE_NAME_MAX_LENGTH,
     VECTOR_SETTINGS_CREATE_TITLE_MAX_LENGTH,
 )
@@ -61,6 +55,12 @@ from argilla.server.schemas.v1.questions import (
     QUESTION_CREATE_DESCRIPTION_MAX_LENGTH,
     QUESTION_CREATE_NAME_MAX_LENGTH,
     QUESTION_CREATE_TITLE_MAX_LENGTH,
+    RANKING_OPTIONS_MAX_ITEMS,
+    RATING_OPTIONS_MAX_ITEMS,
+    RATING_OPTIONS_MIN_ITEMS,
+    VALUE_TEXT_OPTION_DESCRIPTION_MAX_LENGTH,
+    VALUE_TEXT_OPTION_TEXT_MAX_LENGTH,
+    VALUE_TEXT_OPTION_VALUE_MAX_LENGTH,
 )
 from argilla.server.schemas.v1.records import RECORDS_CREATE_MAX_ITEMS, RECORDS_CREATE_MIN_ITEMS
 from argilla.server.search_engine import (
@@ -317,6 +317,7 @@ class TestSuiteDatasets:
                     "description": "Question Description",
                     "required": True,
                     "settings": {"type": "text", "use_markdown": False},
+                    "dataset_id": str(text_question.dataset_id),
                     "inserted_at": text_question.inserted_at.isoformat(),
                     "updated_at": text_question.updated_at.isoformat(),
                 },
@@ -341,6 +342,7 @@ class TestSuiteDatasets:
                             {"value": 10},
                         ],
                     },
+                    "dataset_id": str(rating_question.dataset_id),
                     "inserted_at": rating_question.inserted_at.isoformat(),
                     "updated_at": rating_question.updated_at.isoformat(),
                 },
@@ -396,6 +398,7 @@ class TestSuiteDatasets:
                     "description": question.description,
                     "required": question.required,
                     "settings": {"type": QuestionFactory.settings["type"], **settings},
+                    "dataset_id": str(question.dataset_id),
                     "inserted_at": question.inserted_at.isoformat(),
                     "updated_at": question.updated_at.isoformat(),
                 }
@@ -1265,6 +1268,7 @@ class TestSuiteDatasets:
             "description": None,
             "required": False,
             "settings": expected_settings,
+            "dataset_id": str(UUID(response_body["dataset_id"])),
             "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
             "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
         }


### PR DESCRIPTION
# Description

This PR includes the following changes:
* Move `Question` related schemas for API v1 to his own file at `schemas/v1/questions.py`.
* Use only one `Question` canonical schema removing duplications.
* `Question` schema will include always `dataset_id` as attribute.
* Small renaming of schemas to avoid conflicts in the same file.

Refs #4407 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (change restructuring the codebase without changing functionality)
- [x] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

- [ ] Running and modifying unit tests.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)