### PR TITLE
[CI] Prepare workflow for  `argilla-v1` - 1.29.0

### DIFF
--- a/.github/workflows/argilla-v1.yml
+++ b/.github/workflows/argilla-v1.yml
@@ -5,9 +5,6 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  workflow_dispatch:
-  workflow_call:
-
   push:
     paths:
       - argilla-v1/**
@@ -116,6 +113,15 @@ jobs:
   publish_release:
     name: Publish Release
     runs-on: ubuntu-latest
+    # if: ${{ github.event_name == 'release' }}
+
+    permissions:
+      # This permission is needed for private repositories.
+      # contents: read
+      # IMPORTANT: this permission is mandatory for trusted publishing on PyPI
+      id-token: write
+      # This permission is needed for creating tags
+      contents: write
 
     needs:
       - build
@@ -137,15 +143,10 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         continue-on-error: true
         with:
-          user: __token__
-          password: ${{ secrets.AR_TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
       - name: Test Installing 🍿
         continue-on-error: true
         run: pip install --index-url https://test.pypi.org/simple --no-deps  $PACKAGE_NAME==$PACKAGE_VERSION
       - name: Publish Package to PyPI 🥩
         uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ github.event_name == 'release' }}
-        with:
-          user: __token__
-          password: ${{ secrets.AR_PYPI_API_TOKEN }}

--- a/.github/workflows/argilla-v1.yml
+++ b/.github/workflows/argilla-v1.yml
@@ -13,6 +13,7 @@ on:
       - develop
       - feat/**
       - releases/**
+      - stable # This is for tests purposes
 
   pull_request:
     paths:
@@ -99,7 +100,6 @@ jobs:
   publish_release:
     name: Publish Release
     runs-on: ubuntu-latest
-    # if: ${{ github.event_name == 'release' }}
 
     permissions:
       # This permission is needed for private repositories.
@@ -130,6 +130,14 @@ jobs:
           echo "PACKAGE_NAME=argilla-v1" >> $GITHUB_ENV
           echo "$PACKAGE_NAME==$PACKAGE_VERSION"
 
+      - name: Create tag
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          TAG=${{ env.PACKAGE_NAME }}.v${{ env.PACKAGE_VERSION }}
+          git tag -f -a $TAG -m "Release ${{ env.PACKAGE_NAME }} v${{ env.PACKAGE_VERSION }}"
+          git push -f origin $TAG
+
       - name: Publish Package to TestPyPI 🥪
         uses: pypa/gh-action-pypi-publish@release/v1
         continue-on-error: true
@@ -142,4 +150,4 @@ jobs:
 
       - name: Publish Package to PyPI 🥩
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: ${{ github.event_name == 'release' }}
+        if: github.ref == 'refs/heads/stable'

--- a/.github/workflows/argilla-v1.yml
+++ b/.github/workflows/argilla-v1.yml
@@ -5,6 +5,8 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
+
   push:
     paths:
       - argilla-v1/**
@@ -100,6 +102,7 @@ jobs:
   publish_release:
     name: Publish Release
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/stable' || ${{ github.event_name }} == 'workflow_dispatch'
 
     permissions:
       # This permission is needed for private repositories.
@@ -126,17 +129,10 @@ jobs:
         run: |
           pip install --no-deps dist/*.whl
           PACKAGE_VERSION=$(python -c 'from importlib.metadata import version; print(version("argilla-v1"))')
+          PACKAGE_NAME=argilla-v1
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
-          echo "PACKAGE_NAME=argilla-v1" >> $GITHUB_ENV
+          echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
           echo "$PACKAGE_NAME==$PACKAGE_VERSION"
-
-      - name: Create tag
-        run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-          TAG=${{ env.PACKAGE_NAME }}.v${{ env.PACKAGE_VERSION }}
-          git tag -f -a $TAG -m "Release ${{ env.PACKAGE_NAME }} v${{ env.PACKAGE_VERSION }}"
-          git push -f origin $TAG
 
       - name: Publish Package to TestPyPI 🥪
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -149,5 +145,13 @@ jobs:
         run: pip install --upgrade --no-deps --force-reinstall --index-url https://test.pypi.org/simple  $PACKAGE_NAME==$PACKAGE_VERSION
 
       - name: Publish Package to PyPI 🥩
-        uses: pypa/gh-action-pypi-publish@release/v1
         if: github.ref == 'refs/heads/stable'
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create tag
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          TAG=${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}
+          git tag -f -a $TAG -m "Release ${{ env.PACKAGE_NAME }} v${{ env.PACKAGE_VERSION }}"
+          git push -f origin $TAG

--- a/.github/workflows/argilla-v1.yml
+++ b/.github/workflows/argilla-v1.yml
@@ -119,19 +119,16 @@ jobs:
     needs:
       - build
 
-    defaults:
-      run:
-        shell: bash -l {0}
-        working-directory: argilla-v1
-
     steps:
       - name: Checkout Code 🛎
         uses: actions/checkout@v4
+
       - name: Download python package
         uses: actions/download-artifact@v4
         with:
           name: argilla-v1
           path: dist
+
       - name: Read package info
         run: |
           pip install --no-deps dist/*.whl
@@ -139,14 +136,17 @@ jobs:
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
           echo "PACKAGE_NAME=argilla-v1" >> $GITHUB_ENV
           echo "$PACKAGE_NAME==$PACKAGE_VERSION"
+
       - name: Publish Package to TestPyPI 🥪
         uses: pypa/gh-action-pypi-publish@release/v1
         continue-on-error: true
         with:
           repository-url: https://test.pypi.org/legacy/
+
       - name: Test Installing 🍿
         continue-on-error: true
         run: pip install --index-url https://test.pypi.org/simple --no-deps  $PACKAGE_NAME==$PACKAGE_VERSION
+
       - name: Publish Package to PyPI 🥩
         uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ github.event_name == 'release' }}

--- a/.github/workflows/argilla-v1.yml
+++ b/.github/workflows/argilla-v1.yml
@@ -15,7 +15,6 @@ on:
       - develop
       - feat/**
       - releases/**
-      - releases/stable # This is for tests purposes
 
   pull_request:
     paths:
@@ -102,7 +101,7 @@ jobs:
   publish_release:
     name: Publish Release
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/releases/stable' || ${{ github.event_name }} == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main' || ${{ github.event_name }} == 'workflow_dispatch'
 
     permissions:
       # This permission is needed for private repositories.
@@ -145,13 +144,5 @@ jobs:
         run: pip install --upgrade --no-deps --force-reinstall --index-url https://test.pypi.org/simple  $PACKAGE_NAME==$PACKAGE_VERSION
 
       - name: Publish Package to PyPI 🥩
-        if: github.ref == 'refs/heads/releases/stable'
+        if: github.ref == 'refs/heads/main'
         uses: pypa/gh-action-pypi-publish@release/v1
-
-      - name: Create tag
-        run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
-          TAG=${{ env.PACKAGE_NAME }}_${{ env.PACKAGE_VERSION }}
-          git tag -f -a $TAG -m "Release ${{ env.PACKAGE_NAME }} v${{ env.PACKAGE_VERSION }}"
-          git push -f origin $TAG

--- a/.github/workflows/argilla-v1.yml
+++ b/.github/workflows/argilla-v1.yml
@@ -97,6 +97,13 @@ jobs:
           pip install -U build
           rm -rf dist && python -m build
 
+      - name: Read package info
+        run: |
+          PACKAGE_VERSION=$(python -c 'import argilla_v1; print(argilla_v1.__version__)')
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
+          echo "PACKAGE_NAME=argilla-v1" >> $GITHUB_ENV
+          echo "$PACKAGE_NAME==$PACKAGE_VERSION"
+
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
         with:
@@ -109,7 +116,6 @@ jobs:
   publish_release:
     name: Publish Release
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'release' }}
 
     needs:
       - build
@@ -136,10 +142,10 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
       - name: Test Installing 🍿
         continue-on-error: true
-        run: pip install --index-url https://test.pypi.org/simple --no-deps argilla==${GITHUB_REF#refs/*/v}
-
+        run: pip install --index-url https://test.pypi.org/simple --no-deps  $PACKAGE_NAME==$PACKAGE_VERSION
       - name: Publish Package to PyPI 🥩
         uses: pypa/gh-action-pypi-publish@release/v1
