### PR TITLE
chore: set logger level to error to reduce noise from Elasticsearch and OpenSearch client libraries

### DIFF
--- a/argilla-server/src/argilla_server/_app.py
+++ b/argilla-server/src/argilla_server/_app.py
@@ -171,8 +171,8 @@ def configure_search_engine(app: FastAPI):
         async for search_engine in get_search_engine():
             if not await search_engine.ping():
                 raise ConnectionError(
-                    f"Your {settings.humanized_search_engine} endpoint at {settings.obfuscated_elasticsearch()} is not available or not responding.\n"
-                    f"Please make sure your {settings.humanized_search_engine} instance is launched and correctly running and\n"
+                    f"Your {settings.search_engine} endpoint at {settings.obfuscated_elasticsearch()} is not available or not responding.\n"
+                    f"Please make sure your {settings.search_engine} instance is launched and correctly running and\n"
                     "you have the necessary access permissions. Once you have verified this, restart the argilla server.\n"
                 )
 

--- a/argilla-server/src/argilla_server/_app.py
+++ b/argilla-server/src/argilla_server/_app.py
@@ -66,7 +66,7 @@ def create_server_app() -> FastAPI:
     for app_configure in [
         configure_app_logging,
         configure_database,
-        ping_search_engine,
+        configure_search_engine,
         configure_telemetry,
         configure_middleware,
         configure_app_security,
@@ -148,17 +148,34 @@ def configure_app_statics(app: FastAPI):
     )
 
 
-def ping_search_engine(app: FastAPI):
+def configure_search_engine(app: FastAPI):
+    @app.on_event("startup")
+    async def configure_elasticsearch():
+        if not settings.search_engine_is_elasticsearch:
+            return
+
+        logging.getLogger("elasticsearch").setLevel(logging.ERROR)
+        logging.getLogger("elastic_transport").setLevel(logging.ERROR)
+
+    @app.on_event("startup")
+    async def configure_opensearch():
+        if not settings.search_engine_is_opensearch:
+            return
+
+        logging.getLogger("opensearch").setLevel(logging.ERROR)
+        logging.getLogger("opensearch_transport").setLevel(logging.ERROR)
+
     @app.on_event("startup")
     @backoff.on_exception(backoff.expo, ConnectionError, max_time=60)
-    async def _ping_search_engine():
+    async def ping_search_engine():
         async for search_engine in get_search_engine():
             if not await search_engine.ping():
                 raise ConnectionError(
-                    f"Your Elasticsearch endpoint at {settings.obfuscated_elasticsearch()} is not available or not responding.\n"
-                    "Please make sure your Elasticsearch instance is launched and correctly running and\n"
+                    f"Your {settings.humanized_search_engine} endpoint at {settings.obfuscated_elasticsearch()} is not available or not responding.\n"
+                    f"Please make sure your {settings.humanized_search_engine} instance is launched and correctly running and\n"
                     "you have the necessary access permissions. Once you have verified this, restart the argilla server.\n"
                 )
+
 
 def configure_app_security(app: FastAPI):
     auth.configure_app(app)

--- a/argilla-server/src/argilla_server/constants.py
+++ b/argilla-server/src/argilla_server/constants.py
@@ -15,6 +15,9 @@
 API_KEY_HEADER_NAME = "X-Argilla-Api-Key"
 WORKSPACE_HEADER_NAME = "X-Argilla-Workspace"
 
+SEARCH_ENGINE_ELASTICSEARCH = "elasticsearch"
+SEARCH_ENGINE_OPENSEARCH = "opensearch"
+
 DEFAULT_USERNAME = "argilla"
 DEFAULT_PASSWORD = "1234"
 DEFAULT_API_KEY = "argilla.apikey"

--- a/argilla-server/src/argilla_server/search_engine/elasticsearch.py
+++ b/argilla-server/src/argilla_server/search_engine/elasticsearch.py
@@ -18,6 +18,7 @@ from uuid import UUID
 
 from elasticsearch8 import AsyncElasticsearch, helpers
 
