### PR TITLE
test: avoid using `pytest.warn` with `None` arguments

### DIFF
--- a/tests/integration/client/test_api.py
+++ b/tests/integration/client/test_api.py
@@ -16,6 +16,7 @@
 import concurrent.futures
 import datetime
 import re
+import warnings
 from pathlib import Path
 from time import sleep
 from typing import Iterable
@@ -1054,7 +1055,7 @@ def test_list_datasets_only_feedback_datasets(argilla_user: User):
 
 
 def test_aligned_argilla_versions(mock_init_ok):
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings(record=True) as record:
         Argilla()
         for warning in record:
             assert "You're connecting to Argilla Server" not in str(warning.message)

--- a/tests/unit/client/feedback/schemas/test_records.py
+++ b/tests/unit/client/feedback/schemas/test_records.py
@@ -11,8 +11,8 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-from typing import Any, Dict, List, Optional, Union
+import warnings
+from typing import Any, Dict, List, Optional, Type, Union
 
 import pytest
 from argilla.client.feedback.schemas.records import (
@@ -136,12 +136,18 @@ def test_feedback_record(schema_kwargs: Dict[str, Any]) -> None:
 def test_feedback_record_update(
     schema_kwargs: Dict[str, Any],
     suggestions: Union[SuggestionSchema, List[SuggestionSchema], Dict[str, Any], List[Dict[str, Any]]],
-    expected_warning: Optional[Warning],
+    expected_warning: Optional[Type[Warning]],
     warning_match: Optional[str],
 ) -> None:
     record = FeedbackRecord(**schema_kwargs)
-    with pytest.warns(expected_warning, match=warning_match):
-        record.update(suggestions)
+
+    if expected_warning is None:
+        with warnings.catch_warnings(record=True) as record_:
+            record.update(suggestions)
+            assert len(record_) == 0
+    else:
+        with pytest.warns(expected_warning, match=warning_match):
+            record.update(suggestions)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR addresses errors  produced by using `pytest.warns` with `None` args

See [this failing action](https://github.com/argilla-io/argilla/actions/runs/7715020702/job/21028986681#step:12:23277), and [this thread](https://github.com/scikit-learn/scikit-learn/issues/22572#issuecomment-1047316960) for more info.

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I added relevant documentation
- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
