### PR TITLE
Allow overlap equal to number of users in assign_users

### DIFF
--- a/src/argilla/client/feedback/utils/assignment.py
+++ b/src/argilla/client/feedback/utils/assignment.py
@@ -142,8 +142,11 @@ def assign_records_to_individuals(
     Raises:
         ValueError: If `overlap` is higher than the number of users or negative.
     """
-    if overlap < 0 or overlap >= len(users):
-        raise ValueError("Overlap must be less than the number of users and must not be negative.")
+    if overlap < 0 or overlap > len(users):
+        raise ValueError("Overlap must be less or equal to than the number of users and must not be negative.")
+
+    if overlap == len(users):
+        warnings.warn("Overlap is equal to the number of users. Each user will annotate all records.", UserWarning)
 
     if len(records) < len(users):
         warnings.warn(

--- a/tests/unit/client/feedback/utils/test_assignment.py
+++ b/tests/unit/client/feedback/utils/test_assignment.py
@@ -193,6 +193,16 @@ def test_assign_records_to_groups(mock_shuffle, overlap, shuffle, expected_error
                 "user3": ["record2", "record3", "record5"],
             },
         ),
+        (
+            3,
+            False,
+            None,
+            {
+                "user1": ["record1", "record2", "record3", "record4", "record5"],
+                "user2": ["record1", "record2", "record3", "record4", "record5"],
+                "user3": ["record1", "record2", "record3", "record4", "record5"],
+            },
+        ),
         (5, False, ValueError, None),
         (-1, False, ValueError, None),
     ],


### PR DESCRIPTION
# Description

In `assign_records` it's currently not possible to assign _all records to all users_. I can't see a reason why this would be the case (it's something my team need at the moment), so I've updated the code to allow this and to warn if all records will be assigned to all users.

Note I'm still setting up a dev environment on my machine (with `pip install` the integrations dependencies take ages to resolve), so I haven't confirmed that my test works.

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [x] Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

Updated existing test with a new test case

**Checklist**

- [x] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
