### PR TITLE
refactor: remove API v1 datasets exceptions captures

### DIFF
--- a/argilla-server/src/argilla_server/apis/errors/v1/exception_handlers.py
+++ b/argilla-server/src/argilla_server/apis/errors/v1/exception_handlers.py
@@ -29,8 +29,29 @@ def add_exception_handlers(app: FastAPI):
             content={"detail": exc.message},
         )
 
+    @app.exception_handler(errors.NotUniqueError)
+    async def not_unique_error_exception_handler(request, exc):
+        return JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            # TODO: Once we move to v2.0 we can remove the content using detail attribute
+            # and use the new one using code and message.
+            # content={"code": exc.code, "message": exc.message},
+            content={"detail": exc.message},
+        )
+
     @app.exception_handler(errors.UnprocessableEntityError)
     async def unprocessable_entity_error_exception_handler(request, exc):
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            # TODO: Once we move to v2.0 we can remove the content using detail attribute
+            # and use the new one using code and message.
+            # content={"code": exc.code, "message": exc.message},
+            content={"detail": exc.message},
+        )
+
+    # TODO: Once we move to v2.0 we can remove this exception handler and use UnprocessableEntityError
+    @app.exception_handler(errors.MissingVectorError)
+    async def missing_vector_error_exception_handler(request, exc):
         return JSONResponse(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             content={"code": exc.code, "message": exc.message},

--- a/argilla-server/src/argilla_server/apis/v1/handlers/datasets/records.py
+++ b/argilla-server/src/argilla_server/apis/v1/handlers/datasets/records.py
@@ -214,7 +214,8 @@ async def _get_search_responses(
             await record.awaitable_attrs.vectors
 
             if not record.vector_value_by_vector_settings(vector_settings):
-                raise errors.UnprocessableEntityError(
+                # TODO: Once we move to v2.0 we can use here UnprocessableEntityError instead of MissingVectorError
+                raise errors.MissingVectorError(
                     message=f"Record `{record.id}` does not have a vector for vector settings `{vector_settings.name}`",
                     code=MISSING_VECTOR_ERROR_CODE,
                 )

--- a/argilla-server/src/argilla_server/errors/future/base_errors.py
+++ b/argilla-server/src/argilla_server/errors/future/base_errors.py
@@ -12,9 +12,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__all__ = ["NotFoundError", "NotUniqueError", "UnprocessableEntityError", "AuthenticationError"]
+__all__ = ["NotFoundError", "NotUniqueError", "UnprocessableEntityError", "AuthenticationError", "MissingVectorError"]
 
 NOT_FOUND_ERROR = "not_found"
+NOT_UNIQUE_ERROR = "not_unique"
 UNPROCESSABLE_ENTITY_ERROR_CODE = "unprocessable_entity"
 MISSING_VECTOR_ERROR_CODE = "missing_vector"
 
@@ -30,7 +31,9 @@ class NotFoundError(Exception):
 class NotUniqueError(Exception):
     """Custom Argilla not unique error. Use it for situations where an Argilla domain entity already exists violating a constraint."""
 
-    pass
+    def __init__(self, message, code=NOT_UNIQUE_ERROR):
+        self.message = message
+        self.code = code
 
 
 class UnprocessableEntityError(Exception):
@@ -39,6 +42,11 @@ class UnprocessableEntityError(Exception):
     def __init__(self, message, code=UNPROCESSABLE_ENTITY_ERROR_CODE):
         self.message = message
         self.code = code
+
+
+# TODO: Once we move to v2.0 we can remove this error and use UnprocessableEntityError
+class MissingVectorError(UnprocessableEntityError):
+    pass
 
 
 class AuthenticationError(Exception):

--- a/argilla-server/tests/unit/api/v1/datasets/test_create_dataset_vector_settings.py
+++ b/argilla-server/tests/unit/api/v1/datasets/test_create_dataset_vector_settings.py
@@ -15,7 +15,7 @@
 from uuid import UUID
 
 import pytest
-from argilla_server.apis.v1.handlers.datasets.datasets import CREATE_DATASET_VECTOR_SETTINGS_MAX_COUNT
+from argilla_server.contexts.datasets import CREATE_DATASET_VECTOR_SETTINGS_MAX_COUNT
 from httpx import AsyncClient
 
 from tests.factories import DatasetFactory, VectorSettingsFactory


### PR DESCRIPTION
# Description

This PR focus on removing the exception capture blocks present on API v1 datasets handler.

I have added before moving to v2.0 a new `MissingVectorError` that will be the one returning the new `{"code": "...", "message": "..."}` JSON structure and we will have `UnprocessableEntityError` by now returning the old one with `detail` attribute. With this we don't add any change to our API.

Refs #4871 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (change restructuring the codebase without changing functionality)
- [ ] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [x] Modifying and improving current tests.

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)