### PR TITLE
[FEATURE] encode class labels as names not ints

### DIFF
--- a/argilla/src/argilla/records/_io/_datasets.py
+++ b/argilla/src/argilla/records/_io/_datasets.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Dict, List, Union
-from uuid import uuid4
 
 from datasets import Dataset as HFDataset
-from datasets import IterableDataset, Image
+from datasets import IterableDataset, Image, ClassLabel, Value
 
 from argilla.records._io._generic import GenericIO
 from argilla._helpers._media import pil_to_data_uri, uncast_image
@@ -24,6 +24,116 @@ from argilla._helpers._media import pil_to_data_uri, uncast_image
 if TYPE_CHECKING:
     from argilla.records import Record
     from argilla.datasets import Dataset
+
+
+def _cast_images_as_urls(hf_dataset: "HFDataset", columns: List[str]) -> "HFDataset":
+    """Cast the image features in the Hugging Face dataset as URLs.
+
+    Parameters:
+        hf_dataset (HFDataset): The Hugging Face dataset to cast.
+        repo_id (str): The ID of the Hugging Face Hub repo.
+
+    Returns:
+        HFDataset: The Hugging Face dataset with image features cast as URLs.
+    """
+
+    for column in columns:
+        # make an updated features object with the new column type
+        features = hf_dataset.features.copy()
+        features[column] = Value("string")
+        # cast the column in batches
+        hf_dataset = hf_dataset.map(
+            function=lambda batch: {column: [pil_to_data_uri(sample) for sample in batch]},
+            with_indices=False,
+            batched=True,
+            input_columns=[column],
+            remove_columns=[column],
+            features=features,
+        )
+
+    return hf_dataset
+
+
+def _cast_classlabels_as_strings(hf_dataset: "HFDataset", columns: List[str]) -> "HFDataset":
+    """Cast the class label features in the Hugging Face dataset as strings.
+
+    Parameters:
+        hf_dataset (HFDataset): The Hugging Face dataset to cast.
+        columns (List[str]): The names of the columns containing the class label features.
+
+    Returns:
+        HFDataset: The Hugging Face dataset with class label features cast as strings.
+    """
+    for column in columns:
+        features = hf_dataset.features.copy()
+        features[column] = Value("string")
+        hf_dataset = hf_dataset.map(
+            lambda x: {column: hf_dataset.features[column].int2str(x[column])}, features=features
+        )
+    return hf_dataset
+
+
+FEATURE_CASTERS = {
+    Image: _cast_images_as_urls,
+    ClassLabel: _cast_classlabels_as_strings,
+}
+
+
+def _uncast_uris_as_images(hf_dataset: "HFDataset", columns: List[str]) -> "HFDataset":
+    """Cast the image features in the Hugging Face dataset as PIL images.
+
+    Parameters:
+        hf_dataset (HFDataset): The Hugging Face dataset to cast.
+        columns (List[str]): The names of the columns containing the image features.
+
+    Returns:
+        HFDataset: The Hugging Face dataset with image features cast as PIL images.
+    """
+
+    for column in columns:
+        features = hf_dataset.features.copy()
+        features[column] = Image()
+        hf_dataset = hf_dataset.map(
+            function=lambda batch: {column: [uncast_image(sample) for sample in batch]},
+            with_indices=False,
+            batched=True,
+            input_columns=[column],
+            remove_columns=[column],
+            features=features,
+        )
+    return hf_dataset
+
+
+def _uncast_label_questions_as_classlabels(hf_dataset: "HFDataset", columns: List[str]) -> "HFDataset":
+    """Cast the class label features in the Hugging Face dataset as strings.
+
+    Parameters:
+        hf_dataset (HFDataset): The Hugging Face dataset to cast.
+        columns (List[str]): The names of the columns containing the class label features.
+
+    Returns:
+        HFDataset: The Hugging Face dataset with class label features cast as strings.
+    """
+    for column in columns:
+        column = f"{column}.suggestion"
+        values = list(hf_dataset.unique(column))
+        features = hf_dataset.features.copy()
+        features[column] = ClassLabel(names=values)
+        hf_dataset = hf_dataset.map(
+            function=lambda batch: {column: [values.index(sample) for sample in batch]},
+            with_indices=False,
+            batched=True,
+            input_columns=[column],
+            remove_columns=[column],
+            features=features,
+        )
+    return hf_dataset
+
+
+ATTRIBUTE_UNCASTERS = {
+    "image": _uncast_uris_as_images,
+    "label_selection": _uncast_label_questions_as_classlabels,
+}
 
 
 class HFDatasetsIO:
