### PR TITLE
[DOCS] swap extra_headers for headers in updated sdk docs

### DIFF
--- a/argilla/docs/getting_started/installation.md
+++ b/argilla/docs/getting_started/installation.md
@@ -43,7 +43,7 @@ import argilla as rg
 client = rg.Argilla(
     api_url="<api_url>",
     api_key="<api_key>",
-    # extra_headers={"Authorization": f"Bearer {HF_TOKEN}"}
+    # headers={"Authorization": f"Bearer {HF_TOKEN}"}
 )
 ```
 

--- a/argilla/docs/getting_started/quickstart.md
+++ b/argilla/docs/getting_started/quickstart.md
@@ -49,7 +49,7 @@ import argilla as rg
 client = rg.Argilla(
     api_url="<api_url>",
     api_key="<api_key>"
-    # extra_headers={"Authorization": f"Bearer {HF_TOKEN}"}
+    # headers={"Authorization": f"Bearer {HF_TOKEN}"}
 )
 ```
 

--- a/argilla/docs/tutorials/text_classification.ipynb
+++ b/argilla/docs/tutorials/text_classification.ipynb
@@ -120,7 +120,7 @@
     "client = rg.Argilla(\n",
     "    api_url=\"https://[your-owner-name]-[your_space_name].hf.space\",\n",
     "    api_key=\"owner.apikey\"\n",
-    "    # extra_headers={\"Authorization\": f\"Bearer {HF_TOKEN}\"}\n",
+    "    # headers={\"Authorization\": f\"Bearer {HF_TOKEN}\"}\n",
     ")"
    ]
   },

--- a/docs/_source/_common/snippets/start_page.md
+++ b/docs/_source/_common/snippets/start_page.md
@@ -37,7 +37,7 @@ import argilla as rg
 client = rg.Argilla(
     api_url="<api_url>",
     api_key="<api_key>"
-    # extra_headers={"Authorization": f"Bearer {HF_TOKEN}"}
+    # headers={"Authorization": f"Bearer {HF_TOKEN}"}
 )
 ```
 


### PR DESCRIPTION
This PR passes the extra headers pass to `Argilla` down to the http client so that argilla sdk can be used with authenticate deployment like provate HF spaces.

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- follows the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)