### PR TITLE
chore: Support for optional user id in responses

### DIFF
--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -353,7 +353,7 @@ class SpanQuestion(QuestionSchema):
     _DEFAULT_MAX_VISIBLE_LABELS = 20
     _MIN_VISIBLE_LABELS = 3
 
-    type: Literal[QuestionTypes.span] = Field(QuestionTypes.span, allow_mutation=False, const=True)
+    type: Literal[QuestionTypes.span] = Field(QuestionTypes.span.value, allow_mutation=False, const=True)
 
     field: str = Field(..., description="The field in the input that the user will be asked to annotate.")
     labels: Union[Dict[str, str], conlist(Union[str, SpanLabelOption], min_items=1, unique_items=True)]

--- a/src/argilla/client/sdk/v1/datasets/models.py
+++ b/src/argilla/client/sdk/v1/datasets/models.py
@@ -18,7 +18,7 @@ from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
 
-from argilla.pydantic_v1 import BaseModel, Field, StrictInt, StrictStr, conint, root_validator
+from argilla.pydantic_v1 import BaseModel, Field, StrictStr, conint, root_validator
 
 
 class FeedbackDatasetModel(BaseModel):
@@ -56,7 +56,7 @@ class FeedbackResponseModel(BaseModel):
     id: UUID
     values: Union[Dict[str, FeedbackValueModel], None]
     status: FeedbackResponseStatus
-    user_id: UUID
+    user_id: Optional[UUID]  # Support changes introduced in https://github.com/argilla-io/argilla-server/pull/57
     inserted_at: datetime
     updated_at: datetime
 


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR adds a little change in API client response model to support changes introduced in https://github.com/argilla-io/argilla-server/pull/57. 

This will allow to download records with responses for deleted users.
Closes #<issue_number>

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I added relevant documentation
- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
