### PR TITLE
fix: conditional checking SQLite connection so connection configuration is correctly executed

### DIFF
--- a/argilla-server/CHANGELOG.md
+++ b/argilla-server/CHANGELOG.md
@@ -30,6 +30,7 @@ These are the section headers that we use:
 
 - Fixed error when updating records in bulk with wrong `external_id` but correct record `id`. ([#5014](https://github.com/argilla-io/argilla/pull/5014))
 - Fixed error when searching all record response values. ([#5003](https://github.com/argilla-io/argilla/pull/5003))
+- Fixed SQLite connection settings not working correctly due to a outdated conditional. ([#5149](https://github.com/argilla-io/argilla/pull/5149))
 
 ## [1.29.0](https://github.com/argilla-io/argilla/compare/v1.28.0...v1.29.0)
 

--- a/argilla-server/CHANGELOG.md
+++ b/argilla-server/CHANGELOG.md
@@ -16,6 +16,10 @@ These are the section headers that we use:
 
 ## [Unreleased]()
 
+### Fixed
+
+- Fixed SQLite connection settings not working correctly due to a outdated conditional. ([#5149](https://github.com/argilla-io/argilla/pull/5149))
+
 ## [2.0.0rc1](https://github.com/argilla-io/argilla/compare/v1.29.0...v2.0.0rc1)
 
 ### Changed
@@ -30,7 +34,6 @@ These are the section headers that we use:
 
 - Fixed error when updating records in bulk with wrong `external_id` but correct record `id`. ([#5014](https://github.com/argilla-io/argilla/pull/5014))
 - Fixed error when searching all record response values. ([#5003](https://github.com/argilla-io/argilla/pull/5003))
-- Fixed SQLite connection settings not working correctly due to a outdated conditional. ([#5149](https://github.com/argilla-io/argilla/pull/5149))
 
 ## [1.29.0](https://github.com/argilla-io/argilla/compare/v1.28.0...v1.29.0)
 

--- a/argilla-server/src/argilla_server/database.py
+++ b/argilla-server/src/argilla_server/database.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Generator
 from sqlalchemy import event, make_url
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.dialects.sqlite.aiosqlite import AsyncAdapt_aiosqlite_connection
 
 import argilla_server
 from argilla_server.settings import settings
@@ -44,9 +45,9 @@ TAGGED_REVISIONS = OrderedDict(
 
 @event.listens_for(Engine, "connect")
 def set_sqlite_pragma(dbapi_connection, connection_record):
-    if isinstance(dbapi_connection, SQLite3Connection):
+    if isinstance(dbapi_connection, AsyncAdapt_aiosqlite_connection):
         cursor = dbapi_connection.cursor()
-        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.execute("PRAGMA foreign_keys = ON")
         cursor.close()
 
 

--- a/argilla-server/tests/unit/test_database.py
+++ b/argilla-server/tests/unit/test_database.py
@@ -1,0 +1,28 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.dialects import sqlite
+from sqlalchemy.sql.expression import text
+
+
+@pytest.mark.asyncio
+class TestDatabase:
+    async def test_sqlite_pragma_settings(self, db: AsyncSession):
+        if db.bind.dialect.name != sqlite.dialect.name:
+            return
+
+        assert (await db.execute(text("PRAGMA foreign_keys"))).scalar() == 1


### PR DESCRIPTION
# Description

After changing SQLite connection to be asynchronous on version `1.14.0` using `aiosqlite`. There was a type check that was not changed and causing the connection configuration to not be executed for SQLite.

This PR fix the type check so the configuration statements are correctly executed and add a test to check for the expected values.

**Type of change**

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

- [x] Manually testing it with SQLite.

**Checklist**

- I added relevant documentation
- follows the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)