### PR TITLE
docs: mention ARGILLA_AUTH_SECRET_KEY in docker-compose deployment

### DIFF
--- a/docs/_source/getting_started/installation/deployments/docker_compose.md
+++ b/docs/_source/getting_started/installation/deployments/docker_compose.md
@@ -14,7 +14,7 @@ Then, create a folder:
 mkdir argilla && cd argilla
 ```
 
-and launch the docker-contained web app with the following command, after having set a value for the environment variable `ARGILLA_AUTH_SECRET_KEY` (a valid value can be generated with `openssl rand -hex 32`):
+and launch the docker-contained web app with the following command, after having set a value for the environment variable `ARGILLA_AUTH_SECRET_KEY`, which can be generated with `openssl rand -hex 32`:
 
 ```bash
 wget -O docker-compose.yaml https://raw.githubusercontent.com/argilla-io/argilla/main/docker/docker-compose.yaml && docker-compose up -d

--- a/docs/_source/getting_started/installation/deployments/docker_compose.md
+++ b/docs/_source/getting_started/installation/deployments/docker_compose.md
@@ -14,7 +14,7 @@ Then, create a folder:
 mkdir argilla && cd argilla
 ```
 
-and launch the docker-contained web app with the following command:
+and launch the docker-contained web app with the following command, after having set a value for the environment variable `ARGILLA_AUTH_SECRET_KEY` (a valid value can be generated with `openssl rand -hex 32`):
 
 ```bash
 wget -O docker-compose.yaml https://raw.githubusercontent.com/argilla-io/argilla/main/docker/docker-compose.yaml && docker-compose up -d


### PR DESCRIPTION
# Description

I'm proposing to add a mention to the var `ARGILLA_AUTH_SECRET_KEY` introduced in https://github.com/argilla-io/argilla/pull/4539 to the `docker-compose`-related documentation in docs/_source/getting_started/installation/deployments/docker_compose.md 

As far as I am aware, that env var needs to be set in order to run the service in docker-compose.

It's a small edit, I didn't create (yet) an issue for this.

- [x] Documentation update

**How Has This Been Tested**

- [ ] `sphinx-autobuild` 

 I didn't run sphinx! I had troubles w/ cloning, will update this as soon as I can

**Checklist**

- [x] I added relevant documentation
- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
