### PR TITLE
[FEATURE] `argilla`: add support to create image fields

### DIFF
--- a/.github/workflows/argilla.yml
+++ b/.github/workflows/argilla.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     services:
       argilla-server:
-        image: argilladev/argilla-server:develop
+        image: argilladev/argilla-server:pr-5279
         ports:
           - 6900:6900
         env:

--- a/argilla/src/argilla/_models/_settings/_fields.py
+++ b/argilla/src/argilla/_models/_settings/_fields.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Literal
+from typing import Optional, Literal, Annotated, Union
 from uuid import UUID
 
-from pydantic import BaseModel, field_serializer, field_validator
+from pydantic import BaseModel, field_serializer, field_validator, Field
 from pydantic_core.core_schema import ValidationInfo
 
 from argilla._helpers import log_message
@@ -27,12 +27,25 @@ class TextFieldSettings(BaseModel):
     use_markdown: Optional[bool] = False
 
 
+class ImageFieldSettings(BaseModel):
+    type: Literal["image"] = "image"
+
+
+FieldSettings = Annotated[
+    Union[
+        TextFieldSettings,
+        ImageFieldSettings,
+    ],
+    Field(..., discriminator="type"),
+]
+
+
 class FieldModel(ResourceModel):
     name: str
+    settings: FieldSettings
     title: Optional[str] = None
     required: bool = True
     description: Optional[str] = None
-    settings: TextFieldSettings = TextFieldSettings(use_markdown=False)
     dataset_id: Optional[UUID] = None
 
     @field_validator("name")

--- a/argilla/src/argilla/settings/_field.py
+++ b/argilla/src/argilla/settings/_field.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC
-from typing import Optional, Union, TYPE_CHECKING, TypeAlias
+from typing import Optional, Union, TYPE_CHECKING
 
 from argilla import Argilla
 from argilla._api import FieldsAPI
@@ -158,7 +158,7 @@ class ImageField(AbstractField):
         )
 
 
-Field: TypeAlias = Union[TextField, ImageField]
+Field = Union[TextField, ImageField]
 
 
 def _field_from_model(model: FieldModel) -> Field:

--- a/argilla/src/argilla/settings/_field.py
+++ b/argilla/src/argilla/settings/_field.py
@@ -11,12 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from typing import Optional, Union, TYPE_CHECKING
+from abc import ABC
+from typing import Optional, Union, TYPE_CHECKING, TypeAlias
 
 from argilla import Argilla
 from argilla._api import FieldsAPI
+from argilla._exceptions import ArgillaError
 from argilla._models import FieldModel, TextFieldSettings
+from argilla._models._settings._fields import ImageFieldSettings, FieldSettings
 from argilla.settings._common import SettingsPropertyBase
 from argilla.settings._metadata import MetadataField, MetadataType
 from argilla.settings._vector import VectorField
@@ -29,67 +31,43 @@ except ImportError:
 if TYPE_CHECKING:
     from argilla.datasets import Dataset
 
-__all__ = ["TextField"]
+__all__ = ["Field", "TextField", "ImageField"]
 
 
-class TextField(SettingsPropertyBase):
-    """Text field for use in Argilla `Dataset` `Settings`"""
+class AbstractField(ABC, SettingsPropertyBase):
+    """Abstract base class to work with Field resources"""
 
     _model: FieldModel
     _api: FieldsAPI
-
     _dataset: Optional["Dataset"]
 
     def __init__(
         self,
         name: str,
+        settings: FieldSettings,
         title: Optional[str] = None,
-        use_markdown: Optional[bool] = False,
         required: Optional[bool] = True,
         description: Optional[str] = None,
-        client: Optional[Argilla] = None,
-    ) -> None:
-        """Text field for use in Argilla `Dataset` `Settings`
-        Parameters:
-            name (str): The name of the field
-            title (Optional[str], optional): The title of the field. Defaults to None.
-            use_markdown (Optional[bool], optional): Whether to use markdown. Defaults to False.
-            required (Optional[bool], optional): Whether the field is required. Defaults to True.
-            description (Optional[str], optional): The description of the field. Defaults to None.
-
-        """
-        client = client or Argilla._get_default()
+        _client: Optional[Argilla] = None,
+    ):
+        client = _client or Argilla._get_default()
 
         super().__init__(api=client.api.fields, client=client)
