### PR TITLE
[FEATURE] from_hub raise on existing dataset name

### DIFF
--- a/argilla/src/argilla/datasets/_export/_disk.py
+++ b/argilla/src/argilla/datasets/_export/_disk.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Tuple, Type, Union
 
 from argilla._exceptions import RecordsIngestionError
-from argilla._exceptions._base import ArgillaError
 from argilla._models import DatasetModel
 from argilla.client import Argilla
 from argilla.settings import Settings
@@ -100,11 +99,11 @@ class DiskImportExportMixin(ABC):
         dataset_model.workspace_id = workspace_id
 
         if name:
-            logging.warning(f"Changing dataset name from {dataset_model.name} to {name}")
+            logging.info(f"Changing dataset name from {dataset_model.name} to {name}")
             dataset_model.name = name
 
         if client.api.datasets.name_exists(name=dataset_model.name, workspace_id=workspace_id):
-            logging.warning(
+            warnings.warn(
                 f"Loaded dataset name {dataset_model.name} already exists in the workspace so using it. To create a new dataset, provide a unique name to the `name` parameter."
             )
             dataset_model = client.api.datasets.get_by_name_and_workspace_id(

--- a/argilla/src/argilla/datasets/_export/_disk.py
+++ b/argilla/src/argilla/datasets/_export/_disk.py
@@ -21,6 +21,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Tuple, Type, Union
 from uuid import uuid4
 
+from argilla._exceptions import RecordsIngestionError
+from argilla._exceptions._base import ArgillaError
 from argilla._models import DatasetModel
 from argilla.client import Argilla
 from argilla.settings import Settings
@@ -114,7 +116,10 @@ class DiskImportExportMixin(ABC):
             dataset.create()
 
         if os.path.exists(records_path) and with_records:
-            dataset.records.from_json(path=records_path)
+            try:
+                dataset.records.from_json(path=records_path)
+            except RecordsIngestionError as e:
+                raise ArgillaError(message="Error importing dataset records from disk. Records and datasets settings are not compatible.") from e
         return dataset
 
     ############################

--- a/argilla/src/argilla/datasets/_export/_disk.py
+++ b/argilla/src/argilla/datasets/_export/_disk.py
@@ -90,24 +90,24 @@ class DiskImportExportMixin(ABC):
 
         # Get the relevant workspace_id of the incoming dataset
         if isinstance(workspace, str):
-            workspace_id = client.workspaces(workspace).id
-        elif isinstance(workspace, Workspace):
-            workspace_id = workspace.id
+            workspace = client.workspaces(workspace)
+            if not workspace:
+                raise ValueError(f"Workspace {workspace} not found.")
         else:
             warnings.warn("Workspace not provided. Using default workspace.")
-            workspace_id = client.workspaces.default.id
-        dataset_model.workspace_id = workspace_id
+            workspace = client.workspaces.default
+        dataset_model.workspace_id = workspace.id
 
         if name and (name != dataset_model.name):
             logging.info(f"Changing dataset name from {dataset_model.name} to {name}")
             dataset_model.name = name
 
-        if client.api.datasets.name_exists(name=dataset_model.name, workspace_id=workspace_id):
+        if client.api.datasets.name_exists(name=dataset_model.name, workspace_id=workspace.id):
             warnings.warn(
                 f"Loaded dataset name {dataset_model.name} already exists in the workspace {workspace.name} so using it. To create a new dataset, provide a unique name to the `name` parameter."
             )
             dataset_model = client.api.datasets.get_by_name_and_workspace_id(
-                name=dataset_model.name, workspace_id=workspace_id
+                name=dataset_model.name, workspace_id=workspace.id
             )
             dataset = cls.from_model(model=dataset_model, client=client)
         else:

--- a/argilla/src/argilla/datasets/_export/_disk.py
+++ b/argilla/src/argilla/datasets/_export/_disk.py
@@ -20,7 +20,7 @@ from abc import ABC
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Tuple, Type, Union
 
-from argilla._exceptions import RecordsIngestionError
+from argilla._exceptions import RecordsIngestionError, ArgillaError
 from argilla._models import DatasetModel
 from argilla.client import Argilla
 from argilla.settings import Settings
@@ -92,7 +92,7 @@ class DiskImportExportMixin(ABC):
         if isinstance(workspace, str):
             workspace = client.workspaces(workspace)
             if not workspace:
-                raise ValueError(f"Workspace {workspace} not found.")
+                raise ArgillaError(f"Workspace {workspace} not found on the server.")
         else:
             warnings.warn("Workspace not provided. Using default workspace.")
             workspace = client.workspaces.default

--- a/argilla/src/argilla/datasets/_export/_disk.py
+++ b/argilla/src/argilla/datasets/_export/_disk.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Tuple, Type, Union
 
 from argilla._exceptions import RecordsIngestionError
-from argilla._exceptions._base import ArgillaError
 from argilla._models import DatasetModel
 from argilla.client import Argilla
 from argilla.settings import Settings

--- a/argilla/src/argilla/datasets/_export/_disk.py
+++ b/argilla/src/argilla/datasets/_export/_disk.py
@@ -109,10 +109,12 @@ class DiskImportExportMixin(ABC):
             dataset_model = client.api.datasets.get_by_name_and_workspace_id(
                 name=dataset_model.name, workspace_id=workspace_id
             )
-        # Create the dataset and load the settings and records
-        dataset = cls.from_model(model=dataset_model, client=client)
-        dataset.settings = Settings.from_json(path=settings_path)
-        dataset.create()
+            dataset = cls.from_model(model=dataset_model, client=client)
+        else:
+            # Create a new dataset and load the settings and records
+            dataset = cls.from_model(model=dataset_model, client=client)
+            dataset.settings = Settings.from_json(path=settings_path)
+            dataset.create()
 
         if os.path.exists(records_path) and with_records:
             try:

--- a/argilla/src/argilla/datasets/_export/_disk.py
+++ b/argilla/src/argilla/datasets/_export/_disk.py
@@ -104,7 +104,7 @@ class DiskImportExportMixin(ABC):
 
         if client.api.datasets.name_exists(name=dataset_model.name, workspace_id=workspace_id):
             warnings.warn(
-                f"Loaded dataset name {dataset_model.name} already exists in the workspace so using it. To create a new dataset, provide a unique name to the `name` parameter."
+                f"Loaded dataset name {dataset_model.name} already exists in the workspace {workspace.name} so using it. To create a new dataset, provide a unique name to the `name` parameter."
             )
             dataset_model = client.api.datasets.get_by_name_and_workspace_id(
                 name=dataset_model.name, workspace_id=workspace_id

--- a/argilla/src/argilla/datasets/_export/_disk.py
+++ b/argilla/src/argilla/datasets/_export/_disk.py
@@ -98,7 +98,7 @@ class DiskImportExportMixin(ABC):
             workspace_id = client.workspaces.default.id
         dataset_model.workspace_id = workspace_id
 
-        if name:
+        if name and (name != dataset_model.name):
             logging.info(f"Changing dataset name from {dataset_model.name} to {name}")
             dataset_model.name = name
 

--- a/argilla/src/argilla/datasets/_export/_disk.py
+++ b/argilla/src/argilla/datasets/_export/_disk.py
@@ -19,7 +19,6 @@ import warnings
 from abc import ABC
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Tuple, Type, Union
-from uuid import uuid4
 
 from argilla._models import DatasetModel
 from argilla.client import Argilla
@@ -101,7 +100,7 @@ class DiskImportExportMixin(ABC):
         if name:
             logging.warning(f"Changing dataset name from {dataset_model.name} to {name}")
             dataset_model.name = name
-            
+
         if client.api.datasets.name_exists(name=dataset_model.name, workspace_id=workspace_id):
             logging.warning(
                 f"Loaded dataset name {dataset_model.name} already exists so using it. To create a new dataset, provide a unique name to the `name` parameter."

--- a/argilla/src/argilla/datasets/_export/_disk.py
+++ b/argilla/src/argilla/datasets/_export/_disk.py
@@ -118,7 +118,9 @@ class DiskImportExportMixin(ABC):
             try:
                 dataset.records.from_json(path=records_path)
             except RecordsIngestionError as e:
-                raise ArgillaError(message="Error importing dataset records from disk. Records and datasets settings are not compatible.") from e
+                raise ArgillaError(
+                    message="Error importing dataset records from disk. Records and datasets settings are not compatible."
+                ) from e
         return dataset
 
     ############################

--- a/argilla/tests/integration/test_export_dataset.py
+++ b/argilla/tests/integration/test_export_dataset.py
@@ -187,11 +187,19 @@ class TestHubImportExportMixin:
                 match="Trying to load a dataset `with_records=True` but dataset does not contain any records.",
             ):
                 new_dataset = rg.Dataset.from_hub(
-                    repo_id=repo_id, client=client, with_records=with_records_import, token=token, name=f"test_{uuid.uuid4()}"
+                    repo_id=repo_id,
+                    client=client,
+                    with_records=with_records_import,
+                    token=token,
+                    name=f"test_{uuid.uuid4()}",
                 )
         else:
             new_dataset = rg.Dataset.from_hub(
-                repo_id=repo_id, client=client, with_records=with_records_import, token=token, name=f"test_{uuid.uuid4()}"
+                repo_id=repo_id,
+                client=client,
+                with_records=with_records_import,
+                token=token,
+                name=f"test_{uuid.uuid4()}",
             )
 
         if with_records_import and with_records_export:

--- a/argilla/tests/integration/test_export_dataset.py
+++ b/argilla/tests/integration/test_export_dataset.py
@@ -140,15 +140,6 @@ class TestDiskImportExportMixin:
         assert new_dataset.settings.fields[0].name == "text"
         assert new_dataset.settings.questions[0].name == "label"
 
-    def test_import_dataset_from_disk_existing_name(
-        self, dataset: rg.Dataset, client, mock_data: List[dict[str, Any]], with_records_export: bool
-    ):
-        dataset.records.log(records=mock_data)
-        with pytest.raises(ConflictError):
-            with TemporaryDirectory() as temp_dir:
-                output_dir = dataset.to_disk(path=temp_dir, with_records=with_records_export)
-                rg.Dataset.from_disk(path=output_dir, client=client, with_records=with_records_export)
-
 
 @pytest.mark.flaky(
     retries=_RETRIES, only_on=[BadRequestError, FileMetadataError, HfHubHTTPError, OSError]

--- a/argilla/tests/integration/test_export_dataset.py
+++ b/argilla/tests/integration/test_export_dataset.py
@@ -187,11 +187,11 @@ class TestHubImportExportMixin:
                 match="Trying to load a dataset `with_records=True` but dataset does not contain any records.",
             ):
                 new_dataset = rg.Dataset.from_hub(
-                    repo_id=repo_id, client=client, with_records=with_records_import, token=token
+                    repo_id=repo_id, client=client, with_records=with_records_import, token=token, name=f"test_{uuid.uuid4()}"
                 )
         else:
             new_dataset = rg.Dataset.from_hub(
-                repo_id=repo_id, client=client, with_records=with_records_import, token=token
+                repo_id=repo_id, client=client, with_records=with_records_import, token=token, name=f"test_{uuid.uuid4()}"
             )
 
         if with_records_import and with_records_export:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR changes the behaviour of the `from_disk` method when a dataset of the same name already exists. Currently, a new dataset is create with the name + uuid. This change will:

- check id the dataset name exists, and if so
- warn that the dataset exists and that the `name` parameter could be used to create a new one
- try to push records to the existing dataset with a try except to add more context

Closes #5346 

**Type of change**
- Improvement (change adding some improvement to an existing functionality)

