### PR TITLE
[BUGFIX] `argilla`: `TextField(required=false)` does not allow me to pass empty record entry

### DIFF
--- a/argilla-server/tests/unit/validators/test_records_bulk.py
+++ b/argilla-server/tests/unit/validators/test_records_bulk.py
@@ -29,6 +29,7 @@ class TestRecordsBulkValidators:
         dataset = await DatasetFactory.create(status="ready")
 
         await TextFieldFactory.create(name="text", dataset=dataset)
+        await TextFieldFactory.create(name="optional", dataset=dataset, required=False)
         await dataset.awaitable_attrs.fields
 
         await dataset.awaitable_attrs.metadata_properties
@@ -40,7 +41,9 @@ class TestRecordsBulkValidators:
 
         records_create = RecordsBulkCreate(
             items=[
-                RecordCreate(fields={"text": "hello world"}, metadata={"source": "test"}),
+                RecordCreate(fields={"text": "hello world", "optional": "optional"}, metadata={"source": "test"}),
+                RecordCreate(fields={"text": "hello world", "optional": ""}, metadata={"source": "test"}),
+                RecordCreate(fields={"text": "hello world", "optional": None}, metadata={"source": "test"}),
             ]
         )
 

--- a/argilla/CHANGELOG.md
+++ b/argilla/CHANGELOG.md
@@ -16,6 +16,10 @@ These are the section headers that we use:
 
 ## [Unreleased]()
 
+### Fixed
+
+- Fixed error when creating optional fields. ([#5362](https://github.com/argilla-io/argilla/pull/5362))
+
 ## [2.0.0](https://github.com/argilla-io/argilla/compare/v2.0.0rc1...v2.0.0)
 
 ### Added

--- a/argilla/src/argilla/settings/_field.py
+++ b/argilla/src/argilla/settings/_field.py
@@ -45,7 +45,7 @@ class TextField(SettingsPropertyBase):
         name: str,
         title: Optional[str] = None,
         use_markdown: Optional[bool] = False,
-        required: Optional[bool] = True,
+        required: bool = True,
         description: Optional[str] = None,
         client: Optional[Argilla] = None,
     ) -> None:
@@ -54,16 +54,13 @@ class TextField(SettingsPropertyBase):
             name (str): The name of the field
             title (Optional[str], optional): The title of the field. Defaults to None.
             use_markdown (Optional[bool], optional): Whether to use markdown. Defaults to False.
-            required (Optional[bool], optional): Whether the field is required. Defaults to True.
+            required (bool): Whether the field is required. Defaults to True.
             description (Optional[str], optional): The description of the field. Defaults to None.
 
         """
         client = client or Argilla._get_default()
 
         super().__init__(api=client.api.fields, client=client)
-
-        if required is None:
-            required = True
 
         self._model = FieldModel(
             name=name,

--- a/argilla/src/argilla/settings/_field.py
+++ b/argilla/src/argilla/settings/_field.py
@@ -61,10 +61,14 @@ class TextField(SettingsPropertyBase):
         client = client or Argilla._get_default()
 
         super().__init__(api=client.api.fields, client=client)
+
+        if required is None:
+            required = True
+
         self._model = FieldModel(
             name=name,
             title=title,
-            required=required or True,
+            required=required,
             description=description,
             settings=TextFieldSettings(use_markdown=use_markdown),
         )

--- a/argilla/tests/integration/test_create_datasets.py
+++ b/argilla/tests/integration/test_create_datasets.py
@@ -44,6 +44,23 @@ class TestCreateDatasets:
         assert created_dataset.settings == dataset.settings
         assert created_dataset.settings.distribution == TaskDistribution(min_submitted=1)
 
+    def test_create_dataset_with_optional_fields(self, client: Argilla, dataset_name: str):
+        dataset = Dataset(
+            name=dataset_name,
+            settings=Settings(
+                fields=[TextField(name="test_field"), TextField(name="optional", required=False)],
+                questions=[RatingQuestion(name="test_question", values=[1, 2, 3, 4, 5])],
+            ),
+        )
+        client.datasets.add(dataset)
+
+        assert dataset in client.datasets
+        assert dataset in client.datasets
+        assert dataset is not None
+
+        created_dataset = client.datasets(name=dataset_name)
+        assert created_dataset.settings.fields["optional"].required is False
+
     def test_create_multiple_dataset_with_same_settings(self, client: Argilla, dataset_name: str):
         settings = Settings(
             fields=[TextField(name="text")],


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR prevents converting `required` to `True` when `False` is passed

Closes #5359

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
