### PR TITLE
Docs: Switch quickstart steps

### DIFF
--- a/argilla/docs/getting_started/quickstart.md
+++ b/argilla/docs/getting_started/quickstart.md
@@ -8,14 +8,6 @@ This guide provides a quick overview of the Argilla SDK and how to create your f
 
 ## Setting up your Argilla project
 
-### Install the SDK with pip
-
-To work with Argilla datasets, you need to use the Argilla SDK. You can install the SDK with pip as follows:
-
-```console
-pip install argilla --pre
-```
-
 ### Run the Argilla server
 
 If you have already deployed Argilla Server, you can skip this step. Otherwise, you can quickly deploy it in two different ways:
@@ -31,9 +23,19 @@ If you have already deployed Argilla Server, you can skip this step. Otherwise, 
 docker run -d --name quickstart -p 6900:6900 argilla/argilla-quickstart:v2.0.0rc2
 ```
 
+After succesfully running this step, you should be able to see Argilla's UI sign in page (e.g., at the URL https://localhost:6900 if you ran the local Docker option).
+
 !!! tip "Default user credentials to log into the UI"
 
     This type of deployment automatically sets up some default users for you. Check [this guide](../how-to-guides/user.md) to log in for the first time in the UI.
+
+### Install the SDK with pip
+
+To manage users, workspaces and datasets in Argilla, you need to use the Argilla Python SDK. You can install it with pip as follows:
+
+```console
+pip install argilla --pre
+```
 
 ### Connect to the Argilla server
 


### PR DESCRIPTION
During our onboarding flow analysis, we identified that installing the SDK should come only once the Argilla Server/UI is effectively running, reducing the back and forth between tools. Plus, we'll eventually support new user flows in the UI directly so the SDK might become less relevant (for first experiences with Argilla).