### PR TITLE
[ENHANCEMENT] `argilla`: add support to fetch by `id`

### DIFF
--- a/argilla/docs/how_to_guides/dataset.md
+++ b/argilla/docs/how_to_guides/dataset.md
@@ -436,7 +436,7 @@ import argilla as rg
 
 client = rg.Argilla(api_url="<api_url>", api_key="<api_key>")
 
-dataset = client.datasets("<uuid-or-uuid-string>")
+dataset = client.datasets(id="<uuid-or-uuid-string>")
 ```
 
 In that case, if the dataset does not exist for the given id, an `ArgillaError` will be raised.

--- a/argilla/docs/how_to_guides/dataset.md
+++ b/argilla/docs/how_to_guides/dataset.md
@@ -439,7 +439,7 @@ client = rg.Argilla(api_url="<api_url>", api_key="<api_key>")
 dataset = client.datasets(id="<uuid-or-uuid-string>")
 ```
 
-In that case, if the dataset does not exist for the given id, an `ArgillaError` will be raised.
+If the dataset does not exist for the given id, the call will return `None`.
 
 ## Check dataset existence
 

--- a/argilla/docs/how_to_guides/dataset.md
+++ b/argilla/docs/how_to_guides/dataset.md
@@ -430,6 +430,17 @@ retrieved_dataset = client.datasets(name="my_dataset")
 retrieved_dataset = client.datasets(name="my_dataset", workspace=workspace)
 ```
 
+You can also use the user `id` to fetch the dataset:
+```python
+import argilla as rg
+
+client = rg.Argilla(api_url="<api_url>", api_key="<api_key>")
+
+dataset = client.datasets("<uuid-or-uuid-string>")
+```
+
+In that case, if the dataset does not exist for the given id, an `ArgillaError` will be raised.
+
 ## Check dataset existence
 
 You can check if a dataset exists. The `client.datasets` method will return `None` if the dataset was not found.

--- a/argilla/docs/how_to_guides/user.md
+++ b/argilla/docs/how_to_guides/user.md
@@ -138,7 +138,7 @@ import argilla as rg
 
 client = rg.Argilla(api_url="<api_url>", api_key="<api_key>")
 
-user = client.users("<uuid-or-uuid-string>")
+user = client.users(id="<uuid-or-uuid-string>")
 ```
 
 In that case, if the user does not exist for the given id, an `ArgillaError` will be raised.

--- a/argilla/docs/how_to_guides/user.md
+++ b/argilla/docs/how_to_guides/user.md
@@ -141,7 +141,7 @@ client = rg.Argilla(api_url="<api_url>", api_key="<api_key>")
 user = client.users(id="<uuid-or-uuid-string>")
 ```
 
-In that case, if the user does not exist for the given id, an `ArgillaError` will be raised.
+If the user does not exist for the given id, the call will return `None`
 
 ## List users in a workspace
 

--- a/argilla/docs/how_to_guides/user.md
+++ b/argilla/docs/how_to_guides/user.md
@@ -132,6 +132,17 @@ client = rg.Argilla(api_url="<api_url>", api_key="<api_key>")
 retrieved_user = client.users("my_username")
 ```
 
+You can also use the user `id` to fetch the user:
+```python
+import argilla as rg
+
+client = rg.Argilla(api_url="<api_url>", api_key="<api_key>")
+
+user = client.users("<uuid-or-uuid-string>")
+```
+
+In that case, if the user does not exist for the given id, an `ArgillaError` will be raised.
+
 ## List users in a workspace
 
 You can list all the users in a workspace by accessing the `users` attribute on the `Workspace` class and iterating over them. You can also use `len(workspace.users)` to get the number of users by workspace.

