### PR TITLE
fix:  copy the dataset name by clicking the copy button

### DIFF
--- a/argilla-frontend/components/features/datasets/DatasetsTable.vue
+++ b/argilla-frontend/components/features/datasets/DatasetsTable.vue
@@ -56,13 +56,13 @@ export default {
           },
           actions: [
             {
-              name: "copy",
+              name: "copy-name",
               icon: "copy",
-              title: "Copy url to clipboard",
+              title: "Copy name to clipboard",
               tooltip: "Copied",
             },
             {
-              name: "copy",
+              name: "copy-url",
               icon: "link",
               title: "Copy url to clipboard",
               tooltip: "Copied",
@@ -179,7 +179,7 @@ export default {
         case "go-to-settings":
           this.goToSetting(dataset);
           break;
-        case "copy":
+        case "copy-url":
           this.copyUrl(dataset);
           break;
         case "copy-name":


### PR DESCRIPTION
This PR fixes the copy button behavior in the dataset list