### PR TITLE
docs: add new environment variables to set maximum number of items for questions

### DIFF
--- a/docs/_source/getting_started/installation/configurations/server_configuration.md
+++ b/docs/_source/getting_started/installation/configurations/server_configuration.md
@@ -43,7 +43,6 @@ uvicorn argilla:app
 For more details about FastAPI and uvicorn, see [here](https://fastapi.tiangolo.com/deployment/manually/#run-a-server-manually-uvicorn).
 :::
 
-
 ## Environment variables
 
 You can set the following environment variables to further configure your server and client.
@@ -58,7 +57,7 @@ You can set the following environment variables to further configure your server
 
 - `ARGILLA_CORS_ORIGINS`: List of host patterns for CORS origin access.
 
-- `ARGILLA_DOCS_ENABLED`: If False, disables openapi docs endpoint at */api/docs*.
+- `ARGILLA_DOCS_ENABLED`: If False, disables openapi docs endpoint at _/api/docs_.
 
 - `ARGILLA_ENABLE_TELEMETRY`: If False, disables telemetry for usage metrics.
 
@@ -85,6 +84,12 @@ You can set the following environment variables to further configure your server
 - `ARGILLA_METADATA_FIELDS_LIMIT`: Max number of fields in the metadata (Default: 50, max: 100).
 
 - `ARGILLA_METADATA_FIELD_LENGTH`: Max length supported for the string metadata fields. Higher values will be truncated. Abusing this may lead to Elastic performance issues (Default: 128).
+
+### Feedback Datasets
+
+- `ARGILLA_LABEL_SELECTION_OPTIONS_MAX_ITEMS` (default: `500`): set the number of maximum items to be allowed by label and multi label questions.
+
+- `ARGILLA_SPAN_OPTIONS_MAX_ITEMS` (default: `500`): set the number of maximum items to be allowed by span questions.
 
 ### Client
 


### PR DESCRIPTION
# Description

This PR is associated to the changes at https://github.com/argilla-io/argilla-server/pull/85 adding two new environment variables that could be used to increase (or reduce) the maximum number of items that could be defined for label, multi label and span questions.

Refs #4615 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [x] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [x] Checking that the markdown render as expected.

**Checklist**

- [x] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)