### PR TITLE
feat: add Server-Timing header to app responses

### DIFF
--- a/argilla-server/CHANGELOG.md
+++ b/argilla-server/CHANGELOG.md
@@ -21,6 +21,7 @@ These are the section headers that we use:
 - Added new `ARGILLA_DATABASE_SQLITE_TIMEOUT` environment variable allowing to set transactions timeout for SQLite. ([#5213](https://github.com/argilla-io/argilla/pull/5213))
 - Added new `ARGILLA_DATABASE_POSTGRESQL_POOL_SIZE` environment variable allowing to set the number of connections to keep open inside the database connection pool. ([#5220](https://github.com/argilla-io/argilla/pull/5220))
 - Added new `ARGILLA_DATABASE_POSTGRESQL_MAX_OVERFLOW` environment variable allowing to set the number of connections that can be opened above and beyond the `ARGILLA_DATABASE_POSTGRESQL_POOL_SIZE` setting. ([#5220](https://github.com/argilla-io/argilla/pull/5220))
+- Added new `Server-Timing` header to all responses with the total time in milliseconds the server took to generate the response. ([#5239](https://github.com/argilla-io/argilla/pull/5239))
 
 ### Fixed
 

--- a/argilla-server/tests/unit/test_app.py
+++ b/argilla-server/tests/unit/test_app.py
@@ -49,3 +49,10 @@ class TestApp:
 
         assert len(app.routes) == 1
         assert cast(Mount, app.routes[0]).path == base_url
+
+    def test_server_timing_header(self):
+        client = TestClient(create_server_app())
+
+        response = client.get("/api/v1/version")
+
+        assert response.headers["Server-Timing"]


### PR DESCRIPTION
# Description

Add a [`Server-Timing`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing) header to all responses with the total time the server takes in milliseconds to generate the response.

Other metrics could be added to this header in the future if necessary.

I have followed the FastAPI documentation: https://fastapi.tiangolo.com/tutorial/middleware/#before-and-after-the-response

**Type of change**

- New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [x] Adding new tests to check that the header is present.

**Checklist**

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)