### PR TITLE
[ENHANCEMENT] `argilla`: align usage of questions

### DIFF
--- a/argilla/src/argilla/responses.py
+++ b/argilla/src/argilla/responses.py
@@ -162,7 +162,7 @@ class UserResponse(Resource):
         """Creates a UserResponse from a ResponseModel"""
         responses = cls.__model_as_responses_list(model)
         for response in responses:
-            question = dataset.settings.question_by_name(response.question_name)
+            question = dataset.settings.questions[response.question_name]
             # We need to adapt the ranking question value to the expected format
             if isinstance(question, RankingQuestion):
                 response.value = cls.__ranking_from_model_value(response.value)  # type: ignore
@@ -174,7 +174,7 @@ class UserResponse(Resource):
 
         values = self.__responses_as_model_values(self.responses)
         for question_name, value in values.items():
-            question = self._record.dataset.settings.question_by_name(question_name)
+            question = self._record.dataset.settings.questions[question_name]
             if isinstance(question, RankingQuestion):
                 value["value"] = self.__ranking_to_model_value(value["value"])
 

--- a/argilla/src/argilla/settings/_resource.py
+++ b/argilla/src/argilla/settings/_resource.py
@@ -30,7 +30,6 @@ from argilla.settings._vector import VectorField
 if TYPE_CHECKING:
     from argilla.datasets import Dataset
 
-
 __all__ = ["Settings"]
 
 
@@ -356,7 +355,6 @@ class SettingsProperties(Sequence[Property]):
 
     def __init__(self, settings: "Settings", properties: List[Property]):
         self._properties_by_name = {}
-        self._properties_by_id = {}
         self._settings = settings
 
         for property in properties or []:
@@ -366,7 +364,9 @@ class SettingsProperties(Sequence[Property]):
         if isinstance(key, int):
             return list(self._properties_by_name.values())[key]
         if isinstance(key, UUID):
-            return self._properties_by_id.get(key)
+            for prop in self._properties_by_name.values():
+                if prop.id and prop.id == key:
+                    return prop
         else:
             return self._properties_by_name.get(key)
 
@@ -385,7 +385,6 @@ class SettingsProperties(Sequence[Property]):
     def add(self, property: Property) -> Property:
         self._validate_new_property(property)
         self._properties_by_name[property.name] = property
-        self._properties_by_id[property.id] = property
         setattr(self, property.name, property)
         return property
 

--- a/argilla/src/argilla/settings/_resource.py
+++ b/argilla/src/argilla/settings/_resource.py
@@ -363,7 +363,7 @@ class SettingsProperties(Sequence[Property]):
     def __getitem__(self, key: Union[UUID, str, int]) -> Optional[Property]:
         if isinstance(key, int):
             return list(self._properties_by_name.values())[key]
-        if isinstance(key, UUID):
+        elif isinstance(key, UUID):
             for prop in self._properties_by_name.values():
                 if prop.id and prop.id == key:
                     return prop

--- a/argilla/src/argilla/settings/_resource.py
+++ b/argilla/src/argilla/settings/_resource.py
@@ -24,7 +24,7 @@ from argilla._models._dataset import DatasetModel
 from argilla._resource import Resource
 from argilla.settings._field import TextField
 from argilla.settings._metadata import MetadataType, MetadataField
-from argilla.settings._question import QuestionType, question_from_model, question_from_dict, QuestionPropertyBase
+from argilla.settings._question import QuestionType, question_from_model, question_from_dict
 from argilla.settings._vector import VectorField
 
 if TYPE_CHECKING:
