### PR TITLE
[BUGFIX] `argilla`: prevent errors when vector, suggestion, or responses are `None`

### DIFF
--- a/argilla/src/argilla/_models/_record/_record.py
+++ b/argilla/src/argilla/_models/_record/_record.py
@@ -77,3 +77,29 @@ class RecordModel(ResourceModel):
         if external_id is None:
             external_id = uuid.uuid4()
         return external_id
+
+    @field_validator("vectors", mode="before")
+    @classmethod
+    def empty_vectors_if_none(cls, vectors: Optional[List[VectorModel]]) -> Optional[List[VectorModel]]:
+        """Ensure vectors is None if not provided."""
+        if vectors is None:
+            return []
+        return vectors
+
+    @field_validator("responses", mode="before")
+    @classmethod
+    def empty_responses_if_none(cls, responses: Optional[List[UserResponseModel]]) -> Optional[List[UserResponseModel]]:
+        """Ensure responses is None if not provided."""
+        if responses is None:
+            return []
+        return responses
+
+    @field_validator("suggestions", mode="before")
+    @classmethod
+    def empty_suggestions_if_none(
+        cls, suggestions: Optional[Union[Tuple[SuggestionModel], List[SuggestionModel]]]
+    ) -> Optional[Union[Tuple[SuggestionModel], List[SuggestionModel]]]:
+        """Ensure suggestions is None if not provided."""
+        if suggestions is None:
+            return []
+        return suggestions

--- a/argilla/src/argilla/records/_resource.py
+++ b/argilla/src/argilla/records/_resource.py
@@ -408,6 +408,9 @@ class RecordSuggestions(Iterable[Suggestion]):
     def __getitem__(self, question_name: str):
         return self._suggestion_by_question_name[question_name]
 
+    def __len__(self):
+        return len(self._suggestion_by_question_name)
+
     def __repr__(self) -> str:
         return self.to_dict().__repr__()
 

--- a/argilla/tests/unit/test_resources/test_records.py
+++ b/argilla/tests/unit/test_resources/test_records.py
@@ -15,9 +15,21 @@
 import uuid
 
 import pytest
-from argilla import Record, Response, Suggestion
+
+from argilla import Record, Response, Suggestion, Dataset, Settings, TextQuestion, TextField
 from argilla._exceptions import ArgillaError
-from argilla._models import MetadataModel
+from argilla._models import MetadataModel, RecordModel
+
+
+@pytest.fixture()
+def dataset():
+    return Dataset(
+        name="test_dataset",
+        settings=Settings(
+            fields=[TextField(name="name", required=True), TextField(name="age", required=True)],
+            questions=[TextQuestion(name="question", required=True)],
+        ),
+    )
 
 
 class TestRecords:
@@ -88,3 +100,18 @@ class TestRecords:
 
         with pytest.raises(ArgillaError):
             record.responses.add(response)
+
+    def test_record_from_model_with_none_vectors(self, dataset: Dataset):
+        record = Record.from_model(RecordModel(fields={"name": "John"}, vectors=None), dataset=dataset)
+
+        assert len(record.vectors) == 0
+
+    def test_record_from_model_with_none_suggestions(self, dataset: Dataset):
+        record = Record.from_model(RecordModel(fields={"name": "John"}, suggestions=None), dataset=dataset)
+
+        assert len(record.suggestions) == 0
+
+    def test_record_from_model_with_none_responses(self, dataset: Dataset):
+        record = Record.from_model(RecordModel(fields={"name": "John"}, responses=None), dataset=dataset)
+
+        assert len(record.responses) == 0


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The API can return records with `None` values for vectors, suggestions, or responses, making the SDK raise an error. This PR prevents those errors.

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