--- a/argilla/docs/how_to_guides/workspace.md
+++ b/argilla/docs/how_to_guides/workspace.md
@@ -84,6 +84,17 @@ client = rg.Argilla(api_url="<api_url>", api_key="<api_key>")
 retrieved_workspace = client.workspaces("my_workspace")
 ```
 
+You can also use the user `id` to fetch the workspace:
+```python
+import argilla as rg
+
+client = rg.Argilla(api_url="<api_url>", api_key="<api_key>")
+
+workspace = client.workspaces("<uuid-or-uuid-string>")
+```
+
+In that case, if the workspace does not exist for the given id, an `ArgillaError` will be raised.
+
 ## Check workspace existence
 
 You can check if a workspace exists. The `client.workspaces` method will return `None` if the workspace was not found.

--- a/argilla/docs/how_to_guides/workspace.md
+++ b/argilla/docs/how_to_guides/workspace.md
@@ -93,7 +93,7 @@ client = rg.Argilla(api_url="<api_url>", api_key="<api_key>")
 workspace = client.workspaces(id="<uuid-or-uuid-string>")
 ```
 
-In that case, if the workspace does not exist for the given id, an `ArgillaError` will be raised.
+If the workspace does not exist for the given id, the call will return `None`.
 
 ## Check workspace existence
 

--- a/argilla/docs/how_to_guides/workspace.md
+++ b/argilla/docs/how_to_guides/workspace.md
@@ -90,7 +90,7 @@ import argilla as rg
 
 client = rg.Argilla(api_url="<api_url>", api_key="<api_key>")
 