@@ -62,7 +62,7 @@ class Settings(Resource):
         """
         super().__init__(client=_dataset._client if _dataset else None)
 
-        self.__questions = questions or []
+        self.__questions = QuestionsProperties(self, questions)
         self.__fields = SettingsProperties(self, fields)
         self.__vectors = SettingsProperties(self, vectors)
         self.__metadata = SettingsProperties(self, metadata)
@@ -85,12 +85,12 @@ class Settings(Resource):
         self.__fields = SettingsProperties(self, fields)
 
     @property
-    def questions(self) -> List[QuestionType]:
+    def questions(self) -> "SettingsProperties":
         return self.__questions
 
     @questions.setter
     def questions(self, questions: List[QuestionType]):
-        self.__questions = questions
+        self.__questions = QuestionsProperties(self, questions)
 
     @property
     def vectors(self) -> "SettingsProperties":
@@ -178,7 +178,7 @@ class Settings(Resource):
 
         self._update_dataset_related_attributes()
         self.__fields.create()
-        self._create_questions()
+        self.__questions.create()
         self.__vectors.create()
         self.__metadata.create()
 
@@ -197,23 +197,11 @@ class Settings(Resource):
         self._update_last_api_call()
         return self
 
-    def question_by_name(self, question_name: str) -> QuestionType:
-        for question in self.questions:
-            if question.name == question_name:
-                return question
-        raise ValueError(f"Question with name {question_name} not found")
-
-    def question_by_id(self, question_id: UUID) -> QuestionType:
-        property = self.schema_by_id.get(question_id)
-        if isinstance(property, QuestionPropertyBase):
-            return property
-        raise ValueError(f"Question with id {question_id} not found")
-
     def serialize(self):
         try:
             return {
                 "guidelines": self.guidelines,
-                "questions": self.__serialize_questions(self.questions),
+                "questions": self.__questions.serialize(),
                 "fields": self.__fields.serialize(),
                 "vectors": self.vectors.serialize(),
                 "metadata": self.metadata.serialize(),
@@ -326,16 +314,6 @@ class Settings(Resource):
         )
         self._client.api.datasets.update(dataset_model)
 
-    def _create_questions(self) -> None:
-        for question in self.__questions:
-            try:
-                question_model = self._client.api.questions.create(
-                    dataset_id=self._dataset.id, question=question._model
-                )
-                question._model = question_model
-            except ArgillaAPIError as e:
-                raise SettingsError(f"Failed to create question {question.name}") from e
-
     def _validate_empty_settings(self):
         if not all([self.fields, self.questions]):
             message = "Fields and questions are required"
@@ -366,9 +344,6 @@ class Settings(Resource):
 
         return guidelines
 
-    def __serialize_questions(self, questions: List[QuestionType]):
-        return [question.serialize() for question in questions]
-
 
 Property = Union[TextField, VectorField, MetadataType, QuestionType]
 
@@ -381,15 +356,19 @@ class SettingsProperties(Sequence[Property]):
 
     def __init__(self, settings: "Settings", properties: List[Property]):
         self._properties_by_name = {}
+        self._properties_by_id = {}
         self._settings = settings
 
         for property in properties or []:
             self.add(property)
 
-    def __getitem__(self, key: Union[str, int]) -> Optional[Property]:
+    def __getitem__(self, key: Union[UUID, str, int]) -> Optional[Property]:
         if isinstance(key, int):
             return list(self._properties_by_name.values())[key]
-        return self._properties_by_name.get(key)
+        if isinstance(key, UUID):
+            return self._properties_by_id.get(key)
+        else:
+            return self._properties_by_name.get(key)
 
     def __iter__(self) -> Iterator[Property]:
         return iter(self._properties_by_name.values())
@@ -406,6 +385,7 @@ class SettingsProperties(Sequence[Property]):
     def add(self, property: Property) -> Property:
         self._validate_new_property(property)
         self._properties_by_name[property.name] = property
+        self._properties_by_id[property.id] = property
         setattr(self, property.name, property)
         return property
 
@@ -434,3 +414,28 @@ class SettingsProperties(Sequence[Property]):
 
         if property.name in dir(self):
             raise ValueError(f"Property with name {property.name!r} conflicts with an existing attribute")
+
+
+class QuestionsProperties(SettingsProperties[QuestionType]):
+    """
+    This class is used to align questions with the rest of the settings.
+
+    Since questions are not aligned with the Resource class definition, we use this
+    class to work with questions as we do with fields, vectors, or metadata (specially when creating questions).
+
+    Once issue https://github.com/argilla-io/argilla/issues/4931 is tackled, this class should be removed.
+    """
+
+    def create(self):
+        for question in self:
+            try:
+                self._create_question(question)
+            except ArgillaAPIError as e:
+                raise SettingsError(f"Failed to create question {question.name}") from e
+
+    def _create_question(self, question: QuestionType) -> None:
+        question_model = self._settings._client.api.questions.create(
+            dataset_id=self._settings.dataset.id,
+            question=question.api_model(),
+        )
+        question._model = question_model

--- a/argilla/src/argilla/suggestions.py
+++ b/argilla/src/argilla/suggestions.py
@@ -121,7 +121,7 @@ class Suggestion(Resource):
 
     @classmethod
     def from_model(cls, model: SuggestionModel, dataset: "Dataset") -> "Suggestion":
-        question = dataset.settings.question_by_id(model.question_id)
+        question = dataset.settings.questions[model.question_id]
         model.question_name = question.name
         model.value = cls.__from_model_value(model.value, question)
 
@@ -131,7 +131,7 @@ class Suggestion(Resource):
         if self.record is None or self.record.dataset is None:
             return self._model
 
-        question = self.record.dataset.settings.question_by_name(self.question_name)
+        question = self.record.dataset.settings.questions[self.question_name]
         return SuggestionModel(
             value=self.__to_model_value(self.value, question),
             question_name=self.question_name,

--- a/argilla/tests/unit/test_settings/test_settings.py
+++ b/argilla/tests/unit/test_settings/test_settings.py
@@ -11,10 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import uuid
+
 import pytest
 
 import argilla as rg
 from argilla._exceptions import SettingsError
+from argilla.settings._resource import SettingsProperties
 
 
 class TestSettings:
@@ -91,6 +94,34 @@ class TestSettings:
 
         with pytest.raises(SettingsError, match="names of dataset settings must be unique"):
             settings.validate()
+
+
+class TestSettingsProperties:
+    def test_access_by_id(self):
+        settings = rg.Settings()
+
+        field = rg.TextField(name="text", title="title")
+        field._model.id = uuid.uuid4()
+
+        properties = SettingsProperties(settings, [field])
+        assert properties[field.id] == field
+
+    def test_access_by_none_id(self):
+        settings = rg.Settings()
+
+        field = rg.TextField(name="text", title="title")
+
+        properties = SettingsProperties(settings, [field])
+        assert properties[field.id] is None
+
+    def test_access_by_wrong_id(self):
+        settings = rg.Settings()
+
+        field = rg.TextField(name="text", title="title")
+        field._model.id = uuid.uuid4()
+
+        properties = SettingsProperties(settings, [field])
+        assert properties[uuid.uuid4()] is None
 
 
 class TestSettingsSerialization:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR reviews and aligns the questions' usage with the rest of the settings. Now, questions can be accessed as the rest of the settings:
```python
settings.questions["name"]
```

Note: Updating questions for existing datasets is still not possible. But we can add questions to settings before creating the dataset:
```python
settings.questions.add(...)
dataset = rg.Dataset(..., settings=settings).create()
```

Closes https://github.com/argilla-io/argilla/issues/5231

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (change restructuring the codebase without changing functionality)
- Improvement (change adding some improvement to an existing functionality)
- Documentation update

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)