-        self._model = FieldModel(
-            name=name,
-            title=title,
-            required=required or True,
-            description=description,
-            settings=TextFieldSettings(use_markdown=use_markdown),
-        )
 
         self._dataset = None
+        self._model = FieldModel(name=name, settings=settings, title=title, required=required, description=description)
 
     @classmethod
-    def from_model(cls, model: FieldModel) -> "TextField":
-        instance = cls(name=model.name)
+    def from_model(cls, model: FieldModel) -> "Self":
+        instance = cls(name=model.name)  # noqa
         instance._model = model
 
         return instance
 
     @classmethod
-    def from_dict(cls, data: dict) -> "TextField":
+    def from_dict(cls, data: dict) -> "Self":
         model = FieldModel(**data)
-        return cls.from_model(model=model)
-
-    @property
-    def use_markdown(self) -> Optional[bool]:
-        return self._model.settings.use_markdown
-
-    @use_markdown.setter
-    def use_markdown(self, value: bool) -> None:
-        self._model.settings.use_markdown = value
+        return cls.from_model(model)
 
     @property
     def dataset(self) -> "Dataset":
@@ -109,13 +87,100 @@ class TextField(SettingsPropertyBase):
         return self
 
 
-def field_from_dict(data: dict) -> Union[TextField, VectorField, MetadataType]:
+class TextField(AbstractField):
+    """Text field for use in Argilla `Dataset` `Settings`"""
+
+    def __init__(
+        self,
+        name: str,
+        title: Optional[str] = None,
+        use_markdown: Optional[bool] = False,
+        required: Optional[bool] = True,
+        description: Optional[str] = None,
+        client: Optional[Argilla] = None,
+    ) -> None:
+        """Text field for use in Argilla `Dataset` `Settings`
+        Parameters:
+            name (str): The name of the field
+            title (Optional[str], optional): The title of the field. Defaults to None.
+            use_markdown (Optional[bool], optional): Whether to use markdown. Defaults to False.
+            required (Optional[bool], optional): Whether the field is required. Defaults to True.
+            description (Optional[str], optional): The description of the field. Defaults to None.
+
+        """
+
+        super().__init__(
+            name=name,
+            title=title,
+            required=required or True,
+            description=description,
+            settings=TextFieldSettings(use_markdown=use_markdown),
+            _client=client,
+        )
+
+    @property
+    def use_markdown(self) -> Optional[bool]:
+        return self._model.settings.use_markdown
+
+    @use_markdown.setter
+    def use_markdown(self, value: bool) -> None:
+        self._model.settings.use_markdown = value
+
+
+class ImageField(AbstractField):
+    """Image field for use in Argilla `Dataset` `Settings`"""
+
+    def __init__(
+        self,
+        name: str,
+        title: Optional[str] = None,
+        required: Optional[bool] = True,
+        description: Optional[str] = None,
+        _client: Optional[Argilla] = None,
+    ) -> None:
+        """
+        Text field for use in Argilla `Dataset` `Settings`
+
+        Parameters:
+            name (str): The name of the field
+            title (Optional[str], optional): The title of the field. Defaults to None.
+            required (Optional[bool], optional): Whether the field is required. Defaults to True.
+            description (Optional[str], optional): The description of the field. Defaults to None.
+        """
+
+        super().__init__(
+            name=name,
+            title=title,
+            required=required,
+            description=description,
+            settings=ImageFieldSettings(),
+            _client=_client,
+        )
+
+
+Field: TypeAlias = Union[TextField, ImageField]
+
+
+def _field_from_model(model: FieldModel) -> Field:
+    if model.settings.type == "text":
+        return TextField.from_model(model)
+    elif model.settings.type == "image":
+        return ImageField.from_model(model)
+    else:
+        raise ArgillaError(f"Unsupported field type: {model.settings.type}")
+
+
+def _field_from_dict(data: dict) -> Union[Field, VectorField, MetadataType]:
     """Create a field instance from a field dictionary"""
