### PR TITLE
Update ACCESS_TOKEN naming and documentation hierarchy guides

### DIFF
--- a/.github/workflows/argilla-sdk.docs.yml
+++ b/.github/workflows/argilla-sdk.docs.yml
@@ -54,7 +54,7 @@ jobs:
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
-      - name: Show GitHUb ref info
+      - name: Show GitHub ref info
         run:
           echo "${{ github.ref }}"
           echo "${{ github.head_ref }}"

--- a/.github/workflows/argilla-sdk.docs.yml
+++ b/.github/workflows/argilla-sdk.docs.yml
@@ -54,6 +54,11 @@ jobs:
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
+      - name: Show GitHUb ref info
+        run:
+          echo "${{ github.ref }}"
+          echo "${{ github.head_ref }}"
+
       - run: pdm run mike deploy dev --push
         if: github.ref == 'refs/heads/feat/v2.0.0'
         # if: github.ref == 'refs/heads/develop'

--- a/.github/workflows/argilla-sdk.docs.yml
+++ b/.github/workflows/argilla-sdk.docs.yml
@@ -62,9 +62,13 @@ jobs:
       - run: pdm run mike deploy dev --push
         if: github.ref == 'refs/heads/feat/v2.0.0'
         # if: github.ref == 'refs/heads/develop'
+        env:
+          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - run: pdm run mike deploy ${{ github.ref_name }} latest --update-aliases --push
         if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Extract branch name
         shell: bash
@@ -73,3 +77,5 @@ jobs:
 
       - run: pdm run mike deploy ${{ steps.extract_branch_name.outputs.branch_name }} --push
         if: startsWith(github.ref, 'refs/heads/docs') || startsWith(github.head_ref, 'docs/')
+        env:
+          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/argilla-sdk.docs.yml
+++ b/.github/workflows/argilla-sdk.docs.yml
@@ -72,4 +72,4 @@ jobs:
         id: extract_branch_name
 
       - run: pdm run mike deploy ${{ steps.extract_branch_name.outputs.branch_name }} --push
-        if: startsWith(github.head_ref, 'docs/')
+        if: startsWith(github.ref, 'refs/heads/docs')

--- a/.github/workflows/argilla-sdk.docs.yml
+++ b/.github/workflows/argilla-sdk.docs.yml
@@ -54,7 +54,7 @@ jobs:
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
-      - name: Show GitHub ref info
+      - name: Print GitHub ref info
         run:
           echo "${{ github.ref }}"
           echo "${{ github.head_ref }}"
@@ -72,4 +72,4 @@ jobs:
         id: extract_branch_name
 
       - run: pdm run mike deploy ${{ steps.extract_branch_name.outputs.branch_name }} --push
-        if: startsWith(github.ref, 'refs/heads/docs')
+        if: startsWith(github.ref, 'refs/heads/docs') || startsWith(github.head_ref, 'docs/')

--- a/argilla-sdk/docs/community/contributor.md
+++ b/argilla-sdk/docs/community/contributor.md
@@ -1,5 +1,5 @@
 ---
-description: Argilla-python is the reference Argilla Python server SDK.
+description: the Argilla Python SDK is the reference Argilla Python server SDK.
 hide:
   - footer
 ---

--- a/argilla-sdk/docs/community/contributor.md
+++ b/argilla-sdk/docs/community/contributor.md
@@ -13,7 +13,7 @@ Thank you for investing your time in contributing to the project! Any contributi
     * **Git**: This is a very useful tool to keep track of the changes in your files. Using the command-line interface (CLI), you can make your contributions easily. For that, you need to have it [installed and updated](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) on your computer.
     * **GitHub**: It is a platform and cloud-based service that uses git and allows developers to collaborate on projects. To contribute to Argilla, you'll need to create an account. Check the [Contributor Workflow with Git and Github](#contributor-workflow-with-git-and-github) for more info.
     * **Developer Documentation**: To collaborate, you'll need to set up an efficient environment. Check the [developer documentation](../getting_started/installation.md) to know how to do it.
