### PR TITLE
docs/fixed the syntax for span_marker version used to pip install

### DIFF
--- a/argilla/docs/tutorials/token_classification.ipynb
+++ b/argilla/docs/tutorials/token_classification.ipynb
@@ -72,7 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install gliner==0.2.6 transformers==4.40.2 span_marker=1.5.0"
+    "!pip install gliner==0.2.6 transformers==4.40.2 span_marker==1.5.0"
    ]
   },
   {


### PR DESCRIPTION
# Description
A equal to(=) sign is missing while specifying the version for span_marker in pip install command used in notebook

Closes #5280

**Type of change**
Fixed the syntax error in pip install command used to install span_marker.

- Documentation update

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->


- I followed the style guidelines of this project
- I did a self-review of my code