### PR TITLE
refactor: move MetadataProperty schemas to his own file and unify canonical MetadataProperty schema adding dataset_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ These are the section headers that we use:
 - API v1 responses returning `Response` schema now always include `record_id` as attribute. ([#4482](https://github.com/argilla-io/argilla/pull/4482))
 - API v1 responses returning `Question` schema now always include `dataset_id` attribute. ([#4487](https://github.com/argilla-io/argilla/pull/4487))
 - API v1 responses returning `Field` schema now always include `dataset_id` attribute. ([#4488](https://github.com/argilla-io/argilla/pull/4488))
+- API v1 responses returning `MetadataProperty` schema now always include `dataset_id` attribute. ([#4489](https://github.com/argilla-io/argilla/pull/4489))
 
 ### Changed
 

--- a/src/argilla/server/apis/v1/handlers/datasets/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets/datasets.py
@@ -30,14 +30,12 @@ from argilla.server.schemas.v1.datasets import (
     DatasetMetrics,
     Datasets,
     DatasetUpdate,
-    MetadataProperties,
-    MetadataProperty,
-    MetadataPropertyCreate,
     VectorSettings,
     VectorSettingsCreate,
     VectorsSettings,
 )
 from argilla.server.schemas.v1.fields import Field, FieldCreate, Fields
+from argilla.server.schemas.v1.metadata_properties import MetadataProperties, MetadataProperty, MetadataPropertyCreate
 from argilla.server.schemas.v1.questions import Question, QuestionCreate, Questions
 from argilla.server.search_engine import (
     SearchEngine,

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -53,13 +53,12 @@ from argilla.server.models import (
 from argilla.server.models.suggestions import SuggestionCreateWithRecordId
 from argilla.server.schemas.v1.datasets import (
     DatasetCreate,
-    MetadataPropertyCreate,
 )
 from argilla.server.schemas.v1.datasets import (
     VectorSettings as VectorSettingsSchema,
 )
 from argilla.server.schemas.v1.fields import FieldCreate
-from argilla.server.schemas.v1.metadata_properties import MetadataPropertyUpdate
+from argilla.server.schemas.v1.metadata_properties import MetadataPropertyCreate, MetadataPropertyUpdate
 from argilla.server.schemas.v1.questions import QuestionCreate
 from argilla.server.schemas.v1.records import (
     RecordCreate,

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -44,13 +44,15 @@ from argilla.server.models import (
 from argilla.server.schemas.v1.datasets import (
     DATASET_GUIDELINES_MAX_LENGTH,
     DATASET_NAME_MAX_LENGTH,
-    METADATA_PROPERTY_CREATE_NAME_MAX_LENGTH,
-    METADATA_PROPERTY_CREATE_TITLE_MAX_LENGTH,
-    TERMS_METADATA_PROPERTY_VALUES_MAX_ITEMS,
     VECTOR_SETTINGS_CREATE_NAME_MAX_LENGTH,
     VECTOR_SETTINGS_CREATE_TITLE_MAX_LENGTH,
 )
 from argilla.server.schemas.v1.fields import FIELD_CREATE_NAME_MAX_LENGTH, FIELD_CREATE_TITLE_MAX_LENGTH
+from argilla.server.schemas.v1.metadata_properties import (
+    METADATA_PROPERTY_CREATE_NAME_MAX_LENGTH,
+    METADATA_PROPERTY_CREATE_TITLE_MAX_LENGTH,
+    TERMS_METADATA_PROPERTY_VALUES_MAX_ITEMS,
+)
 from argilla.server.schemas.v1.questions import (
     QUESTION_CREATE_DESCRIPTION_MAX_LENGTH,
     QUESTION_CREATE_NAME_MAX_LENGTH,
@@ -480,6 +482,7 @@ class TestSuiteDatasets:
                     "title": terms_property.title,
                     "settings": {"type": "terms", "values": ["a", "b", "c"]},
                     "visible_for_annotators": True,
+                    "dataset_id": str(terms_property.dataset_id),
                     "inserted_at": terms_property.inserted_at.isoformat(),
                     "updated_at": terms_property.updated_at.isoformat(),
                 },
@@ -489,6 +492,7 @@ class TestSuiteDatasets:
                     "title": integer_property.title,
                     "settings": {"type": "integer", "min": None, "max": None},
                     "visible_for_annotators": True,
+                    "dataset_id": str(integer_property.dataset_id),
                     "inserted_at": integer_property.inserted_at.isoformat(),
                     "updated_at": integer_property.updated_at.isoformat(),
                 },
@@ -498,6 +502,7 @@ class TestSuiteDatasets:
                     "title": float_property.title,
                     "settings": {"type": "float", "min": None, "max": None},
                     "visible_for_annotators": True,
+                    "dataset_id": str(float_property.dataset_id),
                     "inserted_at": float_property.inserted_at.isoformat(),
                     "updated_at": float_property.updated_at.isoformat(),
                 },
@@ -1688,6 +1693,7 @@ class TestSuiteDatasets:
             "title": "title",
             "settings": expected_settings,
             "visible_for_annotators": True,
+            "dataset_id": str(dataset.id),
             "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
             "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
         }
@@ -1720,6 +1726,7 @@ class TestSuiteDatasets:
         assert response_body == {
             "id": str(UUID(response_body["id"])),
             "visible_for_annotators": True,
+            "dataset_id": str(dataset.id),
             "inserted_at": datetime.fromisoformat(response_body["inserted_at"]).isoformat(),
             "updated_at": datetime.fromisoformat(response_body["updated_at"]).isoformat(),
             **metadata_property_json,

--- a/tests/unit/server/api/v1/test_metadata_properties.py
+++ b/tests/unit/server/api/v1/test_metadata_properties.py
@@ -20,7 +20,7 @@ import pytest
 from argilla.server.constants import API_KEY_HEADER_NAME
 from argilla.server.enums import MetadataPropertyType, UserRole
 from argilla.server.models import MetadataProperty, UserRole
-from argilla.server.schemas.v1.datasets import METADATA_PROPERTY_CREATE_TITLE_MAX_LENGTH
+from argilla.server.schemas.v1.metadata_properties import METADATA_PROPERTY_CREATE_TITLE_MAX_LENGTH
 from argilla.server.search_engine import FloatMetadataMetrics, IntegerMetadataMetrics, TermsMetadataMetrics
 from sqlalchemy import func, select
 


### PR DESCRIPTION
# Description

This PR includes the following changes:
* Move `MetadataProperty` related schemas for API v1 to his own file at `schemas/v1/metadata_properties.py`.
* Use only one `MetadataProperty` canonical schema removing duplications.
* `MetadataProperty ` schema will include always `dataset_id` as attribute.

Refs #4407 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

- [ ] Modifying and running unit tests.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)