### PR TITLE
[CI] Point dev version for docs to develop branch

### DIFF
--- a/.github/workflows/argilla.docs.yml
+++ b/.github/workflows/argilla.docs.yml
@@ -15,7 +15,6 @@ on:
     branches:
       - "main"
       - "develop"
-      - "feat/v2.0.0" # Fixing this branch until we merge everything into develop
 
 defaults:
   run:
@@ -63,8 +62,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
 
       - run: pdm run mike deploy dev --push
-        if: github.ref == 'refs/heads/feat/v2.0.0'
-        # if: github.ref == 'refs/heads/develop'
+        if: github.ref == 'refs/heads/develop'
 
       - run: pdm run mike deploy ${{ github.ref_name }}
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
NOTE: This PR will be merged when `feat/v2.0.0` is ready to integrate into `develop`

The change include here is just pointing to the  `develop` branch to build the `dev` version of docs.