-    * **Schedule a meeting with our developer advocate**: If you have more questions, do not hesitate to contact to our developer advocate and [schedule a meeting](https://calendly.com/argilla-office-hours/30min).
+    * **Schedule a meeting with our developer advocate**: If you have more questions, do not hesitate to contact our developer advocate and [schedule a meeting](https://calendly.com/argilla-office-hours/30min).
 
 ## First Contact in Slack
 

--- a/argilla-sdk/docs/community/contributor.md
+++ b/argilla-sdk/docs/community/contributor.md
@@ -1,5 +1,5 @@
 ---
-description: Argilla-python is the reference argilla python server SDK.
+description: Argilla-python is the reference Argilla Python server SDK.
 hide:
   - footer
 ---

--- a/argilla-sdk/docs/community/index.md
+++ b/argilla-sdk/docs/community/index.md
@@ -1,5 +1,5 @@
 ---
-description: the Argilla Python SDK is the reference argilla python server SDK.
+description: the Argilla Python SDK is the reference Argilla Python server.
 hide:
     - toc
     - footer

--- a/argilla-sdk/docs/community/index.md
+++ b/argilla-sdk/docs/community/index.md
@@ -1,5 +1,5 @@
 ---
-description: Argilla-python is the reference argilla python server SDK.
+description: the Argilla Python SDK is the reference argilla python server SDK.
 hide:
     - toc
     - footer

--- a/argilla-sdk/docs/getting_started/faq.md
+++ b/argilla-sdk/docs/getting_started/faq.md
@@ -1,5 +1,5 @@
 ---
-description: Argilla-python is the reference argilla python server SDK.
+description: the Argilla Python SDK is the reference argilla python server SDK.
 hide: toc
 ---
 

--- a/argilla-sdk/docs/getting_started/faq.md
+++ b/argilla-sdk/docs/getting_started/faq.md
@@ -1,5 +1,5 @@
 ---
-description: the Argilla Python SDK is the reference argilla python server SDK.
+description: the Argilla Python SDK is the reference Argilla Python server.
 hide: toc
 ---
 

--- a/argilla-sdk/docs/getting_started/installation.md
+++ b/argilla-sdk/docs/getting_started/installation.md
@@ -1,5 +1,5 @@
 ---
-description: Installation of Argilla-python.
+description: Installation of the Argilla Python SDK.
 ---
 
 # Installation

--- a/argilla-sdk/docs/getting_started/quickstart.md
+++ b/argilla-sdk/docs/getting_started/quickstart.md
@@ -108,12 +108,12 @@ Now you can add the data to your dataset. Use a `mapping` to indicate which keys
 
 ```python
 dataset.records.log(records=data, mapping={"text": "review"})
-```	
+```
 
 🎉 You have successfully created your first dataset with Argilla. You can now access it in the Argilla UI and start annotating the records.
 
 ## More references
 
 * [Installation guide](installation.md)
-* [How-to guides](../guides/how_to_guides/index.md)
+* [How-to guides](../how_to_guides/index.md)
 * [API reference](../reference//argilla_sdk/client.md)

--- a/argilla-sdk/docs/how_to_guides/dataset.md
+++ b/argilla-sdk/docs/how_to_guides/dataset.md
@@ -25,7 +25,7 @@ A **dataset** is a collection of records that you can configure for labelers to 
             client=client
         )
         ```
-        > Check the [Dataset - Python Reference](../../reference/argilla_sdk/datasets/datasets.md) to see the attributes, arguments, and methods of the `Dataset` class in detail.
+        > Check the [Dataset - Python Reference](../reference/argilla_sdk/datasets/datasets.md) to see the attributes, arguments, and methods of the `Dataset` class in detail.
 
     === "`rg.Settings`"
 
@@ -45,7 +45,7 @@ A **dataset** is a collection of records that you can configure for labelers to 
         )
         ```
 
-        > Check the [Settings - Python Reference](../../reference/argilla_sdk/settings/settings.md) to see the attributes, arguments, and methods of the `Settings` class in detail.
+        > Check the [Settings - Python Reference](../reference/argilla_sdk/settings/settings.md) to see the attributes, arguments, and methods of the `Settings` class in detail.
 
 ## Create a dataset
 
@@ -148,7 +148,7 @@ rg.TextField(
     use_markdown=False
 )
 ```
-![TextField](../../assets/images/how_to_guides/dataset/fields.png)
+![TextField](../assets/images/how_to_guides/dataset/fields.png)
 
 ### Questions
 
@@ -172,7 +172,7 @@ To collect feedback for your dataset, you need to formulate questions that annot
         labels={"YES": "Yes", "NO": "No"}, # or ["YES", "NO"]
     )
     ```
-    ![LabelQuestion](../../assets/images/how_to_guides/dataset/label_question.png)
+    ![LabelQuestion](../assets/images/how_to_guides/dataset/label_question.png)
 
 === "Multi-label"
     A `MultiLabelQuestion` asks annotators to choose all applicable labels from a list of options. This type is useful for multi-label text classification tasks. In the UI, they will have a squared shape. It has the following configuration:
@@ -203,7 +203,7 @@ To collect feedback for your dataset, you need to formulate questions that annot
     )
 
     ```
