### PR TITLE
[ENHANCEMENT] add markdown support for chat fields

### DIFF
--- a/.github/workflows/argilla.yml
+++ b/.github/workflows/argilla.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     services:
       argilla-server:
-        image: argilladev/argilla-hf-spaces:pr-5376
+        image: argilladev/argilla-hf-spaces:pr-5482
         ports:
           - 6900:6900
         env:

--- a/argilla-frontend/components/features/annotation/settings/SettingsQuestions.vue
+++ b/argilla-frontend/components/features/annotation/settings/SettingsQuestions.vue
@@ -106,16 +106,14 @@
                 type="button"
                 class="secondary light small"
                 @on-click="restore(question)"
-                :disabled="!question.isSettingsModified"
+                :disabled="!question.isModified"
               >
                 <span v-text="$t('cancel')" />
               </BaseButton>
               <BaseButton
                 type="submit"
                 class="primary small"
-                :disabled="
-                  !question.isSettingsModified || !question.isQuestionValid
-                "
+                :disabled="!question.isModified || !question.isQuestionValid"
               >
                 <span v-text="$t('update')" />
               </BaseButton>

--- a/argilla-server/src/argilla_server/api/schemas/v1/fields.py
+++ b/argilla-server/src/argilla_server/api/schemas/v1/fields.py
@@ -75,7 +75,7 @@ class ImageFieldSettingsUpdate(BaseModel):
 
 class ChatFieldSettings(BaseModel):
     type: Literal[FieldType.chat]
-    use_markdown: bool = True  # Just for dev purposes. Otherwise getting old datasets will fail
+    use_markdown: bool
 
 
 class ChatFieldSettingsCreate(BaseModel):

--- a/argilla-server/src/argilla_server/api/schemas/v1/fields.py
+++ b/argilla-server/src/argilla_server/api/schemas/v1/fields.py
@@ -28,7 +28,6 @@ FIELD_CREATE_NAME_MAX_LENGTH = 200
 FIELD_CREATE_TITLE_MIN_LENGTH = 1
 FIELD_CREATE_TITLE_MAX_LENGTH = 500
 
