### PR TITLE
[FEATURE] [WIP] Persist mapping in Settings

### DIFF
--- a/argilla/src/argilla/datasets/_resource.py
+++ b/argilla/src/argilla/datasets/_resource.py
@@ -73,7 +73,7 @@ class Dataset(Resource, HubImportExportMixin, DiskImportExportMixin):
         self._model = DatasetModel(name=name)
         self._settings = settings._copy() if settings else Settings(_dataset=self)
         self._settings.dataset = self
-        self.__records = DatasetRecords(client=self._client, dataset=self)
+        self.__records = DatasetRecords(client=self._client, dataset=self, mapping=self._settings.mapping)
 
     #####################
     #  Properties       #

--- a/argilla/src/argilla/records/_dataset_records.py
+++ b/argilla/src/argilla/records/_dataset_records.py
@@ -139,7 +139,9 @@ class DatasetRecords(Iterable[Record], LoggingMixin):
     DEFAULT_BATCH_SIZE = 256
     DEFAULT_DELETE_BATCH_SIZE = 64
 
-    def __init__(self, client: "Argilla", dataset: "Dataset"):
+    def __init__(
+        self, client: "Argilla", dataset: "Dataset", mapping: Optional[Dict[str, Union[str, Sequence[str]]]] = None
+    ):
         """Initializes a DatasetRecords object with a client and a dataset.
         Args:
             client: An Argilla client object.
@@ -147,6 +149,7 @@ class DatasetRecords(Iterable[Record], LoggingMixin):
         """
         self.__client = client
         self.__dataset = dataset
+        self._mapping = mapping or {}
         self._api = self.__client.api.records
 
     def __iter__(self):
@@ -380,6 +383,7 @@ class DatasetRecords(Iterable[Record], LoggingMixin):
     ) -> List[RecordModel]:
         """Ingests records from a list of dictionaries, a Hugging Face Dataset, or a list of Record objects."""
 
+        mapping = mapping or self._mapping
         if len(records) == 0:
             raise ValueError("No records provided to ingest.")
 

--- a/argilla/src/argilla/settings/_resource.py
+++ b/argilla/src/argilla/settings/_resource.py
@@ -51,6 +51,7 @@ class Settings(DefaultSettingsMixin, Resource):
         guidelines: Optional[str] = None,
         allow_extra_metadata: bool = False,
         distribution: Optional[TaskDistribution] = None,
+        mapping: Optional[Dict[str, Union[str, Sequence[str]]]] = None,
         _dataset: Optional["Dataset"] = None,
     ) -> None:
         """
@@ -70,6 +71,7 @@ class Settings(DefaultSettingsMixin, Resource):
 
         self._dataset = _dataset
         self._distribution = distribution
+        self._mapping = mapping
         self.__guidelines = self.__process_guidelines(guidelines)
         self.__allow_extra_metadata = allow_extra_metadata
 
@@ -137,6 +139,14 @@ class Settings(DefaultSettingsMixin, Resource):
     @distribution.setter
     def distribution(self, value: TaskDistribution) -> None:
         self._distribution = value
+
+    @property
+    def mapping(self) -> Dict[str, Union[str, Sequence[str]]]:
+        return self._mapping
+
+    @mapping.setter
+    def mapping(self, value: Dict[str, Union[str, Sequence[str]]]):
+        self._mapping = value
 
     @property
     def dataset(self) -> "Dataset":
@@ -221,6 +231,7 @@ class Settings(DefaultSettingsMixin, Resource):
                 "metadata": self.metadata.serialize(),
                 "allow_extra_metadata": self.allow_extra_metadata,
                 "distribution": self.distribution.to_dict(),
+                "mapping": self.mapping,
             }
         except Exception as e:
             raise ArgillaSerializeError(f"Failed to serialize the settings. {e.__class__.__name__}") from e
@@ -272,6 +283,7 @@ class Settings(DefaultSettingsMixin, Resource):
         guidelines = settings_dict.get("guidelines")
         distribution = settings_dict.get("distribution")
         allow_extra_metadata = settings_dict.get("allow_extra_metadata")
+        mapping = settings_dict.get("mapping")
 
         questions = [question_from_dict(question) for question in settings_dict.get("questions", [])]
         fields = [TextField.from_dict(field) for field in fields]
@@ -289,6 +301,7 @@ class Settings(DefaultSettingsMixin, Resource):
             guidelines=guidelines,
             allow_extra_metadata=allow_extra_metadata,
             distribution=distribution,
+            mapping=mapping,
         )
 
     def _copy(self) -> "Settings":

--- a/argilla/tests/unit/test_settings/test_settings_mapping_record_ingestion.py
+++ b/argilla/tests/unit/test_settings/test_settings_mapping_record_ingestion.py
@@ -1,0 +1,72 @@
+# Copyright 2024-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from uuid import uuid4
+
+import pytest
+
+import argilla as rg
+
+
+def test_settings_with_record_mapping():
+    mock_mapping = {
+        "true_label": "label.response",
+        "my_label": "label.suggestion.value",
+        "score": "label.suggestion.score",
+        "model": "label.suggestion.agent",
+        "my_prompt": ("prompt_field", "prompt_question"),
+    }
+    mock_user_id = uuid4()
+    settings = rg.Settings(
+        fields=[rg.TextField(name="prompt_field")],
+        questions=[
+            rg.LabelQuestion(name="label", labels=["negative", "positive"]),
+            rg.TextQuestion(name="prompt_question"),
+        ],
+        metadata=[rg.FloatMetadataProperty(name="score")],
+        vectors=[rg.VectorField(name="vector", dimensions=3)],
+        mapping=mock_mapping,
+    )
+    workspace = rg.Workspace(name="workspace", id=uuid4())
+    dataset = rg.Dataset(
+        name="test_dataset",
+        settings=settings,
+        workspace=workspace,
+    )
+    record_api_models = dataset.records._ingest_records(
+        records=[
+            {
+                "my_prompt": "What is the capital of France?",
+                "my_label": "positive",
+                "true_label": "positive",
+                "score": 0.9,
+                "model": "model_name",
+            }
+        ],
+        user_id=mock_user_id,
+    )
+    record = record_api_models[0]
+    assert record.fields["prompt_field"] == "What is the capital of France?"
+    assert record.suggestions[0].value == "positive"
+    assert record.suggestions[0].question_name == "label"
+    assert record.suggestions[0].score == 0.9
+    assert record.suggestions[0].agent == "model_name"
+    assert record.responses[0].values["label"]["value"] == "positive"
+    assert record.responses[0].user_id == mock_user_id
+
+    record = record_api_models[0]
+    suggestions = [s.value for s in record.suggestions]
+    assert record.fields["prompt_field"] == "What is the capital of France?"
+    assert "positive" in suggestions
+    assert "What is the capital of France?" in suggestions


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR builds on https://github.com/argilla-io/argilla/pull/5426

It expands `rg.Settings` to take a mapping parameter which is passed to `dataset.records`. The purpose of this is
- to store mappings with settings so that records can be ingested using the mapping after persistence. 
- to make it easier to share argilla datasets on the hub
- to make it easier to implement templates for common use cases.

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (change restructuring the codebase without changing functionality)
- Improvement (change adding some improvement to an existing functionality)
- Documentation update

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
