### PR TITLE
[FEAT] argilla server: Parameterize uvicorn app for extended apps

### DIFF
--- a/argilla-server/docker/server/Dockerfile
+++ b/argilla-server/docker/server/Dockerfile
@@ -24,6 +24,8 @@ ENV API_KEY=""
 ENV ARGILLA_HOME_PATH=/var/lib/argilla
 ## Uvicorn defaults
 ENV UVICORN_PORT=6900
+### Uvicorn app. Extended apps can override this variable
+ENV UVICORN_APP=argilla_server:app
 
 RUN useradd -ms /bin/bash argilla
 
@@ -40,6 +42,7 @@ VOLUME $ARGILLA_HOME_PATH
 COPY scripts/start_argilla_server.sh /home/argilla
 # Destination folder must be the same as the builder one. Otherwise installed script won't work (since the installation fixes the path inside the script)
 COPY --chown=argilla:argilla --from=builder /opt/venv /opt/venv
+
 ENV PATH="/opt/venv/bin:$PATH"
 
 WORKDIR /home/argilla

--- a/argilla-server/docker/server/scripts/start_argilla_server.sh
+++ b/argilla-server/docker/server/scripts/start_argilla_server.sh
@@ -37,4 +37,5 @@ fi
 #   with the prefix UVICORN_. For example, in case you want to
 #   run the app on port 5000, just set the environment variable
 #   UVICORN_PORT to 5000.
-python -m uvicorn argilla_server:app --host "0.0.0.0"
+
+python -m uvicorn $UVICORN_APP --host "0.0.0.0"

--- a/argilla/docs/reference/argilla-server/configuration.md
+++ b/argilla/docs/reference/argilla-server/configuration.md
@@ -100,6 +100,7 @@ The following environment variables are useful only when PostgreSQL is used:
 
 - `API_KEY`: The default user api key to user. If API_KEY is not provided, a new random api key will be generated (Default: `""`).
 
+- `UVICORN_APP`: [Advanced] The name of the FastAPI app to run. This is useful when you want to extend the FastAPI app with additional routes or middleware. The default value is `argilla_server:app`.
 
 ## REST API docs
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds a minimal change to allow users to extend in an easy (but not easiest) server app. Users can use an extended version of the FastAPI app including their endpoints when launching the docker container by setting the `UVICORN_APP` environment variable.

This is related to this [discord thread](https://discord.com/channels/879548962464493619/1278288595312054363)

An example of usage [here](https://huggingface.co/spaces/frascuchon/extend-argilla-api-example/tree/main) 

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
