### PR TITLE
bug: fix bug when running integrations tests for text descriptives

### DIFF
--- a/src/argilla/client/feedback/integrations/textdescriptives.py
+++ b/src/argilla/client/feedback/integrations/textdescriptives.py
@@ -282,7 +282,10 @@ class TextDescriptivesExtractor:
         return dataset
 
     def _add_text_descriptives_to_metadata(
-        self, records: List[Union[FeedbackRecord, RemoteFeedbackRecord]], df: pd.DataFrame
+        self,
+        records: List[Union[FeedbackRecord, RemoteFeedbackRecord]],
+        df: pd.DataFrame,
+        metadata_prop_types: Optional[dict] = None,
     ) -> List[Union[FeedbackRecord, RemoteFeedbackRecord]]:
         """
         Add the text descriptives metrics extracted previously as metadata
@@ -291,6 +294,7 @@ class TextDescriptivesExtractor:
         Args:
             records (List[Union[FeedbackRecord, RemoteFeedbackRecord]]): A list of FeedbackDataset or RemoteFeedbackDataset records.
             df (pd.DataFrame): The text descriptives dataframe.
+            metadata_prop_types (Optional[dict]): A dictionary with the name of the metadata property and the type if needed. Defaults to None.
 
         Returns:
             List[Union[FeedbackRecord, RemoteFeedbackRecord]]: A list of FeedbackDataset or RemoteFeedbackDataset records with extracted metrics added as metadata.
@@ -302,6 +306,15 @@ class TextDescriptivesExtractor:
             )
             for record, metrics in zip(records, df.to_dict("records")):
                 filtered_metrics = {key: value for key, value in metrics.items() if not pd.isna(value)}
+                if metadata_prop_types is not None:
+                    filtered_metrics = {
+                        key: int(value)
+                        if metadata_prop_types.get(key) == "integer"
+                        else float(value)
+                        if metadata_prop_types.get(key) == "float"
+                        else value
+                        for key, value in filtered_metrics.items()
+                    }
                 record.metadata.update(filtered_metrics)
                 modified_records.append(record)
                 progress_bar.update(task, advance=1)
@@ -312,6 +325,7 @@ class TextDescriptivesExtractor:
         records: List[Union[FeedbackRecord, RemoteFeedbackRecord]],
         fields: Optional[List[str]] = None,
         overwrite: Optional[bool] = False,
+        metadata_prop_types: Optional[dict] = None,
     ) -> List[Union[FeedbackRecord, RemoteFeedbackRecord]]:
         """
         Extract text descriptives metrics from a list of FeedbackDataset or RemoteFeedbackDataset records,
@@ -321,6 +335,7 @@ class TextDescriptivesExtractor:
             records (List[Union[FeedbackRecord, RemoteFeedbackRecord]]): A list of FeedbackDataset or RemoteFeedbackDataset records.
             fields (List[str]): A list of fields to extract metrics for. If None, extract metrics for all fields.
             overwrite (Optional[bool]): Whether to overwrite existing metadata properties with the same name. Defaults to False.
+            metadata_prop_types (Optional[dict]): A dictionary with the name of the metadata property and the type if needed. Defaults to None.
 
         Returns:
             List[Union[FeedbackRecord, RemoteFeedbackRecord]]: A list of FeedbackDataset or RemoteFeedbackDataset records with text descriptives metrics added as metadata.
@@ -354,7 +369,12 @@ class TextDescriptivesExtractor:
             # Clean column names
             extracted_metrics.columns = [self._clean_column_name(col) for col in extracted_metrics.columns]
             # Add the metrics to the metadata of the records
-            modified_records = self._add_text_descriptives_to_metadata(modified_records, extracted_metrics)
+            if metadata_prop_types is None:
+                modified_records = self._add_text_descriptives_to_metadata(modified_records, extracted_metrics)
+            else:
+                modified_records = self._add_text_descriptives_to_metadata(
+                    modified_records, extracted_metrics, metadata_prop_types
+                )
             return modified_records
 
     def update_dataset(
@@ -396,7 +416,10 @@ class TextDescriptivesExtractor:
 
         # Update the records in the dataset too
         if update_records:
-            records = self.update_records(records=dataset.records, fields=fields, overwrite=overwrite)
+            metadata_prop_types = {item.name: item.type for item in dataset.metadata_properties}
+            records = self.update_records(
+                records=dataset.records, fields=fields, overwrite=overwrite, metadata_prop_types=metadata_prop_types
+            )
             if isinstance(dataset, RemoteFeedbackDataset):
                 dataset.update_records(records)
         return dataset


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

When df swith np.nan are concatenated or fillna is applied in extract_single_field, it cast all the column to floats. This way we make sure that after filtering the nan values, each value is casted according to the metadata property type created.

![image](https://github.com/argilla-io/argilla/assets/127759186/6cec5cda-451c-4c9b-9512-6bac182fd7f2)

Closes #4613 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
