### PR TITLE
[BUGFIX] `argilla-server`: Prevent error updating datasets when the distribution value is the same

### DIFF
--- a/argilla-server/src/argilla_server/validators/datasets.py
+++ b/argilla-server/src/argilla_server/validators/datasets.py
@@ -48,7 +48,11 @@ class DatasetUpdateValidator:
 
     @classmethod
     async def _validate_distribution(cls, dataset: Dataset, dataset_attrs: dict) -> None:
-        if dataset_attrs.get("distribution") is not None and (await dataset.responses_count) > 0:
+        if (
+            dataset_attrs.get("distribution") is not None
+            and dataset.distribution != dataset_attrs.get("distribution")
+            and (await dataset.responses_count) > 0
+        ):
             raise UpdateDistributionWithExistingResponsesError(
                 "Distribution settings can't be modified for a dataset containing user responses"
             )

--- a/argilla-server/tests/unit/api/handlers/v1/datasets/test_update_dataset.py
+++ b/argilla-server/tests/unit/api/handlers/v1/datasets/test_update_dataset.py
@@ -145,6 +145,24 @@ class TestUpdateDataset:
             "message": "Distribution settings can't be modified for a dataset containing user responses",
         }
 
+    async def test_update_dataset_distribution_with_the_same_value_for_dataset_with_responses(
+        self, async_client: AsyncClient, owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create(status=DatasetStatus.ready)
+        records = await RecordFactory.create_batch(10, dataset=dataset)
+
+        for record in records:
+            await ResponseFactory.create(record=record)
+
+        response = await async_client.patch(
+            self.url(dataset.id),
+            headers=owner_auth_header,
+            json={"distribution": dataset.distribution},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["distribution"] == dataset.distribution
+
     async def test_update_dataset_distribution_with_invalid_strategy(
         self, async_client: AsyncClient, owner_auth_header: dict
     ):


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR relaxes the update dataset validation and skips validation if the provided distribution value is the same as the already store.

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