-    if data["type"] == "text":
+    field_type = data["type"]
+
+    if field_type == "text":
         return TextField.from_dict(data)
-    elif data["type"] == "vector":
+    elif field_type == "image":
+        return ImageField.from_dict(data)
+    elif field_type == "vector":
         return VectorField.from_dict(data)
-    elif data["type"] == "metadata":
+    elif field_type == "metadata":
         return MetadataField.from_dict(data)
     else:
-        raise ValueError(f"Unsupported field type: {data['type']}")
+        raise ArgillaError(f"Unsupported field type: {field_type}")

--- a/argilla/src/argilla/settings/_resource.py
+++ b/argilla/src/argilla/settings/_resource.py
@@ -22,7 +22,7 @@ from uuid import UUID
 from argilla._exceptions import SettingsError, ArgillaAPIError, ArgillaSerializeError
 from argilla._models._dataset import DatasetModel
 from argilla._resource import Resource
-from argilla.settings._field import TextField
+from argilla.settings._field import Field, _field_from_dict, _field_from_model
 from argilla.settings._metadata import MetadataType, MetadataField
 from argilla.settings._question import QuestionType, question_from_model, question_from_dict
 from argilla.settings._task_distribution import TaskDistribution
@@ -43,7 +43,7 @@ class Settings(Resource):
 
     def __init__(
         self,
-        fields: Optional[List[TextField]] = None,
+        fields: Optional[List[Field]] = None,
         questions: Optional[List[QuestionType]] = None,
         vectors: Optional[List[VectorField]] = None,
         metadata: Optional[List[MetadataType]] = None,
@@ -54,7 +54,7 @@ class Settings(Resource):
     ) -> None:
         """
         Args:
-            fields (List[TextField]): A list of TextField objects that represent the fields in the Dataset.
+            fields (List[Field]): A list of Field objects that represent the fields in the Dataset.
             questions (List[Union[LabelQuestion, MultiLabelQuestion, RankingQuestion, TextQuestion, RatingQuestion]]):
                 A list of Question objects that represent the questions in the Dataset.
             vectors (List[VectorField]): A list of VectorField objects that represent the vectors in the Dataset.
@@ -86,7 +86,7 @@ class Settings(Resource):
         return self.__fields
 
     @fields.setter
-    def fields(self, fields: List[TextField]):
+    def fields(self, fields: List[Field]):
         self.__fields = SettingsProperties(self, fields)
 
     @property
@@ -165,7 +165,7 @@ class Settings(Resource):
         return schema_dict
 
     @cached_property
-    def schema_by_id(self) -> Dict[UUID, Union[TextField, QuestionType, MetadataType, VectorField]]:
+    def schema_by_id(self) -> Dict[UUID, Union[Field, QuestionType, MetadataType, VectorField]]:
         return {v.id: v for v in self.schema.values()}
 
     def validate(self) -> None:
@@ -273,7 +273,7 @@ class Settings(Resource):
         allow_extra_metadata = settings_dict.get("allow_extra_metadata")
 
         questions = [question_from_dict(question) for question in settings_dict.get("questions", [])]
-        fields = [TextField.from_dict(field) for field in fields]
+        fields = [_field_from_dict(field) for field in fields]
         vectors = [VectorField.from_dict(vector) for vector in vectors]
         metadata = [MetadataField.from_dict(metadata) for metadata in metadata]
 
@@ -294,9 +294,9 @@ class Settings(Resource):
         instance = self.__class__._from_dict(self.serialize())
         return instance
 
-    def _fetch_fields(self) -> List[TextField]:
+    def _fetch_fields(self) -> List[Field]:
         models = self._client.api.fields.list(dataset_id=self._dataset.id)
-        return [TextField.from_model(model) for model in models]
+        return [_field_from_model(model) for model in models]
 
     def _fetch_questions(self) -> List[QuestionType]:
         models = self._client.api.questions.list(dataset_id=self._dataset.id)
@@ -376,7 +376,7 @@ class Settings(Resource):
         return guidelines
 
 
-Property = Union[TextField, VectorField, MetadataType, QuestionType]
+Property = Union[Field, VectorField, MetadataType, QuestionType]
 
 
 class SettingsProperties(Sequence[Property]):

--- a/argilla/tests/integration/test_add_records.py
+++ b/argilla/tests/integration/test_add_records.py
@@ -48,16 +48,19 @@ def test_add_records(client):
     mock_data = [
         {
             "text": "Hello World, how are you?",
+            "image": "http://mock.image.url/image",
             "label": "positive",
             "id": uuid.uuid4(),
         },
         {
             "text": "Hello World, how are you?",
+            "image": "http://mock.image.url/image",
             "label": "negative",
             "id": uuid.uuid4(),
         },
         {
             "text": "Hello World, how are you?",
+            "image": "http://mock.image.url/image",
             "label": "positive",
             "id": uuid.uuid4(),
         },
@@ -65,6 +68,7 @@ def test_add_records(client):
     settings = rg.Settings(
         fields=[
             rg.TextField(name="text"),
+            rg.ImageField(name="image", required=True),
         ],
         questions=[
             rg.TextQuestion(name="comment", use_markdown=False),
@@ -286,9 +290,7 @@ def test_add_records_with_responses_and_suggestions(client, username: str) -> No
         },
     ]
     settings = rg.Settings(
-        fields=[
-            rg.TextField(name="text"),
-        ],
+        fields=[rg.TextField(name="text")],
         questions=[
             rg.LabelQuestion(name="label", labels=["positive", "negative"]),
         ],

--- a/argilla/tests/integration/test_create_datasets.py
+++ b/argilla/tests/integration/test_create_datasets.py
@@ -17,6 +17,7 @@ from argilla import (
     Dataset,
     Settings,
     TextField,
+    ImageField,
     RatingQuestion,
     LabelQuestion,
     Workspace,
@@ -31,7 +32,7 @@ class TestCreateDatasets:
         dataset = Dataset(
             name=dataset_name,
             settings=Settings(
-                fields=[TextField(name="test_field")],
+                fields=[TextField(name="test_field"), ImageField(name="image")],
                 questions=[RatingQuestion(name="test_question", values=[1, 2, 3, 4, 5])],
             ),
         )

--- a/argilla/tests/integration/test_export_dataset.py
+++ b/argilla/tests/integration/test_export_dataset.py
@@ -33,9 +33,10 @@ def dataset(client) -> rg.Dataset:
     settings = rg.Settings(
         fields=[
             rg.TextField(name="text"),
+            rg.ImageField(name="image"),
         ],
         questions=[
-            rg.TextQuestion(name="label", use_markdown=False),
+            rg.LabelQuestion(name="label", labels=["positive", "negative"]),
         ],
     )
     dataset = rg.Dataset(
@@ -53,16 +54,19 @@ def mock_data() -> List[dict[str, Any]]:
     return [
         {
             "text": "Hello World, how are you?",
+            "image": "http://mock.url/image",
             "label": "positive",
             "id": uuid.uuid4(),
         },
         {
             "text": "Hello World, how are you?",
+            "image": "http://mock.url/image",
             "label": "negative",
             "id": uuid.uuid4(),
         },
         {
             "text": "Hello World, how are you?",
+            "image": "http://mock.url/image",
             "label": "positive",
             "id": uuid.uuid4(),
         },
@@ -108,6 +112,7 @@ class TestDiskImportExportMixin:
                 exported_dataset = json.load(f)
 
         assert exported_settings["fields"][0]["name"] == "text"
+        assert exported_settings["fields"][1]["name"] == "image"
         assert exported_settings["questions"][0]["name"] == "label"
 
         assert exported_dataset["name"] == dataset.name
@@ -130,11 +135,13 @@ class TestDiskImportExportMixin:
         if with_records_export and with_records_import:
             for i, record in enumerate(new_dataset.records(with_suggestions=True)):
                 assert record.fields["text"] == mock_data[i]["text"]
+                assert record.fields["image"] == mock_data[i]["image"]
                 assert record.suggestions["label"].value == mock_data[i]["label"]
         else:
             assert len(new_dataset.records.to_list()) == 0
 
         assert new_dataset.settings.fields[0].name == "text"
+        assert new_dataset.settings.fields[1].name == "image"
         assert new_dataset.settings.questions[0].name == "label"
 
 
@@ -185,9 +192,11 @@ class TestHubImportExportMixin:
         if with_records_import and with_records_export:
             for i, record in enumerate(new_dataset.records(with_suggestions=True)):
                 assert record.fields["text"] == mock_data[i]["text"]
+                assert record.fields["image"] == mock_data[i]["image"]
                 assert record.suggestions["label"].value == mock_data[i]["label"]
         else:
             assert len(new_dataset.records.to_list()) == 0
 
         assert new_dataset.settings.fields[0].name == "text"
+        assert new_dataset.settings.fields[1].name == "image"
         assert new_dataset.settings.questions[0].name == "label"

--- a/argilla/tests/unit/conftest.py
+++ b/argilla/tests/unit/conftest.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
+
+import argilla as rg
 
 
 # @pytest.fixture(scope="function", autouse=True)
@@ -19,3 +22,10 @@
 #     argilla.DEFAULT_HTTP_CLIENT = mock_client
 
 #     return mock_client
+
+
+@pytest.fixture(autouse=True)
+def mock_client():
+    # TODO: Mock the http layer
+    client = rg.Argilla(api_url="http://test_url", api_key="mock")
+    return client

--- a/argilla/tests/unit/test_resources/test_fields.py
+++ b/argilla/tests/unit/test_resources/test_fields.py
@@ -20,6 +20,35 @@ from pytest_httpx import HTTPXMock
 
 import argilla as rg
 from argilla._models import FieldModel
+from argilla._models._settings._fields import ImageFieldSettings
+from argilla.settings._field import ImageField
+
+
+class TestImageField:
+    def test_create_image_field_ony_with_required_arguments(self):
+        field = ImageField(name="image")
+
+        assert field.name == "image"
+        assert field.title == "image"
+        assert field.required is True
+        assert field.description is None
+
+    def test_create_image_field_from_dict(self):
+        field = ImageField.from_dict(
+            {
+                "name": "image",
+                "title": "Image title",
+                "required": "false",
+                "description": "Image description",
+                "settings": {"type": "image"},
+            }
+        )
+
+        assert field.name == "image"
+        assert field.title == "Image title"
+        assert field.description == "Image description"
+        assert field.required is False
+        assert isinstance(field._model.settings, ImageFieldSettings)
 
 
 class TestFieldsAPI:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds support to work with image fields using the SDK. 

## TODO (as separate PRs)

- [ ] Add documentation section
- [ ] Verify behavior using from/to_hub methods
- [ ] Add tooling to read data URLs from image files/folders (based on logic defined in `image_to_html`)
- [ ] Add some media type validation (supported image types) 
- [ ] [Optional] Add tooling to re-scale images. The lower the image sizes, the better the UI work. We can define a transparent re-scaling process to support large images (currently the limit size in the backend is 5MB for data URL)


**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- New feature (non-breaking change which adds functionality)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
