### PR TITLE
[BUGFIX] `argilla`: Add support for `visible_for_annotators` on `__init__` attribute to integer and float metadata 

### DIFF
--- a/argilla/CHANGELOG.md
+++ b/argilla/CHANGELOG.md
@@ -16,6 +16,10 @@ These are the section headers that we use:
 
 ## [Unreleased]()
 
+### Fixed
+
+- Fixed error creating integer and float metadata with `visible_for_annotators`. ([#5364](https://github.com/argilla-io/argilla/pull/5364))
+
 ## [2.0.0](https://github.com/argilla-io/argilla/compare/v2.0.0rc1...v2.0.0)
 
 ### Added

--- a/argilla/src/argilla/settings/_metadata.py
+++ b/argilla/src/argilla/settings/_metadata.py
@@ -158,6 +158,7 @@ class FloatMetadataProperty(MetadataPropertyBase):
         min: Optional[float] = None,
         max: Optional[float] = None,
         title: Optional[str] = None,
+        visible_for_annotators: Optional[bool] = True,
         client: Optional[Argilla] = None,
     ) -> None:
         """Create a metadata field with float settings.
@@ -167,6 +168,7 @@ class FloatMetadataProperty(MetadataPropertyBase):
             min (Optional[float]): The minimum value
             max (Optional[float]): The maximum value
             title (Optional[str]): The title of the metadata field
+            visible_for_annotators (Optional[bool]): Whether the metadata field is visible for annotators
             client (Optional[Argilla]): The client to use for API requests
         Raises:
             MetadataError: If an error occurs while defining metadata settings
@@ -185,6 +187,7 @@ class FloatMetadataProperty(MetadataPropertyBase):
             type=MetadataPropertyType.float,
             title=title,
             settings=settings,
+            visible_for_annotators=visible_for_annotators,
         )
 
     @property
@@ -218,6 +221,7 @@ class IntegerMetadataProperty(MetadataPropertyBase):
         min: Optional[int] = None,
         max: Optional[int] = None,
         title: Optional[str] = None,
+        visible_for_annotators: Optional[bool] = True,
         client: Optional[Argilla] = None,
     ) -> None:
         """Create a metadata field with integer settings.
@@ -227,6 +231,7 @@ class IntegerMetadataProperty(MetadataPropertyBase):
             min (Optional[int]): The minimum value
             max (Optional[int]): The maximum value
             title (Optional[str]): The title of the metadata field
+            visible_for_annotators (Optional[bool]): Whether the metadata field is visible for annotators
         Raises:
             MetadataError: If an error occurs while defining metadata settings
         """
@@ -242,6 +247,7 @@ class IntegerMetadataProperty(MetadataPropertyBase):
             type=MetadataPropertyType.integer,
             title=title,
             settings=settings,
+            visible_for_annotators=visible_for_annotators,
         )
 
     @property

--- a/argilla/src/argilla/settings/_metadata.py
+++ b/argilla/src/argilla/settings/_metadata.py
@@ -89,9 +89,7 @@ class MetadataPropertyBase(Resource):
         self._with_client(self._dataset._client)
 
     def __repr__(self) -> str:
-        return (
-            f"{self.__class__.__name__}(name={self.name}, title={self.title}, dimensions={self.visible_for_annotators})"
-        )
+        return f"{self.__class__.__name__}(name={self.name}, title={self.title}, visible_for_annotators={self.visible_for_annotators})"
 
     def _with_client(self, client: "Argilla") -> "Self":
         # TODO: Review and simplify. Maybe only one of them is required

--- a/argilla/tests/unit/test_settings/test_metadata.py
+++ b/argilla/tests/unit/test_settings/test_metadata.py
@@ -18,7 +18,7 @@ import argilla as rg
 from argilla._models import MetadataFieldModel, TermsMetadataPropertySettings
 
 
-class TestTermsMetadata:
+class TestMetadata:
     def test_create_metadata_terms(self):
         property = rg.TermsMetadataProperty(
             title="A metadata property", name="metadata", options=["option1", "option2"]
@@ -81,3 +81,11 @@ class TestTermsMetadata:
         assert property.name == "metadata"
         assert property.visible_for_annotators is True
         assert property.options == ["option1", "option2"]
+
+    def test_create_integer_metadata_with_visible_for_annotators(self):
+        metadata = rg.IntegerMetadataProperty(name="integer", min=10, visible_for_annotators=False)
+        assert metadata.visible_for_annotators is False
+
+    def test_create_float_metadata_with_visible_for_annotators(self):
+        metadata = rg.FloatMetadataProperty(name="integer", min=3.5, max=10.5, visible_for_annotators=False)
+        assert metadata.visible_for_annotators is False


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #5360 

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
