### PR TITLE
[CI] `argilla`: Update services for integration tests

### DIFF
--- a/.github/workflows/argilla.yml
+++ b/.github/workflows/argilla.yml
@@ -20,13 +20,6 @@ on:
 jobs:
   build:
     services:
-      elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.8.2
-        ports:
-          - 9200:9200
-        env:
-          discovery.type: single-node
-          xpack.security.enabled: false
       argilla-server:
         image: argilladev/argilla-server:develop
         ports:
@@ -35,6 +28,13 @@ jobs:
           ARGILLA_ENABLE_TELEMETRY: 0
           ARGILLA_ELASTICSEARCH: http://elasticsearch:9200
           DEFAULT_USER_ENABLED: 1
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.8.2
+        ports:
+          - 9200:9200
+        env:
+          discovery.type: single-node
+          xpack.security.enabled: false
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -55,7 +55,7 @@ jobs:
       - name: Install dependencies
         run: |
           pdm install
-      - name: Wait for argilla-quickstart to start
+      - name: Wait for argilla server to start
         run: |
           while ! curl -XGET http://localhost:6900/api/_status; do sleep 5; done
       - name: Set huggingface hub credentials

--- a/.github/workflows/argilla.yml
+++ b/.github/workflows/argilla.yml
@@ -31,7 +31,6 @@ jobs:
         image: argilladev/argilla-server:develop
         ports:
           - 6900:6900
-        options: --health-cmd "curl -XGET http://localhost:6900/api/_status" --health-interval 15s --health-retries 5 --health-start-interval	10s
         env:
           ARGILLA_ENABLE_TELEMETRY: 0
           ARGILLA_ELASTICSEARCH: http://elasticsearch:9200

--- a/.github/workflows/argilla.yml
+++ b/.github/workflows/argilla.yml
@@ -20,16 +20,19 @@ on:
 jobs:
   build:
     services:
-      argilla-quickstart:
-        image: argilladev/argilla-quickstart:develop
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.8.2
+        ports:
+          - 9200:9200
+        env:
+          discovery.type: single-node
+          xpack.security.enabled: false
+      argilla-server:
+        image: argilladev/argilla-server:develop
         ports:
           - 6900:6900
         env:
-          ANNOTATOR_USERNAME: annotator
-          OWNER_USERNAME: argilla
-          OWNER_API_KEY: argilla.apikey
-          ADMIN_USERNAME: admin
-          ADMIN_API_KEY: admin.apikey
+          DEFAULT_USER_ENABLED: 1
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/argilla.yml
+++ b/.github/workflows/argilla.yml
@@ -31,6 +31,7 @@ jobs:
         image: argilladev/argilla-server:develop
         ports:
           - 6900:6900
+        options: --health-cmd "curl -XGET http://localhost:6900/api/_status" --health-interval 15s --health-retries 5 --health-start-interval	10s
         env:
           DEFAULT_USER_ENABLED: 1
     runs-on: ubuntu-latest

--- a/.github/workflows/argilla.yml
+++ b/.github/workflows/argilla.yml
@@ -33,6 +33,8 @@ jobs:
           - 6900:6900
         options: --health-cmd "curl -XGET http://localhost:6900/api/_status" --health-interval 15s --health-retries 5 --health-start-interval	10s
         env:
+          ARGILLA_ENABLE_TELEMETRY: 0
+          ARGILLA_ELASTICSEARCH: http://elasticsearch:9200
           DEFAULT_USER_ENABLED: 1
     runs-on: ubuntu-latest
     defaults:

--- a/argilla/src/argilla/__init__.py
+++ b/argilla/src/argilla/__init__.py
@@ -22,5 +22,3 @@ from argilla.suggestions import *  # noqa
 from argilla.responses import *  # noqa
 from argilla.records import *  # noqa
 from argilla.vectors import *  # noqa
-
-# TODO: Remove me

--- a/argilla/src/argilla/__init__.py
+++ b/argilla/src/argilla/__init__.py
@@ -22,3 +22,5 @@ from argilla.suggestions import *  # noqa
 from argilla.responses import *  # noqa
 from argilla.records import *  # noqa
 from argilla.vectors import *  # noqa
+
+# TODO: Remove me


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

With the latest changes on docker images, the quickstart image is not used anymore. This PR updates the environment when running integration tests to user the official argilla server image, since API_KEY cannot be set up for the new `argilla-hf-spaces` image.

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
