### PR TITLE
docs: update environment for old docs

### DIFF
--- a/docs/_source/.readthedocs.yaml
+++ b/docs/_source/.readthedocs.yaml
@@ -21,9 +21,3 @@ sphinx:
 python:
   install:
     - requirements: docs/_source/requirements.txt
-    - method: pip
-      path: argilla/
-      extra_requirements:
-       - server
-       - postgresql
-       - listeners

--- a/docs/_source/requirements.txt
+++ b/docs/_source/requirements.txt
@@ -1,6 +1,7 @@
 alabaster==0.7.12 ; python_version >= "3.8" and python_version < "4.0"
 anyio==3.7.0 ; python_version >= "3.8" and python_version < "4.0"
 appnope==0.1.3 ; python_version >= "3.8" and python_version < "4.0" and sys_platform == "darwin" or python_version >= "3.8" and python_version < "4.0" and platform_system == "Darwin"
+argilla==1.29 ; python_version >= "3.8" and python_version < "4.0"
 asttokens==2.2.1 ; python_version >= "3.8" and python_version < "4.0"
 attrs==21.4.0 ; python_version >= "3.8" and python_version < "4.0"
 babel==2.10.3 ; python_version >= "3.8" and python_version < "4.0"


### PR DESCRIPTION
# Pull Request Template
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

References in old docs don't work because `autodoc` retrieves the package from the environment. However, updating the path package would require the usage of argilla-v1, which doesn't work for the docs about versions 1.X. That's why I added argilla to the requirements.txt and removed the editable package installation.

![Screenshot 2024-07-10 at 13 42 38](https://github.com/argilla-io/argilla/assets/127759186/08d5e978-dea7-4d79-9960-2932c64e5955)


Closes #5146 

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Documentation update

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)