@@ -49,9 +159,7 @@ class HFDatasetsIO:
         """
         record_dicts = GenericIO.to_dict(records, flatten=True)
         hf_dataset = HFDataset.from_dict(record_dicts)
-        image_fields = HFDatasetsIO._get_image_fields(schema=dataset.schema)
-        if image_fields:
-            hf_dataset = HFDatasetsIO._cast_uris_as_images(hf_dataset=hf_dataset, columns=image_fields)
+        hf_dataset = HFDatasetsIO._uncast_argilla_attributes_to_datasets(hf_dataset, dataset.schema)
         return hf_dataset
 
     @staticmethod
@@ -64,9 +172,7 @@ class HFDatasetsIO:
         Returns:
             Generator[Dict[str, Union[str, float, int, list]], None, None]: A generator of dictionaries to be passed to DatasetRecords.add or DatasetRecords.update.
         """
-        media_features = HFDatasetsIO._get_image_features(dataset)
-        if media_features:
-            dataset = HFDatasetsIO._cast_images_as_urls(hf_dataset=dataset, columns=media_features)
+        dataset = HFDatasetsIO._cast_datasets_features_to_argilla(hf_dataset=dataset)
         try:
             dataset: IterableDataset = dataset.to_iterable_dataset()
         except AttributeError:
@@ -77,7 +183,7 @@ class HFDatasetsIO:
         return record_dicts
 
     @staticmethod
-    def _get_image_fields(schema: Dict) -> List[str]:
+    def _uncast_argilla_attributes_to_datasets(hf_dataset: "HFDataset", schema: Dict) -> List[str]:
         """Get the names of the Argilla fields that contain image data.
 
         Parameters:
@@ -86,10 +192,15 @@ class HFDatasetsIO:
         Returns:
             List[str]: The names of the Argilla fields that contain image data.
         """
-        return [field_name for field_name, field in schema.items() if field.type == "image"]
+
+        for attribute_type, uncaster in ATTRIBUTE_UNCASTERS.items():
+            attribute_fields = [field_name for field_name, field in schema.items() if field.type == attribute_type]
+            hf_dataset = uncaster(hf_dataset, attribute_fields)
+
+        return hf_dataset
 
     @staticmethod
-    def _get_image_features(dataset: "HFDataset") -> List[str]:
+    def _cast_datasets_features_to_argilla(hf_dataset: "HFDataset") -> List[str]:
         """Check if the Hugging Face dataset contains image features.
 
         Parameters:
@@ -98,64 +209,15 @@ class HFDatasetsIO:
         Returns:
             bool: True if the Hugging Face dataset contains image features, False otherwise.
         """
-        media_features = [name for name, feature in dataset.features.items() if isinstance(feature, Image)]
-        return media_features
+        casted_features = defaultdict(list)
 
-    @staticmethod
-    def _cast_images_as_urls(hf_dataset: "HFDataset", columns: List[str]) -> "HFDataset":
-        """Cast the image features in the Hugging Face dataset as URLs.
+        for name, feature in hf_dataset.features.items():
+            if isinstance(feature, Image):
+                casted_features[Image].append(name)
+            if isinstance(feature, ClassLabel):
+                casted_features[ClassLabel].append(name)
 
-        Parameters:
-            hf_dataset (HFDataset): The Hugging Face dataset to cast.
-            repo_id (str): The ID of the Hugging Face Hub repo.
-
-        Returns:
-            HFDataset: The Hugging Face dataset with image features cast as URLs.
-        """
-
-        unique_identifier = uuid4().hex
-
-        def batch_fn(batch):
-            data_uris = [pil_to_data_uri(sample) for sample in batch]
-            return {unique_identifier: data_uris}
-
-        for column in columns:
-            hf_dataset = hf_dataset.map(
-                function=batch_fn,
-                with_indices=False,
-                batched=True,
-                input_columns=[column],
-                remove_columns=[column],
-            )
-            hf_dataset = hf_dataset.rename_column(original_column_name=unique_identifier, new_column_name=column)
-
-        return hf_dataset
-
-    @staticmethod
-    def _cast_uris_as_images(hf_dataset: "HFDataset", columns: List[str]) -> "HFDataset":
-        """Cast the image features in the Hugging Face dataset as PIL images.
-
-        Parameters:
-            hf_dataset (HFDataset): The Hugging Face dataset to cast.
-            columns (List[str]): The names of the columns containing the image features.
-
-        Returns:
-            HFDataset: The Hugging Face dataset with image features cast as PIL images.
-        """
-        unique_identifier = uuid4().hex
-
-        def batch_fn(batch):
-            images = [uncast_image(sample) for sample in batch]
-            return {unique_identifier: images}
-
-        for column in columns:
-            hf_dataset = hf_dataset.map(
-                function=batch_fn,
-                with_indices=False,
-                batched=True,
-                input_columns=[column],
-                remove_columns=[column],
-            )
-            hf_dataset = hf_dataset.rename_column(original_column_name=unique_identifier, new_column_name=column)
+        for feature_type, columns in casted_features.items():
+            hf_dataset = FEATURE_CASTERS[feature_type](hf_dataset, columns)
 
         return hf_dataset

