### PR TITLE
[BUGFIX] `argilla-server`:  Prevent errors when `allowed_workspaces` is empty

### DIFF
--- a/argilla-server/CHANGELOG.md
+++ b/argilla-server/CHANGELOG.md
@@ -39,7 +39,8 @@ These are the section headers that we use:
 
 ### Fixed
 
-- Fixed SQLite connection settings not working correctly due to a outdated conditional. ([#5149](https://github.com/argilla-io/argilla/pull/5149))
+- Fixed SQLite connection settings not working correctly due to an outdated conditional. ([#5149](https://github.com/argilla-io/argilla/pull/5149))
+- Fixed errors when `allowed_workspaces` in `.oauth.yaml` file is empty. ([#5273](https://github.com/argilla-io/argilla/pull/5273))
 
 ### Removed
 

--- a/argilla-server/src/argilla_server/security/authentication/oauth2/settings.py
+++ b/argilla-server/src/argilla_server/security/authentication/oauth2/settings.py
@@ -83,7 +83,8 @@ class OAuth2Settings:
 
     @classmethod
     def _build_workspaces(cls, settings: dict) -> List[AllowedWorkspace]:
-        return [AllowedWorkspace(**workspace) for workspace in settings.pop(cls.ALLOWED_WORKSPACES_KEY, [])]
+        allowed_workspaces = settings.pop(cls.ALLOWED_WORKSPACES_KEY) or []
+        return [AllowedWorkspace(**workspace) for workspace in allowed_workspaces]
 
     @classmethod
     def _build_providers(cls, settings: dict) -> List["OAuth2ClientProvider"]:

--- a/argilla-server/src/argilla_server/security/authentication/oauth2/settings.py
+++ b/argilla-server/src/argilla_server/security/authentication/oauth2/settings.py
@@ -83,7 +83,7 @@ class OAuth2Settings:
 
     @classmethod
     def _build_workspaces(cls, settings: dict) -> List[AllowedWorkspace]:
-        allowed_workspaces = settings.pop(cls.ALLOWED_WORKSPACES_KEY) or []
+        allowed_workspaces = settings.pop(cls.ALLOWED_WORKSPACES_KEY, None) or []
         return [AllowedWorkspace(**workspace) for workspace in allowed_workspaces]
 
     @classmethod

--- a/argilla-server/tests/unit/security/test_settings.py
+++ b/argilla-server/tests/unit/security/test_settings.py
@@ -11,10 +11,12 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+import json
 import os
+import tempfile
 from unittest import mock
 
+from argilla_server.security.authentication.oauth2 import OAuth2Settings
 from argilla_server.security.settings import Settings
 
 
@@ -58,3 +60,14 @@ def test_configure_oauth_cfg():
         settings = Settings()
 
         assert settings.oauth_cfg == oauth_cfg
+
+
+def test_configure_oauth_with_none_allowed_workspaces():
+    with tempfile.NamedTemporaryFile(mode="wt") as file:
+        file.writelines(["allowed_workspaces:", ""])
+        file.flush()
+
+        with mock.patch.dict(os.environ, {"ARGILLA_AUTH_OAUTH_CFG": file.name}):
+            settings = Settings()
+
+            assert settings.oauth.allowed_workspaces == []


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR fixes errors when `allowed_workspaces` is empty in the `.oauth.yaml` file

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