-    ![MultiLabelQuestion](../../assets/images/how_to_guides/dataset/multilabel_question.png)
+    ![MultiLabelQuestion](../assets/images/how_to_guides/dataset/multilabel_question.png)
 
 === "Ranking"
     A `RankingQuestion` asks annotators to order a list of options. It is useful to gather information on the preference or relevance of a set of options. Ties are allowed and all options will need to be ranked. It has the following configuration:
@@ -228,7 +228,7 @@ To collect feedback for your dataset, you need to formulate questions that annot
     )
     ```
 
-    ![RankingQuestion](../../assets/images/how_to_guides/dataset/ranking_question.png)
+    ![RankingQuestion](../assets/images/how_to_guides/dataset/ranking_question.png)
 
 === "Rating"
     A `RatingQuestion` asks annotators to select one option from a list of integer values. This type is useful for collecting numerical scores. It has the following configuration:
@@ -249,7 +249,7 @@ To collect feedback for your dataset, you need to formulate questions that annot
     )
     ```
 
-    ![RatingQuestion](../../assets/images/how_to_guides/dataset/rating_question.png)
+    ![RatingQuestion](../assets/images/how_to_guides/dataset/rating_question.png)
 
 === "Span"
     A `SpanQuestion` asks annotators to select a portion of the text of a specific field and apply a label to it. This type of question is useful for named entity recognition or information extraction tasks. It has the following configuration:
@@ -281,7 +281,7 @@ To collect feedback for your dataset, you need to formulate questions that annot
     )
     ```
 
-    ![SpanQuestion](../../assets/images/how_to_guides/dataset/span_question.png)
+    ![SpanQuestion](../assets/images/how_to_guides/dataset/span_question.png)
 
 === "Text"
     A `TextQuestion` offers to annotators a free-text area where they can enter any text. This type is useful for collecting natural language data, such as corrections or explanations. It has the following configuration:
@@ -302,7 +302,7 @@ To collect feedback for your dataset, you need to formulate questions that annot
     )
     ```
 
-    ![TextQuestion](../../assets/images/how_to_guides/dataset/text_question.png)
+    ![TextQuestion](../assets/images/how_to_guides/dataset/text_question.png)
 
 ### Metadata
 
@@ -322,7 +322,7 @@ Metadata properties allow you to configure the use of metadata information for t
         options=["group-a", "group-b", "group-c"]
     )
     ```
-    ![TermsMetadataProperty](../../assets/images/how_to_guides/dataset/term_metadata.png)
+    ![TermsMetadataProperty](../assets/images/how_to_guides/dataset/term_metadata.png)
 
 === "Integer"
     An `IntegerMetadataProperty` allows to add integer values as metadata. It has the following configuration:
@@ -340,7 +340,7 @@ Metadata properties allow you to configure the use of metadata information for t
         max=1984,
     )
     ```
-    ![IntegerMetadataProperty](../../assets/images/how_to_guides/dataset/integer_metadata.png)
+    ![IntegerMetadataProperty](../assets/images/how_to_guides/dataset/integer_metadata.png)
 
 === "Float"
     A `FloatMetadataProperty` allows to add float values as metadata. It has the following configuration:
