### PR TITLE
docs: add new environment variable to disable Hugging Face warning when spaces persistant storage is disabled

### DIFF
--- a/docs/_source/getting_started/installation/configurations/server_configuration.md
+++ b/docs/_source/getting_started/installation/configurations/server_configuration.md
@@ -91,6 +91,10 @@ You can set the following environment variables to further configure your server
 
 - `ARGILLA_SPAN_OPTIONS_MAX_ITEMS`: Set the number of maximum items to be allowed by span questions (Default: `500`).
 
+### Hugging Face
+
+- `ARGILLA_SHOW_HUGGINGFACE_SPACE_PERSISTANT_STORAGE_WARNING`: When Argilla is running on Hugging Face Spaces you can use this environment variable to disable the warning message showed when persistant storage is disabled for the space (Default: `true`).
+
 ### Client
 
 - `ARGILLA_API_URL`: The default API URL when calling {meth}`argilla.init`.

--- a/docs/_source/getting_started/installation/deployments/huggingface-spaces.md
+++ b/docs/_source/getting_started/installation/deployments/huggingface-spaces.md
@@ -148,6 +148,10 @@ To enable [persistent storage](https://huggingface.co/docs/hub/spaces-storage#pe
 
 ![Alt text](../../../_static/images/installation/huggingface-spaces/persistent-storage.PNG)
 
+```{note}
+If persistent storage isn't enabled, Argilla will display a warning message by default. If you don't require persistent storage in your space and wish to avoid seeing the warning message, you can set the environment variable `ARGILLA_SHOW_HUGGINGFACE_SPACE_PERSISTANT_STORAGE_WARNING` to `false`. This way, the warning message won't be shown, even if persistent storage is disabled for the space.
+```
+
 ## Setting up secret environment variables
 
 The Space template provides a way to set up different **optional settings** focusing on securing your Argilla Space.

--- a/docs/_source/getting_started/installation/deployments/huggingface-spaces.md
+++ b/docs/_source/getting_started/installation/deployments/huggingface-spaces.md
@@ -142,14 +142,14 @@ If you have improvement suggestions or need specific support, please join [Argil
 
 ## Setting up persistent storage
 
-Hugging Face Spaces recently introduced a feature for persistent storage, which must be enabled manually through the Hugging Face Spaces settings. Without this activation, and if you're not subscribed to a paid space upgrade, the space will automatically shut down after 48 hours of inactivity, resulting in data loss. To prevent this, we highly recommend using the persistent storage layer offered by Hugging Face.
+Hugging Face Spaces recently introduced a feature for persistent storage, which must be enabled manually through the Hugging Face Spaces settings. Without this activation, and if you're not subscribed to a paid space upgrade, the space will automatically shut down after 48 hours of inactivity and do a factory reset when it is restarted, meaning that all the data of the space will be lost, including all created users, workspaces and datasets. To prevent this, we highly recommend using the persistent storage layer offered by Hugging Face.
 
 To enable [persistent storage](https://huggingface.co/docs/hub/spaces-storage#persistent-storage), go to the "Settings" tab on your created Space and click on the desired plan on the "Persistent Storage" section. This will enable persistent storage for your Space and you will be able to use it for data labeling and feedback collection.
 
 ![Alt text](../../../_static/images/installation/huggingface-spaces/persistent-storage.PNG)
 
 ```{note}
-If you haven't enabled persistent storage, Argilla will show a warning message by default. If you don't require persistent storage for your space and want to prevent the warning message from appearing, you can set the environment variable `ARGILLA_SHOW_HUGGINGFACE_SPACE_PERSISTANT_STORAGE_WARNING` to `false`. This will suppress the warning message, even if persistent storage is disabled for the space.
+If you haven't enabled persistent storage, Argilla will show a warning message by default. If you don't require persistent storage for your space and want to prevent the warning message from appearing, you can set the environment variable `ARGILLA_SHOW_HUGGINGFACE_SPACE_PERSISTANT_STORAGE_WARNING` to `false`. This will suppress the warning message, even if persistent storage is not enabled for the space.
 ```
 
 ## Setting up secret environment variables

--- a/docs/_source/getting_started/installation/deployments/huggingface-spaces.md
+++ b/docs/_source/getting_started/installation/deployments/huggingface-spaces.md
@@ -149,7 +149,7 @@ To enable [persistent storage](https://huggingface.co/docs/hub/spaces-storage#pe
 ![Alt text](../../../_static/images/installation/huggingface-spaces/persistent-storage.PNG)
 
 ```{note}
-If persistent storage isn't enabled, Argilla will display a warning message by default. If you don't require persistent storage in your space and wish to avoid seeing the warning message, you can set the environment variable `ARGILLA_SHOW_HUGGINGFACE_SPACE_PERSISTANT_STORAGE_WARNING` to `false`. This way, the warning message won't be shown, even if persistent storage is disabled for the space.
+If you haven't enabled persistent storage, Argilla will show a warning message by default. If you don't require persistent storage for your space and want to prevent the warning message from appearing, you can set the environment variable `ARGILLA_SHOW_HUGGINGFACE_SPACE_PERSISTANT_STORAGE_WARNING` to `False`. This will suppress the warning message, even if persistent storage is disabled for the space.
 ```
 
 ## Setting up secret environment variables

--- a/docs/_source/getting_started/installation/deployments/huggingface-spaces.md
+++ b/docs/_source/getting_started/installation/deployments/huggingface-spaces.md
@@ -149,7 +149,7 @@ To enable [persistent storage](https://huggingface.co/docs/hub/spaces-storage#pe
 ![Alt text](../../../_static/images/installation/huggingface-spaces/persistent-storage.PNG)
 
 ```{note}
-If you haven't enabled persistent storage, Argilla will show a warning message by default. If you don't require persistent storage for your space and want to prevent the warning message from appearing, you can set the environment variable `ARGILLA_SHOW_HUGGINGFACE_SPACE_PERSISTANT_STORAGE_WARNING` to `False`. This will suppress the warning message, even if persistent storage is disabled for the space.
+If you haven't enabled persistent storage, Argilla will show a warning message by default. If you don't require persistent storage for your space and want to prevent the warning message from appearing, you can set the environment variable `ARGILLA_SHOW_HUGGINGFACE_SPACE_PERSISTANT_STORAGE_WARNING` to `false`. This will suppress the warning message, even if persistent storage is disabled for the space.
 ```
 
 ## Setting up secret environment variables


### PR DESCRIPTION
# Description

This PR is associated to changes implemented on https://github.com/argilla-io/argilla-server/pull/124 adding a new environment variable to force disable a warning when Argilla is running on Hugging Face Spaces and persistant storage is disabled.

Closes #4736

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [x] Documentation update

**How Has This Been Tested**

- [x] Checking that the markdown is correctly rendered.

**Checklist**

- [x] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)