-workspace = client.workspaces("<uuid-or-uuid-string>")
+workspace = client.workspaces(id="<uuid-or-uuid-string>")
 ```
 
 In that case, if the workspace does not exist for the given id, an `ArgillaError` will be raised.

--- a/argilla/src/argilla/client.py
+++ b/argilla/src/argilla/client.py
@@ -20,11 +20,12 @@ from typing import TYPE_CHECKING, overload, List, Optional, Union
 from uuid import UUID
 
 from argilla import _api
+from argilla._api._base import ResourceAPI
 from argilla._api._client import DEFAULT_HTTP_CONFIG
-from argilla._exceptions import ArgillaError
+from argilla._exceptions import ArgillaError, NotFoundError
 from argilla._helpers import GenericIterator
 from argilla._helpers._resource_repr import ResourceHTMLReprMixin
-from argilla._models import UserModel, WorkspaceModel, DatasetModel
+from argilla._models import UserModel, WorkspaceModel, DatasetModel, ResourceModel
 
 if TYPE_CHECKING:
     from argilla import Workspace
@@ -113,30 +114,32 @@ class Users(Sequence["User"], ResourceHTMLReprMixin):
         self._api = client.api.users
 
     @overload
-    def __call__(self, username: str) -> Optional["User"]: ...
+    def __call__(self, username: str) -> Optional["User"]:
+        """Get a user by username if exists. Otherwise, returns `None`"""
+        ...
 
     @overload
-    def __call__(self, id: Union[UUID, str]) -> "User": ...
+    def __call__(self, id: Union[UUID, str]) -> Optional["User"]:
+        """Get a user by id if exists. Otherwise, returns `None`"""
+        ...
 
     def __call__(self, username: str = None, id: Union[str, UUID] = None) -> Optional["User"]:
         if not (username or id):
             raise ArgillaError("One of 'username' or 'id' must be provided")
-
         if username and id:
             warnings.warn("Only one of 'username' or 'id' must be provided. Using 'id'")
             username = None
 
         if id is not None:
-            if not isinstance(id, UUID):
-                id = UUID(id)
-            return self._from_model(self._api.get(id))
-
-        user_models = self._api.list()
-        for model in user_models:
-            if model.username == username:
-                return self._from_model(model)
-
-        warnings.warn(f"User with username {username!r} not found.")
+            model = _get_model_by_id(self._api, id)
+            if model:
+                return self._from_model(model)  # noqa
+            warnings.warn(f"User with id {id!r} not found.")
+        else:
+            for model in self._api.list():
+                if model.username == username:
+                    return self._from_model(model)
+            warnings.warn(f"User with username {username!r} not found.")
 
     def __iter__(self):
         return self._Iterator(self.list())
@@ -207,10 +210,14 @@ class Workspaces(Sequence["Workspace"], ResourceHTMLReprMixin):
         self._api = client.api.workspaces
 
     @overload
-    def __call__(self, name: str) -> Optional["Workspace"]: ...
+    def __call__(self, name: str) -> Optional["Workspace"]:
+        """Get a workspace by name if exists. Otherwise, returns `None`"""
+        ...
 
     @overload
-    def __call__(self, id: Union[UUID, str]) -> "Workspace": ...
+    def __call__(self, id: Union[UUID, str]) -> Optional["Workspace"]:
+        """Get a workspace by id if exists. Otherwise, returns `None`"""
+        ...
 
     def __call__(self, name: str = None, id: Union[UUID, str] = None) -> Optional["Workspace"]:
         if not (name or id):
@@ -221,15 +228,15 @@ class Workspaces(Sequence["Workspace"], ResourceHTMLReprMixin):
             name = None
 
         if id is not None:
-            if not isinstance(id, UUID):
-                id = UUID(id)
-            return self._from_model(self._api.get(id))
-
-        workspace_models = self._api.list()
-        for model in workspace_models:
-            if model.name == name:
-                return self._from_model(model)
-        warnings.warn(f"Workspace with name {name!r} not found.")
+            model = _get_model_by_id(self._api, id)
+            if model:
+                return self._from_model(model)  # noqa
+            warnings.warn(f"Workspace with id {id!r} not found")
+        else:
+            for model in self._api.list():
+                if model.name == name:
+                    return self._from_model(model)  # noqa
+            warnings.warn(f"Workspace with name {name!r} not found.")
 
     def __iter__(self):
         return self._Iterator(self.list())
@@ -296,10 +303,14 @@ class Datasets(Sequence["Dataset"], ResourceHTMLReprMixin):
         self._api = client.api.datasets
 
     @overload
-    def __call__(self, name: str, workspace: Optional[Union["Workspace", str]] = None) -> Optional["Dataset"]: ...
+    def __call__(self, name: str, workspace: Optional[Union["Workspace", str]] = None) -> Optional["Dataset"]:
+        """Get a dataset by name and workspace if exists. Otherwise, returns `None`"""
+        ...
 
     @overload
-    def __call__(self, id: Union[UUID, str]) -> "Dataset": ...
+    def __call__(self, id: Union[UUID, str]) -> Optional["Dataset"]:
+        """Get a dataset by id if exists. Otherwise, returns `None`"""
+        ...
 
     def __call__(
         self, name: str = None, workspace: Optional[Union["Workspace", str]] = None, id: Union[UUID, str] = None
@@ -312,18 +323,19 @@ class Datasets(Sequence["Dataset"], ResourceHTMLReprMixin):
             name = None
 
         if id is not None:
-            if not isinstance(id, UUID):
-                id = UUID(id)
-            return self._from_model(self._api.get(id))
+            model = _get_model_by_id(self._api, id)
+            if model:
+                return self._from_model(model)  # noqa
+            warnings.warn(f"Dataset with id {id!r} not found")
+        else:
+            workspace = workspace or self._client.workspaces.default
+            if isinstance(workspace, str):
+                workspace = self._client.workspaces(workspace)
 
-        workspace = workspace or self._client.workspaces.default
-        if isinstance(workspace, str):
-            workspace = self._client.workspaces(workspace)
-
-        for dataset in workspace.datasets:
-            if dataset.name == name:
-                return dataset.get()
-        warnings.warn(f"Dataset with name {name!r} not found in workspace {workspace.name!r}")
+            for dataset in workspace.datasets:
+                if dataset.name == name:
+                    return dataset.get()
+            warnings.warn(f"Dataset with name {name!r} not found in workspace {workspace.name!r}")
 
     def __iter__(self):
         return self._Iterator(self.list())
@@ -372,3 +384,13 @@ class Datasets(Sequence["Dataset"], ResourceHTMLReprMixin):
         from argilla.datasets import Dataset
 
         return Dataset.from_model(model=model, client=self._client)
+
+
+def _get_model_by_id(api: ResourceAPI, resource_id: Union[UUID, str]) -> Optional[ResourceModel]:
+    """Get a resource model by id if found. Otherwise, `None`."""
+    try:
+        if not isinstance(resource_id, UUID):
+            resource_id = UUID(resource_id)
+        return api.get(resource_id)
+    except NotFoundError:
+        pass

--- a/argilla/tests/integration/test_client.py
+++ b/argilla/tests/integration/test_client.py
@@ -1,0 +1,66 @@
+# Copyright 2024-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+
+import pytest
+
+from argilla import Argilla, Dataset, TextField, TextQuestion, Settings, User, Workspace
+from argilla._exceptions import ArgillaAPIError, ArgillaError
+
+
+class TestClient:
+    def test_get_dataset_by_id(self, client: Argilla):
+        dataset = Dataset(
+            name=f"test_dataset{uuid.uuid4()}",
+            settings=Settings(fields=[TextField(name="text")], questions=[TextQuestion(name="question")]),
+        ).create()
+
+        assert client.datasets(id=dataset.id) == dataset
+        assert client.datasets(id=str(dataset.id)) == dataset
+        assert client.datasets(id=str(dataset.id), name="skip this name") == dataset
+
+        with pytest.raises(ArgillaAPIError):
+            client.datasets(id=uuid.uuid4())
+
+    def test_get_user_by_id(self, client: Argilla):
+        user = User(username="test_user", password="test password").create()
+        user = client.users(username=user.username)
+
+        assert client.users(id=user.id) == user
+        assert client.users(id=str(user.id)) == user
+        assert client.users(id=str(user.id), username="skip this username") == user
+
+        with pytest.raises(ArgillaAPIError):
+            client.users(id=uuid.uuid4())
+
+    def test_get_workspace_by_id(self, client: Argilla):
+        workspace = Workspace(name=f"test_workspace{uuid.uuid4()}").create()
+
+        assert client.workspaces(id=workspace.id) == workspace
+        assert client.workspaces(id=str(workspace.id)) == workspace
+        assert client.workspaces(id=str(workspace.id), name="skip this name") == workspace
+
+        with pytest.raises(ArgillaAPIError):
+            client.workspaces(id=uuid.uuid4())
+
+    def test_get_resource_with_missing_args(self, client: Argilla):
+        with pytest.raises(ArgillaError):
+            client.workspaces()
+
+        with pytest.raises(ArgillaError):
+            client.datasets()
+
+        with pytest.raises(ArgillaError):
+            client.users()

--- a/argilla/tests/integration/test_client.py
+++ b/argilla/tests/integration/test_client.py
@@ -31,8 +31,7 @@ class TestClient:
         assert client.datasets(id=str(dataset.id)) == dataset
         assert client.datasets(id=str(dataset.id), name="skip this name") == dataset
 
-        with pytest.raises(ArgillaAPIError):
-            client.datasets(id=uuid.uuid4())
+        assert client.datasets(id=uuid.uuid4()) is None
 
     def test_get_user_by_id(self, client: Argilla):
         user = User(username="test_user", password="test password").create()
@@ -41,9 +40,7 @@ class TestClient:
         assert client.users(id=user.id) == user
         assert client.users(id=str(user.id)) == user
         assert client.users(id=str(user.id), username="skip this username") == user
-
-        with pytest.raises(ArgillaAPIError):
-            client.users(id=uuid.uuid4())
+        assert client.users(id=uuid.uuid4()) is None
 
     def test_get_workspace_by_id(self, client: Argilla):
         workspace = Workspace(name=f"test_workspace{uuid.uuid4()}").create()
@@ -51,9 +48,7 @@ class TestClient:
         assert client.workspaces(id=workspace.id) == workspace
         assert client.workspaces(id=str(workspace.id)) == workspace
         assert client.workspaces(id=str(workspace.id), name="skip this name") == workspace
-
-        with pytest.raises(ArgillaAPIError):
-            client.workspaces(id=uuid.uuid4())
+        assert client.workspaces(id=uuid.uuid4()) is None
 
     def test_get_resource_with_missing_args(self, client: Argilla):
         with pytest.raises(ArgillaError):


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds support to fetch users, workspaces, and datasets by id:

````python 
client.workspaces(id=...)

client.datasets(id=...)
````

When using the `id` and the resource is not found in the argilla server, an error will be raised 

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (change restructuring the codebase without changing functionality)
- Improvement (change adding some improvement to an existing functionality)
- Documentation update

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