@@ -358,7 +358,7 @@ Metadata properties allow you to configure the use of metadata information for t
         max=119.6975,
     )
     ```
-    ![FloatMetadataProperty](../../assets/images/how_to_guides/dataset/float_metadata.png)
+    ![FloatMetadataProperty](../assets/images/how_to_guides/dataset/float_metadata.png)
 
 ### Vectors
 
@@ -375,7 +375,7 @@ rg.VectorField(
     dimensions=768
 ),
 ```
-![VectorField](../../assets/images/how_to_guides/dataset/vectors.png)
+![VectorField](../assets/images/how_to_guides/dataset/vectors.png)
 
 ### Guidelines
 
@@ -385,10 +385,10 @@ Once you have decided on the data to show and the questions to ask, it's importa
 ```python
 guidelines = "In this dataset, you will find a collection of records that show a category, an instruction, a context and a response to that instruction. [...]"
 ```
-![Guidelines](../../assets/images/how_to_guides/dataset/guidelines.png)
+![Guidelines](../assets/images/how_to_guides/dataset/guidelines.png)
 
 * As question descriptions: these are added as an argument when you create questions in the Python SDK. This text will appear in a tooltip next to the question in the UI.
-![Guidelines as descriptions](../../assets/images/how_to_guides/dataset/guidelines_description.png)
+![Guidelines as descriptions](../assets/images/how_to_guides/dataset/guidelines_description.png)
 
 It is good practice to use at least the dataset guidelines if not both methods. Question descriptions should be short and provide context to a specific question. They can be a summary of the guidelines to that question, but often that is not sufficient to align the whole annotation team. In the guidelines, you can include a description of the project, details on how to answer each question with examples, instructions on when to discard a record, etc.
 

--- a/argilla-sdk/docs/how_to_guides/index.md
+++ b/argilla-sdk/docs/how_to_guides/index.md
@@ -1,11 +1,11 @@
 ---
-description: These are the how-to guides for the Argilla-python SDK. They provide step-by-step instructions for common scenarios, including detailed explanations and code samples.
+description: These are the how-to guides for the the Argilla Python SDK SDK. They provide step-by-step instructions for common scenarios, including detailed explanations and code samples.
 hide: toc
 ---
 
 # How-to guides
 
-These are the how-to guides for the *Argilla-python SDK*. They provide step-by-step instructions for common scenarios, including detailed explanations and code samples.
+These are the how-to guides for the *the Argilla Python SDK SDK*. They provide step-by-step instructions for common scenarios, including detailed explanations and code samples.
 
 <div class="grid cards" markdown>
 

--- a/argilla-sdk/docs/how_to_guides/query_export.md
+++ b/argilla-sdk/docs/how_to_guides/query_export.md
@@ -18,7 +18,7 @@ You can search for records in your dataset by **querying** or **filtering**. The
             filter=filter
         )
         ```
-        > Check the [Query - Python Reference](../../reference/argilla_sdk/search.md) to see the attributes, arguments, and methods of the `Query` class in detail.
+        > Check the [Query - Python Reference](../reference/argilla_sdk/search.md) to see the attributes, arguments, and methods of the `Query` class in detail.
 
     === "`rg.Filter`"
 
@@ -29,7 +29,7 @@ You can search for records in your dataset by **querying** or **filtering**. The
             ]
         )
         ```
-        > Check the [Filter - Python Reference](../../reference/argilla_sdk/search.md) to see the attributes, arguments, and methods of the `Filter` class in detail.
+        > Check the [Filter - Python Reference](../reference/argilla_sdk/search.md) to see the attributes, arguments, and methods of the `Filter` class in detail.
 
 ## Query with search terms
 

--- a/argilla-sdk/docs/how_to_guides/record.md
+++ b/argilla-sdk/docs/how_to_guides/record.md
@@ -33,7 +33,7 @@ A **record** in Argilla is a data item that requires annotation, consisting of o
         ],
     )
     ```
-    > Check the [Record - Python Reference](../../reference/argilla_sdk/records/records.md) to see the attributes, arguments, and methods of the `Record` class in detail.
+    > Check the [Record - Python Reference](../reference/argilla_sdk/records/records.md) to see the attributes, arguments, and methods of the `Record` class in detail.
 
 ## Add records
 
@@ -73,18 +73,18 @@ You can add records to a dataset in two different ways: either by using a dictio
 
     dataset.records.log(records)
     ```