+        if: ${{ github.event_name == 'release' }}
         with:
           user: __token__
           password: ${{ secrets.AR_PYPI_API_TOKEN }}

--- a/.github/workflows/argilla-v1.yml
+++ b/.github/workflows/argilla-v1.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Test Installing 🍿
         continue-on-error: true
-        run: pip install --index-url https://test.pypi.org/simple --no-deps  $PACKAGE_NAME==$PACKAGE_VERSION
+        run: pip install --upgrade --no-deps --force-reinstall --index-url https://test.pypi.org/simple  $PACKAGE_NAME==$PACKAGE_VERSION
 
       - name: Publish Package to PyPI 🥩
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/argilla-v1.yml
+++ b/.github/workflows/argilla-v1.yml
@@ -15,7 +15,7 @@ on:
       - develop
       - feat/**
       - releases/**
-      - stable # This is for tests purposes
+      - releases/stable # This is for tests purposes
 
   pull_request:
     paths:
@@ -102,7 +102,7 @@ jobs:
   publish_release:
     name: Publish Release
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/stable' || ${{ github.event_name }} == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/releases/stable' || ${{ github.event_name }} == 'workflow_dispatch'
 
     permissions:
       # This permission is needed for private repositories.
@@ -145,7 +145,7 @@ jobs:
         run: pip install --upgrade --no-deps --force-reinstall --index-url https://test.pypi.org/simple  $PACKAGE_NAME==$PACKAGE_VERSION
 
       - name: Publish Package to PyPI 🥩
-        if: github.ref == 'refs/heads/stable'
+        if: github.ref == 'refs/heads/releases/stable'
         uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Create tag

--- a/.github/workflows/argilla-v1.yml
+++ b/.github/workflows/argilla-v1.yml
@@ -94,13 +94,6 @@ jobs:
           pip install -U build
           rm -rf dist && python -m build
 
-      - name: Read package info
-        run: |
-          PACKAGE_VERSION=$(python -c 'import argilla_v1; print(argilla_v1.__version__)')
-          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
-          echo "PACKAGE_NAME=argilla-v1" >> $GITHUB_ENV
-          echo "$PACKAGE_NAME==$PACKAGE_VERSION"
-
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
         with:
@@ -139,6 +132,13 @@ jobs:
         with:
           name: argilla-v1
           path: dist
+      - name: Read package info
+        run: |
+          pip install --no-deps dist/*.whl
+          PACKAGE_VERSION=$(python -c 'from importlib.metadata import version; print(version("argilla-v1"))')
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
+          echo "PACKAGE_NAME=argilla-v1" >> $GITHUB_ENV
+          echo "$PACKAGE_NAME==$PACKAGE_VERSION"
       - name: Publish Package to TestPyPI 🥪
         uses: pypa/gh-action-pypi-publish@release/v1
         continue-on-error: true

--- a/argilla-v1/src/argilla_v1/_version.py
+++ b/argilla-v1/src/argilla_v1/_version.py
@@ -13,4 +13,4 @@
 #  limitations under the License.
 
 # coding: utf-8
-version = "1.29.0-alpha.1"
+version = "1.29.0-alpha0"


### PR DESCRIPTION
This PR reviews the `argilla-v1` release job and modifies the execution conditions. In general (and this will apply to all the projects):

- Each project will release when merging changes to `main` (if paths config detects project changes)
- The project release won't create a repo status. This tag must be created from the `main` branch.
