### PR TITLE
UI - update textarea height

### DIFF
--- a/argilla-frontend/components/features/annotation/container/questions/form/text-area/TextAreaContents.vue
+++ b/argilla-frontend/components/features/annotation/container/questions/form/text-area/TextAreaContents.vue
@@ -115,10 +115,10 @@ export default {
 <style lang="scss" scoped>
 .container {
   display: flex;
+  min-height: 5em;
   padding: $base-space;
   border: 1px solid $black-20;
   border-radius: $border-radius-s;
-  min-height: 10em;
   background: palette(white);
   outline: none;
   &.--editing {

--- a/argilla-frontend/components/features/annotation/container/questions/form/text-area/TextAreaContents.vue
+++ b/argilla-frontend/components/features/annotation/container/questions/form/text-area/TextAreaContents.vue
@@ -115,7 +115,7 @@ export default {
 <style lang="scss" scoped>
 .container {
   display: flex;
-  min-height: 5em;
+  min-height: 4em;
   padding: $base-space;
   border: 1px solid $black-20;
   border-radius: $border-radius-s;

--- a/argilla-frontend/components/features/annotation/container/questions/form/text-area/TextAreaSuggestion.vue
+++ b/argilla-frontend/components/features/annotation/container/questions/form/text-area/TextAreaSuggestion.vue
@@ -32,7 +32,7 @@ export default {
   padding: $base-space * 2;
   border: 1px solid $black-20;
   border-radius: $border-radius-s;
-  min-height: 10em;
+  min-height: 5em;
   background: palette(white);
   &:hover {
     .button-copy {


### PR DESCRIPTION
This PR updates text question height in dataset annotation form, this way, we save space and homogenize with textareas from other pages.

fix #5399