### PR TITLE
ci: Allow manual execution for deploy argilla environment

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -1,13 +1,15 @@
 name: Deploy Argilla environment
 
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       image-name:
         description: The name of the Docker image to deploy.
         type: string
+        default: argilla/argilla-quickstart-for-dev
       image-version:
-        description: The version of the Docker image to deploy.
+        description: The version of the Docker image to deploy. In the form pr-<PR_NUMBER>.
         type: string
 
 jobs:

--- a/.github/workflows/teardown-pr-environemnts.yml
+++ b/.github/workflows/teardown-pr-environemnts.yml
@@ -1,0 +1,36 @@
+name: Close Pull Request
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # every day at midnight
+
+jobs:
+  teardown_pr_environments:
+    name: Teardown Cloud Run PR environments
+    runs-on: ubuntu-latest
+
+    # Grant permissions to `GITHUB_TOKEN` for Google Cloud Workload Identity Provider
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: "actions/checkout@v3"
+
+      - name: Authenticate to Google Cloud
+        uses: "google-github-actions/auth@v1"
+        with:
+          workload_identity_provider: ${{ secrets.GOOGLE_CLOUD_WIP }}
+          service_account: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: "google-github-actions/setup-gcloud@v1"
+        with:
+          version: ">= 435.0.0"
+
+      - name: Remove running PR environments
+        run: |
+          services=$(gcloud run services list --project=argilla-ci --format="value(metadata.name)")
+          for service in $services; do
+            gcloud run services delete $service --project=argilla-ci --region=europe-southwest1 --quiet
+          done


### PR DESCRIPTION
This PR configs the manual execution of the PR environments.

Also, clean running environments once per day.