### PR TITLE
[CI] docs: Configure docs publish for releases

### DIFF
--- a/.github/workflows/argilla.docs.yml
+++ b/.github/workflows/argilla.docs.yml
@@ -11,11 +11,11 @@ on:
     paths:
       - "argilla/docs/**"
       - "argilla/src/**"
+      - "argilla/mkdocs.yml"
     branches:
       - "main"
       - "develop"
       - "feat/v2.0.0" # Fixing this branch until we merge everything into develop
-      - "docs/**" # When we create a new branch only for docs
 
 defaults:
   run:
@@ -68,11 +68,3 @@ jobs:
 
       - run: pdm run mike deploy ${{ github.ref_name }}
         if: startsWith(github.ref, 'refs/tags/')
-
-      - name: Extract branch name
-        shell: bash
-        run: echo "branch_name=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" | sed 's/\//_/g'  >> $GITHUB_OUTPUT
-        id: extract_branch_name
-
-      - run: pdm run mike deploy ${{ steps.extract_branch_name.outputs.branch_name }} --push
-        if: startsWith(github.ref, 'refs/heads/docs') || startsWith(github.head_ref, 'docs/')

--- a/.github/workflows/argilla.docs.yml
+++ b/.github/workflows/argilla.docs.yml
@@ -6,12 +6,14 @@ concurrency:
 
 on:
   push:
+    tags:
+      - "v*"
     paths:
       - "argilla/docs/**"
       - "argilla/src/**"
     branches:
-      # - "main"
-      # - "develop"
+      - "main"
+      - "develop"
       - "feat/v2.0.0" # Fixing this branch until we merge everything into develop
       - "docs/**" # When we create a new branch only for docs
 
@@ -22,10 +24,10 @@ defaults:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10"]
+
+    env:
+      GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+
     steps:
       - name: checkout docs-site
         uses: actions/checkout@v4
@@ -37,10 +39,10 @@ jobs:
       - name: Setup Python
         uses: pdm-project/setup-pdm@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
           cache: true
           cache-dependency-path: |
-            argilla/pyproject.toml
+            argilla/pdm.lock
 
       - name: Install dependencies
         run: |
@@ -55,16 +57,17 @@ jobs:
         run: echo "${{ github.ref }}"
           echo "${{ github.head_ref }}"
 
+      - run: |
+          pdm run mike deploy latest --push
+          pdm run mike set-default latest
+        if: github.ref == 'refs/heads/main'
+
       - run: pdm run mike deploy dev --push
         if: github.ref == 'refs/heads/feat/v2.0.0'
         # if: github.ref == 'refs/heads/develop'
-        env:
-          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
-      - run: pdm run mike deploy ${{ github.ref_name }} latest --update-aliases --push
+      - run: pdm run mike deploy ${{ github.ref_name }}
         if: startsWith(github.ref, 'refs/tags/')
-        env:
-          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Extract branch name
         shell: bash
@@ -73,5 +76,3 @@ jobs:
 
       - run: pdm run mike deploy ${{ steps.extract_branch_name.outputs.branch_name }} --push
         if: startsWith(github.ref, 'refs/heads/docs') || startsWith(github.head_ref, 'docs/')
-        env:
-          GH_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
This PR reviews the workflow for publishing docs:

- A merge to the `main`  (release/stable branch) will deploy docs `latest` version.
- A tag creation (tag pattern = v*) will deploy `vX.Y.Z` version. (we can iterate on this and keep just the minor version)
