### PR TITLE
docs: Fix typo Argila -> Argilla

### DIFF
--- a/docs/_source/getting_started/installation/configurations/server_configuration.md
+++ b/docs/_source/getting_started/installation/configurations/server_configuration.md
@@ -69,7 +69,7 @@ You can set the following environment variables to further configure your server
 
 - `ARGILLA_ELASTICSEARCH`: URL of the connection endpoint of the Elasticsearch instance (Default: `http://localhost:9200`).
 
-- `ARGILA_SEARCH_ENGINE`: (Only for Feedback datasets) Search engine to use. Valid values are "elasticsearch" and "opensearch" (Default: "elasticsearch").
+- `ARGILLA_SEARCH_ENGINE`: (Only for Feedback datasets) Search engine to use. Valid values are "elasticsearch" and "opensearch" (Default: "elasticsearch").
 
 - `ARGILLA_ELASTICSEARCH_SSL_VERIFY`: If "False", disables SSL certificate verification when connecting to the Elasticsearch backend.
 

--- a/docs/_source/practical_guides/create_update_dataset/records.md
+++ b/docs/_source/practical_guides/create_update_dataset/records.md
@@ -324,7 +324,7 @@ dataset.add_records(records)
 ```
 
 ```{note}
-As soon as you add records to a remote dataset, these should be available in the Argila UI. If you cannot see them, try hitting the `Refresh` button on the sidebar.
+As soon as you add records to a remote dataset, these should be available in the Argilla UI. If you cannot see them, try hitting the `Refresh` button on the sidebar.
 ```
 
 ### Update records
@@ -351,7 +351,7 @@ dataset.update_records(modified_records)
 ```
 
 ```{note}
-As soon as you update the records in a remote dataset, the changes should be available in the Argila UI. If you cannot see them, try hitting the `Refresh` button on the sidebar.
+As soon as you update the records in a remote dataset, the changes should be available in the Argilla UI. If you cannot see them, try hitting the `Refresh` button on the sidebar.
 ```
 
 ```{note}


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

I've noticed an env variable in the docs with the following typo: `ARGILA` instead of `ARGILLA`, so I fix it. 

**Type of change**

(Remember to title the PR according to the type of change)

- [x] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes.)

- [ ] `sphinx-autobuild` (read [Developer Documentation](https://docs.argilla.io/en/latest/community/developer_docs.html#building-the-documentation) for more details)

**Checklist**

- [x] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [x] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
