### PR TITLE
[ENHANCEMENT / BUGFIX] CI: publish version docs on tag creation

### DIFF
--- a/.github/workflows/argilla.docs.yml
+++ b/.github/workflows/argilla.docs.yml
@@ -9,7 +9,7 @@ on:
 
   push:
     tags:
-      - "v*"
+      - "v[0-9]+.[0-9]+"
     branches:
       - "main"
       - "develop"

--- a/.github/workflows/argilla.docs.yml
+++ b/.github/workflows/argilla.docs.yml
@@ -62,11 +62,11 @@ jobs:
       - run: pdm run mike deploy dev --push
         if: github.ref == 'refs/heads/develop'
 
-      - name: pdm run mike deploy $version
+      - name: pdm run mike deploy $version --push
         run: |
           version=$(echo $TAG_VERSION | awk -F \. {'print $1"."$2'})
           echo "Deploying version ${version}"
-          pdm run mike deploy $version
+          pdm run mike deploy $version --push
         if: startsWith(github.ref, 'refs/tags/')
         env:
           TAG_VERSION: ${{ github.ref_name }}

--- a/.github/workflows/argilla.docs.yml
+++ b/.github/workflows/argilla.docs.yml
@@ -9,7 +9,7 @@ on:
 
   push:
     tags:
-      - "v[0-9]+.[0-9]+"
+      - "v[2-9]+.[0-9]+.[0-9]+"
     branches:
       - "main"
       - "develop"
@@ -62,5 +62,11 @@ jobs:
       - run: pdm run mike deploy dev --push
         if: github.ref == 'refs/heads/develop'
 
-      - run: pdm run mike deploy ${{ github.ref_name }}
+      - name: pdm run mike deploy $version
+        run: |
+          version=$(echo $TAG_VERSION | awk -F \. {'print $1"."$2'})
+          echo "Deploying version ${version}"
+          pdm run mike deploy $version
         if: startsWith(github.ref, 'refs/tags/')
+        env:
+          TAG_VERSION: ${{ github.ref_name }}


### PR DESCRIPTION
This PR reviews the specific tag version deployment and deploys (and pushes) versions when a tag in the format vX.Y.Z is pushed. 

- The `--push` option was missing in the previous version
- The version deployed will keep only the minor version. That means tags for a patch version `v2.1.3` will deploy the docs `v2.1`

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)
- Improvement (change adding some improvement to an existing functionality)
- Documentation update

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- follows the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)