-    
-    1. This is an illustration of a definition. In a real world scenario, you would iterate over a data structure and create `Record` objects for each iteration. 
+
+    1. This is an illustration of a definition. In a real world scenario, you would iterate over a data structure and create `Record` objects for each iteration.
 
 === "From a generic data structure"
 
-    You can add the data directly as a dictionary like structure, where the keys correspond to the names of fields, questions, metadata or vectors in the dataset and the values are the data to be added. 
-    
+    You can add the data directly as a dictionary like structure, where the keys correspond to the names of fields, questions, metadata or vectors in the dataset and the values are the data to be added.
+
     If your data structure does not correspond to your Argilla dataset names, you can use a `mapping` to indicate which keys in the source data correspond to the dataset fields.
 
     We illustrate this python dictionaries that represent your data, but we would not advise you to to define dictionaries. Instead use the `Record` object for instatiating records.
 
-    ```python	
+    ```python
     import argilla_sdk as rg
 
     client = rg.Argilla(api_url="<api_url>", api_key="<api_key>")
@@ -118,7 +118,7 @@ You can add records to a dataset in two different ways: either by using a dictio
     dataset.records.log(data, mapping={"query": "question", "response": "answer"}) # (2)
     ```
 
-    1. The data structure's keys must match the fields or questions in the Argilla dataset. In this case, there are fields named `question` and `answer`. 
+    1. The data structure's keys must match the fields or questions in the Argilla dataset. In this case, there are fields named `question` and `answer`.
     2. The data structure has keys `query` and `response` and the Argilla dataset has `question` and `answer`. You can use the `mapping` parameter to map the keys in the data structure to the fields in the Argilla dataset.
 
 
@@ -126,8 +126,8 @@ You can add records to a dataset in two different ways: either by using a dictio
 
     You can also add records to a dataset using a Hugging Face dataset. This is useful when you want to use a dataset from the Hugging Face Hub and add it to your Argilla dataset.
 
-    You can add the dataset where the column names correspond to the names of fields, questions, metadata or vectors in the Argilla dataset. 
-    
+    You can add the dataset where the column names correspond to the names of fields, questions, metadata or vectors in the Argilla dataset.
+
     If the dataset's schema does not correspond to your Argilla dataset names, you can use a `mapping` to indicate which columns in the dataset correspond to the Argilla dataset fields.
 
     ```python
@@ -142,14 +142,14 @@ You can add records to a dataset in two different ways: either by using a dictio
     hf_dataset = load_dataset("imdb", split="train[:100]") # (2)
 
     dataset.records.log(records=hf_dataset)
-    ```	
+    ```
 
     1. In this case, we are using the `my_dataset` dataset from the Argilla workspace. The dataset has a `text` field and a `label` question.
 
     2. In this example, the Hugging Face dataset matches the Argilla dataset schema. If that is not the case, you could use the `.map` of the `datasets` library to prepare the data before adding it to the Argilla dataset.
 
     Here we use the `mapping` parameter to specify the relationship between the Hugging Face dataset and the Argilla dataset.
-    
+
     ```python
     dataset.records.log(records=hf_dataset, mapping={"txt": "text", "y": "label"}) # (1)
     ```
@@ -166,7 +166,7 @@ Record metadata can include any information about the record that is not part of
 
 === "As `Record` objects"
 
-    You can add metadata to a record in an initialized `Record` object. 
+    You can add metadata to a record in an initialized `Record` object.
 
     ```python
     # Add records to the dataset with the metadata 'category'
@@ -222,7 +222,7 @@ You can associate vectors, like text embeddings, to your records. They can be us
 
     You can also add vectors to a record in an initialized `Record` object.
 
-    > Check the [Vector - Python Reference](../../reference/argilla_sdk/records/vectors.md) to see the attributes, arguments, and methods of the `Vector` class in detail.
+    > Check the [Vector - Python Reference](../reference/argilla_sdk/records/vectors.md) to see the attributes, arguments, and methods of the `Vector` class in detail.
 
     ```python
     # Add records to the dataset with the vector 'my_vector' and dimension=3
@@ -277,7 +277,7 @@ Suggestions refer to suggested responses (e.g. model predictions) that you can a
 === "As `Record objects"
     You can also add suggestions to a record in an initialized `Record` object.
 
