### PR TITLE
feat: improve Records `responses_submitted` relationship to be view only

### DIFF
--- a/argilla-server/src/argilla_server/models/database.py
+++ b/argilla-server/src/argilla_server/models/database.py
@@ -206,8 +206,7 @@ class Record(DatabaseModel):
     )
     responses_submitted: Mapped[List["Response"]] = relationship(
         back_populates="record",
-        cascade="all, delete-orphan",
-        passive_deletes=True,
+        viewonly=True,
         primaryjoin=f"and_(Record.id==Response.record_id, Response.status=='{ResponseStatus.submitted}')",
         order_by=Response.inserted_at.asc(),
     )


### PR DESCRIPTION
# Description

Add changes to `responses_submitted` relationship to avoid problems with existent `responses` relationship and avoid a warning message that SQLAlchemy was reporting.

Refs #5000 

**Type of change**

- Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

- [x] Warning is not showing anymore.
- [x] Test are passing.

**Checklist**

- I added relevant documentation
- follows the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)