### PR TITLE
Fix nested parent directory to hub method

### DIFF
--- a/argilla/src/argilla/datasets/_export/_hub.py
+++ b/argilla/src/argilla/datasets/_export/_hub.py
@@ -68,8 +68,7 @@ class HubImportExportMixin(DiskImportExportMixin):
             hf_api.create_repo(repo_id=repo_id, repo_type="dataset", exist_ok=kwargs.get("exist_ok") or True)
 
         with TemporaryDirectory() as tmpdirname:
-            config_dir = os.path.join(tmpdirname, self._DEFAULT_CONFIG_REPO_DIR)
-            os.makedirs(config_dir)
+            config_dir = os.path.join(tmpdirname)
             self.to_disk(path=config_dir, with_records=False)
 
             if generate_card:

--- a/argilla/tests/integration/test_export_dataset.py
+++ b/argilla/tests/integration/test_export_dataset.py
@@ -139,7 +139,7 @@ class TestDiskImportExportMixin:
 
 
 @pytest.mark.flaky(
-    retries=_RETRIES, only_on=[BadRequestError, FileMetadataError, HfHubHTTPError]
+    retries=_RETRIES, only_on=[BadRequestError, FileMetadataError, HfHubHTTPError, OSError]
 )  # Hub consistency CICD pipline
 @pytest.mark.skipif(
     not os.getenv("HF_TOKEN_ARGILLA_INTERNAL_TESTING"),


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
There was a small mistake in the `to_hub`method, leading to creating a `.argilla/.argilla` config when writing to the hub.

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
