### PR TITLE
refactor: define provider based on auth backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,9 @@ These are the section headers that we use:
 - API v1 responses returning `MetadataProperty` schema now always include `dataset_id` attribute. ([#4489](https://github.com/argilla-io/argilla/pull/4489))
 - API v1 responses returning `VectorSettings` schema now always include `dataset_id` attribute. ([#4490](https://github.com/argilla-io/argilla/pull/4490))
 - Added `pdf_to_html` function to `.html_utils` module that convert PDFs to dataURL to be able to render them in tha Argilla UI. ([#4481](https://github.com/argilla-io/argilla/issues/4481#issuecomment-1903695755))
+- Added `ARGILLA_AUTH_SECRET_KEY` environment variable. ([#4539](https://github.com/argilla-io/argilla/pull/4539))
+- Added `ARGILLA_AUTH_ALGORITHM` environment variable. ([#4539](https://github.com/argilla-io/argilla/pull/4539))
 - Added `ARGILLA_AUTH_TOKEN_EXPIRATION` environment variable. ([#4539](https://github.com/argilla-io/argilla/pull/4539))
-
-### Changed
-
-- Changed `ARGILLA_LOCAL_AUTH_*` environment names to `ARGILLA_AUTH_*` (with temporary backwards compatibility, all except `ARGILLA_LOCAL_AUTH_USERS_DB_FILE`). ([#4539](https://github.com/argilla-io/argilla/pull/4539))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ These are the section headers that we use:
 - API v1 responses returning `MetadataProperty` schema now always include `dataset_id` attribute. ([#4489](https://github.com/argilla-io/argilla/pull/4489))
 - API v1 responses returning `VectorSettings` schema now always include `dataset_id` attribute. ([#4490](https://github.com/argilla-io/argilla/pull/4490))
 - Added `pdf_to_html` function to `.html_utils` module that convert PDFs to dataURL to be able to render them in tha Argilla UI. ([#4481](https://github.com/argilla-io/argilla/issues/4481#issuecomment-1903695755))
+- Added `ARGILLA_AUTH_TOKEN_EXPIRATION` environment variable. ([#4539](https://github.com/argilla-io/argilla/pull/4539))
+
+### Changed
+
+- Changed `ARGILLA_LOCAL_AUTH_*` environment names to `ARGILLA_AUTH_*` (with temporary backwards compatibility, all except `ARGILLA_LOCAL_AUTH_USERS_DB_FILE`). ([#4539](https://github.com/argilla-io/argilla/pull/4539))
+
+### Deprecated
+
+- Deprecated `ARGILLA_LOCAL_AUTH_*` environment variables. Will be removed in the release v1.25.0. ([#4539](https://github.com/argilla-io/argilla/pull/4539))
 
 ### Removed
 

--- a/docker/docker-compose.with.postgresql.yaml
+++ b/docker/docker-compose.with.postgresql.yaml
@@ -21,7 +21,7 @@ services:
     environment:
       ARGILLA_ELASTICSEARCH: http://elasticsearch:9200
       ARGILLA_DATABASE_URL: postgresql://postgres:postgres@db:5432
-      ARGILLA_LOCAL_AUTH_SECRET_KEY: ${ARGILLA_LOCAL_AUTH_SECRET_KEY:? Please generate a 32 character random string with `openssl rand -hex 32`}
+      ARGILLA_AUTH_SECRET_KEY: ${ARGILLA_AUTH_SECRET_KEY:? Please generate a 32 character random string with `openssl rand -hex 32`}
       # ARGILLA_ENABLE_TELEMETRY: 0 # Opt-out for telemetry https://docs.argilla.io/en/latest/reference/telemetry.html
 
       # Set user configuration https://docs.argilla.io/en/latest/getting_started/installation/configurations/user_management.html

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
       # If you change ARGILLA_HOME_PATH value please copy that same value to argilladata volume too.
       - argilladata:/var/lib/argilla
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.8.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.3
     environment:
       - node.name=elasticsearch
       - cluster.name=es-argilla-local
@@ -49,7 +49,7 @@ services:
     volumes:
       - elasticdata:/usr/share/elasticsearch/data/
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.8.2
+    image: docker.elastic.co/kibana/kibana:8.5.3
     ports:
       - "5601:5601"
     environment:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     environment:
       ARGILLA_HOME_PATH: /var/lib/argilla
       ARGILLA_ELASTICSEARCH: http://elasticsearch:9200
-      ARGILLA_LOCAL_AUTH_SECRET_KEY: ${ARGILLA_LOCAL_AUTH_SECRET_KEY:? Please generate a 32 character random string with `openssl rand -hex 32`}
+      ARGILLA_AUTH_SECRET_KEY: ${ARGILLA_AUTH_SECRET_KEY:? Please generate a 32 character random string with `openssl rand -hex 32`}
 
       # ARGILLA_ENABLE_TELEMETRY: 0 # Opt-out for telemetry https://docs.argilla.io/en/latest/reference/telemetry.html
 
@@ -29,7 +29,7 @@ services:
       # If you change ARGILLA_HOME_PATH value please copy that same value to argilladata volume too.
       - argilladata:/var/lib/argilla
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.8.2
     environment:
       - node.name=elasticsearch
       - cluster.name=es-argilla-local
@@ -49,7 +49,7 @@ services:
     volumes:
       - elasticdata:/usr/share/elasticsearch/data/
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.5.3
+    image: docker.elastic.co/kibana/kibana:8.8.2
     ports:
       - "5601:5601"
     environment:

--- a/docker/nginx/docker-compose.yaml
+++ b/docker/nginx/docker-compose.yaml
@@ -14,6 +14,6 @@ services:
     environment:
       ARGILLA_ENABLE_TELEMETRY: 0
       ARGILLA_BASE_URL: /argilla
-      ARGILLA_LOCAL_AUTH_SECRET_KEY: ${ARGILLA_LOCAL_AUTH_SECRET_KEY:? Please generate a 32 character random string with `openssl rand -hex 32`}
+      ARGILLA_AUTH_SECRET_KEY: ${ARGILLA_AUTH_SECRET_KEY:? Please generate a 32 character random string with `openssl rand -hex 32`}
     ports:
       - "6900:6900"

--- a/docker/traefik/docker-compose.yaml
+++ b/docker/traefik/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     environment:
       ARGILLA_ENABLE_TELEMETRY: 0
       ARGILLA_BASE_URL: /argilla
-      ARGILLA_LOCAL_AUTH_SECRET_KEY: ${ARGILLA_LOCAL_AUTH_SECRET_KEY:? Please generate a 32 character random string with `openssl rand -hex 32`}
+      ARGILLA_AUTH_SECRET_KEY: ${ARGILLA_AUTH_SECRET_KEY:? Please generate a 32 character random string with `openssl rand -hex 32`}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.argilla.rule=PathPrefix(`/argilla/`)"

--- a/docs/_source/conf.py
+++ b/docs/_source/conf.py
@@ -95,7 +95,7 @@ services:
      - "80:80"
    environment:
      ARGILLA_ELASTICSEARCH: <elasticsearch-host_and_port>
-     ARGILLA_LOCAL_AUTH_SECRET_KEY: Please generate a 32 character random string with: openssl rand -hex 32
+     ARGILLA_AUTH_SECRET_KEY: Please generate a 32 character random string with: openssl rand -hex 32
    restart: unless-stopped
 ```""".format(
     myst_substitutions["dockertag"]
@@ -111,7 +111,7 @@ services:
       - "6900:80"
     environment:
       ARGILLA_ELASTICSEARCH: http://elasticsearch:9200
-      ARGILLA_LOCAL_AUTH_SECRET_KEY: Please generate a 32 character random string with: openssl rand -hex 32
+      ARGILLA_AUTH_SECRET_KEY: Please generate a 32 character random string with: openssl rand -hex 32
       ARGILLA_LOCAL_AUTH_USERS_DB_FILE: /config/.users.yaml
 
     volumes:

--- a/docs/_source/getting_started/installation/configurations/user_management.md
+++ b/docs/_source/getting_started/installation/configurations/user_management.md
@@ -369,7 +369,7 @@ Then open the provided `docker-compose.yaml` file and modify your Argilla instan
     environment:
       ARGILLA_HOME_PATH: /var/lib/argilla
       ARGILLA_ELASTICSEARCH: http://elasticsearch:9200
-      ARGILLA_LOCAL_AUTH_SECRET_KEY: ${ARGILLA_LOCAL_AUTH_SECRET_KEY:? Please generate a 32 character random string with `openssl rand -hex 32`}
+      ARGILLA_AUTH_SECRET_KEY: ${ARGILLA_AUTH_SECRET_KEY:? Please generate a 32 character random string with `openssl rand -hex 32`}
 +     ARGILLA_LOCAL_AUTH_USERS_DB_FILE: /var/lib/argilla-migrate/users.yaml
     networks:
       - argilla

--- a/k8s/argilla-server-deployment.yaml
+++ b/k8s/argilla-server-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           env:
             - name: ARGILLA_ELASTICSEARCH
               value: "http://elasticsearch:9200"
-            - name: ARGILLA_LOCAL_AUTH_SECRET_KEY
+            - name: ARGILLA_AUTH_SECRET_KEY
               value: "CHANGE_ME"
           ports:
             - containerPort: 6900

--- a/src/argilla/server/security/__init__.py
+++ b/src/argilla/server/security/__init__.py
@@ -12,7 +12,5 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from .auth_provider import DBAuthProvider
-from .auth_provider.base import AuthProvider, api_key_header
 
-auth = DBAuthProvider.new_instance()
+from argilla.server.security.authentication import auth  # noqa

--- a/src/argilla/server/security/authentication/__init__.py
+++ b/src/argilla/server/security/authentication/__init__.py
@@ -1,0 +1,21 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from .jwt import JWT  # noqa
+from .provider import AuthenticationProvider  # noqa
+from .userinfo import UserInfo  # noqa
+
+
+auth = AuthenticationProvider.new_instance()

--- a/src/argilla/server/security/authentication/db/__init__.py
+++ b/src/argilla/server/security/authentication/db/__init__.py
@@ -1,0 +1,19 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from .api_key_backend import APIKeyAuthenticationBackend
+from .bearer_token_backend import BearerTokenAuthenticationBackend
+from .router import router
+
+__all__ = ["BearerTokenAuthenticationBackend", "APIKeyAuthenticationBackend", "router"]

--- a/src/argilla/server/security/authentication/db/api_key_backend.py
+++ b/src/argilla/server/security/authentication/db/api_key_backend.py
@@ -1,0 +1,46 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Optional, Tuple
+
+from fastapi import Request
+from fastapi.security import APIKeyHeader
+from starlette.authentication import AuthCredentials, AuthenticationBackend, BaseUser
+
+from argilla.server.constants import API_KEY_HEADER_NAME
+from argilla.server.contexts import accounts
+from argilla.server.security.authentication.userinfo import UserInfo
+
+
+class APIKeyAuthenticationBackend(AuthenticationBackend):
+    """Authentication backend for API Key authentication"""
+
+    scheme = APIKeyHeader(name=API_KEY_HEADER_NAME, auto_error=False)
+
+    async def authenticate(self, request: Request) -> Optional[Tuple[AuthCredentials, BaseUser]]:
+        """Authenticate the user using the API Key header"""
+        api_key: str = await self.scheme(request)
+
+        if not api_key:
+            return None
+
+        db = request.state.db
+        user = await accounts.get_user_by_api_key(db, api_key=api_key)
+
+        if not user:
+            return None
+
+        return AuthCredentials(["authenticated"]), UserInfo(
+            username=user.username, name=user.full_name, role=user.role, identity=str(user.id)
+        )

--- a/src/argilla/server/security/authentication/db/api_key_backend.py
+++ b/src/argilla/server/security/authentication/db/api_key_backend.py
@@ -31,16 +31,14 @@ class APIKeyAuthenticationBackend(AuthenticationBackend):
     async def authenticate(self, request: Request) -> Optional[Tuple[AuthCredentials, BaseUser]]:
         """Authenticate the user using the API Key header"""
         api_key: str = await self.scheme(request)
-
         if not api_key:
             return None
 
         db = request.state.db
         user = await accounts.get_user_by_api_key(db, api_key=api_key)
-
         if not user:
             return None
 
-        return AuthCredentials(["authenticated"]), UserInfo(
-            username=user.username, name=user.full_name, role=user.role, identity=str(user.id)
+        return AuthCredentials(), UserInfo(
+            username=user.username, name=user.first_name, role=user.role, identity=str(user.id)
         )

--- a/src/argilla/server/security/authentication/db/bearer_token_backend.py
+++ b/src/argilla/server/security/authentication/db/bearer_token_backend.py
@@ -1,0 +1,49 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import typing
+
+from fastapi import Request
+from fastapi.security import HTTPBearer
+from starlette.authentication import AuthCredentials, AuthenticationBackend, BaseUser
+
+from argilla.server.contexts import accounts
+from argilla.server.security.authentication.jwt import JWT
+from argilla.server.security.authentication.userinfo import UserInfo
+
+
+class BearerTokenAuthenticationBackend(AuthenticationBackend):
+    """Authenticate the user using the username and password Bearer header"""
+
+    scheme = HTTPBearer(auto_error=False)
+
+    async def authenticate(self, request: Request) -> typing.Optional[typing.Tuple[AuthCredentials, BaseUser]]:
+        """Authenticate the user using the username and password Bearer header"""
+        credentials = await self.scheme(request)
+
+        if not credentials:
+            return None
+
+        token = credentials.credentials
+        username = JWT.decode(token).get("username")
+
+        db = request.state.db
+        user = await accounts.get_user_by_username(db, username)
+
+        if not user:
+            return None
+
+        return AuthCredentials(["authenticated"]), UserInfo(
+            username=user.username, name=user.full_name, role=user.role, identity=str(user.id)
+        )

--- a/src/argilla/server/security/authentication/db/bearer_token_backend.py
+++ b/src/argilla/server/security/authentication/db/bearer_token_backend.py
@@ -31,7 +31,6 @@ class BearerTokenAuthenticationBackend(AuthenticationBackend):
     async def authenticate(self, request: Request) -> typing.Optional[typing.Tuple[AuthCredentials, BaseUser]]:
         """Authenticate the user using the username and password Bearer header"""
         credentials = await self.scheme(request)
-
         if not credentials:
             return None
 
@@ -40,10 +39,9 @@ class BearerTokenAuthenticationBackend(AuthenticationBackend):
 
         db = request.state.db
         user = await accounts.get_user_by_username(db, username)
-
         if not user:
             return None
 
-        return AuthCredentials(["authenticated"]), UserInfo(
-            username=user.username, name=user.full_name, role=user.role, identity=str(user.id)
+        return AuthCredentials(), UserInfo(
+            username=user.username, name=user.first_name, role=user.role, identity=str(user.id)
         )

--- a/src/argilla/server/security/authentication/db/router.py
+++ b/src/argilla/server/security/authentication/db/router.py
@@ -1,0 +1,49 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Form
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from argilla.server.contexts import accounts
+from argilla.server.database import get_async_db
+from argilla.server.errors import UnauthorizedError
+from argilla.server.security.authentication.jwt import JWT
+from argilla.server.security.authentication.userinfo import UserInfo
+from argilla.server.security.model import Token
+
+router = APIRouter()
+
+
+class UserPasswordRequestForm:
+    """User password request form."""
+
+    def __init__(self, *, username: Annotated[str, Form()], password: Annotated[str, Form()]):
+        self.username = username
+        self.password = password
+
+
+@router.post("/token", response_model=Token)
+async def create_access_token(
+    db: AsyncSession = Depends(get_async_db), form: UserPasswordRequestForm = Depends()
+) -> Token:
+    user = await accounts.authenticate_user(db, form.username, form.password)
+
+    if not user:
+        raise UnauthorizedError()
+
+    token = JWT.create(UserInfo(username=user.username, name=user.full_name, role=user.role, identity=str(user.id)))
+
+    return Token(access_token=token)

--- a/src/argilla/server/security/authentication/db/router.py
+++ b/src/argilla/server/security/authentication/db/router.py
@@ -44,6 +44,6 @@ async def create_access_token(
     if not user:
         raise UnauthorizedError()
 
-    token = JWT.create(UserInfo(username=user.username, name=user.full_name, role=user.role, identity=str(user.id)))
+    token = JWT.create(UserInfo(username=user.username, name=user.first_name, role=user.role, identity=str(user.id)))
 
     return Token(access_token=token)

--- a/src/argilla/server/security/authentication/db/router.py
+++ b/src/argilla/server/security/authentication/db/router.py
@@ -40,7 +40,6 @@ async def create_access_token(
     db: AsyncSession = Depends(get_async_db), form: UserPasswordRequestForm = Depends()
 ) -> Token:
     user = await accounts.authenticate_user(db, form.username, form.password)
-
     if not user:
         raise UnauthorizedError()
 

--- a/src/argilla/server/security/authentication/jwt.py
+++ b/src/argilla/server/security/authentication/jwt.py
@@ -1,0 +1,44 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from datetime import datetime, timedelta
+
+from jose import JWTError, jwt
+
+from argilla.server.errors import UnauthorizedError
+from argilla.server.security.authentication.userinfo import UserInfo
+from argilla.server.security.settings import settings
+
+
+class JWT:
+    secret: str = settings.secret_key
+    algorithm: str = settings.algorithm
+    expires: int = settings.token_expire_time
+
+    @classmethod
+    def encode(cls, data: dict) -> str:
+        return jwt.encode(data, cls.secret, algorithm=cls.algorithm)
+
+    @classmethod
+    def decode(cls, token: str) -> dict:
+        try:
+            return jwt.decode(token, cls.secret, algorithms=[cls.algorithm])
+
+        except JWTError:
+            raise UnauthorizedError("Invalid token")
+
+    @classmethod
+    def create(cls, user: UserInfo) -> str:
+        expire = datetime.utcnow() + timedelta(seconds=cls.expires)
+        return cls.encode({**user, "exp": expire})

--- a/src/argilla/server/security/authentication/jwt.py
+++ b/src/argilla/server/security/authentication/jwt.py
@@ -34,7 +34,6 @@ class JWT:
     def decode(cls, token: str) -> dict:
         try:
             return jwt.decode(token, cls.secret, algorithms=[cls.algorithm])
-
         except JWTError:
             raise UnauthorizedError("Invalid token")
 

--- a/src/argilla/server/security/authentication/jwt.py
+++ b/src/argilla/server/security/authentication/jwt.py
@@ -24,7 +24,7 @@ from argilla.server.security.settings import settings
 class JWT:
     secret: str = settings.secret_key
     algorithm: str = settings.algorithm
-    expires: int = settings.token_expire_time
+    expires: int = settings.token_expiration
 
     @classmethod
     def encode(cls, data: dict) -> str:

--- a/src/argilla/server/security/authentication/provider.py
+++ b/src/argilla/server/security/authentication/provider.py
@@ -19,10 +19,10 @@ from fastapi.security import SecurityScopes
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.requests import Request
 
-import argilla.server.schemas.v0.users
 from argilla.server.contexts import accounts
 from argilla.server.database import get_async_db
 from argilla.server.errors import UnauthorizedError
+from argilla.server.models import User
 from argilla.server.security.authentication import db
 from argilla.server.security.authentication.db import APIKeyAuthenticationBackend, BearerTokenAuthenticationBackend
 
@@ -44,7 +44,7 @@ class AuthenticationProvider:
         db: AsyncSession = Depends(get_async_db),
         _api_key: Optional[str] = Depends(APIKeyAuthenticationBackend.scheme),
         _bearer: Optional[str] = Depends(BearerTokenAuthenticationBackend.scheme),
-    ) -> argilla.server.schemas.v0.users.User:
+    ) -> User:
         # This db will be used by the backends. Ideally this should be done as a global dependency
         # but is not working as expected. Sometimes the db is not available in the request state at the
         # middlewares level.

--- a/src/argilla/server/security/authentication/provider.py
+++ b/src/argilla/server/security/authentication/provider.py
@@ -12,11 +12,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import Optional
+from typing import ClassVar, List, Optional
 
 from fastapi import Depends, FastAPI
 from fastapi.security import SecurityScopes
 from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.authentication import AuthenticationBackend
 from starlette.requests import Request
 
 from argilla.server.contexts import accounts
@@ -25,10 +26,16 @@ from argilla.server.errors import UnauthorizedError
 from argilla.server.models import User
 from argilla.server.security.authentication import db
 from argilla.server.security.authentication.db import APIKeyAuthenticationBackend, BearerTokenAuthenticationBackend
+from argilla.server.security.authentication.userinfo import UserInfo
 
 
 class AuthenticationProvider:
-    backends = [APIKeyAuthenticationBackend(), BearerTokenAuthenticationBackend()]
+    """Authentication provider for the API requests."""
+
+    backends: ClassVar[List[AuthenticationBackend]] = [
+        APIKeyAuthenticationBackend(),
+        BearerTokenAuthenticationBackend(),
+    ]
 
     @classmethod
     def new_instance(cls):
@@ -39,23 +46,15 @@ class AuthenticationProvider:
 
     async def get_current_user(
         self,
-        _: SecurityScopes,
+        security_scopes: SecurityScopes,  # noqa
         request: Request,
         db: AsyncSession = Depends(get_async_db),
         _api_key: Optional[str] = Depends(APIKeyAuthenticationBackend.scheme),
         _bearer: Optional[str] = Depends(BearerTokenAuthenticationBackend.scheme),
     ) -> User:
-        # This db will be used by the backends. Ideally this should be done as a global dependency
-        # but is not working as expected. Sometimes the db is not available in the request state at the
-        # middlewares level.
-        request.state.db = db
+        """Get the current user from the request."""
 
-        userinfo = None
-        for backend in self.backends:
-            if results := await backend.authenticate(request):
-                _, userinfo = results
-                break
-
+        userinfo = await self._authenticate_request_user(db, request)
         if not userinfo:
             raise UnauthorizedError()
 
@@ -64,3 +63,16 @@ class AuthenticationProvider:
             raise UnauthorizedError()
 
         return user
+
+    async def _authenticate_request_user(self, db: AsyncSession, request: Request) -> Optional[UserInfo]:
+        # This db will be used by the backends. Ideally this should be done as a global dependency
+        # but is not working as expected. Sometimes the db is not available in the request state at the
+        # middlewares level.
+        request.state.db = db
+
+        for backend in self.backends:
+            if results := await backend.authenticate(request):
+                _, userinfo = results
+                return userinfo
+
+        return None

--- a/src/argilla/server/security/authentication/provider.py
+++ b/src/argilla/server/security/authentication/provider.py
@@ -1,0 +1,66 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Optional
+
+from fastapi import Depends, FastAPI
+from fastapi.security import SecurityScopes
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.requests import Request
+
+import argilla.server.schemas.v0.users
+from argilla.server.contexts import accounts
+from argilla.server.database import get_async_db
+from argilla.server.errors import UnauthorizedError
+from argilla.server.security.authentication import db
+from argilla.server.security.authentication.db import APIKeyAuthenticationBackend, BearerTokenAuthenticationBackend
+
+
+class AuthenticationProvider:
+    backends = [APIKeyAuthenticationBackend(), BearerTokenAuthenticationBackend()]
+
+    @classmethod
+    def new_instance(cls):
+        return AuthenticationProvider()
+
+    def configure_app(self, app: FastAPI) -> None:
+        app.include_router(db.router, prefix="/api/security", tags=["security"])
+
+    async def get_current_user(
+        self,
+        _: SecurityScopes,
+        request: Request,
+        db: AsyncSession = Depends(get_async_db),
+        _api_key: Optional[str] = Depends(APIKeyAuthenticationBackend.scheme),
+        _bearer: Optional[str] = Depends(BearerTokenAuthenticationBackend.scheme),
+    ) -> argilla.server.schemas.v0.users.User:
+        # This db will be used by the backends. Ideally this should be done as a global dependency
+        # but is not working as expected. Sometimes the db is not available in the request state at the
+        # middlewares level.
+        request.state.db = db
+
+        userinfo = None
+        for backend in self.backends:
+            if results := await backend.authenticate(request):
+                _, userinfo = results
+                break
+
+        if not userinfo:
+            raise UnauthorizedError()
+
+        user = await accounts.get_user_by_username(db, userinfo.username)
+        if not user:
+            raise UnauthorizedError()
+
+        return user

--- a/src/argilla/server/security/authentication/userinfo.py
+++ b/src/argilla/server/security/authentication/userinfo.py
@@ -1,0 +1,32 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import Any
+
+from starlette.authentication import BaseUser
+
+
+class UserInfo(BaseUser, dict):
+    """User info from a provider."""
+
+    @property
+    def is_authenticated(self) -> bool:
+        return True
+
+    def __getprop__(self, item, default="") -> Any:
+        if callable(item):
+            return item(self)
+        return self.get(item, default)
+
+    __getattr__ = __getprop__

--- a/src/argilla/server/security/settings.py
+++ b/src/argilla/server/security/settings.py
@@ -38,7 +38,6 @@ class Settings(BaseSettings):
 
     secret_key: str = uuid4().hex
     algorithm: str = "HS256"
-
     token_expiration: int = 120 * 60
 
     @validator("token_expiration", always=True)

--- a/src/argilla/server/security/settings.py
+++ b/src/argilla/server/security/settings.py
@@ -13,7 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import os
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 from uuid import uuid4
 
 from argilla.server.pydantic_v1 import BaseSettings, validator

--- a/src/argilla/server/security/settings.py
+++ b/src/argilla/server/security/settings.py
@@ -40,10 +40,10 @@ class Settings(BaseSettings):
     algorithm: str = "HS256"
 
     token_expiration_in_minutes: int = 15
-    token_expiration: int
+    token_expiration: Optional[int]
 
     @validator("token_expiration", always=True)
-    def set_token_expire_time(cls, v, values, **kwargs) -> int:
+    def default_token_expiration(cls, v, values, **kwargs) -> int:
         if v is not None:
             return v
         return values["token_expiration_in_minutes"] * 60

--- a/src/argilla/server/security/settings.py
+++ b/src/argilla/server/security/settings.py
@@ -1,0 +1,67 @@
+#  coding=utf-8
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+from typing import Optional, TYPE_CHECKING
+from uuid import uuid4
+
+from argilla.server.pydantic_v1 import BaseSettings, validator
+
+
+class Settings(BaseSettings):
+
+    """
+    Attributes
+    ----------
+
+    secret_key:
+        The secret key used for signed the token data
+
+    algorithm:
+        Encryption algorithm for token data
+
+    token_expiration_in_minutes:
+        The session token expiration in minutes. Default=30000
+
+    """
+
+    secret_key: str = uuid4().hex
+    algorithm: str = "HS256"
+
+    token_expiration_in_minutes: int = 15
+    token_expiration: int
+
+    @validator("token_expiration", always=True)
+    def set_token_expire_time(cls, v, values, **kwargs) -> int:
+        if v is not None:
+            return v
+        return values["token_expiration_in_minutes"] * 60
+
+    class Config:
+        env_prefix = "ARGILLA_AUTH_"
+
+        fields = {
+            # Support for old local auth env variables
+            "algorithm": {"env": ["ARGILLA_LOCAL_AUTH_ALGORITHM", f"{env_prefix}ALGORITHM"]},
+            "secret_key": {"env": ["ARGILLA_LOCAL_AUTH_SECRET_KEY", f"{env_prefix}SECRET_KEY"]},
+            "token_expiration_in_minutes": {
+                "env": [
+                    "ARGILLA_LOCAL_AUTH_TOKEN_EXPIRATION_IN_MINUTES",
+                    f"{env_prefix}TOKEN_EXPIRATION_IN_MINUTES",
+                ]
+            },
+        }
+
+
+settings = Settings()

--- a/src/argilla/server/security/settings.py
+++ b/src/argilla/server/security/settings.py
@@ -31,8 +31,8 @@ class Settings(BaseSettings):
     algorithm:
         Encryption algorithm for token data
 
-    token_expiration_in_minutes:
-        The session token expiration in minutes. Default=30000
+    token_expiration:
+        The session token expiration . Default=7200 (2 hours)
 
     """
 
@@ -47,7 +47,7 @@ class Settings(BaseSettings):
             return v
 
         # This is a backwards compatibility hack to support the old env variable and
-        # it will be removed in version 1.25.0
+        # it will be removed in version 1.25.0. See https://github.com/argilla-io/argilla/issues/4542
         expiration_in_minutes = os.getenv("ARGILLA_LOCAL_AUTH_TOKEN_EXPIRATION_IN_MINUTES")
         if expiration_in_minutes is not None:
             return int(expiration_in_minutes) * 60
@@ -58,7 +58,8 @@ class Settings(BaseSettings):
         env_prefix = "ARGILLA_AUTH_"
 
         fields = {
-            # Support for old local auth env variables
+            # Support for old local auth env variables.
+            # It will be removed in version 1.25.0 (See https://github.com/argilla-io/argilla/issues/4542)
             "algorithm": {"env": ["ARGILLA_LOCAL_AUTH_ALGORITHM", f"{env_prefix}ALGORITHM"]},
             "secret_key": {"env": ["ARGILLA_LOCAL_AUTH_SECRET_KEY", f"{env_prefix}SECRET_KEY"]},
             "token_expiration_in_minutes": {

--- a/src/argilla/server/security/settings.py
+++ b/src/argilla/server/security/settings.py
@@ -32,13 +32,13 @@ class Settings(BaseSettings):
         Encryption algorithm for token data
 
     token_expiration:
-        The session token expiration . Default=7200 (2 hours)
+        The session token expiration . Default=86400 (1 day)
 
     """
 
     secret_key: str = uuid4().hex
     algorithm: str = "HS256"
-    token_expiration: int = 120 * 60
+    token_expiration: int = 24 * 60 * 60  # 1 day
 
     @validator("token_expiration", always=True)
     def default_token_expiration(cls, v, values, **kwargs) -> int:

--- a/src/argilla/server/security/settings.py
+++ b/src/argilla/server/security/settings.py
@@ -39,14 +39,20 @@ class Settings(BaseSettings):
     secret_key: str = uuid4().hex
     algorithm: str = "HS256"
 
-    token_expiration_in_minutes: int = 15
-    token_expiration: Optional[int]
+    token_expiration: int = 120 * 60
 
     @validator("token_expiration", always=True)
     def default_token_expiration(cls, v, values, **kwargs) -> int:
-        if v is not None:
+        if "token_expiration" in values:
             return v
-        return values["token_expiration_in_minutes"] * 60
+
+        # This is a backwards compatibility hack to support the old env variable and
+        # it will be removed in version 1.25.0
+        expiration_in_minutes = os.getenv("ARGILLA_LOCAL_AUTH_TOKEN_EXPIRATION_IN_MINUTES")
+        if expiration_in_minutes is not None:
+            return int(expiration_in_minutes) * 60
+
+        return v
 
     class Config:
         env_prefix = "ARGILLA_AUTH_"

--- a/tests/unit/server/security/test_settings.py
+++ b/tests/unit/server/security/test_settings.py
@@ -8,7 +8,7 @@ def test_default_security_settings():
     settings = Settings()
 
     assert settings.algorithm == "HS256"
-    assert settings.token_expiration == 7200
+    assert settings.token_expiration == 86400
     assert len(settings.secret_key) == 32
 
 

--- a/tests/unit/server/security/test_settings.py
+++ b/tests/unit/server/security/test_settings.py
@@ -1,0 +1,63 @@
+import os
+from unittest import mock
+
+from argilla.server.security.settings import Settings
+
+
+def test_default_security_settings():
+    settings = Settings()
+
+    assert settings.algorithm == "HS256"
+    assert settings.token_expiration == 7200
+    assert len(settings.secret_key) == 32
+
+
+def test_configure_algorithm():
+    algorithm = "mock-algorithm"
+    with mock.patch.dict(os.environ, {"ARGILLA_AUTH_ALGORITHM": algorithm}):
+        settings = Settings()
+
+        assert settings.algorithm == algorithm
+
+
+def test_configure_token_expiration():
+    token_expiration = 3600
+    with mock.patch.dict(os.environ, {"ARGILLA_AUTH_TOKEN_EXPIRATION": str(token_expiration)}):
+        settings = Settings()
+
+        assert settings.token_expiration == token_expiration
+
+
+def test_configure_secret_key():
+    secret_key = "mock-secret-key"
+    with mock.patch.dict(os.environ, {"ARGILLA_AUTH_SECRET_KEY": secret_key}):
+        settings = Settings()
+
+        assert settings.secret_key == secret_key
+
+
+def test_configure_algorithm_with_old_env_name():
+    algorithm = "old_mock-algorithm"
+    with mock.patch.dict(os.environ, {"ARGILLA_LOCAL_AUTH_ALGORITHM": algorithm}):
+        settings = Settings()
+
+        assert settings.algorithm == algorithm
+
+# TODO: remove this test when ARGILLA_LOCAL_AUTH_SECRET_KEY will be removed
+def test_configure_secret_key_with_old_env_name():
+    secret_key = "old_mock-secret-key"
+    with mock.patch.dict(os.environ, {"ARGILLA_LOCAL_AUTH_SECRET_KEY": secret_key}):
+        settings = Settings()
+
+        assert settings.secret_key == secret_key
+
+
+# TODO: remove this test when ARGILLA_LOCAL_AUTH_TOKEN_EXPIRATION_IN_MINUTES will be removed
+def test_configure_token_expiration_in_minutes():
+    token_expiration_in_minutes = 30
+    with mock.patch.dict(
+        os.environ, {"ARGILLA_LOCAL_AUTH_TOKEN_EXPIRATION_IN_MINUTES": str(token_expiration_in_minutes)}
+    ):
+        settings = Settings()
+
+        assert settings.token_expiration == token_expiration_in_minutes * 60

--- a/tests/unit/server/security/test_settings.py
+++ b/tests/unit/server/security/test_settings.py
@@ -1,3 +1,17 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 import os
 from unittest import mock
 
@@ -42,6 +56,7 @@ def test_configure_algorithm_with_old_env_name():
         settings = Settings()
 
         assert settings.algorithm == algorithm
+
 
 # TODO: remove this test when ARGILLA_LOCAL_AUTH_SECRET_KEY will be removed
 def test_configure_secret_key_with_old_env_name():


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR is a refactor of the authentication provider. A new authentication provider is created based on the Starlette Authentication Backends. This change simplifies the auth. workflow and prepare incoming oauth integration.

Since the authentication backends should be used by the auth middleware component, the implementation done in this PR does not use it in that way since there are some problems exposing the db session at the middleware level (using global dependencies does not work).



**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

Running locally

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I added relevant documentation
- [X] I followed the style guidelines of this project
- [X] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
