### PR TITLE
bugfix: `question.to_local` returns description as `None` though it exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ These are the section headers that we use:
 
 - Fixed prepare for training when passing `RankingValueSchema` instances to suggestions. ([#4628](https://github.com/argilla-io/argilla/pull/4628))
 - Fixed parsing ranking values in suggestions from HF datasets. ([#4629](https://github.com/argilla-io/argilla/pull/4629))
+- Fixed reading description from API response payload. ([#4632](https://github.com/argilla-io/argilla/pull/4632))
 
 ## [1.25.0](https://github.com/argilla-io/argilla/compare/v1.24.0...v1.25.0)
 

--- a/src/argilla/client/feedback/schemas/remote/questions.py
+++ b/src/argilla/client/feedback/schemas/remote/questions.py
@@ -43,6 +43,7 @@ class RemoteTextQuestion(TextQuestion, RemoteSchema):
             id=payload.id,
             name=payload.name,
             title=payload.title,
+            description=payload.description,
             required=payload.required,
             use_markdown=payload.settings["use_markdown"],
         )
@@ -64,6 +65,7 @@ class RemoteRatingQuestion(RatingQuestion, RemoteSchema):
             id=payload.id,
             name=payload.name,
             title=payload.title,
+            description=payload.description,
             required=payload.required,
             values=[option["value"] for option in payload.settings["options"]],
         )
@@ -93,6 +95,7 @@ class RemoteLabelQuestion(LabelQuestion, RemoteSchema):
             id=payload.id,
             name=payload.name,
             title=payload.title,
+            description=payload.description,
             required=payload.required,
             labels=_parse_options_from_api(payload),
             visible_labels=payload.settings["visible_options"],
@@ -116,6 +119,7 @@ class RemoteMultiLabelQuestion(MultiLabelQuestion, RemoteSchema):
             id=payload.id,
             name=payload.name,
             title=payload.title,
+            description=payload.description,
             required=payload.required,
             labels=_parse_options_from_api(payload),
             visible_labels=payload.settings["visible_options"],
@@ -138,6 +142,7 @@ class RemoteRankingQuestion(RankingQuestion, RemoteSchema):
             id=payload.id,
             name=payload.name,
             title=payload.title,
+            description=payload.description,
             required=payload.required,
             values=_parse_options_from_api(payload),
         )

--- a/tests/unit/client/feedback/schemas/remote/test_questions.py
+++ b/tests/unit/client/feedback/schemas/remote/test_questions.py
@@ -80,6 +80,7 @@ def test_remote_text_question(schema_kwargs: Dict[str, Any], server_payload: Dic
             id=uuid4(),
             name="a",
             title="A",
+            description="Description",
             required=True,
             settings={"type": "text", "use_markdown": False},
             inserted_at=datetime.now(),
@@ -89,6 +90,7 @@ def test_remote_text_question(schema_kwargs: Dict[str, Any], server_payload: Dic
             id=uuid4(),
             name="b",
             title="B",
+            description="Description",
             required=False,
             settings={"type": "text", "use_markdown": True},
             inserted_at=datetime.now(),
@@ -148,6 +150,7 @@ def test_remote_rating_question(schema_kwargs: Dict[str, Any], server_payload: D
             id=uuid4(),
             name="a",
             title="A",
+            description="Description",
             required=True,
             settings={"type": "rating", "options": [{"value": 1}, {"value": 2}, {"value": 3}]},
             inserted_at=datetime.now(),
@@ -157,6 +160,7 @@ def test_remote_rating_question(schema_kwargs: Dict[str, Any], server_payload: D
             id=uuid4(),
             name="b",
             title="B",
+            description="Description",
             required=False,
             settings={"type": "rating", "options": [{"value": 1}, {"value": 2}, {"value": 3}]},
             inserted_at=datetime.now(),
@@ -232,6 +236,7 @@ def test_remote_label_question(schema_kwargs: Dict[str, Any], server_payload: Di
             name="a",
             title="A",
             required=True,
+            description="Description",
             settings={
                 "type": "label_selection",
                 "options": [{"text": "a", "value": "a"}, {"text": "b", "value": "b"}, {"text": "c", "value": "c"}],
@@ -244,6 +249,7 @@ def test_remote_label_question(schema_kwargs: Dict[str, Any], server_payload: Di
             id=uuid4(),
             name="b",
             title="B",
+            description="Description",
             required=False,
             settings={
                 "type": "label_selection",
@@ -322,6 +328,7 @@ def test_remote_multi_label_question(schema_kwargs: Dict[str, Any], server_paylo
             id=uuid4(),
             name="a",
             title="A",
+            description="Description",
             required=True,
             settings={
                 "type": "multi_label_selection",
@@ -335,6 +342,7 @@ def test_remote_multi_label_question(schema_kwargs: Dict[str, Any], server_paylo
             id=uuid4(),
             name="b",
             title="B",
+            description="Description",
             required=False,
             settings={
                 "type": "multi_label_selection",
@@ -410,6 +418,7 @@ def test_remote_ranking_question(schema_kwargs: Dict[str, Any], server_payload: 
             id=uuid4(),
             name="a",
             title="A",
+            description="Description",
             required=True,
             settings={
                 "type": "ranking",
@@ -422,6 +431,7 @@ def test_remote_ranking_question(schema_kwargs: Dict[str, Any], server_payload: 
             id=uuid4(),
             name="b",
             title="B",
+            description="Description",
             required=False,
             settings={
                 "type": "ranking",


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR maps the missing `description` attribute for questions from API response payloads. 

Closes #4523 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

Tested locally 

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [X] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
