### PR TITLE
[IMPROVEMENT] Update pip when building docker image

### DIFF
--- a/argilla-server/docker/server/Dockerfile
+++ b/argilla-server/docker/server/Dockerfile
@@ -6,6 +6,7 @@ RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 RUN apt-get update && \
   apt-get install -y python-dev-is-python3 libpq-dev gcc && \
+  pip install --upgrade pip && \
   pip install uvicorn[standard] && \
   for wheel in /packages/*.whl; do pip install "$wheel"[server,postgresql]; done && \
   apt-get remove -y python-dev-is-python3 libpq-dev gcc && \


### PR DESCRIPTION
The latests CI builds are taking longer than expected (around 8 minutes) - [here](https://github.com/argilla-io/argilla/actions/runs/9288762405/job/25561563438?pr=4906#step:9:2092) an example - because pip needs to download multiple package version to match the proper dependency. 

This [should be fixed](https://stackoverflow.com/questions/76758834/pip-is-looking-for-multiple-version-of-library-to-determine-which-version-is-c) by upgrading pip. This PR includes a pip upgrade when building the docker image.

