### PR TITLE
Fix `Dataset` go to definition ambiguity

### DIFF
--- a/argilla/src/argilla/__init__.py
+++ b/argilla/src/argilla/__init__.py
@@ -15,8 +15,8 @@ from argilla._version import __version__  # noqa
 
 from argilla.client import *  # noqa
 from argilla.datasets import *  # noqa
-from argilla.workspaces._resource import *  # noqa
-from argilla.users._resource import *  # noqa
+from argilla.workspaces import *  # noqa
+from argilla.users import *  # noqa
 from argilla.settings import *  # noqa
 from argilla.suggestions import *  # noqa
 from argilla.responses import *  # noqa

--- a/argilla/src/argilla/workspaces/_resource.py
+++ b/argilla/src/argilla/workspaces/_resource.py
@@ -23,7 +23,8 @@ from argilla._resource import Resource
 from argilla.client import Argilla
 
 if TYPE_CHECKING:
-    from argilla import Dataset, User
+    from argilla.datasets._resource import Dataset
+    from argilla.users._resource import User
 
 
 class Workspace(Resource):


### PR DESCRIPTION
# Description

When using the "Go to definition" feature with `rg.Dataset` some IDEs (tested in VSCode and NVIM) displayed two results:

1. One to `argilla.workspaces._resource` because `Dataset` is imported from there
2. One to `argilla.datasets._resource` which is where `Dataset` class is defined and should be the only result.

This is caused because in `argilla.__init__` we're importing everything using `*` from `argilla.workspaces._resource`. As we're importing `from argilla import Dataset`, then the IDE it's not able to resolve this ambiguity. There were two ways to fix this issue:

- Use the full import `from argilla.datasets._resource import Dataset` from `argilla.workspace._resource` helps the IDE to resolve the ambiguity (this won't be needed with the other fix, but I think it's recommended to use the full import within the package code and not use the "user imports").
- Update the import from `workspaces` sub-package in `argilla.__init__` from `from argilla.workspaces._resource import *` to `from argilla.workspaces import *` (I guess we forgot to update it as the rest of the sub-packages are being imported like this). As `argilla.workspaces.__init__` has an `__all__` defined, then only `Workspace` is imported which is the expected thing to happen.

**Type of change**

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
After the updates, "Go to definition" in VSCode and NVIM works well.

**Checklist**

- I followed the style guidelines of this project
- I did a self-review of my code
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works