### PR TITLE
fix: restore data after an error while updating the distribution task setting

### DIFF
--- a/argilla-frontend/components/features/annotation/container/fields/Record.vue
+++ b/argilla-frontend/components/features/annotation/container/fields/Record.vue
@@ -62,7 +62,7 @@ export default {
         if (
           this.record?.questions
             .filter((q) => q.isSpanType)
-            .some((q) => q.isModified)
+            .some((q) => q.isAnswerModified)
         ) {
           this.onSelectedRecord(true);
         }

--- a/argilla-frontend/components/features/annotation/settings/SettingsInfo.vue
+++ b/argilla-frontend/components/features/annotation/settings/SettingsInfo.vue
@@ -56,7 +56,7 @@
             <BaseButton
               type="button"
               class="secondary light small"
-              @on-click="settings.dataset.restoreDistribution()"
+              @on-click="settings.dataset.restore('distribution')"
               :disabled="!settings.dataset.isModifiedTaskDistribution"
             >
               <span v-text="$t('cancel')" />
@@ -91,7 +91,7 @@
             <BaseButton
               type="button"
               class="secondary light small"
-              @on-click="settings.dataset.restoreGuidelines()"
+              @on-click="settings.dataset.restore('guidelines')"
               :disabled="!settings.dataset.isModifiedGuidelines"
             >
               <span v-text="$t('cancel')" />

--- a/argilla-frontend/components/features/annotation/settings/SettingsMetadata.vue
+++ b/argilla-frontend/components/features/annotation/settings/SettingsMetadata.vue
@@ -60,7 +60,7 @@
           <BaseButton
             type="button"
             class="secondary light small"
-            @on-click="settings.dataset.restoreMetadata()"
+            @on-click="settings.dataset.restore('metadata')"
             :disabled="!settings.dataset.isModifiedExtraMetadata"
           >
             <span v-text="$t('cancel')" />

--- a/argilla-frontend/components/features/annotation/settings/SettingsQuestions.vue
+++ b/argilla-frontend/components/features/annotation/settings/SettingsQuestions.vue
@@ -106,14 +106,16 @@
                 type="button"
                 class="secondary light small"
                 @on-click="restore(question)"
-                :disabled="!question.isModified"
+                :disabled="!question.isSettingsModified"
               >
                 <span v-text="$t('cancel')" />
               </BaseButton>
               <BaseButton
                 type="submit"
                 class="primary small"
-                :disabled="!question.isModified || !question.isQuestionValid"
+                :disabled="
+                  !question.isSettingsModified || !question.isQuestionValid
+                "
               >
                 <span v-text="$t('update')" />
               </BaseButton>

--- a/argilla-frontend/v1/domain/entities/dataset/Dataset.test.ts
+++ b/argilla-frontend/v1/domain/entities/dataset/Dataset.test.ts
@@ -66,47 +66,41 @@ describe("Dataset", () => {
   });
 
   describe("restore", () => {
-    describe("restoreDistribution should", () => {
-      test("restore only the distribution based on original values", () => {
-        const dataset = createEmptyDataset();
-        dataset.distribution.minSubmitted = 20;
+    test("restore only the distribution based on original values", () => {
+      const dataset = createEmptyDataset();
+      dataset.distribution.minSubmitted = 20;
 
-        expect(dataset.distribution).not.toEqual(dataset.original.distribution);
+      expect(dataset.distribution).not.toEqual(dataset.original.distribution);
 
-        dataset.restoreDistribution();
+      dataset.restore("distribution");
 
-        expect(dataset.distribution).toEqual(dataset.original.distribution);
-      });
+      expect(dataset.distribution).toEqual(dataset.original.distribution);
     });
 
-    describe("restoreMetadata should", () => {
-      test("restore only the metadata info based on original values", () => {
-        const dataset = createEmptyDataset();
-        dataset.allowExtraMetadata = true;
+    test("restore only the metadata info based on original values", () => {
+      const dataset = createEmptyDataset();
+      dataset.allowExtraMetadata = true;
 
-        expect(dataset.allowExtraMetadata).not.toEqual(
-          dataset.original.allowExtraMetadata
-        );
+      expect(dataset.allowExtraMetadata).not.toEqual(
+        dataset.original.allowExtraMetadata
+      );
 
-        dataset.restoreMetadata();
+      dataset.restore("metadata");
 
-        expect(dataset.allowExtraMetadata).toEqual(
-          dataset.original.allowExtraMetadata
-        );
-      });
+      expect(dataset.allowExtraMetadata).toEqual(
+        dataset.original.allowExtraMetadata
+      );
     });
 
-    describe("restoreGuidelines should", () => {
-      test("restore only the guidelines based on original values", () => {
-        const dataset = createEmptyDataset();
-        dataset.guidelines = "NEW GUIDELINES";
+    test("restore only the guidelines based on original values", () => {
+      const dataset = createEmptyDataset();
+      dataset.guidelines = "NEW GUIDELINES";
 
-        expect(dataset.guidelines).not.toEqual(dataset.original.guidelines);
+      expect(dataset.guidelines).not.toEqual(dataset.original.guidelines);
 
-        dataset.restoreGuidelines();
+      dataset.restore("guidelines");
 
-        expect(dataset.guidelines).toEqual(dataset.original.guidelines);
-      });
+      expect(dataset.guidelines).toEqual(dataset.original.guidelines);
     });
   });
 

--- a/argilla-frontend/v1/domain/entities/dataset/Dataset.ts
+++ b/argilla-frontend/v1/domain/entities/dataset/Dataset.ts
@@ -58,21 +58,23 @@ export class Dataset {
     );
   }
 
-  restore() {
-    this.restoreGuidelines();
-    this.restoreMetadata();
-    this.restoreDistribution();
+  restore(part: "guidelines" | "metadata" | "distribution") {
+    if (part === "guidelines") return this.restoreGuidelines();
+
+    if (part === "metadata") return this.restoreMetadata();
+
+    if (part === "distribution") return this.restoreDistribution();
   }
 
-  restoreGuidelines() {
+  private restoreGuidelines() {
     this.guidelines = this.original.guidelines;
   }
 
-  restoreMetadata() {
+  private restoreMetadata() {
     this.allowExtraMetadata = this.original.allowExtraMetadata;
   }
 
-  restoreDistribution() {
+  private restoreDistribution() {
     this.distribution = {
       ...this.original.distribution,
     };

--- a/argilla-frontend/v1/domain/entities/question/Question.ts
+++ b/argilla-frontend/v1/domain/entities/question/Question.ts
@@ -99,10 +99,15 @@ export class Question {
 
   public get isModified(): boolean {
     return (
+      this.isSettingsModified || !this.answer.isEqual(this.original.answer)
+    );
+  }
+
+  public get isSettingsModified(): boolean {
+    return (
       this.title !== this.original.title ||
       this.description !== this.original.description ||
-      !this.settings.isEqual(this.original.settings) ||
-      !this.answer.isEqual(this.original.answer)
+      !this.settings.isEqual(this.original.settings)
     );
   }
 

--- a/argilla-frontend/v1/domain/entities/question/Question.ts
+++ b/argilla-frontend/v1/domain/entities/question/Question.ts
@@ -97,13 +97,11 @@ export class Question {
     return this.type.isRatingType;
   }
 
-  public get isModified(): boolean {
-    return (
-      this.isSettingsModified || !this.answer.isEqual(this.original.answer)
-    );
+  public get isAnswerModified(): boolean {
+    return !this.answer.isEqual(this.original.answer);
   }
 
-  public get isSettingsModified(): boolean {
+  public get isModified(): boolean {
     return (
       this.title !== this.original.title ||
       this.description !== this.original.description ||

--- a/argilla-frontend/v1/domain/usecases/dataset-setting/update-dataset-setting-use-case.ts
+++ b/argilla-frontend/v1/domain/usecases/dataset-setting/update-dataset-setting-use-case.ts
@@ -8,9 +8,12 @@ export class UpdateDatasetSettingUseCase {
     dataset: Dataset,
     part: "guidelines" | "metadata" | "distribution"
   ) {
-    const response = await this.update(dataset, part);
-
-    dataset.update(response.when, part);
+    try {
+      const response = await this.update(dataset, part);
+      dataset.update(response.when, part);
+    } catch (e) {
+      this.restore(dataset, part);
+    }
   }
 
   private update(
@@ -34,5 +37,16 @@ export class UpdateDatasetSettingUseCase {
         id: dataset.id,
         distribution: dataset.distribution,
       });
+  }
+
+  private restore(
+    dataset: Dataset,
+    part: "guidelines" | "metadata" | "distribution"
+  ) {
+    if (part === "guidelines") dataset.restoreGuidelines();
+
+    if (part === "metadata") dataset.restoreMetadata();
+
+    if (part === "distribution") dataset.restoreDistribution();
   }
 }

--- a/argilla-frontend/v1/domain/usecases/dataset-setting/update-dataset-setting-use-case.ts
+++ b/argilla-frontend/v1/domain/usecases/dataset-setting/update-dataset-setting-use-case.ts
@@ -10,9 +10,10 @@ export class UpdateDatasetSettingUseCase {
   ) {
     try {
       const response = await this.update(dataset, part);
+
       dataset.update(response.when, part);
     } catch (e) {
-      this.restore(dataset, part);
+      dataset.restore(part);
     }
   }
 
@@ -37,16 +38,5 @@ export class UpdateDatasetSettingUseCase {
         id: dataset.id,
         distribution: dataset.distribution,
       });
-  }
-
-  private restore(
-    dataset: Dataset,
-    part: "guidelines" | "metadata" | "distribution"
-  ) {
-    if (part === "guidelines") dataset.restoreGuidelines();
-
-    if (part === "metadata") dataset.restoreMetadata();
-
-    if (part === "distribution") dataset.restoreDistribution();
   }
 }


### PR DESCRIPTION
This PR forces to restore the original data in the input field after pressing the 'Update' button and getting an error in the distribution task section of the settings page