-    > Check the [Suggestions - Python Reference](../../reference/argilla_sdk/records/suggestions.md) to see the attributes, arguments, and methods of the `Suggestion` class in detail.
+    > Check the [Suggestions - Python Reference](../reference/argilla_sdk/records/suggestions.md) to see the attributes, arguments, and methods of the `Suggestion` class in detail.
 
     ```python
     # Add records to the dataset with the label 'my_label'
@@ -348,7 +348,7 @@ If your dataset includes some annotations, you can add those to the records as y
 === "As `Record` objects"
     You can also add suggestions to a record in an initialized `Record` object.
 
-    > Check the [Responses - Python Reference](../../reference/argilla_sdk/records/responses.md) to see the attributes, arguments, and methods of the `Suggestion` class in detail.
+    > Check the [Responses - Python Reference](../reference/argilla_sdk/records/responses.md) to see the attributes, arguments, and methods of the `Suggestion` class in detail.
 
     ```python
     # Add records to the dataset with the label 'my_label'
@@ -443,12 +443,12 @@ dataset.records.log(records=updated_data)
 
     ```python
     updated_records = []
-    
+
     for record in dataset.records():
 
         record.metadata["my_metadata"] = "new_value"
         record.metadata["my_new_metadata"] = "new_value"
-        
+
         updated_records.append(record)
 
     dataset.records.log(records=updated_records)

--- a/argilla-sdk/docs/how_to_guides/user.md
+++ b/argilla-sdk/docs/how_to_guides/user.md
@@ -69,7 +69,7 @@ Argilla provides a default user with the `owner` role to help you get started in
         client=client
     )
     ```
-    > Check the [User - Python Reference](../../reference/argilla_sdk/users.md) to see the attributes, arguments, and methods of the `User` class in detail.
+    > Check the [User - Python Reference](../reference/argilla_sdk/users.md) to see the attributes, arguments, and methods of the `User` class in detail.
 
 ## Get current user
 

--- a/argilla-sdk/docs/how_to_guides/workspace.md
+++ b/argilla-sdk/docs/how_to_guides/workspace.md
@@ -31,7 +31,7 @@ Argilla provides a default workspace to help you get started in Python and the U
         client=client
     )
     ```
-    > Check the [Workspace - Python Reference](../../reference/argilla_sdk/workspaces.md) to see the attributes, arguments, and methods of the `Workspace` class in detail.
+    > Check the [Workspace - Python Reference](../reference/argilla_sdk/workspaces.md) to see the attributes, arguments, and methods of the `Workspace` class in detail.
 
 ## Create a new workspace
 

--- a/argilla-sdk/docs/index.md
+++ b/argilla-sdk/docs/index.md
@@ -23,7 +23,7 @@ Argilla is a **collaboration platform for AI engineers and domain experts** that
 
     Get familiar with basic and complex workflows for Argilla. From managing `Users`, `Workspaces`. `Datasets` and `Records` to fine-tuning a model.
 
-    [:octicons-arrow-right-24: Learn more](guides/how_to_guides/index.md)
+    [:octicons-arrow-right-24: Learn more](how_to_guides/index.md)
 
 </div>
 

--- a/argilla-sdk/docs/reference/argilla_sdk/client.md
+++ b/argilla-sdk/docs/reference/argilla_sdk/client.md
@@ -3,7 +3,7 @@ hide: footer
 ---
 # `rg.Argilla`
 
-To interact with the Argilla server from python you can use the `Argilla` class. The `Argilla` client is used to create, get, update, and delete all Argilla resources, such as workspaces, users, datasets, and records.
+To interact with the Argilla server from Python you can use the `Argilla` class. The `Argilla` client is used to create, get, update, and delete all Argilla resources, such as workspaces, users, datasets, and records.
 
 ## Usage Examples
 

--- a/argilla-sdk/docs/reference/argilla_sdk/datasets/datasets.md
+++ b/argilla-sdk/docs/reference/argilla_sdk/datasets/datasets.md
@@ -26,7 +26,7 @@ dataset = rg.Dataset(
 dataset.create()
 ```
 
