### PR TITLE
improvement: move serializable isolation and transaction inside `distribution.update_record_status` function

### DIFF
--- a/argilla-server/src/argilla_server/api/handlers/v1/records.py
+++ b/argilla-server/src/argilla_server/api/handlers/v1/records.py
@@ -26,7 +26,7 @@ from argilla_server.api.schemas.v1.responses import Response, ResponseCreate
 from argilla_server.api.schemas.v1.suggestions import Suggestion as SuggestionSchema
 from argilla_server.api.schemas.v1.suggestions import SuggestionCreate, Suggestions
 from argilla_server.contexts import datasets
-from argilla_server.database import get_async_db, get_serializable_async_db
+from argilla_server.database import get_async_db
 from argilla_server.errors.future.base_errors import NotFoundError, UnprocessableEntityError
 from argilla_server.models import Dataset, Question, Record, Suggestion, User
 from argilla_server.search_engine import SearchEngine, get_search_engine
@@ -88,7 +88,7 @@ async def update_record(
 @router.post("/records/{record_id}/responses", status_code=status.HTTP_201_CREATED, response_model=Response)
 async def create_record_response(
     *,
-    db: AsyncSession = Depends(get_serializable_async_db),
+    db: AsyncSession = Depends(get_async_db),
     search_engine: SearchEngine = Depends(get_search_engine),
     record_id: UUID,
     response_create: ResponseCreate,

--- a/argilla-server/src/argilla_server/api/handlers/v1/responses.py
+++ b/argilla-server/src/argilla_server/api/handlers/v1/responses.py
@@ -28,7 +28,7 @@ from argilla_server.api.schemas.v1.responses import (
     ResponseUpdate,
 )
 from argilla_server.contexts import datasets
-from argilla_server.database import get_serializable_async_db
+from argilla_server.database import get_async_db
 from argilla_server.models import Dataset, Record, Response, User
 from argilla_server.search_engine import SearchEngine, get_search_engine
 from argilla_server.security import auth
@@ -55,7 +55,7 @@ async def create_current_user_responses_bulk(
 @router.put("/responses/{response_id}", response_model=ResponseSchema)
 async def update_response(
     *,
-    db: AsyncSession = Depends(get_serializable_async_db),
+    db: AsyncSession = Depends(get_async_db),
     search_engine: SearchEngine = Depends(get_search_engine),
     response_id: UUID,
     response_update: ResponseUpdate,
@@ -77,7 +77,7 @@ async def update_response(
 @router.delete("/responses/{response_id}", response_model=ResponseSchema)
 async def delete_response(
     *,
-    db: AsyncSession = Depends(get_serializable_async_db),
+    db: AsyncSession = Depends(get_async_db),
     search_engine=Depends(get_search_engine),
     response_id: UUID,
     current_user: User = Security(auth.get_current_user),

--- a/argilla-server/src/argilla_server/bulk/records_bulk.py
+++ b/argilla-server/src/argilla_server/bulk/records_bulk.py
@@ -68,7 +68,7 @@ class CreateRecordsBulk:
 
             await self._upsert_records_relationships(records, bulk_create.items)
             await _preload_records_relationships_before_index(self._db, records)
-            await distribution.update_records_status(self._db, records)
+            await distribution.unsafe_update_records_status(self._db, records)
             await self._search_engine.index_records(dataset, records)
 
         await self._db.commit()
@@ -209,7 +209,7 @@ class UpsertRecordsBulk(CreateRecordsBulk):
 
             await self._upsert_records_relationships(records, bulk_upsert.items)
             await _preload_records_relationships_before_index(self._db, records)
-            await distribution.update_records_status(self._db, records)
+            await distribution.unsafe_update_records_status(self._db, records)
             await self._search_engine.index_records(dataset, records)
 
         await self._db.commit()

--- a/argilla-server/src/argilla_server/contexts/datasets.py
+++ b/argilla-server/src/argilla_server/contexts/datasets.py
@@ -95,8 +95,6 @@ NOT_VISIBLE_FOR_ANNOTATORS_ALLOWED_ROLES = [UserRole.admin]
 
 CREATE_DATASET_VECTOR_SETTINGS_MAX_COUNT = 5
 
-MAX_TIME_RETRY_SQLALCHEMY_ERROR = 15
-
 
 async def _touch_dataset_last_activity_at(db: AsyncSession, dataset: Dataset) -> None:
     await db.execute(

--- a/argilla-server/src/argilla_server/database.py
+++ b/argilla-server/src/argilla_server/database.py
@@ -59,11 +59,6 @@ async def get_async_db() -> AsyncGenerator[AsyncSession, None]:
         yield db
 
 
-async def get_serializable_async_db() -> AsyncGenerator[AsyncSession, None]:
-    async for db in _get_async_db(isolation_level="SERIALIZABLE"):
-        yield db
-
-
 async def _get_async_db(isolation_level: Optional[IsolationLevel] = None) -> AsyncGenerator[AsyncSession, None]:
     db: AsyncSession = AsyncSessionLocal()
 

--- a/argilla-server/src/argilla_server/use_cases/responses/upsert_responses_in_bulk.py
+++ b/argilla-server/src/argilla_server/use_cases/responses/upsert_responses_in_bulk.py
@@ -20,7 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from argilla_server.api.policies.v1 import RecordPolicy, authorize
 from argilla_server.api.schemas.v1.responses import Response, ResponseBulk, ResponseBulkError, ResponseUpsert
 from argilla_server.contexts import datasets
-from argilla_server.database import get_serializable_async_db
+from argilla_server.database import get_async_db
 from argilla_server.errors import future as errors
 from argilla_server.models import User
 from argilla_server.search_engine import SearchEngine, get_search_engine
@@ -57,7 +57,7 @@ class UpsertResponsesInBulkUseCase:
 class UpsertResponsesInBulkUseCaseFactory:
     def __call__(
         self,
-        db: AsyncSession = Depends(get_serializable_async_db),
+        db: AsyncSession = Depends(get_async_db),
         search_engine: SearchEngine = Depends(get_search_engine),
     ):
         return UpsertResponsesInBulkUseCase(db, search_engine)

--- a/argilla-server/tests/unit/conftest.py
+++ b/argilla-server/tests/unit/conftest.py
@@ -22,9 +22,10 @@ from httpx import AsyncClient
 from opensearchpy import OpenSearch
 
 from argilla_server import telemetry
+from argilla_server.contexts import distribution
 from argilla_server.api.routes import api_v1
 from argilla_server.constants import API_KEY_HEADER_NAME, DEFAULT_API_KEY
-from argilla_server.database import get_async_db, get_serializable_async_db
+from argilla_server.database import get_async_db
 from argilla_server.models import User, UserRole, Workspace
 from argilla_server.search_engine import SearchEngine, get_search_engine
 from argilla_server.settings import settings
@@ -81,27 +82,20 @@ async def async_client(
     async def override_get_async_db(isolation_level: Optional[IsolationLevel] = None):
         session = TestSession()
 
-        if isolation_level is not None:
-            await session.connection(execution_options={"isolation_level": isolation_level})
+        # NOTE: We are ignoring the isolation_level because is causing errors with the tests.
+        # if isolation_level is not None:
+        #     await session.connection(execution_options={"isolation_level": isolation_level})
 
         yield session
-
-    async def override_get_serializable_async_db():
-        async for session in override_get_async_db(isolation_level="SERIALIZABLE"):
-            yield session
 
     async def override_get_search_engine():
         yield mock_search_engine
 
-    # TODO: Once the db and search engine are wrapped in high-level dependencies, this code should works.
-    #  Commented for now.
-    # mocker.patch("argilla_server.database.get_async_db", wraps=override_get_async_db)
-    # mocker.patch("argilla_server.search_engine.get_search_engine", wraps=override_get_search_engine)
+    mocker.patch.object(distribution, "_get_async_db", override_get_async_db)
 
     api_v1.dependency_overrides.update(
         {
             get_async_db: override_get_async_db,
-            get_serializable_async_db: override_get_serializable_async_db,
             get_search_engine: override_get_search_engine,
         }
     )


### PR DESCRIPTION
# Description

This PR add changes to avoid locked errors on SQLite and serialization errors on PostgreSQL with big transactions using `SERIALIZABLE` isolation levels.

In order to avoid this we are using `SERIALIZABLE` only in function `distribution.update_record_status` function. The `backoff` retry logic is done only in this function as well.

**Type of change**

- Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

- [x] Use a highly number of concurrent requests with PostgreSQL and check that we are not receiving serializable errors.
- [x] Use a highly number of concurrent requests with SQLite and check that we are not receiving locked database errors.
- [x] Manually check that record statuses are changing fine with PostgreSQL.
- [x] Manually check that record statuses are changing fine with SQLite.

**Checklist**

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