--- a/argilla/src/argilla/records/_io/_datasets.py
+++ b/argilla/src/argilla/records/_io/_datasets.py
@@ -116,6 +116,8 @@ def _uncast_label_questions_as_classlabels(hf_dataset: "HFDataset", columns: Lis
     """
     for column in columns:
         column = f"{column}.suggestion"
+        if column not in hf_dataset.column_names:
+            continue
         values = list(hf_dataset.unique(column))
         features = hf_dataset.features.copy()
         features[column] = ClassLabel(names=values)

--- a/argilla/src/argilla/settings/_io/_hub.py
+++ b/argilla/src/argilla/settings/_io/_hub.py
@@ -143,10 +143,14 @@ def _define_settings_from_features(features: Union[List[Dict], Dict[str, Any]]) 
 
         elif feature_type == FeatureType.LABEL:
             fields.append(TextField(name=f"{name}_field"))
+            names = feature.get("names")
+            if names is None:
+                warnings.warn(f"Feature '{name}' has no labels. Skipping.")
+                continue
             questions.append(
                 LabelQuestion(
                     name=f"{name}_question",
-                    labels={str(i): label for i, label in enumerate(feature.get("names", []))},
+                    labels=names,
                 )
             )
             mapping[name] = (f"{name}_field", f"{name}_question")

--- a/argilla/tests/integration/test_export_features.py
+++ b/argilla/tests/integration/test_export_features.py
@@ -1,0 +1,113 @@
+# Copyright 2024-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import random
+import uuid
+from string import ascii_lowercase
+from tempfile import TemporaryDirectory
+from typing import Any, List
+
+import argilla as rg
+import pytest
+from argilla._exceptions import ConflictError, SettingsError
+from datasets import Dataset as HFDataset, Value, Features, ClassLabel
+from huggingface_hub.utils._errors import BadRequestError, FileMetadataError, HfHubHTTPError
+
+_RETRIES = 5
+
+
+@pytest.fixture
+def dataset(client) -> rg.Dataset:
+    mock_dataset_name = "".join(random.choices(ascii_lowercase, k=16))
+    settings = rg.Settings(
+        fields=[
+            rg.TextField(name="text"),
+            rg.ImageField(name="image"),
+        ],
+        questions=[
+            rg.LabelQuestion(name="label", labels=["positive", "negative"]),
+        ],
+    )
+    dataset = rg.Dataset(
+        name=mock_dataset_name,
+        settings=settings,
+        client=client,
+    )
+    dataset.create()
+    yield dataset
+    dataset.delete()
+
+
+@pytest.fixture
+def mock_data() -> List[dict[str, Any]]:
+    return [
+        {
+            "text": "Hello World, how are you?",
+            "image": "http://mock.url/image",
+            "label": "positive",
+            "id": uuid.uuid4(),
+        },
+        {
+            "text": "Hello World, how are you?",
+            "image": "http://mock.url/image",
+            "label": "negative",
+            "id": uuid.uuid4(),
+        },
+        {
+            "text": "Hello World, how are you?",
+            "image": "http://mock.url/image",
+            "label": "positive",
+            "id": uuid.uuid4(),
+        },
+    ]
+
+
+@pytest.fixture
+def token():
+    return os.getenv("HF_TOKEN_ARGILLA_INTERNAL_TESTING")
+
+
+class TestExportFeaturesToHub:
+    def test_import_records_from_datasets_with_classlabel(
+        self, token: str, dataset: rg.Dataset, client, mock_data: List[dict[str, Any]]
+    ):
+        repo_id = f"argilla-internal-testing/test_import_dataset_from_hub_with_classlabel_{uuid.uuid4()}"
+
+        hf_dataset = HFDataset.from_dict(
+            {
+                "text": [record["text"] for record in mock_data],
+                "label": [record["label"] for record in mock_data],
+            },
+            features=Features(
+                {
+                    "text": Value("string"),
+                    "label": ClassLabel(names=["positive", "negative"]),
+                }
+            ),
+        )
+
+        hf_dataset.push_to_hub(repo_id=repo_id, token=token)
+
+        dataset.records.log(mock_data)
+
+        for i, record in enumerate(dataset.records(with_suggestions=True)):
+            assert record.fields["text"] == mock_data[i]["text"]
+            assert record.suggestions["label"].value == mock_data[i]["label"]
+
+        exported_dataset = dataset.records.to_datasets()
+
+        assert exported_dataset.features["label.suggestion"].names == ["positive", "negative"]
+        assert exported_dataset["label.suggestion"] == [0, 1, 0]


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR add to the settings from_hub PR by supporting ClassLabels coming from datasets package. 

It renders a label question with names based on the ClassLabel.

It uncasts the 'label.suggestion' to a corresponding class label.

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- New feature (non-breaking change which adds functionality)



