### PR TITLE
Docs: fix imports for annotator metrics

### DIFF
--- a/argilla/src/argilla/client/feedback/metrics/annotator_metrics.py
+++ b/argilla/src/argilla/client/feedback/metrics/annotator_metrics.py
@@ -53,7 +53,7 @@ class AnnotatorMetric(MetricBase):
 
     Example:
         >>> import argilla as rg
-        >>> from argilla.client.feedback.metrics import AnnotatorMetric
+        >>> from argilla.client.feedback.metrics.annotator_metrics import AnnotatorMetric
         >>> metric = AnnotatorMetric(dataset=dataset, question_name=question)
         >>> metrics_report = metric.compute("accuracy")
 
@@ -171,7 +171,7 @@ class UnifiedAnnotatorMetric(AnnotatorMetric):
 
     Example:
         >>> import argilla as rg
-        >>> from argilla.client.feedback.metrics import UnifiedAnnotatorMetric
+        >>> from argilla.client.feedback.metrics.annotator_metrics import UnifiedAnnotatorMetric
         >>> metric = UnifiedAnnotatorMetric(dataset=dataset, question_name=question)
         >>> metrics_report = metric.compute("accuracy")
     """


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

While preparing my Argilla meetup talk for next week, I noticed that the examples from the docs on Metrics were failing with this error messsage:
```
ImportError: cannot import name 'AnnotatorMetric' from 'argilla.client.feedback.metrics' 
```
So I fixed the docstrings.

**Type of change**

- [x] Documentation update

**How Has This Been Tested**

I have run no test. This is a 1-line change.
- [ ] `sphinx-autobuild` (read [Developer Documentation](https://docs.argilla.io/en/latest/community/developer_docs.html#building-the-documentation) for more details)

**Checklist**

- [x] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/) -> I don't think my change is notable and deserves to be in the Changelog