-For a detail guide of the dataset creation and publication process, see the [Dataset how to guide](/argilla-python/guides/how_to_guides/dataset).
+For a detail guide of the dataset creation and publication process, see the [Dataset how to guide](/argilla-python/how_to_guides/dataset).
 
 ### Retrieving an existing Dataset
 

--- a/argilla-sdk/docs/scripts/gen_changelog.py
+++ b/argilla-sdk/docs/scripts/gen_changelog.py
@@ -24,7 +24,7 @@ RETRIEVED_BRANCH = "develop"
 
 DATA_PATH = "community/changelog.md"
 
-GITHUB_ACCESS_TOKEN = os.environ["GH_ACCESS_TOKEN"]  # public_repo and read:org scopes are requiredwha
+GITHUB_ACCESS_TOKEN = os.environ["GH_ACCESS_TOKEN"]  # public_repo and read:org scopes are required
 
 
 def fetch_file_from_github(repository, changelog_path, branch, auth_token):

--- a/argilla-sdk/docs/scripts/gen_changelog.py
+++ b/argilla-sdk/docs/scripts/gen_changelog.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import os
 
-import requests
-import base64
 import mkdocs_gen_files
-
+import requests
 
 REPOSITORY = "argilla-io/argilla"
 CHANGELOG_PATH = "argilla/CHANGELOG.md"
@@ -25,7 +24,7 @@ RETRIEVED_BRANCH = "develop"
 
 DATA_PATH = "community/changelog.md"
 
-GITHUB_ACCESS_TOKEN = os.environ["GITHUB_ACCESS_TOKEN"]
+GITHUB_ACCESS_TOKEN = os.environ["GH_ACCESS_TOKEN"]  # public_repo and read:org scopes are requiredwha
 
 
 def fetch_file_from_github(repository, changelog_path, branch, auth_token):

--- a/argilla-sdk/docs/scripts/gen_popular_issues.py
+++ b/argilla-sdk/docs/scripts/gen_popular_issues.py
@@ -15,15 +15,14 @@
 import os
 from datetime import datetime
 
+import mkdocs_gen_files
 import pandas as pd
 import requests
-import mkdocs_gen_files
-
 
 REPOSITORY = "argilla-io/argilla"
 DATA_PATH = "community/popular_issues.md"
 
-GITHUB_ACCESS_TOKEN = os.environ["GITHUB_ACCESS_TOKEN"]
+GITHUB_ACCESS_TOKEN = os.environ["GH_ACCESS_TOKEN"]  # public_repo and read:org scopes are required
 
 
 def fetch_data_from_github(repository, auth_token):

--- a/argilla-sdk/mkdocs.yml
+++ b/argilla-sdk/mkdocs.yml
@@ -133,14 +133,13 @@ nav:
     - Quickstart: getting_started/quickstart.md
     - Installation: getting_started/installation.md
     - FAQ: getting_started/faq.md
-  - Guides:
-    - How-to guides:
-      - guides/how_to_guides/index.md
-      - Manage users and credentials: guides/how_to_guides/user.md
-      - Manage workspaces: guides/how_to_guides/workspace.md
-      - Manage and create datasets: guides/how_to_guides/dataset.md
-      - Add, update, and delete records: guides/how_to_guides/record.md
-      - Query, filter, and export records: guides/how_to_guides/query_export.md
+  - How-to guides:
+    - how_to_guides/index.md
+    - Manage users and credentials: how_to_guides/user.md
+    - Manage workspaces: how_to_guides/workspace.md
+    - Manage and create datasets: how_to_guides/dataset.md
+    - Add, update, and delete records: how_to_guides/record.md
+    - Query, filter, and export records: how_to_guides/query_export.md
   - API Reference:
     - Python SDK: reference/argilla_sdk/
   - Community:


### PR DESCRIPTION
<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

GITHUB_ACCESS_TOKEN for issues and changelog retrieval was not added to the GH actions and needed a renaming to GH_ACCESS_TOKEN due to protected naming of GITHUB_*.

Additionally reverted guides/how_to_guides back to how_to_guides


Closes #4989

**Type of change**

- [X] Documentation update

**How Has This Been Tested**

N.A. 

**Checklist**

- [ ] I added relevant documentation
- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [ ] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
