### PR TITLE
[BUGFIX] `argilla`: Fix some `from_hub` method errors

### DIFF
--- a/argilla/CHANGELOG.md
+++ b/argilla/CHANGELOG.md
@@ -16,6 +16,12 @@ These are the section headers that we use:
 
 ## [Unreleased]()
 
+### Fixed
+
+- Fixed `from_hub` errors when columns names contain uppercase letters. ([#5523](https://github.com/argilla-io/argilla/pull/5523))
+- Fixed `from_hub` errors when class feature values contains unlabelled values. ([#5523](https://github.com/argilla-io/argilla/pull/5523))
+- Fixed `from_hub` errors when loading cached datasets. ([#5523](https://github.com/argilla-io/argilla/pull/5523))
+
 ## [2.2.0](https://github.com/argilla-io/argilla/compare/v2.1.0...v2.2.0)
 
 - Added new `ChatField` supporting chat messages. ([#5376](https://github.com/argilla-io/argilla/pull/5376))

--- a/argilla/src/argilla/_exceptions/__init__.py
+++ b/argilla/src/argilla/_exceptions/__init__.py
@@ -18,3 +18,4 @@ from argilla._exceptions._metadata import *  # noqa: F403
 from argilla._exceptions._serialization import *  # noqa: F403
 from argilla._exceptions._settings import *  # noqa: F403
 from argilla._exceptions._records import *  # noqa: F403
+from argilla._exceptions._hub import *  # noqa: F403

--- a/argilla/src/argilla/_exceptions/_hub.py
+++ b/argilla/src/argilla/_exceptions/_hub.py
@@ -11,7 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from argilla._exceptions import ArgillaError
+
+__all__ = [
+    "ImportDatasetError",
+    "DatasetsServerException",
+]
 
 
-class DatasetsServerException(Exception):
-    message: str = "Error connecting to Hugging Face Hub datasets-server API"
+class ImportDatasetError(ArgillaError):
+    def __init__(self, message: str = "Error importing dataset") -> None:
+        super().__init__(message)
+
+
+class DatasetsServerException(ArgillaError):
+    def __init__(self, message: str = "Error connecting to Hugging Face Hub datasets-server API") -> None:
+        super().__init__(message)

--- a/argilla/src/argilla/datasets/_io/_hub.py
+++ b/argilla/src/argilla/datasets/_io/_hub.py
@@ -24,6 +24,7 @@ from datasets import DatasetDict
 from datasets.data_files import EmptyDatasetError
 from PIL import Image
 
+from argilla._exceptions import ImportDatasetError
 from argilla._exceptions._api import UnprocessableEntityError
 from argilla._exceptions._records import RecordsIngestionError
 from argilla._exceptions._settings import SettingsError
@@ -156,7 +157,7 @@ class HubImportExportMixin(DiskImportExportMixin):
                 dataset = cls.from_disk(
                     path=folder_path, workspace=workspace, name=name, client=client, with_records=with_records
                 )
-            except NotADirectoryError:
+            except ImportDatasetError:
                 from argilla import Settings
 
                 settings = Settings.from_hub(repo_id=repo_id)

--- a/argilla/src/argilla/datasets/_io/_hub.py
+++ b/argilla/src/argilla/datasets/_io/_hub.py
@@ -192,8 +192,11 @@ class HubImportExportMixin(DiskImportExportMixin):
     @staticmethod
     def _log_dataset_records(hf_dataset: "HFDataset", dataset: "Dataset"):
         """This method extracts the responses from a Hugging Face dataset and returns a list of `Record` objects"""
+        # THIS IS REQUIRED SINCE NAME IN ARGILLA ARE LOWERCASE. The Settings BaseModel models apply this logic
+        # Ideally, the restrictions in Argilla should be removed and the names should be case-insensitive
+        hf_dataset = hf_dataset.rename_columns({col: col.lower() for col in hf_dataset.column_names})
 
-        # Identify columns that colunms that contain responses
+        # Identify columns that columns that contain responses
         responses_columns = [col for col in hf_dataset.column_names if ".responses" in col]
         response_questions = defaultdict(dict)
         user_ids = {}

--- a/argilla/src/argilla/settings/_io/_hub.py
+++ b/argilla/src/argilla/settings/_io/_hub.py
@@ -165,6 +165,9 @@ def _define_settings_from_features(
         feature_type = _map_feature_type(feature)
         attribute_definition = _map_attribute_type(feature_mapping.get(name))
 
+        # Lowercase the name to avoid case sensitivity issues when mapping the features to the settings.
+        name = name.lower()
+
         if feature_type == FeatureType.CHAT:
             fields.append(ChatField(name=name, required=False))
         elif feature_type == FeatureType.TEXT:

--- a/argilla/tests/integration/test_import_features.py
+++ b/argilla/tests/integration/test_import_features.py
@@ -80,6 +80,7 @@ def token():
     return os.getenv("HF_TOKEN_ARGILLA_INTERNAL_TESTING")
 
 
+@pytest.mark.skipif(not os.getenv("HF_TOKEN_ARGILLA_INTERNAL_TESTING"), reason="No HF token provided")
 class TestImportFeaturesFromHub:
     def test_import_records_from_datasets_with_classlabel(
         self, token: str, dataset: rg.Dataset, client, mock_data: List[dict[str, Any]]

--- a/argilla/tests/integration/test_import_features.py
+++ b/argilla/tests/integration/test_import_features.py
@@ -112,3 +112,21 @@ class TestImportFeaturesFromHub:
 
         assert exported_dataset.features["label.suggestion"].names == ["positive", "negative"]
         assert exported_dataset["label.suggestion"] == [0, 1, 0]
+
+    def test_import_from_hub_with_upper_case_columns(self, client: rg.Argilla, token: str, dataset_name: str):
+        created_dataset = rg.Dataset.from_hub(
+            "argilla-internal-testing/test_import_from_hub_with_upper_case_columns",
+            token=token,
+            name=dataset_name,
+        )
+
+        assert created_dataset.settings.fields[0].name == "text"
+        assert list(created_dataset.records)[0].fields["text"] == "Hello World, how are you?"
+
+    def test_import_from_hub_with_unlabelled_classes(self, client: rg.Argilla, token: str, dataset_name: str):
+        created_dataset = rg.Dataset.from_hub(
+            "argilla-internal-testing/test_import_from_hub_with_unlabelled_classes", token=token, name=dataset_name
+        )
+
+        assert created_dataset.settings.fields[0].name == "text"
+        assert list(created_dataset.records)[0].fields["text"] == "Hello World, how are you?"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Trying this code:

```python
import argilla as rg

client = rg.Argilla(...)

dataset = rg.Dataset.from_hub("google-research-datasets/circa")
```
I found several errors ([Here the source dataset](https://huggingface.co/datasets/google-research-datasets/circa/viewer/default/train?f[goldstandard2][value]=0)):
- The mapping for records does not match since column names contain uppercase characters
- Some values for the ClassValue column are unlabelled,  making the uncast process fail (-1)
- Importing cached datasets without config files fails when trying to read the dataset JSON file.

So, this PR tackles all the problems commented below.



**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
