### PR TITLE
refactor: move Field schemas to his own file and unify canonical Field schema adding dataset_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ These are the section headers that we use:
 - API v1 responses returning `Record` schema now always include `dataset_id` as attribute. ([#4482](https://github.com/argilla-io/argilla/pull/4482))
 - API v1 responses returning `Response` schema now always include `record_id` as attribute. ([#4482](https://github.com/argilla-io/argilla/pull/4482))
 - API v1 responses returning `Question` schema now always include `dataset_id` attribute. ([#4487](https://github.com/argilla-io/argilla/pull/4487))
-- API v1 responses returning `Field` schema now always include `dataset_id` attribute. ([]())
+- API v1 responses returning `Field` schema now always include `dataset_id` attribute. ([#4488](https://github.com/argilla-io/argilla/pull/4488))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ These are the section headers that we use:
 - API v1 responses returning `Record` schema now always include `dataset_id` as attribute. ([#4482](https://github.com/argilla-io/argilla/pull/4482))
 - API v1 responses returning `Response` schema now always include `record_id` as attribute. ([#4482](https://github.com/argilla-io/argilla/pull/4482))
 - API v1 responses returning `Question` schema now always include `dataset_id` attribute. ([#4487](https://github.com/argilla-io/argilla/pull/4487))
+- API v1 responses returning `Field` schema now always include `dataset_id` attribute. ([]())
 
 ### Changed
 

--- a/src/argilla/server/apis/v1/handlers/datasets/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets/datasets.py
@@ -30,9 +30,6 @@ from argilla.server.schemas.v1.datasets import (
     DatasetMetrics,
     Datasets,
     DatasetUpdate,
-    Field,
-    FieldCreate,
-    Fields,
     MetadataProperties,
     MetadataProperty,
     MetadataPropertyCreate,
@@ -40,6 +37,7 @@ from argilla.server.schemas.v1.datasets import (
     VectorSettingsCreate,
     VectorsSettings,
 )
+from argilla.server.schemas.v1.fields import Field, FieldCreate, Fields
 from argilla.server.schemas.v1.questions import Question, QuestionCreate, Questions
 from argilla.server.search_engine import (
     SearchEngine,

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -53,12 +53,12 @@ from argilla.server.models import (
 from argilla.server.models.suggestions import SuggestionCreateWithRecordId
 from argilla.server.schemas.v1.datasets import (
     DatasetCreate,
-    FieldCreate,
     MetadataPropertyCreate,
 )
 from argilla.server.schemas.v1.datasets import (
     VectorSettings as VectorSettingsSchema,
 )
+from argilla.server.schemas.v1.fields import FieldCreate
 from argilla.server.schemas.v1.metadata_properties import MetadataPropertyUpdate
 from argilla.server.schemas.v1.questions import QuestionCreate
 from argilla.server.schemas.v1.records import (

--- a/src/argilla/server/schemas/v1/datasets.py
+++ b/src/argilla/server/schemas/v1/datasets.py
@@ -18,7 +18,7 @@ from uuid import UUID
 
 from fastapi import Query
 
-from argilla.server.enums import DatasetStatus, FieldType, MetadataPropertyType, SimilarityOrder, SortOrder
+from argilla.server.enums import DatasetStatus, MetadataPropertyType, SimilarityOrder, SortOrder
 from argilla.server.pydantic_v1 import BaseModel, PositiveInt, constr, root_validator
 from argilla.server.pydantic_v1 import Field as PydanticField
 from argilla.server.pydantic_v1.generics import GenericModel
@@ -38,12 +38,6 @@ DATASET_NAME_MIN_LENGTH = 1
 DATASET_NAME_MAX_LENGTH = 200
 DATASET_GUIDELINES_MIN_LENGTH = 1
 DATASET_GUIDELINES_MAX_LENGTH = 10000
-
-FIELD_CREATE_NAME_REGEX = r"^(?=.*[a-z0-9])[a-z0-9_-]+$"
-FIELD_CREATE_NAME_MIN_LENGTH = 1
-FIELD_CREATE_NAME_MAX_LENGTH = 200
-FIELD_CREATE_TITLE_MIN_LENGTH = 1
-FIELD_CREATE_TITLE_MAX_LENGTH = 500
 
 METADATA_PROPERTY_CREATE_NAME_REGEX = r"^(?=.*[a-z0-9])[a-z0-9_-]+$"
 METADATA_PROPERTY_CREATE_NAME_MIN_LENGTH = 1
@@ -129,50 +123,6 @@ class ResponseMetrics(BaseModel):
 class DatasetMetrics(BaseModel):
     records: RecordMetrics
     responses: ResponseMetrics
-
-
-class TextFieldSettings(BaseModel):
-    type: Literal[FieldType.text]
-    use_markdown: bool = False
-
-
-class Field(BaseModel):
-    id: UUID
-    name: str
-    title: str
-    required: bool
-    settings: TextFieldSettings
-    inserted_at: datetime
-    updated_at: datetime
-
-    class Config:
-        orm_mode = True
-
-
-class Fields(BaseModel):
-    items: List[Field]
-
-
-FieldName = Annotated[
-    constr(
-        regex=FIELD_CREATE_NAME_REGEX,
-        min_length=FIELD_CREATE_NAME_MIN_LENGTH,
-        max_length=FIELD_CREATE_NAME_MAX_LENGTH,
-    ),
-    PydanticField(..., description="The name of the field"),
-]
-
-FieldTitle = Annotated[
-    constr(min_length=FIELD_CREATE_TITLE_MIN_LENGTH, max_length=FIELD_CREATE_TITLE_MAX_LENGTH),
-    PydanticField(..., description="The title of the field"),
-]
-
-
-class FieldCreate(BaseModel):
-    name: FieldName
-    title: FieldTitle
-    required: Optional[bool]
-    settings: TextFieldSettings
 
 
 class VectorSettings(BaseModel):

--- a/src/argilla/server/schemas/v1/fields.py
+++ b/src/argilla/server/schemas/v1/fields.py
@@ -13,18 +13,51 @@
 #  limitations under the License.
 
 from datetime import datetime
-from typing import Literal, Optional
+from typing import Annotated, List, Literal, Optional
 from uuid import UUID
 
+from typing_extensions import Annotated
+
 from argilla.server.enums import FieldType
-from argilla.server.pydantic_v1 import BaseModel
+from argilla.server.pydantic_v1 import BaseModel, constr
+from argilla.server.pydantic_v1 import Field as PydanticField
 from argilla.server.schemas.base import UpdateSchema
-from argilla.server.schemas.v1.datasets import FieldTitle
+
+FIELD_CREATE_NAME_REGEX = r"^(?=.*[a-z0-9])[a-z0-9_-]+$"
+FIELD_CREATE_NAME_MIN_LENGTH = 1
+FIELD_CREATE_NAME_MAX_LENGTH = 200
+
+FIELD_CREATE_TITLE_MIN_LENGTH = 1
+FIELD_CREATE_TITLE_MAX_LENGTH = 500
+
+
+FieldName = Annotated[
+    constr(
+        regex=FIELD_CREATE_NAME_REGEX,
+        min_length=FIELD_CREATE_NAME_MIN_LENGTH,
+        max_length=FIELD_CREATE_NAME_MAX_LENGTH,
+    ),
+    PydanticField(..., description="The name of the field"),
+]
+
+
+FieldTitle = Annotated[
+    constr(
+        min_length=FIELD_CREATE_TITLE_MIN_LENGTH,
+        max_length=FIELD_CREATE_TITLE_MAX_LENGTH,
+    ),
+    PydanticField(..., description="The title of the field"),
+]
 
 
 class TextFieldSettings(BaseModel):
     type: Literal[FieldType.text]
     use_markdown: bool = False
+
+
+class TextFieldSettingsUpdate(UpdateSchema):
+    type: Literal[FieldType.text]
+    use_markdown: bool
 
 
 class Field(BaseModel):
@@ -41,9 +74,15 @@ class Field(BaseModel):
         orm_mode = True
 
 
-class TextFieldSettingsUpdate(UpdateSchema):
-    type: Literal[FieldType.text]
-    use_markdown: bool
+class Fields(BaseModel):
+    items: List[Field]
+
+
+class FieldCreate(BaseModel):
+    name: FieldName
+    title: FieldTitle
+    required: Optional[bool]
+    settings: TextFieldSettings
 
 
 class FieldUpdate(UpdateSchema):

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -43,14 +43,13 @@ from argilla.server.models import (
 from argilla.server.schemas.v1.datasets import (
     DATASET_GUIDELINES_MAX_LENGTH,
     DATASET_NAME_MAX_LENGTH,
-    FIELD_CREATE_NAME_MAX_LENGTH,
-    FIELD_CREATE_TITLE_MAX_LENGTH,
     METADATA_PROPERTY_CREATE_NAME_MAX_LENGTH,
     METADATA_PROPERTY_CREATE_TITLE_MAX_LENGTH,
     TERMS_METADATA_PROPERTY_VALUES_MAX_ITEMS,
     VECTOR_SETTINGS_CREATE_NAME_MAX_LENGTH,
     VECTOR_SETTINGS_CREATE_TITLE_MAX_LENGTH,
 )
+from argilla.server.schemas.v1.fields import FIELD_CREATE_NAME_MAX_LENGTH, FIELD_CREATE_TITLE_MAX_LENGTH
 from argilla.server.schemas.v1.questions import (
     QUESTION_CREATE_DESCRIPTION_MAX_LENGTH,
     QUESTION_CREATE_NAME_MAX_LENGTH,
@@ -224,6 +223,7 @@ class TestSuiteDatasets:
                     "title": "Text Field A",
                     "required": True,
                     "settings": {"type": "text", "use_markdown": False},
+                    "dataset_id": str(dataset.id),
                     "inserted_at": text_field_a.inserted_at.isoformat(),
                     "updated_at": text_field_a.updated_at.isoformat(),
                 },
@@ -233,6 +233,7 @@ class TestSuiteDatasets:
                     "title": "Text Field B",
                     "required": False,
                     "settings": {"type": "text", "use_markdown": False},
+                    "dataset_id": str(dataset.id),
                     "inserted_at": text_field_b.inserted_at.isoformat(),
                     "updated_at": text_field_b.updated_at.isoformat(),
                 },
@@ -953,6 +954,7 @@ class TestSuiteDatasets:
             "title": "title",
             "required": False,
             "settings": expected_settings,
+            "dataset_id": str(dataset.id),
             "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
             "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
         }

--- a/tests/unit/server/api/v1/test_fields.py
+++ b/tests/unit/server/api/v1/test_fields.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 import pytest
 from argilla._constants import API_KEY_HEADER_NAME
 from argilla.server.models import DatasetStatus, Field, UserRole
-from argilla.server.schemas.v1.datasets import FIELD_CREATE_TITLE_MAX_LENGTH
+from argilla.server.schemas.v1.fields import FIELD_CREATE_TITLE_MAX_LENGTH
 from sqlalchemy import func, select
 
 from tests.factories import (


### PR DESCRIPTION
# Description

This PR includes the following changes:
* Move `Field` related schemas for API v1 to his own file at `schemas/v1/fields.py`.
* Use only one `Field` canonical schema removing duplications.
* `Field` schema will include always `dataset_id` as attribute.

Refs #4407 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

- [ ] Modifying and running unit tests.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)