### PR TITLE
refactor: move VectorSettings schemas to his own file and unify canonical VectorSetting schema adding dataset_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ These are the section headers that we use:
 - API v1 responses returning `Question` schema now always include `dataset_id` attribute. ([#4487](https://github.com/argilla-io/argilla/pull/4487))
 - API v1 responses returning `Field` schema now always include `dataset_id` attribute. ([#4488](https://github.com/argilla-io/argilla/pull/4488))
 - API v1 responses returning `MetadataProperty` schema now always include `dataset_id` attribute. ([#4489](https://github.com/argilla-io/argilla/pull/4489))
+- API v1 responses returning `VectorSettings` schema now always include `dataset_id` attribute. ([#4490](https://github.com/argilla-io/argilla/pull/4490))
 
 ### Changed
 

--- a/src/argilla/server/apis/v1/handlers/datasets/datasets.py
+++ b/src/argilla/server/apis/v1/handlers/datasets/datasets.py
@@ -30,13 +30,11 @@ from argilla.server.schemas.v1.datasets import (
     DatasetMetrics,
     Datasets,
     DatasetUpdate,
-    VectorSettings,
-    VectorSettingsCreate,
-    VectorsSettings,
 )
 from argilla.server.schemas.v1.fields import Field, FieldCreate, Fields
 from argilla.server.schemas.v1.metadata_properties import MetadataProperties, MetadataProperty, MetadataPropertyCreate
 from argilla.server.schemas.v1.questions import Question, QuestionCreate, Questions
+from argilla.server.schemas.v1.vector_settings import VectorSettings, VectorSettingsCreate, VectorsSettings
 from argilla.server.search_engine import (
     SearchEngine,
     get_search_engine,

--- a/src/argilla/server/apis/v1/handlers/datasets/records.py
+++ b/src/argilla/server/apis/v1/handlers/datasets/records.py
@@ -45,7 +45,6 @@ from argilla.server.schemas.v1.datasets import (
     SearchSuggestionsOptions,
     SuggestionFilterScope,
     TermsFilter,
-    VectorSettings,
 )
 from argilla.server.schemas.v1.records import (
     Record as RecordSchema,
@@ -58,6 +57,7 @@ from argilla.server.schemas.v1.records import (
     RecordsUpdate,
 )
 from argilla.server.schemas.v1.responses import ResponseFilterScope
+from argilla.server.schemas.v1.vector_settings import VectorSettings
 from argilla.server.search_engine import (
     AndFilter,
     FloatMetadataFilter,

--- a/src/argilla/server/contexts/datasets.py
+++ b/src/argilla/server/contexts/datasets.py
@@ -54,9 +54,6 @@ from argilla.server.models.suggestions import SuggestionCreateWithRecordId
 from argilla.server.schemas.v1.datasets import (
     DatasetCreate,
 )
-from argilla.server.schemas.v1.datasets import (
-    VectorSettings as VectorSettingsSchema,
-)
 from argilla.server.schemas.v1.fields import FieldCreate
 from argilla.server.schemas.v1.metadata_properties import MetadataPropertyCreate, MetadataPropertyUpdate
 from argilla.server.schemas.v1.questions import QuestionCreate
@@ -74,6 +71,12 @@ from argilla.server.schemas.v1.responses import (
     ResponseValueCreate,
     ResponseValueUpdate,
 )
+from argilla.server.schemas.v1.vector_settings import (
+    VectorSettings as VectorSettingsSchema,
+)
+from argilla.server.schemas.v1.vector_settings import (
+    VectorSettingsCreate,
+)
 from argilla.server.schemas.v1.vectors import Vector as VectorSchema
 from argilla.server.search_engine import SearchEngine
 from argilla.server.security.model import User
@@ -83,7 +86,6 @@ if TYPE_CHECKING:
 
     from argilla.server.schemas.v1.datasets import (
         DatasetUpdate,
-        VectorSettingsCreate,
     )
     from argilla.server.schemas.v1.fields import FieldUpdate
     from argilla.server.schemas.v1.questions import QuestionUpdate

--- a/tests/unit/server/api/v1/test_datasets.py
+++ b/tests/unit/server/api/v1/test_datasets.py
@@ -44,8 +44,6 @@ from argilla.server.models import (
 from argilla.server.schemas.v1.datasets import (
     DATASET_GUIDELINES_MAX_LENGTH,
     DATASET_NAME_MAX_LENGTH,
-    VECTOR_SETTINGS_CREATE_NAME_MAX_LENGTH,
-    VECTOR_SETTINGS_CREATE_TITLE_MAX_LENGTH,
 )
 from argilla.server.schemas.v1.fields import FIELD_CREATE_NAME_MAX_LENGTH, FIELD_CREATE_TITLE_MAX_LENGTH
 from argilla.server.schemas.v1.metadata_properties import (
@@ -65,6 +63,10 @@ from argilla.server.schemas.v1.questions import (
     VALUE_TEXT_OPTION_VALUE_MAX_LENGTH,
 )
 from argilla.server.schemas.v1.records import RECORDS_CREATE_MAX_ITEMS, RECORDS_CREATE_MIN_ITEMS
+from argilla.server.schemas.v1.vector_settings import (
+    VECTOR_SETTINGS_CREATE_NAME_MAX_LENGTH,
+    VECTOR_SETTINGS_CREATE_TITLE_MAX_LENGTH,
+)
 from argilla.server.search_engine import (
     FloatMetadataFilter,
     IntegerMetadataFilter,
@@ -617,6 +619,7 @@ class TestSuiteDatasets:
                     "name": vector_settings.name,
                     "title": vector_settings.title,
                     "dimensions": vector_settings.dimensions,
+                    "dataset_id": str(vector_settings.dataset_id),
                     "inserted_at": vector_settings.inserted_at.isoformat(),
                     "updated_at": vector_settings.updated_at.isoformat(),
                 }
@@ -2014,6 +2017,7 @@ class TestSuiteDatasets:
             "name": "vectors-for-semantic-search",
             "title": "Vectors generated with sentence-transformers/all-MiniLM-L6-v2",
             "dimensions": 384,
+            "dataset_id": str(vector_settings.dataset_id),
             "inserted_at": vector_settings.inserted_at.isoformat(),
             "updated_at": vector_settings.updated_at.isoformat(),
         }

--- a/tests/unit/server/api/v1/test_vectors_settings.py
+++ b/tests/unit/server/api/v1/test_vectors_settings.py
@@ -18,7 +18,7 @@ from uuid import uuid4
 import pytest
 from argilla.server.constants import API_KEY_HEADER_NAME
 from argilla.server.enums import UserRole
-from argilla.server.schemas.v1.datasets import VECTOR_SETTINGS_CREATE_TITLE_MAX_LENGTH
+from argilla.server.schemas.v1.vector_settings import VECTOR_SETTINGS_CREATE_TITLE_MAX_LENGTH
 
 from tests.factories import AdminFactory, AnnotatorFactory, UserFactory, VectorSettingsFactory
 


### PR DESCRIPTION
# Description

This PR includes the following changes:
* Move `VectorSettings` related schemas for API v1 to his own file at `schemas/v1/vector_settings.py`.
* Use only one `VectorSettings` canonical schema removing duplications.
* `VectorSettings ` schema will include always `dataset_id` as attribute.

Refs #4407 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

- [ ] Modifying and running unit tests.

**Checklist**

- [ ] I added relevant documentation
- [x] follows the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)