-
 FieldName = Annotated[
     constr(
         regex=FIELD_CREATE_NAME_REGEX,
@@ -37,7 +36,6 @@ FieldName = Annotated[
     ),
     PydanticField(..., description="The name of the field"),
 ]
-
 
 FieldTitle = Annotated[
     constr(
@@ -77,14 +75,17 @@ class ImageFieldSettingsUpdate(BaseModel):
 
 class ChatFieldSettings(BaseModel):
     type: Literal[FieldType.chat]
+    use_markdown: bool
 
 
 class ChatFieldSettingsCreate(BaseModel):
     type: Literal[FieldType.chat]
+    use_markdown: bool = True
 
 
 class ChatFieldSettingsUpdate(BaseModel):
     type: Literal[FieldType.chat]
+    use_markdown: bool
 
 
 FieldSettings = Annotated[
@@ -96,7 +97,6 @@ FieldSettings = Annotated[
     PydanticField(..., discriminator="type"),
 ]
 
-
 FieldSettingsCreate = Annotated[
     Union[
         TextFieldSettingsCreate,
@@ -106,9 +106,12 @@ FieldSettingsCreate = Annotated[
     PydanticField(..., discriminator="type"),
 ]
 
-
 FieldSettingsUpdate = Annotated[
-    Union[TextFieldSettingsUpdate, ImageFieldSettingsUpdate, ChatFieldSettingsUpdate],
+    Union[
+        TextFieldSettingsUpdate,
+        ImageFieldSettingsUpdate,
+        ChatFieldSettingsUpdate,
+    ],
     PydanticField(..., discriminator="type"),
 ]
 

--- a/argilla-server/src/argilla_server/api/schemas/v1/fields.py
+++ b/argilla-server/src/argilla_server/api/schemas/v1/fields.py
@@ -75,7 +75,7 @@ class ImageFieldSettingsUpdate(BaseModel):
 
 class ChatFieldSettings(BaseModel):
     type: Literal[FieldType.chat]
-    use_markdown: bool
+    use_markdown: bool = True  # Just for dev purposes. Otherwise getting old datasets will fail
 
 
 class ChatFieldSettingsCreate(BaseModel):

--- a/argilla-server/tests/factories.py
+++ b/argilla-server/tests/factories.py
@@ -270,6 +270,7 @@ class ImageFieldFactory(FieldFactory):
 class ChatFieldFactory(FieldFactory):
     settings = {
         "type": FieldType.chat,
+        "use_markdown": True,
     }
 
 

--- a/argilla-server/tests/unit/api/handlers/v1/datasets/fields/test_create_dataset_field.py
+++ b/argilla-server/tests/unit/api/handlers/v1/datasets/fields/test_create_dataset_field.py
@@ -61,3 +61,63 @@ class TestCreateDatasetField:
             "inserted_at": image_field.inserted_at.isoformat(),
             "updated_at": image_field.updated_at.isoformat(),
         }
+
+    async def test_create_dataset_chat_field(
+        self, db: AsyncSession, async_client: AsyncClient, owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+
+        response = await async_client.post(
+            self.url(dataset.id),
+            headers=owner_auth_header,
+            json={
+                "name": "name",
+                "title": "title",
+                "required": True,
+                "settings": {"type": FieldType.chat},
+            },
+        )
+
+        chat_field = (await db.execute(select(Field))).scalar_one()
+
+        assert response.status_code == 201
+        assert response.json() == {
+            "id": str(chat_field.id),
+            "name": "name",
+            "title": "title",
+            "required": True,
+            "settings": {"type": FieldType.chat, "use_markdown": True},
+            "dataset_id": str(dataset.id),
+            "inserted_at": chat_field.inserted_at.isoformat(),
+            "updated_at": chat_field.updated_at.isoformat(),
+        }
+
+    async def test_create_dataset_chat_field_with_use_markdown(
+        self, db: AsyncSession, async_client: AsyncClient, owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+
+        response = await async_client.post(
+            self.url(dataset.id),
+            headers=owner_auth_header,
+            json={
+                "name": "name",
+                "title": "title",
+                "required": True,
+                "settings": {"type": FieldType.chat, "use_markdown": False},
+            },
+        )
+
+        chat_field = (await db.execute(select(Field))).scalar_one()
+
+        assert response.status_code == 201
+        assert response.json() == {
+            "id": str(chat_field.id),
+            "name": "name",
+            "title": "title",
+            "required": True,
+            "settings": {"type": FieldType.chat, "use_markdown": False},
+            "dataset_id": str(dataset.id),
+            "inserted_at": chat_field.inserted_at.isoformat(),
+            "updated_at": chat_field.updated_at.isoformat(),
+        }

--- a/argilla-server/tests/unit/api/handlers/v1/datasets/fields/test_list_dataset_fields.py
+++ b/argilla-server/tests/unit/api/handlers/v1/datasets/fields/test_list_dataset_fields.py
@@ -63,7 +63,9 @@ class TestListDatasetFields:
     async def test_list_dataset_fields_with_chat_field(self, async_client: AsyncClient, owner_auth_header: dict):
         dataset = await DatasetFactory.create()
         chat_field_a = await ChatFieldFactory.create(dataset=dataset)
-        chat_field_b = await ChatFieldFactory.create(dataset=dataset)
+        chat_field_b = await ChatFieldFactory.create(
+            dataset=dataset, settings={"type": FieldType.chat, "use_markdown": False}
+        )
 
         response = await async_client.get(self.url(dataset.id), headers=owner_auth_header)
 
@@ -75,7 +77,7 @@ class TestListDatasetFields:
                     "name": chat_field_a.name,
                     "title": chat_field_a.title,
                     "required": False,
-                    "settings": {"type": FieldType.chat},
+                    "settings": {"type": FieldType.chat, "use_markdown": True},
                     "dataset_id": str(dataset.id),
                     "inserted_at": chat_field_a.inserted_at.isoformat(),
                     "updated_at": chat_field_a.updated_at.isoformat(),
@@ -85,7 +87,7 @@ class TestListDatasetFields:
                     "name": chat_field_b.name,
                     "title": chat_field_b.title,
                     "required": False,
-                    "settings": {"type": FieldType.chat},
+                    "settings": {"type": FieldType.chat, "use_markdown": False},
                     "dataset_id": str(dataset.id),
                     "inserted_at": chat_field_b.inserted_at.isoformat(),
                     "updated_at": chat_field_b.updated_at.isoformat(),

--- a/argilla-server/tests/unit/api/handlers/v1/fields/test_update_field.py
+++ b/argilla-server/tests/unit/api/handlers/v1/fields/test_update_field.py
@@ -53,7 +53,7 @@ class TestUpdateField:
             "updated_at": image_field.updated_at.isoformat(),
         }
 
-    async def test_update_chat_field(self, async_client: AsyncClient, owner_auth_header: dict):
+    async def test_update_chat_field_title(self, async_client: AsyncClient, owner_auth_header: dict):
         chat_field = await ChatFieldFactory.create()
 
         response = await async_client.patch(
@@ -70,7 +70,38 @@ class TestUpdateField:
             "name": chat_field.name,
             "title": "Updated title",
             "required": False,
-            "settings": {"type": FieldType.chat},
+            "settings": chat_field.settings,
+            "dataset_id": str(chat_field.dataset_id),
+            "inserted_at": chat_field.inserted_at.isoformat(),
+            "updated_at": chat_field.updated_at.isoformat(),
+        }
+
+    async def test_update_chat_field_use_markdown(self, async_client: AsyncClient, owner_auth_header: dict):
+        chat_field = await ChatFieldFactory.create(
+            settings={
+                "type": FieldType.chat,
+                "use_markdown": True,
+            }
+        )
+
+        response = await async_client.patch(
+            self.url(chat_field.id),
+            headers=owner_auth_header,
+            json={
+                "settings": {
+                    "type": "chat",
+                    "use_markdown": False,
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "id": str(chat_field.id),
+            "name": chat_field.name,
+            "title": chat_field.title,
+            "required": False,
+            "settings": {"type": FieldType.chat, "use_markdown": False},
             "dataset_id": str(chat_field.dataset_id),
             "inserted_at": chat_field.inserted_at.isoformat(),
             "updated_at": chat_field.updated_at.isoformat(),

--- a/argilla/src/argilla/_models/_settings/_fields.py
+++ b/argilla/src/argilla/_models/_settings/_fields.py
@@ -33,6 +33,7 @@ class ImageFieldSettings(BaseModel):
 
 class ChatFieldSettings(BaseModel):
     type: Literal["chat"] = "chat"
+    use_markdown: Optional[bool] = True
 
 
 FieldSettings = Annotated[

--- a/argilla/src/argilla/settings/_field.py
+++ b/argilla/src/argilla/settings/_field.py
@@ -164,6 +164,7 @@ class ChatField(AbstractField):
         self,
         name: str,
         title: Optional[str] = None,
+        use_markdown: Optional[bool] = True,
         required: Optional[bool] = True,
         description: Optional[str] = None,
         _client: Optional[Argilla] = None,
@@ -174,6 +175,7 @@ class ChatField(AbstractField):
         Parameters:
             name (str): The name of the field
             title (Optional[str], optional): The title of the field. Defaults to None.
+            use_markdown (Optional[bool], optional): Whether to use markdown. Defaults to True.
             required (Optional[bool], optional): Whether the field is required. Defaults to True.
             description (Optional[str], optional): The description of the field. Defaults to None.
         """
@@ -183,9 +185,17 @@ class ChatField(AbstractField):
             title=title,
             required=required,
             description=description,
-            settings=ChatFieldSettings(),
+            settings=ChatFieldSettings(use_markdown=use_markdown),
             _client=_client,
         )
+
+    @property
+    def use_markdown(self) -> Optional[bool]:
+        return self._model.settings.use_markdown
+
+    @use_markdown.setter
+    def use_markdown(self, value: bool) -> None:
+        self._model.settings.use_markdown = value
 
 
 Field = Union[TextField, ImageField, ChatField]

--- a/argilla/tests/integration/test_create_datasets.py
+++ b/argilla/tests/integration/test_create_datasets.py
@@ -12,19 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from argilla import (
     Argilla,
     Dataset,
-    LabelQuestion,
-    RatingQuestion,
+    ChatField,
     Settings,
     TermsMetadataProperty,
     TextField,
     ImageField,
     RatingQuestion,
     LabelQuestion,
-    Workspace,
     VectorField,
     Workspace,
 )
@@ -36,7 +33,11 @@ class TestCreateDatasets:
         dataset = Dataset(
             name=dataset_name,
             settings=Settings(
-                fields=[TextField(name="test_field"), ImageField(name="image")],
+                fields=[
+                    TextField(name="test_field"),
+                    ImageField(name="image"),
+                    ChatField(name="chat", use_markdown=False),
+                ],
                 questions=[RatingQuestion(name="test_question", values=[1, 2, 3, 4, 5])],
             ),
         )

--- a/argilla/tests/integration/test_update_dataset_settings.py
+++ b/argilla/tests/integration/test_update_dataset_settings.py
@@ -16,7 +16,7 @@ import uuid
 
 import pytest
 
-from argilla import Dataset, Settings, TextField, LabelQuestion, Argilla, VectorField, FloatMetadataProperty
+from argilla import Dataset, Settings, TextField, ChatField, LabelQuestion, Argilla, VectorField, FloatMetadataProperty
 
 
 @pytest.fixture
@@ -24,7 +24,10 @@ def dataset(dataset_name: str):
     return Dataset(
         name=dataset_name,
         settings=Settings(
-            fields=[TextField(name="text", use_markdown=False)],
+            fields=[
+                TextField(name="text", use_markdown=False),
+                ChatField(name="chat", use_markdown=True),
+            ],
             questions=[LabelQuestion(name="label", labels=["a", "b", "c"])],
         ),
     ).create()
@@ -35,6 +38,7 @@ class TestUpdateDatasetSettings:
         settings = dataset.settings
 
         settings.fields["text"].use_markdown = True
+        settings.fields["chat"].use_markdown = False
         dataset.settings.vectors.add(VectorField(name="vector", dimensions=10))
         dataset.settings.metadata.add(FloatMetadataProperty(name="metadata"))
         dataset.settings.update()
@@ -42,6 +46,7 @@ class TestUpdateDatasetSettings:
         dataset = client.datasets(dataset.name)
         settings = dataset.settings
         assert settings.fields["text"].use_markdown is True
+        assert settings.fields["chat"].use_markdown is False
         assert settings.vectors["vector"].dimensions == 10
         assert isinstance(settings.metadata["metadata"], FloatMetadataProperty)
 

--- a/argilla/tests/unit/test_settings/test_settings_fields.py
+++ b/argilla/tests/unit/test_settings/test_settings_fields.py
@@ -63,3 +63,23 @@ class TestTextField:
         mock_use_markdown = True
         text_field = rg.TextField(name=name, use_markdown=mock_use_markdown, title=title)
         assert text_field.title == expected
+
+
+class TestChatField:
+    def test_create_chat_field(self):
+        field = rg.ChatField(name="chat")
+
+        assert field.name == "chat"
+        assert field.use_markdown is True
+
+    def test_create_chat_field_with_use_markdown(self):
+        field = rg.ChatField(name="chat", use_markdown=False)
+
+        assert field.name == "chat"
+        assert field.use_markdown is False
+
+    def test_update_chat_field_use_markdown(self):
+        field = rg.ChatField(name="chat", use_markdown=True)
+        field.use_markdown = False
+
+        assert field.use_markdown is False


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds changes in SDK and server to support markdown configuration for `ChatField` by using the `use_markdown` flag in the same way as  `TextField`

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- New feature (non-breaking change which adds functionality)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
