### PR TITLE
fix(import): remove non-existent server module

### DIFF
--- a/argilla/CHANGELOG.md
+++ b/argilla/CHANGELOG.md
@@ -22,7 +22,7 @@ These are the section headers that we use:
 
 ### Fixed
 
-- Fix wildcard import for the whole argilla module. ([#4874](https://github.com/argilla-io/argilla/pull/4874)) 
+- Fix wildcard import for the whole argilla module. ([#4874](https://github.com/argilla-io/argilla/pull/4874))
 - Fix issue when record does not have vectors related. ([#4856](https://github.com/argilla-io/argilla/pull/4856))
 - Fix issue on character level. ([#4836](https://github.com/argilla-io/argilla/pull/4836))
 

--- a/argilla/CHANGELOG.md
+++ b/argilla/CHANGELOG.md
@@ -22,8 +22,9 @@ These are the section headers that we use:
 
 ### Fixed
 
-- Fix issue when record does not have vectors related ([#4856](https://github.com/argilla-io/argilla/pull/4856))
-- Fix issue on character level ([#4836](https://github.com/argilla-io/argilla/pull/4836))
+- Fix wildcard import for the whole argilla module. ([#4874](https://github.com/argilla-io/argilla/pull/4874)) 
+- Fix issue when record does not have vectors related. ([#4856](https://github.com/argilla-io/argilla/pull/4856))
+- Fix issue on character level. ([#4836](https://github.com/argilla-io/argilla/pull/4836))
 
 ## [1.28.0](https://github.com/argilla-io/argilla/compare/v1.27.0...v1.28.0)
 

--- a/argilla/src/argilla/__init__.py
+++ b/argilla/src/argilla/__init__.py
@@ -158,7 +158,6 @@ _import_structure = {
         "TextClassificationSettings",
         "TokenClassificationSettings",
     ],
-    "server.app": ["app"],
 }
 
 _sys.modules[__name__] = _LazyargillaModule(


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

This PR remove the non-existent "server" module from `__init__` definitions so users can import everything without errors:
```python
from argilla import *
````


**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [ ] Test A
- [ ] Test B

**Checklist**

- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
