### PR TITLE
[BUGFIX] `argilla`: support reading datasets without distribution

### DIFF
--- a/argilla/src/argilla/settings/_resource.py
+++ b/argilla/src/argilla/settings/_resource.py
@@ -25,7 +25,7 @@ from argilla._resource import Resource
 from argilla.settings._field import TextField
 from argilla.settings._metadata import MetadataType, MetadataField
 from argilla.settings._question import QuestionType, question_from_model, question_from_dict
-from argilla.settings._task_distribution import DEFAULT_TASK_DISTRIBUTION, TaskDistribution
+from argilla.settings._task_distribution import TaskDistribution
 from argilla.settings._vector import VectorField
 
 if TYPE_CHECKING:
@@ -75,7 +75,7 @@ class Settings(Resource):
         self.__guidelines = self.__process_guidelines(guidelines)
         self.__allow_extra_metadata = allow_extra_metadata
 
-        self._distribution = distribution or DEFAULT_TASK_DISTRIBUTION
+        self._distribution = distribution
 
         self._dataset = _dataset
 
@@ -133,7 +133,7 @@ class Settings(Resource):
 
     @property
     def distribution(self) -> TaskDistribution:
-        return self._distribution
+        return self._distribution or TaskDistribution.default()
 
     @distribution.setter
     def distribution(self, value: TaskDistribution) -> None:
@@ -325,7 +325,9 @@ class Settings(Resource):
 
         self.guidelines = dataset_model.guidelines
         self.allow_extra_metadata = dataset_model.allow_extra_metadata
-        self.distribution = TaskDistribution.from_model(dataset_model.distribution)
+
+        if dataset_model.distribution:
+            self.distribution = TaskDistribution.from_model(dataset_model.distribution)
 
     def _update_dataset_related_attributes(self):
         # This flow may be a bit weird, but it's the only way to update the dataset related attributes

--- a/argilla/src/argilla/settings/_task_distribution.py
+++ b/argilla/src/argilla/settings/_task_distribution.py
@@ -41,6 +41,10 @@ class OverlapTaskDistribution:
 
         return self._model == other._model
 
+    @classmethod
+    def default(cls) -> "OverlapTaskDistribution":
+        return cls(min_submitted=1)
+
     @property
     def min_submitted(self):
         return self._model.min_submitted
@@ -65,5 +69,3 @@ class OverlapTaskDistribution:
 
 
 TaskDistribution = OverlapTaskDistribution
-
-DEFAULT_TASK_DISTRIBUTION = OverlapTaskDistribution(min_submitted=1)

--- a/argilla/tests/unit/test_settings/test_settings.py
+++ b/argilla/tests/unit/test_settings/test_settings.py
@@ -18,7 +18,7 @@ import pytest
 
 import argilla as rg
 from argilla._exceptions import SettingsError
-from argilla.settings._resource import SettingsProperties
+from argilla.settings._task_distribution import TaskDistribution
 
 
 class TestSettings:
@@ -153,6 +153,15 @@ class TestSettings:
         settings = rg.Settings(fields=[rg.TextField(name="text", title="title")])
         with pytest.raises(IndexError):
             _ = settings.fields[10]
+
+    def test_settings_with_modified_default_task_distribution(self):
+        settings = rg.Settings(fields=[rg.TextField(name="text", title="title")])
+
+        assert settings.distribution == TaskDistribution(min_submitted=1)
+        settings.distribution.min_submitted = 10
+
+        other_settings = rg.Settings(fields=[rg.TextField(name="text", title="title")])
+        assert other_settings.distribution == TaskDistribution(min_submitted=1)
 
 
 class TestSettingsSerialization:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR fixes errors when loading dataset settings and the optional distribution model is `None` (thanks @jfcalvo for reporting this).

Also, prevent mutating the default task distribution by defining a default factory instead of a default value.

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
