### PR TITLE
[BUGFIX] Renamed 'response' to 'existing_response' to avoid variable re-declaring

### DIFF
--- a/argilla-server/CHANGELOG.md
+++ b/argilla-server/CHANGELOG.md
@@ -20,6 +20,10 @@ These are the section headers that we use:
 
 - Added new endpoint `GET /api/v1/datsets/:dataset_id/users/progress` to compute the users progress. ([#5367](https://github.com/argilla-io/argilla/pull/5367))
 
+### Fixed
+
+- Fixed response duplicate checking ([#5357](https://github.com/argilla-io/argilla/issues/5357))
+
 ## [2.0.0](https://github.com/argilla-io/argilla/compare/v2.0.0rc1...v2.0.0)
 
 > [!IMPORTANT]

--- a/argilla/src/argilla/records/_resource.py
+++ b/argilla/src/argilla/records/_resource.py
@@ -370,8 +370,8 @@ class RecordResponses(Iterable[Response]):
 
     def _check_response_already_exists(self, response: Response) -> None:
         """Checks if a response for the same question name and user id already exists"""
-        for response in self.__responses_by_question_name[response.question_name]:
-            if response.user_id == response.user_id:
+        for existing_response in self.__responses_by_question_name[response.question_name]:
+            if existing_response.user_id == response.user_id:
                 raise ArgillaError(
                     f"Response for question with name {response.question_name!r} and user id {response.user_id!r} "
                     f"already found. The responses for the same question name do not support more than one user"


### PR DESCRIPTION
# Description
When checking collisions of responses to avoid duplicate responses given by the same user to the same question, the response argument is redeclared and the `response.user_id == response.user_id ` will always be satisfied, raising an exception.

Closes #5357

**Type of change**

- Bug fix (non-breaking change which fixes an issue)


**How Has This Been Tested**

Changes done locally, installed the local version and tested on top of our Argilla server with this piece of code (details were obfuscated):
```

for user in client.users:
       record_to_add.responses.add(rg.Response("label_name", label, user_id=user.id, status="submitted"))
```

