### PR TITLE
fix: UI - get translation for "copied"

### DIFF
--- a/argilla-frontend/components/features/annotation/container/fields/span-annotation/SpanAnnotationTextField.vue
+++ b/argilla-frontend/components/features/annotation/container/fields/span-annotation/SpanAnnotationTextField.vue
@@ -9,7 +9,7 @@
       <span class="text_field_component__title-content" v-text="title" />
       <BaseActionTooltip
         class="text_field_component__tooltip"
-        tooltip="$t('copied')"
+        :tooltip="$t('copied')"
         tooltip-position="left"
       >
         <BaseButton

--- a/argilla-frontend/components/features/annotation/settings/SettingsInfo.vue
+++ b/argilla-frontend/components/features/annotation/settings/SettingsInfo.vue
@@ -10,7 +10,7 @@
               v-html="settings.dataset.name"
             />
           </div>
-          <base-action-tooltip tooltip="$t('copied')">
+          <base-action-tooltip :tooltip="$t('copied')">
             <base-button
               title="Copy to clipboard"
               class="secondary small"

--- a/argilla-frontend/components/features/annotation/settings/SettingsInfoReadOnly.vue
+++ b/argilla-frontend/components/features/annotation/settings/SettingsInfoReadOnly.vue
@@ -9,7 +9,7 @@
             v-html="settings.dataset.name"
           />
         </div>
-        <base-action-tooltip tooltip="$t('copied')">
+        <base-action-tooltip :tooltip="$t('copied')">
           <base-button
             title="Copy to clipboard"
             class="secondary small"


### PR DESCRIPTION
This PR includes a small fix to get the translation the right way