### PR TITLE
bug: FloatMetadataProperty: value is not a valid float when it is an rounded integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ These are the section headers that we use:
 
 - Reorder labels in `dataset settings page` for single/multi label questions ([#4598](https://github.com/argilla-io/argilla/pull/4598))
 
+### Fixed
+
+- Fixed FloatMetadataProperty: value is not a valid float ([#4570](https://github.com/argilla-io/argilla/pull/4605))
+
 ## [1.24.0](https://github.com/argilla-io/argilla/compare/v1.23.0...v1.24.0)
 
 > [!NOTE]

--- a/src/argilla/client/feedback/integrations/textdescriptives.py
+++ b/src/argilla/client/feedback/integrations/textdescriptives.py
@@ -302,10 +302,6 @@ class TextDescriptivesExtractor:
             )
             for record, metrics in zip(records, df.to_dict("records")):
                 filtered_metrics = {key: value for key, value in metrics.items() if not pd.isna(value)}
-                filtered_metrics = {
-                    key: int(value) if isinstance(value, float) and value.is_integer() else value
-                    for key, value in filtered_metrics.items()
-                }
                 record.metadata.update(filtered_metrics)
                 modified_records.append(record)
                 progress_bar.update(task, advance=1)

--- a/tests/integration/client/feedback/integrations/huggingface/test_model_card.py
+++ b/tests/integration/client/feedback/integrations/huggingface/test_model_card.py
@@ -289,7 +289,7 @@ def test_model_card_trl(
         from trl import PPOConfig
 
         reward_model = pipeline("sentiment-analysis", model="lvwerra/distilbert-imdb")
-        trainer.update_config(config=PPOConfig(batch_size=1, ppo_epochs=2), reward_model=reward_model)
+        trainer.update_config(config=PPOConfig(batch_size=128, ppo_epochs=2), reward_model=reward_model)
     else:
         trainer.update_config(max_steps=1)
 


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

With the removal of this line,  x.0 values will not be rounded so that it passes the FloatMetadataProperty validation. The error comes from the initial definition of the metadata property as float, but then casting and adding as value an integer.

NOTE: This fixes the bug error directly, although this question is still pending @alvarobartt:
>However, from a usability perspective there is also the issue of not allowing for passing a rounded float like 1.0 to an IntegerMetadataProperty and perhaps also not an integer like1 to a FloatMetadataProperty.

Closes #4570 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
