### PR TITLE
feat: expose allow overlapping property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ These are the section headers that we use:
 
 ## [Unreleased]()
 
+### Added
+
+- Added `allow_overlapping` field for span questions. ([#4697](https://github.com/argilla-io/argilla/pull/4697))
+
 ## [1.26.1](https://github.com/argilla-io/argilla/compare/v1.26.0...v1.26.1)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ These are the section headers that we use:
 
 ### Added
 
-- Added `allow_overlapping` field for span questions. ([#4697](https://github.com/argilla-io/argilla/pull/4697))
+- Added `allow_overlapping` parameter for span questions. ([#4697](https://github.com/argilla-io/argilla/pull/4697))
 
 ## [1.26.1](https://github.com/argilla-io/argilla/compare/v1.26.0...v1.26.1)
 

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -66,6 +66,6 @@ dependencies:
       - ipynbname>=2023.2.0.0
       - httpx~=0.26.0
       # For now we can just install argilla-server from the GitHub repo
-      - git+https://github.com/argilla-io/argilla-server.git
+      - git+https://github.com/argilla-io/argilla-server.git@feat/expose-allow-overlapping-property
       # install Argilla in editable mode
       - -e .[listeners]

--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -66,6 +66,6 @@ dependencies:
       - ipynbname>=2023.2.0.0
       - httpx~=0.26.0
       # For now we can just install argilla-server from the GitHub repo
-      - git+https://github.com/argilla-io/argilla-server.git@feat/expose-allow-overlapping-property
+      - git+https://github.com/argilla-io/argilla-server.git@feat/overlapped-span-questions
       # install Argilla in editable mode
       - -e .[listeners]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,8 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-server = ["argilla-server ~= 1.26.1"]
-server-postgresql = ["argilla-server[postgresql] ~= 1.26.1"]
+server = ["argilla-server ~= 1.27.0.dev0"]
+server-postgresql = ["argilla-server[postgresql] ~= 1.27.0.dev0"]
 listeners = ["schedule ~= 1.1.0", "prodict ~= 0.8.0"]
 integrations = [
     "PyYAML >= 5.4.1,< 6.1.0", # Required by `argilla.client.feedback.config` just used in `HuggingFaceDatasetMixin`

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -358,7 +358,7 @@ class SpanQuestion(QuestionSchema):
     field: str = Field(..., description="The field in the input that the user will be asked to annotate.")
     labels: Union[Dict[str, str], conlist(Union[str, SpanLabelOption], min_items=1, unique_items=True)]
     visible_labels: Union[conint(ge=3), None] = _DEFAULT_MAX_VISIBLE_LABELS
-    allow_overlapping: bool = Field(False, description="Configure the span overlapping support")
+    allow_overlapping: bool = Field(False, description="Configure span to support overlap")
 
     @validator("labels", pre=True)
     def parse_labels_dict(cls, labels) -> List[SpanLabelOption]:

--- a/src/argilla/client/feedback/schemas/questions.py
+++ b/src/argilla/client/feedback/schemas/questions.py
@@ -358,6 +358,7 @@ class SpanQuestion(QuestionSchema):
     field: str = Field(..., description="The field in the input that the user will be asked to annotate.")
     labels: Union[Dict[str, str], conlist(Union[str, SpanLabelOption], min_items=1, unique_items=True)]
     visible_labels: Union[conint(ge=3), None] = _DEFAULT_MAX_VISIBLE_LABELS
+    allow_overlapping: bool = Field(False, description="Configure the span overlapping support")
 
     @validator("labels", pre=True)
     def parse_labels_dict(cls, labels) -> List[SpanLabelOption]:
@@ -408,6 +409,7 @@ class SpanQuestion(QuestionSchema):
             "type": self.type,
             "field": self.field,
             "visible_options": self.visible_labels,
+            "allow_overlapping": self.allow_overlapping,
             "options": [label.dict() for label in self.labels],
         }
 

--- a/src/argilla/client/feedback/schemas/remote/questions.py
+++ b/src/argilla/client/feedback/schemas/remote/questions.py
@@ -160,6 +160,7 @@ class RemoteSpanQuestion(SpanQuestion, RemoteSchema):
             required=self.required,
             labels=self.labels,
             visible_labels=self.visible_labels,
+            allow_overlapping=self.allow_overlapping,
         )
 
     @classmethod
@@ -168,14 +169,16 @@ class RemoteSpanQuestion(SpanQuestion, RemoteSchema):
 
     @classmethod
     def from_api(cls, payload: "FeedbackQuestionModel") -> "RemoteSpanQuestion":
+        question_settings = payload.settings
         return RemoteSpanQuestion(
             id=payload.id,
             name=payload.name,
             title=payload.title,
-            field=payload.settings["field"],
+            field=question_settings["field"],
             required=payload.required,
-            visible_labels=payload.settings["visible_options"],
-            labels=cls._parse_options_from_api(payload.settings["options"]),
+            visible_labels=question_settings["visible_options"],
+            labels=cls._parse_options_from_api(question_settings["options"]),
+            allow_overlapping=question_settings["allow_overlapping"],
         )
 
 

--- a/tests/integration/client/feedback/dataset/local/test_dataset.py
+++ b/tests/integration/client/feedback/dataset/local/test_dataset.py
@@ -15,10 +15,9 @@
 import tempfile
 from typing import TYPE_CHECKING, List, Type, Union
 
+import argilla.client.singleton
 import datasets
 import pytest
-
-import argilla.client.singleton
 from argilla import ResponseSchema, User, Workspace
 from argilla.client.feedback.config import DatasetConfig
 from argilla.client.feedback.constants import FETCHING_BATCH_SIZE

--- a/tests/integration/client/feedback/dataset/local/test_dataset.py
+++ b/tests/integration/client/feedback/dataset/local/test_dataset.py
@@ -15,9 +15,10 @@
 import tempfile
 from typing import TYPE_CHECKING, List, Type, Union
 
-import argilla.client.singleton
 import datasets
 import pytest
+
+import argilla.client.singleton
 from argilla import ResponseSchema, User, Workspace
 from argilla.client.feedback.config import DatasetConfig
 from argilla.client.feedback.constants import FETCHING_BATCH_SIZE
@@ -72,7 +73,7 @@ def test_create_dataset_with_span_questions(argilla_user: "ServerUser") -> None:
 
     ds = FeedbackDataset(
         fields=[TextField(name="text")],
-        questions=[SpanQuestion(name="spans", field="text", labels=["label1", "label2"], allow_overlapping=True)],
+        questions=[SpanQuestion(name="spans", field="text", labels=["label1", "label2"])],
     )
 
     rg_dataset = ds.push_to_argilla(name="new_dataset")
@@ -82,7 +83,30 @@ def test_create_dataset_with_span_questions(argilla_user: "ServerUser") -> None:
     assert question.name == "spans"
     assert question.field == "text"
     assert question.labels == [SpanLabelOption(value="label1"), SpanLabelOption(value="label2")]
-    assert question.allow_overlapping is True
+    assert question.allow_overlapping is False
+
+
+@pytest.mark.parametrize("allow_overlapping", [True, False])
+def test_create_dataset_with_span_questions_allow_overlapping(
+    argilla_user: "ServerUser", allow_overlapping: bool
+) -> None:
+    argilla.client.singleton.init(api_key=argilla_user.api_key)
+
+    ds = FeedbackDataset(
+        fields=[TextField(name="text")],
+        questions=[
+            SpanQuestion(name="spans", field="text", labels=["label1", "label2"], allow_overlapping=allow_overlapping)
+        ],
+    )
+
+    rg_dataset = ds.push_to_argilla(name="new_dataset")
+
+    assert rg_dataset.id
+    question = rg_dataset.questions[0]
+    assert question.name == "spans"
+    assert question.field == "text"
+    assert question.labels == [SpanLabelOption(value="label1"), SpanLabelOption(value="label2")]
+    assert question.allow_overlapping is allow_overlapping
 
 
 @pytest.mark.asyncio

--- a/tests/integration/client/feedback/dataset/local/test_dataset.py
+++ b/tests/integration/client/feedback/dataset/local/test_dataset.py
@@ -15,9 +15,10 @@
 import tempfile
 from typing import TYPE_CHECKING, List, Type, Union
 
-import argilla.client.singleton
 import datasets
 import pytest
+
+import argilla.client.singleton
 from argilla import ResponseSchema, User, Workspace
 from argilla.client.feedback.config import DatasetConfig
 from argilla.client.feedback.constants import FETCHING_BATCH_SIZE
@@ -72,15 +73,17 @@ def test_create_dataset_with_span_questions(argilla_user: "ServerUser") -> None:
 
     ds = FeedbackDataset(
         fields=[TextField(name="text")],
-        questions=[SpanQuestion(name="spans", field="text", labels=["label1", "label2"])],
+        questions=[SpanQuestion(name="spans", field="text", labels=["label1", "label2"], allow_overlapping=True)],
     )
 
     rg_dataset = ds.push_to_argilla(name="new_dataset")
 
     assert rg_dataset.id
-    assert rg_dataset.questions[0].name == "spans"
-    assert rg_dataset.questions[0].field == "text"
-    assert rg_dataset.questions[0].labels == [SpanLabelOption(value="label1"), SpanLabelOption(value="label2")]
+    question = rg_dataset.questions[0]
+    assert question.name == "spans"
+    assert question.field == "text"
+    assert question.labels == [SpanLabelOption(value="label1"), SpanLabelOption(value="label2")]
+    assert question.allow_overlapping is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/client/feedback/schemas/remote/test_questions.py
+++ b/tests/unit/client/feedback/schemas/remote/test_questions.py
@@ -17,6 +17,7 @@ from typing import Any, Dict
 from uuid import uuid4
 
 import pytest
+
 from argilla.client.feedback.schemas.enums import QuestionTypes
 from argilla.client.feedback.schemas.questions import (
     LabelQuestion,
@@ -460,6 +461,7 @@ def test_span_questions_from_api():
             "type": "span",
             "field": "field",
             "visible_options": None,
+            "allow_overlapping": False,
             "options": [
                 {"text": "Span label a", "value": "a", "description": None},
                 {
@@ -490,6 +492,7 @@ def test_span_questions_from_api_with_visible_labels():
             "type": "span",
             "field": "field",
             "visible_options": 3,
+            "allow_overlapping": False,
             "options": [
                 {"text": "Span label a", "value": "a", "description": None},
                 {"text": "Span label b", "value": "b", "description": None},

--- a/tests/unit/client/feedback/schemas/remote/test_questions.py
+++ b/tests/unit/client/feedback/schemas/remote/test_questions.py
@@ -17,7 +17,6 @@ from typing import Any, Dict
 from uuid import uuid4
 
 import pytest
-
 from argilla.client.feedback.schemas.enums import QuestionTypes
 from argilla.client.feedback.schemas.questions import (
     LabelQuestion,

--- a/tests/unit/client/feedback/schemas/test_questions.py
+++ b/tests/unit/client/feedback/schemas/test_questions.py
@@ -15,7 +15,6 @@
 from typing import Any, Dict
 
 import pytest
-
 from argilla.client.feedback.schemas.enums import QuestionTypes
 from argilla.client.feedback.schemas.questions import (
     LabelQuestion,
@@ -27,6 +26,7 @@ from argilla.client.feedback.schemas.questions import (
     TextQuestion,
     _LabelQuestion,
 )
+
 from tests.pydantic_v1 import ValidationError
 
 
@@ -465,7 +465,7 @@ def test_span_question() -> None:
         "field": "field",
         "visible_options": None,
         "allow_overlapping": True,
-        "options": [{"value": "a", "text": "a", "description": None}, {"value": "b", "text": "b", "description": None}]
+        "options": [{"value": "a", "text": "a", "description": None}, {"value": "b", "text": "b", "description": None}],
     }
 
 

--- a/tests/unit/client/feedback/schemas/test_questions.py
+++ b/tests/unit/client/feedback/schemas/test_questions.py
@@ -15,6 +15,7 @@
 from typing import Any, Dict
 
 import pytest
+
 from argilla.client.feedback.schemas.enums import QuestionTypes
 from argilla.client.feedback.schemas.questions import (
     LabelQuestion,
@@ -26,7 +27,6 @@ from argilla.client.feedback.schemas.questions import (
     TextQuestion,
     _LabelQuestion,
 )
-
 from tests.pydantic_v1 import ValidationError
 
 
@@ -455,6 +455,7 @@ def test_span_question() -> None:
         title="Question",
         description="Description",
         required=True,
+        allow_overlapping=True,
         labels=["a", "b"],
     )
 
@@ -463,7 +464,8 @@ def test_span_question() -> None:
         "type": "span",
         "field": "field",
         "visible_options": None,
-        "options": [{"value": "a", "text": "a", "description": None}, {"value": "b", "text": "b", "description": None}],
+        "allow_overlapping": True,
+        "options": [{"value": "a", "text": "a", "description": None}, {"value": "b", "text": "b", "description": None}]
     }
 
 
@@ -481,6 +483,7 @@ def test_span_question_with_labels_dict() -> None:
         "type": "span",
         "field": "field",
         "visible_options": None,
+        "allow_overlapping": False,
         "options": [
             {"value": "a", "text": "A text", "description": None},
             {"value": "b", "text": "B text", "description": None},
@@ -503,6 +506,7 @@ def test_span_question_with_visible_labels() -> None:
         "type": "span",
         "field": "field",
         "visible_options": 3,
+        "allow_overlapping": False,
         "options": [
             {"value": "a", "text": "a", "description": None},
             {"value": "b", "text": "b", "description": None},


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR adds the `allow_overlapping` field for span questions to configure span questions with overlapping support. The default value is set to `False` to align the previous version of the span question.

It must be merged after https://github.com/argilla-io/argilla-server/pull/89

```python
span_question = rg.SpanQuestion(name="spans", .., allow_overlapping=True)
...
```

Closes https://github.com/argilla-io/argilla/issues/4694

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [X] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I added relevant documentation
- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
