### PR TITLE
fix: add error code when searching for a record missing specific vector

### DIFF
--- a/argilla-frontend/plugins/plugins/axios.ts
+++ b/argilla-frontend/plugins/plugins/axios.ts
@@ -28,6 +28,8 @@ type BackendError = {
       detail: string;
     };
   };
+  code?: string;
+  message?: string;
 };
 
 export default ({ $axios, app }) => {
@@ -48,7 +50,7 @@ export default ({ $axios, app }) => {
   });
 
   $axios.onError((error: AxiosError<BackendError>) => {
-    const { status } = error.response ?? {};
+    const { status, data } = error.response ?? {};
     const t = (key: string) => app.i18n.t(key);
 
     Notification.dispatch("clear");
@@ -67,6 +69,18 @@ export default ({ $axios, app }) => {
         message: handledTranslatedError,
         type: "error",
       });
+    }
+
+    if (data.code) {
+      const errorHandledKey = `validations.businessLogic.${data.code}.message`;
+      const handledTranslatedError = t(errorHandledKey);
+
+      if (handledTranslatedError !== errorHandledKey) {
+        Notification.dispatch("notify", {
+          message: handledTranslatedError,
+          type: "error",
+        });
+      }
     }
 
     throw error;

--- a/argilla-frontend/translation/de.js
+++ b/argilla-frontend/translation/de.js
@@ -216,6 +216,11 @@ export default {
   },
 
   validations: {
+    businessLogic: {
+      missing_vector: {
+        message: "Vektor nicht im ausgewählten Datensatz gefunden",
+      },
+    },
     http: {
       401: {
         message: "Anmeldedaten konnten nicht überprüft werden",

--- a/argilla-frontend/translation/en.js
+++ b/argilla-frontend/translation/en.js
@@ -228,6 +228,11 @@ export default {
       "Persistent storage is not enabled. All data will be lost if this space restarts.",
   },
   validations: {
+    businessLogic: {
+      missing_vector: {
+        message: "Vector not found in selected record",
+      },
+    },
     http: {
       401: {
         message: "Could not validate credentials",

--- a/argilla-server/src/argilla_server/apis/errors/__init__.py
+++ b/argilla-server/src/argilla_server/apis/errors/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/argilla-server/src/argilla_server/apis/errors/v1/__init__.py
+++ b/argilla-server/src/argilla_server/apis/errors/v1/__init__.py
@@ -1,0 +1,13 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.

--- a/argilla-server/src/argilla_server/apis/errors/v1/exception_handlers.py
+++ b/argilla-server/src/argilla_server/apis/errors/v1/exception_handlers.py
@@ -22,5 +22,6 @@ def add_exception_handlers(app: FastAPI):
     @app.exception_handler(errors.UnprocessableEntityError)
     async def unprocessable_entity_error_exception_handler(request, exc):
         return JSONResponse(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, content={"code": exc.code, "message": exc.message}
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content={"code": exc.code, "message": exc.message},
         )

--- a/argilla-server/src/argilla_server/apis/errors/v1/exception_handlers.py
+++ b/argilla-server/src/argilla_server/apis/errors/v1/exception_handlers.py
@@ -1,0 +1,26 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from fastapi import FastAPI, status
+from fastapi.responses import JSONResponse
+
+import argilla_server.errors.future as errors
+
+
+def add_exception_handlers(app: FastAPI):
+    @app.exception_handler(errors.UnprocessableEntityError)
+    async def unprocessable_entity_error_exception_handler(request, exc):
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, content={"code": exc.code, "message": exc.message}
+        )

--- a/argilla-server/src/argilla_server/apis/routes.py
+++ b/argilla-server/src/argilla_server/apis/routes.py
@@ -21,6 +21,7 @@ set the required security dependencies if api security is enabled
 from fastapi import FastAPI
 
 from argilla_server._version import __version__ as argilla_version
+from argilla_server.apis.errors.v1.exception_handlers import add_exception_handlers as add_exception_handlers_v1
 from argilla_server.apis.v0.handlers import (
     authentication,
     datasets,
@@ -113,6 +114,8 @@ def create_api_v1():
     # Now, we can control the error responses for the API v1.
     # We keep the same error responses as the API v0 for the moment
     APIErrorHandler.configure_app(api_v1)
+
+    add_exception_handlers_v1(api_v1)
 
     for router in [
         info_v1.router,

--- a/argilla-server/src/argilla_server/apis/v1/handlers/datasets/records.py
+++ b/argilla-server/src/argilla_server/apis/v1/handlers/datasets/records.py
@@ -27,6 +27,7 @@ from argilla_server.apis.v1.handlers.datasets.datasets import _get_dataset_or_ra
 from argilla_server.contexts import datasets, search
 from argilla_server.database import get_async_db
 from argilla_server.enums import MetadataPropertyType, RecordSortField, ResponseStatusFilter, SortOrder
+from argilla_server.errors.future.base_errors import MISSING_VECTOR_ERROR_CODE
 from argilla_server.models import Dataset as DatasetModel
 from argilla_server.models import Record, User
 from argilla_server.policies import DatasetPolicyV1, authorize
@@ -217,7 +218,7 @@ async def _get_search_responses(
             if not record.vector_value_by_vector_settings(vector_settings):
                 raise errors.UnprocessableEntityError(
                     message=f"Record `{record.id}` does not have a vector for vector settings `{vector_settings.name}`",
-                    code="missing_vector",
+                    code=MISSING_VECTOR_ERROR_CODE,
                 )
 
     if (

--- a/argilla-server/src/argilla_server/apis/v1/handlers/datasets/records.py
+++ b/argilla-server/src/argilla_server/apis/v1/handlers/datasets/records.py
@@ -17,6 +17,7 @@ from typing import Dict, List, Optional, Tuple, Union
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Security, status
+from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 
@@ -214,9 +215,9 @@ async def _get_search_responses(
             await record.awaitable_attrs.vectors
 
             if not record.vector_value_by_vector_settings(vector_settings):
-                raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    detail=f"Record `{record.id}` does not have a vector for vector settings `{vector_settings.name}`",
+                raise errors.UnprocessableEntityError(
+                    message=f"Record `{record.id}` does not have a vector for vector settings `{vector_settings.name}`",
+                    code="missing_vector",
                 )
 
     if (
@@ -575,18 +576,24 @@ async def search_current_user_dataset_records(
 
     await _validate_search_records_query(db, body, dataset_id)
 
-    search_responses = await _get_search_responses(
-        db=db,
-        search_engine=search_engine,
-        dataset=dataset,
-        search_records_query=body,
-        parsed_metadata=metadata.metadata_parsed,
-        limit=limit,
-        offset=offset,
-        user=current_user,
-        response_statuses=response_statuses,
-        sort_by_query_param=sort_by_query_param,
-    )
+    try:
+        search_responses = await _get_search_responses(
+            db=db,
+            search_engine=search_engine,
+            dataset=dataset,
+            search_records_query=body,
+            parsed_metadata=metadata.metadata_parsed,
+            limit=limit,
+            offset=offset,
+            user=current_user,
+            response_statuses=response_statuses,
+            sort_by_query_param=sort_by_query_param,
+        )
+    except errors.UnprocessableEntityError as e:
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content={"code": e.code, "message": e.message},
+        )
 
     record_id_score_map = {
         response.record_id: {"query_score": response.score, "search_record": None}
@@ -637,17 +644,23 @@ async def search_dataset_records(
 
     await _validate_search_records_query(db, body, dataset_id)
 
-    search_responses = await _get_search_responses(
-        db=db,
-        search_engine=search_engine,
-        dataset=dataset,
-        search_records_query=body,
-        limit=limit,
-        offset=offset,
-        parsed_metadata=metadata.metadata_parsed,
-        response_statuses=response_statuses,
-        sort_by_query_param=sort_by_query_param,
-    )
+    try:
+        search_responses = await _get_search_responses(
+            db=db,
+            search_engine=search_engine,
+            dataset=dataset,
+            search_records_query=body,
+            limit=limit,
+            offset=offset,
+            parsed_metadata=metadata.metadata_parsed,
+            response_statuses=response_statuses,
+            sort_by_query_param=sort_by_query_param,
+        )
+    except errors.UnprocessableEntityError as e:
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content={"code": e.code, "message": e.message},
+        )
 
     record_id_score_map = {
         response.record_id: {"query_score": response.score, "search_record": None}

--- a/argilla-server/src/argilla_server/apis/v1/handlers/datasets/records.py
+++ b/argilla-server/src/argilla_server/apis/v1/handlers/datasets/records.py
@@ -17,7 +17,6 @@ from typing import Dict, List, Optional, Tuple, Union
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Security, status
-from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing_extensions import Annotated
 
@@ -577,24 +576,18 @@ async def search_current_user_dataset_records(
 
     await _validate_search_records_query(db, body, dataset_id)
 
-    try:
-        search_responses = await _get_search_responses(
-            db=db,
-            search_engine=search_engine,
-            dataset=dataset,
-            search_records_query=body,
-            parsed_metadata=metadata.metadata_parsed,
-            limit=limit,
-            offset=offset,
-            user=current_user,
-            response_statuses=response_statuses,
-            sort_by_query_param=sort_by_query_param,
-        )
-    except errors.UnprocessableEntityError as e:
-        return JSONResponse(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            content={"code": e.code, "message": e.message},
-        )
+    search_responses = await _get_search_responses(
+        db=db,
+        search_engine=search_engine,
+        dataset=dataset,
+        search_records_query=body,
+        parsed_metadata=metadata.metadata_parsed,
+        limit=limit,
+        offset=offset,
+        user=current_user,
+        response_statuses=response_statuses,
+        sort_by_query_param=sort_by_query_param,
+    )
 
     record_id_score_map = {
         response.record_id: {"query_score": response.score, "search_record": None}
@@ -645,23 +638,17 @@ async def search_dataset_records(
 
     await _validate_search_records_query(db, body, dataset_id)
 
-    try:
-        search_responses = await _get_search_responses(
-            db=db,
-            search_engine=search_engine,
-            dataset=dataset,
-            search_records_query=body,
-            limit=limit,
-            offset=offset,
-            parsed_metadata=metadata.metadata_parsed,
-            response_statuses=response_statuses,
-            sort_by_query_param=sort_by_query_param,
-        )
-    except errors.UnprocessableEntityError as e:
-        return JSONResponse(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            content={"code": e.code, "message": e.message},
-        )
+    search_responses = await _get_search_responses(
+        db=db,
+        search_engine=search_engine,
+        dataset=dataset,
+        search_records_query=body,
+        limit=limit,
+        offset=offset,
+        parsed_metadata=metadata.metadata_parsed,
+        response_statuses=response_statuses,
+        sort_by_query_param=sort_by_query_param,
+    )
 
     record_id_score_map = {
         response.record_id: {"query_score": response.score, "search_record": None}

--- a/argilla-server/src/argilla_server/errors/future/base_errors.py
+++ b/argilla-server/src/argilla_server/errors/future/base_errors.py
@@ -12,7 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__all__ = ["NotFoundError", "NotUniqueError", "AuthenticationError"]
+__all__ = ["NotFoundError", "NotUniqueError", "UnprocessableEntityError", "AuthenticationError"]
+
+UNPROCESSABLE_ENTITY_ERROR_CODE = "unprocessable_entity"
 
 
 class NotFoundError(Exception):
@@ -25,6 +27,14 @@ class NotUniqueError(Exception):
     """Custom Argilla not unique error. Use it for situations where an Argilla domain entity already exists violating a constraint."""
 
     pass
+
+
+class UnprocessableEntityError(Exception):
+    """Custom Argilla unprocessable entity error. Use it for situations where an Argilla domain entity can not be processed."""
+
+    def __init__(self, message, code=UNPROCESSABLE_ENTITY_ERROR_CODE):
+        self.message = message
+        self.code = code
 
 
 class AuthenticationError(Exception):

--- a/argilla-server/src/argilla_server/errors/future/base_errors.py
+++ b/argilla-server/src/argilla_server/errors/future/base_errors.py
@@ -15,6 +15,7 @@
 __all__ = ["NotFoundError", "NotUniqueError", "UnprocessableEntityError", "AuthenticationError"]
 
 UNPROCESSABLE_ENTITY_ERROR_CODE = "unprocessable_entity"
+MISSING_VECTOR_ERROR_CODE = "missing_vector"
 
 
 class NotFoundError(Exception):

--- a/argilla-server/tests/unit/api/v1/datasets/test_search_current_user_dataset_records.py
+++ b/argilla-server/tests/unit/api/v1/datasets/test_search_current_user_dataset_records.py
@@ -53,7 +53,8 @@ class TestSearchCurrentUserDatasetRecords:
 
         assert response.status_code == 422
         assert response.json() == {
-            "detail": f"Record `{record_without_vector.id}` does not have a vector for vector settings `{vector_settings.name}`"
+            "code": "missing_vector",
+            "message": f"Record `{record_without_vector.id}` does not have a vector for vector settings `{vector_settings.name}`",
         }
 
     async def test_with_invalid_filter(self, async_client: AsyncClient, owner_auth_header: dict):

--- a/argilla-server/tests/unit/api/v1/datasets/test_search_dataset_records.py
+++ b/argilla-server/tests/unit/api/v1/datasets/test_search_dataset_records.py
@@ -258,7 +258,8 @@ class TestSearchDatasetRecords:
 
         assert response.status_code == 422
         assert response.json() == {
-            "detail": f"Record `{record_without_vector.id}` does not have a vector for vector settings `{vector_settings.name}`"
+            "code": "missing_vector",
+            "message": f"Record `{record_without_vector.id}` does not have a vector for vector settings `{vector_settings.name}`",
         }
 
     async def test_with_filter(

--- a/argilla/CHANGELOG.md
+++ b/argilla/CHANGELOG.md
@@ -18,6 +18,7 @@ These are the section headers that we use:
 
 ### Fixed
 
+- Fix issue when record does not have vectors related ([#4856](https://github.com/argilla-io/argilla/pull/4856))
 - Fix issue on character level ([#4836](https://github.com/argilla-io/argilla/pull/4836))
 
 ## [1.28.0](https://github.com/argilla-io/argilla/compare/v1.27.0...v1.28.0)


### PR DESCRIPTION
# Description

An error is raised from backend when trying to find similar records when the vector is not defined for the used record. The error is fine but an additional attribute is needed on the front to support mapping that specific error to a translated message to the user.

This PR adds a new custom error using `message` and `code` attributes to be rendered as a JSON response.

Closes #4655 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Modifying existents tests.

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

## Frontend handling

![Argilla](https://github.com/argilla-io/argilla/assets/7398909/38123437-4d8b-4e7b-9de5-fabc46b6823e)
