### PR TITLE
[BUGFIX] `argilla-server`: add authorize statement when creating records in bulk

### DIFF
--- a/argilla-server/src/argilla_server/api/handlers/v1/datasets/records_bulk.py
+++ b/argilla-server/src/argilla_server/api/handlers/v1/datasets/records_bulk.py
@@ -56,6 +56,8 @@ async def create_dataset_records_bulk(
         ],
     )
 
+    await authorize(current_user, DatasetPolicy.create_records(dataset))
+
     records_bulk = await CreateRecordsBulk(db, search_engine).create_records_bulk(dataset, records_bulk_create)
 
     telemetry_client.track_data(action="DatasetRecordsCreated", data={"records": len(records_bulk.items)})


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR reverts the fix introduced in https://github.com/argilla-io/argilla/pull/4959 by adding the `authorize` statement when creating records in bulk

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)


**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)