### PR TITLE
[BUGFIX] ci: Configure argilla server deps properly

### DIFF
--- a/argilla/environment_dev.yml
+++ b/argilla/environment_dev.yml
@@ -68,5 +68,4 @@ dependencies:
       - nltk < 4.0.0
       - httpx~=0.26.0
       # install Argilla packages in editable mode
-      - -e ../argilla-server[postgresql]
       - -e .[listeners]


### PR DESCRIPTION
This PR removes argilla dependencies with the server path since they are not compatible anymore.