### PR TITLE
[BUGFIX] server: Skip responses without user ids when indexing

### DIFF
--- a/argilla-server/CHANGELOG.md
+++ b/argilla-server/CHANGELOG.md
@@ -16,6 +16,10 @@ These are the section headers that we use:
 
 ## [Unreleased]()
 
+### Fixed
+
+- Fixed error when indexing responses without user_id. ([#5093](https://github.com/argilla-io/argilla/pull/5093))
+
 ## [2.0.0rc1](https://github.com/argilla-io/argilla/compare/v1.29.0...v2.0.0rc1)
 
 ### Removed

--- a/argilla-server/src/argilla_server/search_engine/commons.py
+++ b/argilla-server/src/argilla_server/search_engine/commons.py
@@ -575,6 +575,7 @@ class BaseElasticAndOpenSearchEngine(SearchEngine):
                 "status": response.status,
             }
             for response in responses
+            if response.user is not None
         }
 
     @staticmethod


### PR DESCRIPTION
# Pull Request Template
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Since the `user_id` is a nullable column, the search engine must tackle responses for those scenarios. This PR changes the search engine and skips responses when the user_id is None. 

This can be tackled in a better way in the future once we have a clearer view of how to deal with deleted users.


Refs: #5070 

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- follows the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)