### PR TITLE
fix: Duplicate workflow inputs in workflow_dispatch

### DIFF
--- a/.github/actions/slack-post-credentials/app/main.py
+++ b/.github/actions/slack-post-credentials/app/main.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, Union
 from slack_sdk import WebClient
 
 SLACK_BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN")
-GITHUB_REF = os.environ["GITHUB_REF"]
+GITHUB_REF: str = os.environ.get("GITHUB_REF")
 
 # Inputs
 SLACK_CHANNEL_NAME = os.environ.get("INPUT_SLACK-CHANNEL-NAME")

--- a/.github/actions/slack-post-credentials/app/main.py
+++ b/.github/actions/slack-post-credentials/app/main.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, Union
 from slack_sdk import WebClient
 
 SLACK_BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN")
-GITHUB_REF: str = os.environ.get("GITHUB_REF")
+GITHUB_REF = os.environ["GITHUB_REF"]
 
 # Inputs
 SLACK_CHANNEL_NAME = os.environ.get("INPUT_SLACK-CHANNEL-NAME")

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -68,6 +68,7 @@ jobs:
 
       - name: Post credentials in Slack
         uses: ./.github/actions/slack-post-credentials
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
           slack-channel-name: argilla-github
           url: ${{ steps.deploy.outputs.url }}
@@ -79,6 +80,7 @@ jobs:
 
       - name: Comment PR with Cloud Run URL
         uses: thollander/actions-comment-pull-request@v2
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
           message: |
             The URL of the deployed environment for this PR is ${{ steps.deploy.outputs.url }}

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -1,7 +1,17 @@
 name: Deploy Argilla environment
 
 on:
+
   workflow_dispatch:
+    inputs:
+      image-name:
+        description: The name of the Docker image to deploy.
+        type: string
+        default: argilla/argilla-quickstart-for-dev
+      image-version:
+        description: The version of the Docker image to deploy. In the form pr-<PR_NUMBER>.
+        type: string
+
   workflow_call:
     inputs:
       image-name:

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -1,4 +1,4 @@
-name: Deploy Argilla PR environment
+name: Deploy Argilla environment
 
 on:
 

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -1,4 +1,4 @@
-name: Deploy Argilla environment
+name: Deploy Argilla PR environment
 
 on:
 

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -17,7 +17,6 @@ on:
       image-name:
         description: The name of the Docker image to deploy.
         type: string
-        default: argilla/argilla-quickstart-for-dev
       image-version:
         description: The version of the Docker image to deploy. In the form pr-<PR_NUMBER>.
         type: string

--- a/.github/workflows/teardown-pr-environemnts.yml
+++ b/.github/workflows/teardown-pr-environemnts.yml
@@ -2,7 +2,7 @@ name: Close Pull Request
 
 on:
   schedule:
-    - cron: "0 0 * * *" # every day at midnight
+    - cron: "0 8,20 * * *" # every day at 8:00 and 20:00 UTC
 
 jobs:
   teardown_pr_environments:


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR adds the missing workflow inputs when running it manually (changes introduced in #4749 ). 

Now, the manual execution is available [here](https://github.com/argilla-io/argilla/actions/workflows/deploy-environment.yml) (Run workflow button)

<img width="1148" alt="Captura de pantalla 2024-04-29 a las 17 01 06" src="https://github.com/argilla-io/argilla/assets/2518789/3c676c96-7bab-4d74-8eb6-6922538201d7">


Also, the cron schedule to shutdown running PR environments has been configured to run twice a day (at 8:00 and 20:00)



**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
