### PR TITLE
feat: ignore deploying preview environment for fork PRs

### DIFF
--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -2,12 +2,13 @@ name: Close Pull Request
 
 on:
   pull_request:
-    types: [ closed ]
+    types: [closed]
 
 jobs:
   teardown_pr_environment:
     name: Teardown Cloud Run PR environment
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     # Grant permissions to `GITHUB_TOKEN` for Google Cloud Workload Identity Provider
     permissions:
@@ -15,18 +16,18 @@ jobs:
       id-token: write
 
     steps:
-      - uses: 'actions/checkout@v3'
+      - uses: "actions/checkout@v3"
 
       - name: Authenticate to Google Cloud
-        uses: 'google-github-actions/auth@v1'
+        uses: "google-github-actions/auth@v1"
         with:
           workload_identity_provider: ${{ secrets.GOOGLE_CLOUD_WIP }}
           service_account: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
-        uses: 'google-github-actions/setup-gcloud@v1'
+        uses: "google-github-actions/setup-gcloud@v1"
         with:
-          version: '>= 435.0.0'
+          version: ">= 435.0.0"
 
       - name: Remove PR environment if exists
         run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -165,6 +165,7 @@ jobs:
     needs: build_quickstart_for_develop_docker_image
     if: |
       !cancelled() &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       needs.build_quickstart_for_develop_docker_image.result == 'success' &&
       github.event_name == 'pull_request' && github.event.pull_request.draft == false
     with:


### PR DESCRIPTION
# Description

This PR updates the `package.yml` and `close-pr.yml` workflows so a preview environment is not created/removed from fork PRs.

**Type of change**

- [x] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

Created a PR from fork: https://github.com/argilla-io/argilla/pull/4581

**Checklist**

- [ ] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
