### PR TITLE
Fix wrong URLs within `Text Classification` docs

### DIFF
--- a/docs/_source/_static/tutorials/labelling-feedback-setfit/modal.md
+++ b/docs/_source/_static/tutorials/labelling-feedback-setfit/modal.md
@@ -1,6 +1,6 @@
 ```{grid-item-card} ✨ Add zero-shot suggestions using SetFit
 :img-top: /_static/images/llms/labelling-feedback-setfit/snapshot_setfit_suggestions.png
-:link: ../../guides/llms/examples/labelling-feedback-setfit.html
+:link: ../../tutorials_and_integrations/tutorials/feedback/labelling-feedback-setfit.html
 MLOps Steps: Labelling \
 NLP Tasks: Text Classification \
 Libraries: SetFit \

--- a/docs/_source/_static/tutorials/training-feedback-setfit/modal.md
+++ b/docs/_source/_static/tutorials/training-feedback-setfit/modal.md
@@ -1,6 +1,6 @@
 ```{grid-item-card} 🎛️ Fine-tune a SetFit model using the ArgillaTrainer
 :img-top: /_static/images/llms/training-feedback-setfit/screenshot-demo-feedback-dataset.png
-:link: ../../guides/llms/examples/trainer-feedback-setfit.html
+:link: ../../tutorials_and_integrations/tutorials/feedback/trainer-feedback-setfit.html
 MLOps Steps: Training \
 NLP Tasks: Text Classification \
 Libraries: SetFit \


### PR DESCRIPTION
# Description

The URLs to both `Fine-tune a SetFit model using the ArgillaTrainer` and `Add zero-shot suggestions using SetFit` under the `Text Classification` section, were broken.

So on, this PR updates the paths to point to the actual HTML files now placed under `tutorials_and_guides/tutorials/feedback/*`.

<img width="1624" alt="image" src="https://github.com/argilla-io/argilla/assets/36760800/92da6225-2d1b-484f-8db6-b46ea08e2e1a">

**Type of change**

- [x] Documentation update

**How Has This Been Tested**

- [X] `sphinx-autobuild` (read [Developer Documentation](https://docs.argilla.io/en/latest/community/developer_docs.html#building-the-documentation) for more details)

**Checklist**

- [X] I followed the style guidelines of this project
- [X] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)