+from argilla_server.constants import SEARCH_ENGINE_ELASTICSEARCH
 from argilla_server.models import VectorSettings
 from argilla_server.search_engine import SearchEngine
 from argilla_server.search_engine.commons import (
@@ -37,7 +38,7 @@ def _compute_num_candidates_from_k(k: int) -> int:
     return 2000
 
 
-@SearchEngine.register(engine_name="elasticsearch")
+@SearchEngine.register(engine_name=SEARCH_ENGINE_ELASTICSEARCH)
 @dataclasses.dataclass
 class ElasticSearchEngine(BaseElasticAndOpenSearchEngine):
     config: Dict[str, Any] = dataclasses.field(default_factory=dict)

--- a/argilla-server/src/argilla_server/search_engine/opensearch.py
+++ b/argilla-server/src/argilla_server/search_engine/opensearch.py
@@ -18,6 +18,7 @@ from uuid import UUID
 
 from opensearchpy import AsyncOpenSearch, helpers
 
+from argilla_server.constants import SEARCH_ENGINE_OPENSEARCH
 from argilla_server.models import VectorSettings
 from argilla_server.search_engine.base import SearchEngine
 from argilla_server.search_engine.commons import (
@@ -29,7 +30,7 @@ from argilla_server.search_engine.commons import (
 from argilla_server.settings import settings
 
 
-@SearchEngine.register(engine_name="opensearch")
+@SearchEngine.register(engine_name=SEARCH_ENGINE_OPENSEARCH)
 @dataclasses.dataclass
 class OpenSearchEngine(BaseElasticAndOpenSearchEngine):
     config: Dict[str, Any] = dataclasses.field(default_factory=dict)

--- a/argilla-server/src/argilla_server/settings.py
+++ b/argilla-server/src/argilla_server/settings.py
@@ -21,7 +21,7 @@ import os
 import re
 import warnings
 from pathlib import Path
-from typing import List, Literal, Optional, Union
+from typing import List, Optional
 from urllib.parse import urlparse
 
 from argilla_server.constants import (
@@ -99,10 +99,7 @@ class Settings(BaseSettings):
 
     es_mapping_total_fields_limit: int = 2000
 
-    search_engine: Union[
-        Literal[SEARCH_ENGINE_ELASTICSEARCH],
-        Literal[SEARCH_ENGINE_OPENSEARCH],
-    ] = SEARCH_ENGINE_ELASTICSEARCH
+    search_engine: str = SEARCH_ENGINE_ELASTICSEARCH
 
     vectors_fields_limit: int = Field(
         default=5,
@@ -229,13 +226,6 @@ class Settings(BaseSettings):
     @property
     def search_engine_is_opensearch(self) -> bool:
         return self.search_engine == SEARCH_ENGINE_OPENSEARCH
-
-    @property
-    def humanized_search_engine(self) -> str:
-        if self.search_engine_is_elasticsearch:
-            return "Elasticsearch"
-        elif self.search_engine_is_opensearch:
-            return "OpenSearch"
 
     def obfuscated_elasticsearch(self) -> str:
         """Returns configured elasticsearch url obfuscating the provided password, if any"""

--- a/argilla-server/src/argilla_server/settings.py
+++ b/argilla-server/src/argilla_server/settings.py
@@ -21,7 +21,7 @@ import os
 import re
 import warnings
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Literal, Optional, Union
 from urllib.parse import urlparse
 
 from argilla_server.constants import (
@@ -29,6 +29,8 @@ from argilla_server.constants import (
     DEFAULT_MAX_KEYWORD_LENGTH,
     DEFAULT_SPAN_OPTIONS_MAX_ITEMS,
     DEFAULT_TELEMETRY_KEY,
+    SEARCH_ENGINE_ELASTICSEARCH,
+    SEARCH_ENGINE_OPENSEARCH,
 )
 from argilla_server.pydantic_v1 import BaseSettings, Field, root_validator, validator
 
@@ -97,7 +99,10 @@ class Settings(BaseSettings):
 
     es_mapping_total_fields_limit: int = 2000
 
-    search_engine: str = "elasticsearch"
+    search_engine: Union[
+        Literal[SEARCH_ENGINE_ELASTICSEARCH],
+        Literal[SEARCH_ENGINE_OPENSEARCH],
+    ] = SEARCH_ENGINE_ELASTICSEARCH
 
     vectors_fields_limit: int = Field(
         default=5,
@@ -216,6 +221,21 @@ class Settings(BaseSettings):
         if ns is None:
             return index_name.replace("<NAMESPACE>", "")
         return index_name.replace("<NAMESPACE>", f".{ns}")
+
+    @property
+    def search_engine_is_elasticsearch(self) -> bool:
+        return self.search_engine == SEARCH_ENGINE_ELASTICSEARCH
+
+    @property
+    def search_engine_is_opensearch(self) -> bool:
+        return self.search_engine == SEARCH_ENGINE_OPENSEARCH
+
+    @property
+    def humanized_search_engine(self) -> str:
+        if self.search_engine_is_elasticsearch:
+            return "Elasticsearch"
+        elif self.search_engine_is_opensearch:
+            return "OpenSearch"
 
     def obfuscated_elasticsearch(self) -> str:
         """Returns configured elasticsearch url obfuscating the provided password, if any"""


### PR DESCRIPTION
# Description

This PR includes some changes to reduce the logger level of Elasticsearch and OpenSearch to error. With this we are reducing a little bit the output noise of these client libraries.

I have improved a little bit the settings so only `elasticsearch` and `opensearch` are valid options for `search_engine` attribute. I have added some small useful functions too.

Refs #4946 

**Type of change**

(Please delete options that are not relevant. Remember to title the PR according to the type of change)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (change restructuring the codebase without changing functionality)
- [x] Improvement (change adding some improvement to an existing functionality)
- [ ] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes. And ideally, reference `tests`)

- [x] Manually testing that warning messages are not showed anymore using Elasticsearch and OpenSearch.

**Checklist**

- [ ] I added relevant documentation
- [ ] follows the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)