### PR TITLE
[BUGFIX] remove name as default description in settings models

### DIFF
--- a/argilla/src/argilla/_models/_settings/_questions/_base.py
+++ b/argilla/src/argilla/_models/_settings/_questions/_base.py
@@ -30,7 +30,7 @@ class QuestionBaseModel(BaseModel, validate_assignment=True):
     settings: QuestionSettings
 
     title: str = Field(None, validate_default=True)
-    description: Optional[str] = Field(None, validate_default=True)
+    description: Optional[str] = None
     required: bool = True
     inserted_at: Optional[datetime] = None
     updated_at: Optional[datetime] = None
@@ -46,12 +46,6 @@ class QuestionBaseModel(BaseModel, validate_assignment=True):
     def __title_default(cls, title, info: ValidationInfo):
         validated_title = title or info.data["name"]
         return validated_title
-
-    @field_validator("description")
-    @classmethod
-    def __description_default(cls, description, info: ValidationInfo) -> Optional[str]:
-        data = info.data
-        return description or data["title"]
 
     @field_serializer("inserted_at", "updated_at", when_used="unless-none")
     def serialize_datetime(self, value: datetime) -> str:


### PR DESCRIPTION
This change adapt the base settings model so that name is not used as a default description for questions.

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- follows the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)