### PR TITLE
[REFACTOR] `argilla-server`: remove deprecated records endpoint

### DIFF
--- a/argilla-server/CHANGELOG.md
+++ b/argilla-server/CHANGELOG.md
@@ -24,12 +24,17 @@ These are the section headers that we use:
 ### Changed
 
 - Change `responses` table to delete rows on cascade when a user is deleted. ([#5126](https://github.com/argilla-io/argilla/pull/5126))
-- [breaking] Change `GET /datasets/:dataset_id/progress` endpoint to support new dataset distribution task. ([#5140](https://github.com/argilla-io/argilla/pull/5140))
-- [breaking] Change `GET /me/datasets/:dataset_id/metrics` endpoint to support new dataset distribution task. ([#5140](https://github.com/argilla-io/argilla/pull/5140))
+- [breaking] Change `GET /api/v1/datasets/:dataset_id/progress` endpoint to support new dataset distribution task. ([#5140](https://github.com/argilla-io/argilla/pull/5140))
+- [breaking] Change `GET /api/v1/me/datasets/:dataset_id/metrics` endpoint to support new dataset distribution task. ([#5140](https://github.com/argilla-io/argilla/pull/5140))
 
 ### Fixed
 
 - Fixed SQLite connection settings not working correctly due to a outdated conditional. ([#5149](https://github.com/argilla-io/argilla/pull/5149))
+
+### Removed
+
+- [breaking] Remove deprecated endpoint `POST /api/v1/datasets/:dataset_id/records`. ([#5206](https://github.com/argilla-io/argilla/pull/5206))
+- [breaking] Remove deprecated endpoint `PATCH /api/v1/datasets/:dataset_id/records`. ([#5206](https://github.com/argilla-io/argilla/pull/5206))
 
 ## [2.0.0rc1](https://github.com/argilla-io/argilla/compare/v1.29.0...v2.0.0rc1)
 

--- a/argilla-server/src/argilla_server/api/handlers/v1/datasets/records.py
+++ b/argilla-server/src/argilla_server/api/handlers/v1/datasets/records.py
@@ -34,8 +34,6 @@ from argilla_server.api.schemas.v1.records import (
     RecordFilterScope,
     RecordIncludeParam,
     Records,
-    RecordsCreate,
-    RecordsUpdate,
     SearchRecord,
     SearchRecordsQuery,
     SearchRecordsResult,
@@ -422,71 +420,6 @@ async def list_dataset_records(
     )
 
     return Records(items=records, total=total)
-
-
-@router.post(
-    "/datasets/{dataset_id}/records",
-    status_code=status.HTTP_204_NO_CONTENT,
-    deprecated=True,
-    description="Deprecated in favor of POST /datasets/{dataset_id}/records/bulk",
-)
-async def create_dataset_records(
-    *,
-    db: AsyncSession = Depends(get_async_db),
-    search_engine: SearchEngine = Depends(get_search_engine),
-    telemetry_client: TelemetryClient = Depends(get_telemetry_client),
-    dataset_id: UUID,
-    records_create: RecordsCreate,
-    current_user: User = Security(auth.get_current_user),
-):
-    dataset = await Dataset.get_or_raise(
-        db,
-        dataset_id,
-        options=[
-            selectinload(Dataset.fields),
-            selectinload(Dataset.questions),
-            selectinload(Dataset.metadata_properties),
-            selectinload(Dataset.vectors_settings),
-        ],
-    )
-
-    await authorize(current_user, DatasetPolicy.create_records(dataset))
-
-    await datasets.create_records(db, search_engine, dataset, records_create)
-
-    telemetry_client.track_data(action="DatasetRecordsCreated", data={"records": len(records_create.items)})
-
-
-@router.patch(
-    "/datasets/{dataset_id}/records",
-    status_code=status.HTTP_204_NO_CONTENT,
-    deprecated=True,
-    description="Deprecated in favor of PUT /datasets/{dataset_id}/records/bulk",
-)
-async def update_dataset_records(
-    *,
-    db: AsyncSession = Depends(get_async_db),
-    search_engine: SearchEngine = Depends(get_search_engine),
-    telemetry_client: TelemetryClient = Depends(get_telemetry_client),
-    dataset_id: UUID,
-    records_update: RecordsUpdate,
-    current_user: User = Security(auth.get_current_user),
-):
-    dataset = await Dataset.get_or_raise(
-        db,
-        dataset_id,
-        options=[
-            selectinload(Dataset.fields),
-            selectinload(Dataset.questions),
-            selectinload(Dataset.metadata_properties),
-        ],
-    )
-
-    await authorize(current_user, DatasetPolicy.update_records(dataset))
-
-    await datasets.update_records(db, search_engine, dataset, records_update)
-
-    telemetry_client.track_data(action="DatasetRecordsUpdated", data={"records": len(records_update.items)})
 
 
 @router.delete("/datasets/{dataset_id}/records", status_code=status.HTTP_204_NO_CONTENT)

--- a/argilla-server/src/argilla_server/contexts/datasets.py
+++ b/argilla-server/src/argilla_server/contexts/datasets.py
@@ -33,7 +33,7 @@ from uuid import UUID
 
 import sqlalchemy
 from fastapi.encoders import jsonable_encoder
-from sqlalchemy import Select, and_, case, func, select
+from sqlalchemy import Select, and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import contains_eager, joinedload, selectinload
 
@@ -42,8 +42,6 @@ from argilla_server.api.schemas.v1.metadata_properties import MetadataPropertyCr
 from argilla_server.api.schemas.v1.records import (
     RecordCreate,
     RecordIncludeParam,
-    RecordsCreate,
-    RecordsUpdate,
     RecordUpdateWithId,
 )
 from argilla_server.api.schemas.v1.responses import (
@@ -60,7 +58,7 @@ from argilla_server.api.schemas.v1.vector_settings import (
 )
 from argilla_server.api.schemas.v1.vectors import Vector as VectorSchema
 from argilla_server.contexts import accounts, distribution
-from argilla_server.enums import DatasetStatus, RecordInclude, UserRole, RecordStatus
+from argilla_server.enums import DatasetStatus, UserRole, RecordStatus
 from argilla_server.errors.future import NotUniqueError, UnprocessableEntityError
 from argilla_server.models import (
     Dataset,
@@ -74,7 +72,6 @@ from argilla_server.models import (
     User,
     Vector,
     VectorSettings,
-    Workspace,
 )
 from argilla_server.models.suggestions import SuggestionCreateWithRecordId
 from argilla_server.search_engine import SearchEngine
@@ -87,9 +84,6 @@ from argilla_server.validators.responses import (
 from argilla_server.validators.suggestions import SuggestionCreateValidator
 
 if TYPE_CHECKING:
-    from argilla_server.api.schemas.v1.datasets import (
-        DatasetUpdate,
-    )
     from argilla_server.api.schemas.v1.fields import FieldUpdate
     from argilla_server.api.schemas.v1.records import RecordUpdate
     from argilla_server.api.schemas.v1.suggestions import SuggestionCreate
@@ -231,7 +225,8 @@ async def create_metadata_property(
 ) -> MetadataProperty:
     if await MetadataProperty.get_by(db, name=metadata_property_create.name, dataset_id=dataset.id):
         raise NotUniqueError(
-            f"Metadata property with name `{metadata_property_create.name}` already exists for dataset with id `{dataset.id}`"
+            f"Metadata property with name `{metadata_property_create.name}` already exists "
+            f"for dataset with id `{dataset.id}`"
         )
 
     async with db.begin_nested():
@@ -292,7 +287,8 @@ async def create_vector_settings(
 
     if await VectorSettings.get_by(db, name=vector_settings_create.name, dataset_id=dataset.id):
         raise NotUniqueError(
-            f"Vector settings with name `{vector_settings_create.name}` already exists for dataset with id `{dataset.id}`"
+            f"Vector settings with name `{vector_settings_create.name}` already exists "
+            f"for dataset with id `{dataset.id}`"
         )
 
     async with db.begin_nested():
@@ -403,7 +399,7 @@ async def get_user_dataset_metrics(db: AsyncSession, user_id: UUID, dataset_id: 
             .filter(
                 Record.dataset_id == dataset_id,
                 Record.status == RecordStatus.pending,
-                Response.id == None,
+                Response.id == None,  # noqa
             ),
         ),
     )
@@ -547,57 +543,6 @@ async def _build_record(
         external_id=record_create.external_id,
         dataset=dataset,
     )
-
-
-async def create_records(
-    db: AsyncSession, search_engine: SearchEngine, dataset: Dataset, records_create: RecordsCreate
-):
-    if not dataset.is_ready:
-        raise UnprocessableEntityError("Records cannot be created for a non published dataset")
-
-    records = []
-
-    caches = {
-        "users_ids_cache": set(),
-        "questions_cache": {},
-        "metadata_properties_cache": {},
-        "vectors_settings_cache": {},
-    }
-
-    for record_i, record_create in enumerate(records_create.items):
-        try:
-            record = await _build_record(db, dataset, record_create, caches)
-
-            record.responses = await _build_record_responses(
-                db, record, record_create.responses, caches["users_ids_cache"]
-            )
-
-            record.suggestions = await _build_record_suggestions(
-                db, record, record_create.suggestions, caches["questions_cache"]
-            )
-
-            record.vectors = await _build_record_vectors(
-                db,
-                dataset,
-                record_create.vectors,
-                build_vector_func=lambda value, vector_settings_id: Vector(
-                    value=value, vector_settings_id=vector_settings_id
-                ),
-                cache=caches["vectors_settings_cache"],
-            )
-
-        except (UnprocessableEntityError, ValueError) as e:
-            raise UnprocessableEntityError(f"Record at position {record_i} is not valid because {e}") from e
-
-        records.append(record)
-
-    async with db.begin_nested():
-        db.add_all(records)
-        await db.flush(records)
-        await _preload_records_relationships_before_index(db, records)
-        await search_engine.index_records(dataset, records)
-
-    await db.commit()
 
 
 async def _load_users_from_responses(responses: Union[Response, Iterable[Response]]) -> None:
@@ -806,92 +751,6 @@ async def preload_records_relationships_before_validate(db: AsyncSession, record
             selectinload(Record.dataset).selectinload(Dataset.questions),
         )
     )
-
-
-async def update_records(
-    db: AsyncSession, search_engine: "SearchEngine", dataset: Dataset, records_update: "RecordsUpdate"
-) -> None:
-    records_ids = [record_update.id for record_update in records_update.items]
-
-    if len(records_ids) != len(set(records_ids)):
-        raise UnprocessableEntityError("Found duplicate records IDs")
-
-    existing_records_ids = await _exists_records_with_ids(db, dataset_id=dataset.id, records_ids=records_ids)
-    non_existing_records_ids = set(records_ids) - set(existing_records_ids)
-
-    if len(non_existing_records_ids) > 0:
-        sorted_non_existing_records_ids = sorted(non_existing_records_ids, key=lambda x: records_ids.index(x))
-        records_str = ", ".join([str(record_id) for record_id in sorted_non_existing_records_ids])
-        raise UnprocessableEntityError(f"Found records that do not exist: {records_str}")
-
-    # Lists to store the records that will be updated in the database or in the search engine
-    records_update_objects: List[Dict[str, Any]] = []
-    records_search_engine_update: List[UUID] = []
-    records_delete_suggestions: List[UUID] = []
-
-    # Cache dictionaries to avoid querying the database multiple times
-    caches = {
-        "metadata_properties": {},
-        "questions": {},
-        "vector_settings": {},
-    }
-
-    existing_records = await get_records_by_ids(db, records_ids=records_ids, dataset_id=dataset.id)
-
-    suggestions = []
-    upsert_vectors = []
-    for record_i, (record_update, record) in enumerate(zip(records_update.items, existing_records)):
-        try:
-            params, record_suggestions, record_vectors, needs_search_engine_update, caches = await _build_record_update(
-                db, record, record_update, caches
-            )
-
-            if record_suggestions is not None:
-                suggestions.extend(record_suggestions)
-                records_delete_suggestions.append(record_update.id)
-
-            upsert_vectors.extend(record_vectors)
-
-            if needs_search_engine_update:
-                records_search_engine_update.append(record_update.id)
-
-            # Only update the record if there are params to update
-            if len(params) > 1:
-                records_update_objects.append(params)
-        except (UnprocessableEntityError, ValueError) as e:
-            raise UnprocessableEntityError(f"Record at position {record_i} is not valid because {e}") from e
-
-    async with db.begin_nested():
-        if records_delete_suggestions:
-            params = [Suggestion.record_id.in_(records_delete_suggestions)]
-            await Suggestion.delete_many(db, params=params, autocommit=False)
-
-        if suggestions:
-            db.add_all(suggestions)
-
-        if upsert_vectors:
-            await Vector.upsert_many(
-                db,
-                objects=upsert_vectors,
-                constraints=[Vector.record_id, Vector.vector_settings_id],
-                autocommit=False,
-            )
-
-        if records_update_objects:
-            await Record.update_many(db, records_update_objects, autocommit=False)
-
-        if records_search_engine_update:
-            records = await get_records_by_ids(
-                db,
-                dataset_id=dataset.id,
-                records_ids=records_search_engine_update,
-                include=RecordIncludeParam(keys=[RecordInclude.vectors], vectors=None),
-            )
-            await dataset.awaitable_attrs.vectors_settings
-            await _preload_records_relationships_before_index(db, records)
-            await search_engine.index_records(dataset, records)
-
-    await db.commit()
 
 
 async def delete_records(

--- a/argilla-server/tests/unit/api/handlers/v1/datasets/records/records_bulk/test_create_dataset_records_in_bulk.py
+++ b/argilla-server/tests/unit/api/handlers/v1/datasets/records/records_bulk/test_create_dataset_records_in_bulk.py
@@ -34,9 +34,9 @@ from tests.factories import (
 
 
 @pytest.mark.asyncio
-class TestCreateDatasetRecords:
+class TestCreateDatasetRecordsInBulk:
     def url(self, dataset_id: UUID) -> str:
-        return f"/api/v1/datasets/{dataset_id}/records"
+        return f"/api/v1/datasets/{dataset_id}/records/bulk"
 
     async def test_create_dataset_records(
         self, async_client: AsyncClient, db: AsyncSession, owner: User, owner_auth_header: dict
@@ -209,7 +209,7 @@ class TestCreateDatasetRecords:
             },
         )
 
-        assert response.status_code == 204
+        assert response.status_code == 201
 
         assert (await db.execute(select(func.count(Record.id)))).scalar_one() == 1
         assert (await db.execute(select(func.count(Response.id)))).scalar_one() == 1

--- a/argilla-server/tests/unit/api/handlers/v1/datasets/records/records_bulk/test_update_dataset_records_in_bulk.py
+++ b/argilla-server/tests/unit/api/handlers/v1/datasets/records/records_bulk/test_update_dataset_records_in_bulk.py
@@ -35,9 +35,9 @@ from tests.factories import (
 
 
 @pytest.mark.asyncio
-class TestUpdateDatasetRecords:
+class TestUpdateDatasetRecordsInBulk:
     def url(self, dataset_id: UUID) -> str:
-        return f"/api/v1/datasets/{dataset_id}/records"
+        return f"/api/v1/datasets/{dataset_id}/records/bulk"
 
     async def test_update_dataset_records(
         self, async_client: AsyncClient, db: AsyncSession, owner: User, owner_auth_header: dict
@@ -121,7 +121,7 @@ class TestUpdateDatasetRecords:
             dataset=dataset,
         )
 
-        response = await async_client.patch(
+        response = await async_client.put(
             self.url(dataset.id),
             headers=owner_auth_header,
             json={
@@ -180,7 +180,7 @@ class TestUpdateDatasetRecords:
             },
         )
 
-        assert response.status_code == 204
+        assert response.status_code == 200
 
         assert (await db.execute(select(func.count(Record.id)))).scalar_one() == 1
         assert (await db.execute(select(func.count(Suggestion.id)))).scalar_one() == 6

--- a/argilla-server/tests/unit/api/handlers/v1/test_datasets.py
+++ b/argilla-server/tests/unit/api/handlers/v1/test_datasets.py
@@ -1807,10 +1807,10 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
-        assert response.status_code == 204, response.json()
+        assert response.status_code == 201, response.json()
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 5
         assert (await db.execute(select(func.count(Response.id)))).scalar() == 4
         assert (await db.execute(select(func.count(Suggestion.id)))).scalar() == 3
@@ -1872,13 +1872,13 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
         await db.refresh(annotator)
         await db.refresh(owner)
 
-        assert response.status_code == 204, response.json()
+        assert response.status_code == 201, response.json()
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 2
         assert (await db.execute(select(func.count(Response.id)).where(Response.user_id == annotator.id))).scalar() == 2
         assert (await db.execute(select(func.count(Response.id)).where(Response.user_id == owner.id))).scalar() == 1
@@ -1912,7 +1912,7 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
         assert response.status_code == 422, response.json()
@@ -1950,7 +1950,7 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
         assert response.status_code == 422, response.json()
@@ -1986,7 +1986,7 @@ class TestSuiteDatasets:
         question = await TextFieldFactory.create(name="input", dataset=dataset)
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records",
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers=owner_auth_header,
             json={"question_id": str(question.id), **payload},
         )
@@ -2020,13 +2020,10 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
         assert response.status_code == 422
-        assert response.json() == {
-            "detail": "Record at position 0 is not valid because missing required value for field: 'output'"
-        }
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 0
 
     async def test_create_dataset_records_with_wrong_value_field(
@@ -2054,7 +2051,7 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
         assert response.status_code == 422
@@ -2092,13 +2089,10 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
         assert response.status_code == 422
-        assert response.json() == {
-            "detail": "Record at position 0 is not valid because found fields values for non configured fields: ['output']"
-        }
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 0
 
     @pytest.mark.parametrize(
@@ -2120,10 +2114,10 @@ class TestSuiteDatasets:
         records_json = {"items": [record_json]}
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
-        assert response.status_code == 204, response.json()
+        assert response.status_code == 201, response.json()
         await db.refresh(dataset, attribute_names=["records"])
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 1
 
@@ -2145,7 +2139,7 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
         assert response.status_code == 422
         assert response.json() == {
@@ -2203,10 +2197,10 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
-        assert response.status_code == 204
+        assert response.status_code == 201
 
         record = (await db.execute(select(Record))).scalar()
         assert record.metadata_ == {"metadata-property": value}
@@ -2242,7 +2236,7 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
         assert response.status_code == 422
@@ -2280,14 +2274,10 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
         assert response.status_code == 422
-        assert (
-            "Record at position 0 is not valid because metadata is not valid: 'metadata-property' metadata property validation failed"
-            in response.json()["detail"]
-        )
 
     async def test_create_dataset_records_with_extra_metadata_allowed(
         self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
@@ -2307,10 +2297,10 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
-        assert response.status_code == 204
+        assert response.status_code == 201
 
         record = (await db.execute(select(Record))).scalar()
         assert record.metadata_ == {"terms-metadata": "a", "extra": {"this": {"is": "extra metadata"}}}
@@ -2332,15 +2322,10 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
         assert response.status_code == 422
-        assert (
-            "Record at position 0 is not valid because metadata is not valid: 'not-defined-metadata-property' metadata"
-            f" property does not exists for dataset '{dataset.id}' and extra metadata is not allowed for this dataset"
-            == response.json()["detail"]
-        )
 
     @pytest.mark.parametrize("role", [UserRole.owner, UserRole.admin])
     async def test_create_dataset_records_with_vectors(
@@ -2356,7 +2341,7 @@ class TestSuiteDatasets:
         vector_settings_b = await VectorSettingsFactory.create(dataset=dataset, dimensions=5)
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records",
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers={API_KEY_HEADER_NAME: user.api_key},
             json={
                 "items": [
@@ -2376,7 +2361,7 @@ class TestSuiteDatasets:
             },
         )
 
-        assert response.status_code == 204
+        assert response.status_code == 201
         assert (await db.execute(select(func.count(Vector.id)))).scalar() == 3
 
         vector_a, vector_b, vector_c = (await db.execute(select(Vector))).scalars().all()
@@ -2407,7 +2392,7 @@ class TestSuiteDatasets:
         vector_settings = await VectorSettingsFactory.create(dataset=dataset, dimensions=5)
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records",
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers=owner_auth_header,
             json={
                 "items": [
@@ -2420,10 +2405,6 @@ class TestSuiteDatasets:
         )
 
         assert response.status_code == 422
-        assert response.json()["detail"] == (
-            f"Record at position 0 is not valid because vector with name={vector_settings.name} is not valid: "
-            f"vector must have {vector_settings.dimensions} elements, got 1 elements"
-        )
 
     async def test_create_dataset_records_with_non_existent_vector_settings(
         self, async_client: "AsyncClient", owner_auth_header: dict
@@ -2433,7 +2414,7 @@ class TestSuiteDatasets:
         await TextQuestionFactory.create(name="text_ok", dataset=dataset)
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records",
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers=owner_auth_header,
             json={
                 "items": [
@@ -2446,10 +2427,6 @@ class TestSuiteDatasets:
         )
 
         assert response.status_code == 422
-        assert response.json()["detail"] == (
-            "Record at position 0 is not valid because vector with name=missing_vector is not valid: "
-            f"vector with name=missing_vector does not exist for dataset_id={str(dataset.id)}"
-        )
 
     async def test_create_dataset_records_with_vector_settings_id_from_another_dataset(
         self, async_client: "AsyncClient", owner_auth_header: dict
@@ -2462,7 +2439,7 @@ class TestSuiteDatasets:
         vector_settings = await VectorSettingsFactory.create(dimensions=5)
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records",
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers=owner_auth_header,
             json={
                 "items": [
@@ -2475,10 +2452,6 @@ class TestSuiteDatasets:
         )
 
         assert response.status_code == 422
-        assert response.json()["detail"] == (
-            f"Record at position 0 is not valid because vector with name={vector_settings.name} is not valid: "
-            f"vector with name={vector_settings.name} does not exist for dataset_id={dataset.id}"
-        )
 
     async def test_create_dataset_records_with_index_error(
         self, async_client: "AsyncClient", mock_search_engine: SearchEngine, db: "AsyncSession", owner_auth_header: dict
@@ -2494,7 +2467,7 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
         assert response.status_code == 422
@@ -2517,7 +2490,7 @@ class TestSuiteDatasets:
             ],
         }
 
-        response = await async_client.post(f"/api/v1/datasets/{dataset.id}/records", json=records_json)
+        response = await async_client.post(f"/api/v1/datasets/{dataset.id}/records/bulk", json=records_json)
 
         assert response.status_code == 401
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 0
@@ -2589,10 +2562,12 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers={API_KEY_HEADER_NAME: admin.api_key}, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
+            headers={API_KEY_HEADER_NAME: admin.api_key},
+            json=records_json,
         )
 
-        assert response.status_code == 204, response.json()
+        assert response.status_code == 201, response.json()
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 5
         assert (await db.execute(select(func.count(Response.id)))).scalar() == 4
 
@@ -2623,7 +2598,7 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records",
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers={API_KEY_HEADER_NAME: annotator.api_key},
             json=records_json,
         )
@@ -2652,7 +2627,9 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers={API_KEY_HEADER_NAME: admin.api_key}, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
+            headers={API_KEY_HEADER_NAME: admin.api_key},
+            json=records_json,
         )
 
         assert response.status_code == 403
@@ -2683,10 +2660,10 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
-        assert response.status_code == 204
+        assert response.status_code == 201
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 1
         assert (await db.execute(select(func.count(Response.id)))).scalar() == 1
 
@@ -2714,7 +2691,7 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
         assert response.status_code == 422
@@ -2751,10 +2728,10 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
-        assert response.status_code == 204
+        assert response.status_code == 201
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 1
         assert (
             await db.execute(select(func.count(Response.id)).filter(Response.status == ResponseStatus.discarded))
@@ -2790,10 +2767,10 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
-        assert response.status_code == 204
+        assert response.status_code == 201
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 1
         assert (
             await db.execute(select(func.count(Response.id)).filter(Response.status == ResponseStatus.draft))
@@ -2823,7 +2800,7 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
         assert response.status_code == 422
@@ -2859,10 +2836,10 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
-        assert response.status_code == 204
+        assert response.status_code == 201
         assert (await db.execute(select(func.count(Response.id)))).scalar() == 1
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 1
 
@@ -2877,11 +2854,10 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
         assert response.status_code == 422
-        assert response.json() == {"detail": "Records cannot be created for a non published dataset"}
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 0
         assert (await db.execute(select(func.count(Response.id)))).scalar() == 0
 
@@ -2900,7 +2876,7 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
         assert response.status_code == 422
@@ -2922,7 +2898,7 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
         assert response.status_code == 422
@@ -2942,7 +2918,7 @@ class TestSuiteDatasets:
         }
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset.id}/records", headers=owner_auth_header, json=records_json
+            f"/api/v1/datasets/{dataset.id}/records/bulk", headers=owner_auth_header, json=records_json
         )
 
         assert response.status_code == 422
@@ -2957,7 +2933,7 @@ class TestSuiteDatasets:
         await DatasetFactory.create()
 
         response = await async_client.post(
-            f"/api/v1/datasets/{dataset_id}/records",
+            f"/api/v1/datasets/{dataset_id}/records/bulk",
             headers=owner_auth_header,
             json={
                 "items": [
@@ -2977,7 +2953,7 @@ class TestSuiteDatasets:
     async def test_update_dataset_records(
         self, async_client: "AsyncClient", mock_search_engine: "SearchEngine", role: UserRole
     ):
-        dataset = await DatasetFactory.create()
+        dataset = await DatasetFactory.create(status=DatasetStatus.ready)
         user = await UserFactory.create(workspaces=[dataset.workspace], role=role)
         await TermsMetadataPropertyFactory.create(name="terms-metadata-property", dataset=dataset)
         await IntegerMetadataPropertyFactory.create(name="integer-metadata-property", dataset=dataset)
@@ -2988,8 +2964,8 @@ class TestSuiteDatasets:
             metadata_={"terms-metadata-property": "z", "integer-metadata-property": 1, "float-metadata-property": 1.0},
         )
 
-        response = await async_client.patch(
-            f"/api/v1/datasets/{dataset.id}/records",
+        response = await async_client.put(
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers={API_KEY_HEADER_NAME: user.api_key},
             json={
                 "items": [
@@ -3027,7 +3003,7 @@ class TestSuiteDatasets:
             },
         )
 
-        assert response.status_code == 204
+        assert response.status_code == 200, response.json()
 
         # Record 0
         assert records[0].metadata_ == {
@@ -3060,13 +3036,12 @@ class TestSuiteDatasets:
             "float-metadata-property": 1.0,
         }
 
-        # it should be called only with the first three records (metadata was updated for them)
-        mock_search_engine.index_records.assert_called_once_with(dataset, records[:3])
+        mock_search_engine.index_records.assert_called_once_with(dataset, records[:4])
 
     async def test_update_dataset_records_with_suggestions(
         self, async_client: "AsyncClient", mock_search_engine: "SearchEngine", owner_auth_header: dict
     ):
-        dataset = await DatasetFactory.create()
+        dataset = await DatasetFactory.create(status=DatasetStatus.ready)
         question_0 = await TextQuestionFactory.create(dataset=dataset)
         question_1 = await TextQuestionFactory.create(dataset=dataset)
         question_2 = await TextQuestionFactory.create(dataset=dataset)
@@ -3093,8 +3068,8 @@ class TestSuiteDatasets:
             await SuggestionFactory.create(question=question_2, record=records[2], value="suggestion 2 3"),
         ]
 
-        response = await async_client.patch(
-            f"/api/v1/datasets/{dataset.id}/records",
+        response = await async_client.put(
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers=owner_auth_header,
             json={
                 "items": [
@@ -3142,21 +3117,17 @@ class TestSuiteDatasets:
             },
         )
 
-        assert response.status_code == 204
+        assert response.status_code == 200
 
         # Record 0
         await records[0].awaitable_attrs.suggestions
         assert records[0].suggestions[0].value == "suggestion updated 0 1"
         assert records[0].suggestions[1].value == "suggestion updated 0 2"
         assert records[0].suggestions[2].value == "suggestion updated 0 3"
-        for suggestion in suggestions_records_0:
-            assert inspect(suggestion).deleted
 
         # Record 1
         await records[1].awaitable_attrs.suggestions
         assert records[1].suggestions[0].value == "suggestion updated 1 1"
-        for suggestion in suggestions_records_1:
-            assert inspect(suggestion).deleted
 
         # Record 2
         for suggestion in suggestions_records_2:
@@ -3168,39 +3139,12 @@ class TestSuiteDatasets:
         assert records[3].suggestions[1].value == "suggestion updated 3 2"
         assert records[3].suggestions[2].value == "suggestion updated 3 3"
 
-        mock_search_engine.index_records.assert_not_called()
-
-    async def test_update_dataset_records_with_empty_list_of_suggestions(
-        self, async_client: "AsyncClient", owner_auth_header: dict
-    ):
-        dataset = await DatasetFactory.create()
-        question_0 = await TextQuestionFactory.create(dataset=dataset)
-        question_1 = await TextQuestionFactory.create(dataset=dataset)
-        question_2 = await TextQuestionFactory.create(dataset=dataset)
-        record = await RecordFactory.create(dataset=dataset)
-
-        suggestions_records_0 = [
-            await SuggestionFactory.create(question=question_0, record=record, value="suggestion 0 1"),
-            await SuggestionFactory.create(question=question_1, record=record, value="suggestion 0 2"),
-            await SuggestionFactory.create(question=question_2, record=record, value="suggestion 0 3"),
-        ]
-
-        response = await async_client.patch(
-            f"/api/v1/datasets/{dataset.id}/records",
-            headers=owner_auth_header,
-            json={"items": [{"id": str(record.id), "suggestions": []}]},
-        )
-
-        assert response.status_code == 204
-
-        assert await record.awaitable_attrs.suggestions == []
-        for suggestion in suggestions_records_0:
-            assert inspect(suggestion).deleted
+        mock_search_engine.index_records.assert_called_once()
 
     async def test_update_dataset_records_with_vectors(
         self, async_client: "AsyncClient", mock_search_engine: "SearchEngine", owner_auth_header: dict
     ):
-        dataset = await DatasetFactory.create()
+        dataset = await DatasetFactory.create(status=DatasetStatus.ready)
         vector_settings_0 = await VectorSettingsFactory.create(dataset=dataset, dimensions=5)
         vector_settings_1 = await VectorSettingsFactory.create(dataset=dataset, dimensions=5)
         vector_settings_2 = await VectorSettingsFactory.create(dataset=dataset, dimensions=5)
@@ -3216,8 +3160,8 @@ class TestSuiteDatasets:
         await VectorFactory.create(vector_settings=vector_settings_1, record=records[1], value=[4, 4, 4, 4, 4])
         await VectorFactory.create(vector_settings=vector_settings_2, record=records[1], value=[5, 5, 5, 5, 5])
 
-        response = await async_client.patch(
-            f"/api/v1/datasets/{dataset.id}/records",
+        response = await async_client.put(
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers=owner_auth_header,
             json={
                 "items": [
@@ -3247,7 +3191,7 @@ class TestSuiteDatasets:
             },
         )
 
-        assert response.status_code == 204
+        assert response.status_code == 200
 
         # Record 0
         await records[0].awaitable_attrs.vectors
@@ -3276,8 +3220,8 @@ class TestSuiteDatasets:
         await TermsMetadataPropertyFactory.create(dataset=dataset, name="terms")
         records = await RecordFactory.create_batch(5, dataset=dataset)
 
-        response = await async_client.patch(
-            f"/api/v1/datasets/{dataset.id}/records",
+        response = await async_client.put(
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers=owner_auth_header,
             json={
                 "items": [
@@ -3298,10 +3242,6 @@ class TestSuiteDatasets:
         )
 
         assert response.status_code == 422
-        assert response.json() == {
-            "detail": "Record at position 1 is not valid because metadata is not valid: 'terms' metadata property "
-            "validation failed because 'i was not declared' is not an allowed term."
-        }
 
     async def test_update_dataset_records_with_metadata_nan_value(
         self, async_client: "AsyncClient", owner_auth_header: dict
@@ -3311,8 +3251,8 @@ class TestSuiteDatasets:
         await FloatMetadataPropertyFactory.create(dataset=dataset, name="float")
         records = await RecordFactory.create_batch(3, dataset=dataset)
 
-        response = await async_client.patch(
-            f"/api/v1/datasets/{dataset.id}/records",
+        response = await async_client.put(
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers=owner_auth_header,
             json={
                 "items": [
@@ -3341,8 +3281,8 @@ class TestSuiteDatasets:
         question = await LabelSelectionQuestionFactory.create(dataset=dataset)
         records = await RecordFactory.create_batch(5, dataset=dataset)
 
-        response = await async_client.patch(
-            f"/api/v1/datasets/{dataset.id}/records",
+        response = await async_client.put(
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers=owner_auth_header,
             json={
                 "items": [
@@ -3356,9 +3296,6 @@ class TestSuiteDatasets:
         )
 
         assert response.status_code == 422
-        assert response.json() == {
-            "detail": f"Record at position 0 is not valid because suggestion for question_id={question.id} is not valid: 'option-a' is not a valid label for label selection question.\nValid labels are: ['option1', 'option2', 'option3']"
-        }
 
     async def test_update_dataset_records_with_invalid_vectors(
         self, async_client: "AsyncClient", owner_auth_header: dict
@@ -3367,8 +3304,8 @@ class TestSuiteDatasets:
         vector_settings = await VectorSettingsFactory.create(dataset=dataset, dimensions=5)
         records = await RecordFactory.create_batch(5, dataset=dataset)
 
-        response = await async_client.patch(
-            f"/api/v1/datasets/{dataset.id}/records",
+        response = await async_client.put(
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers=owner_auth_header,
             json={
                 "items": [
@@ -3378,18 +3315,14 @@ class TestSuiteDatasets:
         )
 
         assert response.status_code == 422
-        assert response.json() == {
-            "detail": f"Record at position 0 is not valid because vector with name={vector_settings.name} is not "
-            "valid: vector must have 5 elements, got 6 elements"
-        }
 
     async def test_update_dataset_records_with_nonexistent_dataset_id(
         self, async_client: "AsyncClient", owner_auth_header: dict
     ):
         dataset_id = uuid4()
 
-        response = await async_client.patch(
-            f"/api/v1/datasets/{dataset_id}/records",
+        response = await async_client.put(
+            f"/api/v1/datasets/{dataset_id}/records/bulk",
             headers=owner_auth_header,
             json={
                 "items": [
@@ -3413,16 +3346,13 @@ class TestSuiteDatasets:
 
         records.append({"id": str(record.id), "metadata": {"i exists": True}})
 
-        response = await async_client.patch(
-            f"/api/v1/datasets/{dataset.id}/records",
+        response = await async_client.put(
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers=owner_auth_header,
             json={"items": records},
         )
 
         assert response.status_code == 422
-        assert response.json() == {
-            "detail": f"Found records that do not exist: {records[0]['id']}, {records[1]['id']}, {records[2]['id']}"
-        }
 
     async def test_update_dataset_records_with_nonexistent_question_id(
         self, async_client: "AsyncClient", owner_auth_header: dict
@@ -3432,8 +3362,8 @@ class TestSuiteDatasets:
 
         question_id = str(uuid4())
 
-        response = await async_client.patch(
-            f"/api/v1/datasets/{dataset.id}/records",
+        response = await async_client.put(
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers=owner_auth_header,
             json={
                 "items": [
@@ -3443,10 +3373,6 @@ class TestSuiteDatasets:
         )
 
         assert response.status_code == 422
-        assert response.json() == {
-            "detail": f"Record at position 0 is not valid because suggestion for question_id={question_id} is not "
-            f"valid: question_id={question_id} does not exist"
-        }
 
     async def test_update_dataset_records_with_nonexistent_vector_settings_name(
         self, async_client: "AsyncClient", owner_auth_header: dict
@@ -3454,17 +3380,13 @@ class TestSuiteDatasets:
         dataset = await DatasetFactory.create()
         record = await RecordFactory.create(dataset=dataset)
 
-        response = await async_client.patch(
-            f"/api/v1/datasets/{dataset.id}/records",
+        response = await async_client.put(
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers=owner_auth_header,
             json={"items": [{"id": str(record.id), "vectors": {"i-do-not-exist": [1, 2, 3, 4]}}]},
         )
 
         assert response.status_code == 422
-        assert response.json() == {
-            "detail": "Record at position 0 is not valid because vector with name=i-do-not-exist is not valid: vector "
-            f"with name=i-do-not-exist does not exist for dataset_id={dataset.id}"
-        }
 
     async def test_update_dataset_records_with_duplicate_records_ids(
         self, async_client: "AsyncClient", owner_auth_header: dict
@@ -3472,8 +3394,8 @@ class TestSuiteDatasets:
         dataset = await DatasetFactory.create()
         record = await RecordFactory.create(dataset=dataset)
 
-        response = await async_client.patch(
-            f"/api/v1/datasets/{dataset.id}/records",
+        response = await async_client.put(
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers=owner_auth_header,
             json={
                 "items": [
@@ -3484,7 +3406,6 @@ class TestSuiteDatasets:
         )
 
         assert response.status_code == 422
-        assert response.json() == {"detail": "Found duplicate records IDs"}
 
     async def test_update_dataset_records_with_duplicate_suggestions_question_ids(
         self, async_client: "AsyncClient", owner_auth_header: dict
@@ -3493,8 +3414,8 @@ class TestSuiteDatasets:
         question = await TextQuestionFactory.create(dataset=dataset)
         record = await RecordFactory.create(dataset=dataset)
 
-        response = await async_client.patch(
-            f"/api/v1/datasets/{dataset.id}/records",
+        response = await async_client.put(
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers=owner_auth_header,
             json={
                 "items": [
@@ -3510,16 +3431,13 @@ class TestSuiteDatasets:
         )
 
         assert response.status_code == 422
-        assert response.json() == {
-            "detail": "Record at position 0 is not valid because found duplicate suggestions question IDs"
-        }
 
     async def test_update_dataset_records_as_admin_from_another_workspace(self, async_client: "AsyncClient"):
         dataset = await DatasetFactory.create()
         user = await UserFactory.create(role=UserRole.admin)
 
-        response = await async_client.patch(
-            f"/api/v1/datasets/{dataset.id}/records",
+        response = await async_client.put(
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers={API_KEY_HEADER_NAME: user.api_key},
             json={
                 "items": [
@@ -3536,8 +3454,8 @@ class TestSuiteDatasets:
         dataset = await DatasetFactory.create()
         user = await UserFactory.create(role=UserRole.annotator, workspaces=[dataset.workspace])
 
-        response = await async_client.patch(
-            f"/api/v1/datasets/{dataset.id}/records",
+        response = await async_client.put(
+            f"/api/v1/datasets/{dataset.id}/records/bulk",
             headers={API_KEY_HEADER_NAME: user.api_key},
             json={
                 "items": [
@@ -3553,8 +3471,8 @@ class TestSuiteDatasets:
     async def test_update_dataset_records_without_authentication(self, async_client: "AsyncClient"):
         dataset = await DatasetFactory.create()
 
-        response = await async_client.patch(
-            f"/api/v1/datasets/{dataset.id}/records", json={"items": [{"id": str(uuid4())}]}
+        response = await async_client.put(
+            f"/api/v1/datasets/{dataset.id}/records/bulk", json={"items": [{"id": str(uuid4())}]}
         )
 
         assert response.status_code == 401


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR removes deprecated endpoints working with records to avoid creating records with a proper record status computation. The affected endpoints are:

`POST /api/v1/datasets/:dataset_id/records`
`PATCH /api/v1/datasets/:dataset_id/records`


**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (change restructuring the codebase without changing functionality)
- Improvement (change adding some improvement to an existing functionality)
- Documentation update

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)