### PR TITLE
chore: upgrade argilla-server Docker image trying to fix some vulnerabilities

### DIFF
--- a/argilla-server/docker/server/Dockerfile
+++ b/argilla-server/docker/server/Dockerfile
@@ -1,20 +1,21 @@
-FROM python:3.10.12-slim AS builder
+FROM python:3.10.15-slim AS builder
 
 # Copying argilla distribution files
 COPY dist/*.whl /packages/
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 RUN apt-get update && \
-  apt-get install -y python-dev-is-python3 libpq-dev gcc && \
-  pip install --upgrade pip && \
-  pip install uvicorn[standard] && \
-  for wheel in /packages/*.whl; do pip install "$wheel"[server,postgresql]; done && \
-  apt-get remove -y python-dev-is-python3 libpq-dev gcc && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* && \
-  rm -rf /packages
+    apt-get upgrade -y && \
+    apt-get install -y python-dev-is-python3 libpq-dev gcc && \
+    pip install --upgrade pip && \
+    pip install uvicorn[standard] && \
+    for wheel in /packages/*.whl; do pip install "$wheel"[server,postgresql]; done && \
+    apt-get remove -y python-dev-is-python3 libpq-dev gcc && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /packages
 
-FROM python:3.10.12-slim
+FROM python:3.10.15-slim
 
 # Environment Variables
 ENV USERNAME=""
@@ -31,12 +32,13 @@ RUN useradd -ms /bin/bash argilla
 
 # Create argilla volume
 RUN mkdir -p "$ARGILLA_HOME_PATH" && \
-  chown argilla:argilla "$ARGILLA_HOME_PATH" && \
-  apt-get update && \
-  apt-get install -y libpq-dev && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* && \
-  rm -rf /packages
+    chown argilla:argilla "$ARGILLA_HOME_PATH" && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y libpq-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /packages
 VOLUME $ARGILLA_HOME_PATH
 
 COPY scripts/start_argilla_server.sh /home/argilla

--- a/argilla-server/docker/server/Dockerfile
+++ b/argilla-server/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.15-slim AS builder
+FROM python:3.10-slim AS builder
 
 # Copying argilla distribution files
 COPY dist/*.whl /packages/
@@ -15,7 +15,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /packages
 
-FROM python:3.10.15-slim
+FROM python:3.10-slim
 
 # Environment Variables
 ENV USERNAME=""

--- a/argilla-server/docker/server/Dockerfile
+++ b/argilla-server/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim AS builder
+FROM python:3.10-slim-buster AS builder
 
 # Copying argilla distribution files
 COPY dist/*.whl /packages/
@@ -15,7 +15,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /packages
 
-FROM python:3.10-slim
+FROM python:3.10-slim-buster
 
 # Environment Variables
 ENV USERNAME=""

--- a/argilla-server/docker/server/Dockerfile
+++ b/argilla-server/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-buster AS builder
+FROM python:3.10-slim AS builder
 
 # Copying argilla distribution files
 COPY dist/*.whl /packages/
@@ -15,7 +15,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /packages
 
-FROM python:3.10-slim-buster
+FROM python:3.10-slim
 
 # Environment Variables
 ENV USERNAME=""


### PR DESCRIPTION
# Description

This PR includes some changes to our Dockerfile at argilla-server:
* Increase Python Docker image from `python:3.10.12-slim` to `python:3.10.15-slim`.
* Add calls to `apt-get upgrade` so we have the latest version of the dependencies.

**Type of change**

- Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

- [x] Manually check that the generated Docker image does not have vulnerabilities or at least some of them disappear.
- [x] Manually test that HF Spaces correctly support these changes.

**Checklist**

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
