### PR TITLE
[BUGFIX] `argilla-server`: Increase oauth state cookie max age to 90 seconds

### DIFF
--- a/argilla-server/src/argilla_server/security/authentication/oauth2/providers/_base.py
+++ b/argilla-server/src/argilla_server/security/authentication/oauth2/providers/_base.py
@@ -49,7 +49,7 @@ class OAuth2ClientProvider:
     """OAuth2 flow handler  of a certain provider."""
 
     OAUTH_STATE_COOKIE_NAME = "oauth2_state"
-    OAUTH_STATE_COOKIE_MAX_AGE = 10
+    OAUTH_STATE_COOKIE_MAX_AGE = 90
 
     name: ClassVar[str]
     backend_class: ClassVar[Type[BaseOAuth2]]


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR fixes errors when using OAuth. The default max-age for the OAuth `state` (a random code used for security reasons) has been increased to avoid cookie expiration making the flow fail.

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
