### PR TITLE
[ENHANCEMENT]: `argilla-server`: allow update distribution for non annotated datasets

### DIFF
--- a/argilla-server/src/argilla_server/models/database.py
+++ b/argilla-server/src/argilla_server/models/database.py
@@ -361,7 +361,8 @@ class Dataset(DatabaseModel):
 
     responses_count: Mapped[int] = column_property(
         select(func.count(Response.id))
-        .where(Response.record_id.in_(select(Record.id).where(text("datasets.id == records.dataset_id"))))
+        .join(Record)
+        .filter(text("datasets.id == records.dataset_id"))
         .scalar_subquery(),
         deferred=True,
     )

--- a/argilla-server/src/argilla_server/validators/datasets.py
+++ b/argilla-server/src/argilla_server/validators/datasets.py
@@ -44,7 +44,7 @@ class DatasetUpdateValidator:
 
     @classmethod
     async def _validate_distribution(cls, dataset: Dataset, dataset_attrs: dict) -> None:
-        if dataset_attrs.get("distribution") is not None and (await dataset.awaitable_attrs.responses_count) > 0:
+        if dataset_attrs.get("distribution") is not None and (await dataset.responses_count) > 0:
             raise UnprocessableEntityError(
                 "Distribution settings cannot be modified for a dataset with records including responses"
             )

--- a/argilla-server/src/argilla_server/validators/datasets.py
+++ b/argilla-server/src/argilla_server/validators/datasets.py
@@ -40,9 +40,11 @@ class DatasetCreateValidator:
 class DatasetUpdateValidator:
     @classmethod
     async def validate(cls, db: AsyncSession, dataset: Dataset, dataset_attrs: dict) -> None:
-        cls._validate_distribution(dataset, dataset_attrs)
+        await cls._validate_distribution(dataset, dataset_attrs)
 
     @classmethod
-    def _validate_distribution(cls, dataset: Dataset, dataset_attrs: dict) -> None:
-        if dataset.is_ready and dataset_attrs.get("distribution") is not None:
-            raise UnprocessableEntityError(f"Distribution settings cannot be modified for a published dataset")
+    async def _validate_distribution(cls, dataset: Dataset, dataset_attrs: dict) -> None:
+        if dataset_attrs.get("distribution") is not None and (await dataset.awaitable_attrs.responses_count) > 0:
+            raise UnprocessableEntityError(
+                "Distribution settings cannot be modified for a dataset with records including responses"
+            )


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR changes the current validator when updating the distribution task to allow updating the distribution task settings for datasets with records without ANY response.

cc @nataliaElv 

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)