### PR TITLE
[BUGFIX] `argilla`: improve `from_hub` robustness

### DIFF
--- a/argilla/src/argilla/datasets/_io/_hub.py
+++ b/argilla/src/argilla/datasets/_io/_hub.py
@@ -193,11 +193,16 @@ class HubImportExportMixin(DiskImportExportMixin):
     @staticmethod
     def _log_dataset_records(hf_dataset: "HFDataset", dataset: "Dataset"):
         """This method extracts the responses from a Hugging Face dataset and returns a list of `Record` objects"""
-        # THIS IS REQUIRED SINCE NAME IN ARGILLA ARE LOWERCASE. The Settings BaseModel models apply this logic
-        # Ideally, the restrictions in Argilla should be removed and the names should be case-insensitive
-        hf_dataset = hf_dataset.rename_columns(
-            {col: dataset.settings._curated_settings_name(col) for col in hf_dataset.column_names}
-        )
+        # THIS IS REQUIRED SINCE THE NAME RESTRICTION IN ARGILLA. HUGGING FACE DATASET COLUMNS ARE CASE SENSITIVE
+        # Also, there is a logic with column names including ".responses" and ".suggestion" in the name.
+        columns_map = {}
+        for column in hf_dataset.column_names:
+            if ".responses" in column or ".suggestion" in column:
+                columns_map[column] = column.lower()
+            else:
+                columns_map[column] = dataset.settings._curated_settings_name(column)
+
+        hf_dataset = hf_dataset.rename_columns(columns_map)
 
         # Identify columns that columns that contain responses
         responses_columns = [col for col in hf_dataset.column_names if ".responses" in col]

--- a/argilla/src/argilla/datasets/_io/_hub.py
+++ b/argilla/src/argilla/datasets/_io/_hub.py
@@ -137,6 +137,7 @@ class HubImportExportMixin(DiskImportExportMixin):
         """
         from datasets import load_dataset
         from huggingface_hub import snapshot_download
+        from argilla import Dataset
 
         if name is None:
             name = Dataset._sanitize_name(repo_id)

--- a/argilla/src/argilla/datasets/_io/_hub.py
+++ b/argilla/src/argilla/datasets/_io/_hub.py
@@ -139,7 +139,7 @@ class HubImportExportMixin(DiskImportExportMixin):
         from huggingface_hub import snapshot_download
 
         if name is None:
-            name = repo_id.replace("/", "_")
+            name = Dataset._sanitize_name(repo_id)
 
         if settings is not None:
             dataset = cls(name=name, settings=settings)
@@ -200,7 +200,7 @@ class HubImportExportMixin(DiskImportExportMixin):
             if ".responses" in column or ".suggestion" in column:
                 columns_map[column] = column.lower()
             else:
-                columns_map[column] = dataset.settings._curated_settings_name(column)
+                columns_map[column] = dataset.settings._sanitize_settings_name(column)
 
         hf_dataset = hf_dataset.rename_columns(columns_map)
 

--- a/argilla/src/argilla/datasets/_io/_hub.py
+++ b/argilla/src/argilla/datasets/_io/_hub.py
@@ -195,7 +195,9 @@ class HubImportExportMixin(DiskImportExportMixin):
         """This method extracts the responses from a Hugging Face dataset and returns a list of `Record` objects"""
         # THIS IS REQUIRED SINCE NAME IN ARGILLA ARE LOWERCASE. The Settings BaseModel models apply this logic
         # Ideally, the restrictions in Argilla should be removed and the names should be case-insensitive
-        hf_dataset = hf_dataset.rename_columns({col: col.lower() for col in hf_dataset.column_names})
+        hf_dataset = hf_dataset.rename_columns(
+            {col: dataset.settings._curated_settings_name(col) for col in hf_dataset.column_names}
+        )
 
         # Identify columns that columns that contain responses
         responses_columns = [col for col in hf_dataset.column_names if ".responses" in col]

--- a/argilla/src/argilla/datasets/_io/_hub.py
+++ b/argilla/src/argilla/datasets/_io/_hub.py
@@ -118,6 +118,7 @@ class HubImportExportMixin(DiskImportExportMixin):
         with_records: bool = True,
         settings: Optional["Settings"] = None,
         split: Optional[str] = None,
+        subset: Optional[str] = None,
         **kwargs: Any,
     ):
         """Loads a `Dataset` from the Hugging Face Hub.
@@ -170,6 +171,7 @@ class HubImportExportMixin(DiskImportExportMixin):
                     with_records=with_records,
                     settings=settings,
                     split=split,
+                    subset=subset,
                     **kwargs,
                 )
                 return dataset
@@ -179,6 +181,7 @@ class HubImportExportMixin(DiskImportExportMixin):
                 hf_dataset = load_dataset(
                     path=repo_id,
                     split=split,
+                    name=subset,
                     **kwargs,
                 )  # type: ignore
                 hf_dataset = cls._get_dataset_split(hf_dataset=hf_dataset, split=split, **kwargs)

--- a/argilla/src/argilla/datasets/_io/_hub.py
+++ b/argilla/src/argilla/datasets/_io/_hub.py
@@ -162,7 +162,7 @@ class HubImportExportMixin(DiskImportExportMixin):
             except ImportDatasetError:
                 from argilla import Settings
 
-                settings = Settings.from_hub(repo_id=repo_id)
+                settings = Settings.from_hub(repo_id=repo_id, subset=subset)
                 dataset = cls.from_hub(
                     repo_id=repo_id,
                     name=name,

--- a/argilla/src/argilla/datasets/_resource.py
+++ b/argilla/src/argilla/datasets/_resource.py
@@ -269,3 +269,11 @@ class Dataset(Resource, HubImportExportMixin, DiskImportExportMixin):
 
     def _is_published(self) -> bool:
         return self._model.status == "ready"
+
+    @classmethod
+    def _sanitize_name(cls, name: str):
+        name = name.replace(" ", "_")
+
+        for character in ["/", "\\", ".", ",", ";", ":", "-", "+", "="]:
+            name = name.replace(character, "-")
+        return name

--- a/argilla/src/argilla/settings/_io/_hub.py
+++ b/argilla/src/argilla/settings/_io/_hub.py
@@ -136,7 +136,7 @@ def _render_code_snippet(repo_id: str):
     from rich.syntax import Syntax
 
     message = """
-    No questions found in the dataset features. A default question 'quality' has been added. 
+    No questions found in the dataset features. A default question 'quality' has been added.
     If you want to customize the dataset differently, you can do the following:
     """
     code_block = f"""

--- a/argilla/src/argilla/settings/_io/_hub.py
+++ b/argilla/src/argilla/settings/_io/_hub.py
@@ -142,7 +142,7 @@ def _render_code_snippet(repo_id: str):
     code_block = f"""
     # 1. map the dataset columns to question, field, vector, or metadata                                      
     settings = rg.Settings.from_hub(                                                                               
-        repo_id="yahma/alpaca-cleaned",                                                                            
+        repo_id="{repo_id}",                                                                            
         feature_mapping={"{"}"<column_name>": "question"{"}"},                                         
     )                                                                                                              
     # 2. or, create new questions, fields, vectors, or metadata properties                                         
@@ -172,6 +172,7 @@ def _define_settings_from_features(
         ImageField,
         LabelQuestion,
         TextQuestion,
+        RatingQuestion,
         Settings,
         TextField,
         ChatField,
@@ -227,7 +228,15 @@ def _define_settings_from_features(
             warnings.warn(f"Feature '{name}' has an unsupported type. Skipping. Feature type: {feature_type}")
 
     if not questions:
-        questions.append(LabelQuestion(name="quality", required=True, labels=["good", "bad"]))
+        questions.append(
+            RatingQuestion(
+                name="quality",
+                title="Quality",
+                description="How would you rate the quality of the record?",
+                required=True,
+                values=[0, 1, 2, 3, 4, 5],
+            )
+        )
         warnings.warn(
             "No questions found in the dataset features. A default question 'quality' with labels ['good', 'bad'] has been added"
         )

--- a/argilla/src/argilla/settings/_io/_hub.py
+++ b/argilla/src/argilla/settings/_io/_hub.py
@@ -210,7 +210,7 @@ def _define_settings_from_features(
         feature_type = _map_feature_type(feature)
         attribute_definition = _map_attribute_type(feature_mapping.get(name))
 
-        name = Settings._curated_settings_name(name)
+        name = Settings._sanitize_settings_name(name)
 
         if not Settings._is_valid_name(name):
             warnings.warn(f"Feature '{name}' has an invalid name. Skipping.")

--- a/argilla/src/argilla/settings/_io/_hub.py
+++ b/argilla/src/argilla/settings/_io/_hub.py
@@ -140,14 +140,14 @@ def _render_code_snippet(repo_id: str):
     You can also add custom settings to the dataset by manipulting the settings object.
     """
     code_block = f"""
-    # 1. map the dataset columns to question, field, vector, or metadata                                      
-    settings = rg.Settings.from_hub(                                                                               
-        repo_id="{repo_id}",                                                                            
-        feature_mapping={"{"}"<column_name>": "question"{"}"},                                         
-    )                                                                                                              
-    # 2. or, create new questions, fields, vectors, or metadata properties                                         
-    settings.questions = [rg.TextQuestion(name="new_question", required=True)]                                     
-    dataset = rg.Dataset.from_hub(repo_id="{repo_id}", settings=settings) 
+    # 1. map the dataset columns to question, field, vector, or metadata
+    settings = rg.Settings.from_hub(
+        repo_id="{repo_id}",
+        feature_mapping={"{"}"<column_name>": "question"{"}"},
+    )
+    # 2. or, create new questions, fields, vectors, or metadata properties
+    settings.questions = [rg.TextQuestion(name="new_question", required=True)]
+    dataset = rg.Dataset.from_hub(repo_id="{repo_id}", settings=settings)
     """
 
     console = Console()

--- a/argilla/src/argilla/settings/_io/_hub.py
+++ b/argilla/src/argilla/settings/_io/_hub.py
@@ -136,8 +136,8 @@ def _render_code_snippet(repo_id: str):
     from rich.syntax import Syntax
 
     message = """
-    You can assign the dataset's columns to questions, fields, or metadata properties using the feature_mapping argument.
-    You can also add custom settings to the dataset by manipulting the settings object.
+    No questions found in the dataset features. A default question 'quality' has been added. 
+    If you want to customize the dataset differently, you can do the following:
     """
     code_block = f"""
     # 1. map the dataset columns to question, field, vector, or metadata                                      
@@ -152,8 +152,7 @@ def _render_code_snippet(repo_id: str):
 
     console = Console()
     code_block = Syntax(code_block, "python", theme="github-dark", line_numbers=False, indent_guides=False)
-    console.print(message)
-    console.print(code_block)
+    console.print(message, code_block)
 
 
 def _define_settings_from_features(
@@ -239,9 +238,6 @@ def _define_settings_from_features(
                 required=True,
                 values=[0, 1, 2, 3, 4, 5],
             )
-        )
-        warnings.warn(
-            "No questions found in the dataset features. A default question 'quality' with labels ['good', 'bad'] has been added"
         )
         _render_code_snippet(repo_id)
 

--- a/argilla/src/argilla/settings/_io/_hub.py
+++ b/argilla/src/argilla/settings/_io/_hub.py
@@ -140,20 +140,19 @@ def _render_code_snippet(repo_id: str):
     You can also add custom settings to the dataset by manipulting the settings object.
     """
     code_block = f"""
-    settings = rg.Settings(
-        repo_id="{repo_id}",
-        feature_mapping={{{{"<column_name>": "question"}}}}
-    )
-    # add more custom settings here
-    # via settings.questions, settings.fields, settings.vectors, or settings.metadata
-    dataset = rg.Dataset(name="{repo_id}", settings=settings)
-    ds = load_dataset("{repo_id}")
-    dataset.records.log(ds)
+    # 1. map the dataset columns to question, field, vector, or metadata                                      
+    settings = rg.Settings.from_hub(                                                                               
+        repo_id="yahma/alpaca-cleaned",                                                                            
+        feature_mapping={"{"}"<column_name>": "question"{"}"},                                         
+    )                                                                                                              
+    # 2. or, create new questions, fields, vectors, or metadata properties                                         
+    settings.questions = [rg.TextQuestion(name="new_question", required=True)]                                     
+    dataset = rg.Dataset.from_hub(repo_id="{repo_id}", settings=settings) 
     """
 
     console = Console()
-    code_block = Syntax(code_block, "python", theme="monokai", line_numbers=True)
-    console.print(f"[bold yellow]{message}[/bold yellow]")
+    code_block = Syntax(code_block, "python", theme="github-dark", line_numbers=False, indent_guides=False)
+    console.print(message)
     console.print(code_block)
 
 

--- a/argilla/src/argilla/settings/_io/_hub.py
+++ b/argilla/src/argilla/settings/_io/_hub.py
@@ -189,8 +189,11 @@ def _define_settings_from_features(
         feature_type = _map_feature_type(feature)
         attribute_definition = _map_attribute_type(feature_mapping.get(name))
 
-        # Lowercase the name to avoid case sensitivity issues when mapping the features to the settings.
-        name = name.lower()
+        name = Settings._curated_settings_name(name)
+
+        if not Settings._is_valid_name(name):
+            warnings.warn(f"Feature '{name}' has an invalid name. Skipping.")
+            continue
 
         if feature_type == FeatureType.CHAT:
             fields.append(ChatField(name=name, required=False))

--- a/argilla/src/argilla/settings/_io/_hub.py
+++ b/argilla/src/argilla/settings/_io/_hub.py
@@ -140,14 +140,14 @@ def _render_code_snippet(repo_id: str):
     You can also add custom settings to the dataset by manipulting the settings object.
     """
     code_block = f"""
-    # 1. map the dataset columns to question, field, vector, or metadata                                      
-    settings = rg.Settings.from_hub(                                                                               
-        repo_id="yahma/alpaca-cleaned",                                                                            
-        feature_mapping={"{"}"<column_name>": "question"{"}"},                                         
-    )                                                                                                              
-    # 2. or, create new questions, fields, vectors, or metadata properties                                         
-    settings.questions = [rg.TextQuestion(name="new_question", required=True)]                                     
-    dataset = rg.Dataset.from_hub(repo_id="{repo_id}", settings=settings) 
+    # 1. map the dataset columns to question, field, vector, or metadata
+    settings = rg.Settings.from_hub(
+        repo_id="yahma/alpaca-cleaned",
+        feature_mapping={"{"}"<column_name>": "question"{"}"},
+    )
+    # 2. or, create new questions, fields, vectors, or metadata properties
+    settings.questions = [rg.TextQuestion(name="new_question", required=True)]
+    dataset = rg.Dataset.from_hub(repo_id="{repo_id}", settings=settings)
     """
 
     console = Console()

--- a/argilla/src/argilla/settings/_io/_hub.py
+++ b/argilla/src/argilla/settings/_io/_hub.py
@@ -14,7 +14,6 @@
 
 import httpx
 import warnings
-from collections import defaultdict
 from enum import Enum
 from typing import Any, Dict, TYPE_CHECKING, Union, List, Optional
 
@@ -136,13 +135,13 @@ def _render_code_snippet(repo_id: str):
     from rich.console import Console
     from rich.syntax import Syntax
 
-    message = f"""
+    message = """
     You can assign the dataset's columns to questions, fields, or metadata properties using the feature_mapping argument.
     You can also add custom settings to the dataset by manipulting the settings object.
     """
     code_block = f"""
     settings = rg.Settings(
-        repo_id="{repo_id}", 
+        repo_id="{repo_id}",
         feature_mapping={{{{"<column_name>": "question"}}}}
     )
     # add more custom settings here

--- a/argilla/src/argilla/settings/_io/_hub.py
+++ b/argilla/src/argilla/settings/_io/_hub.py
@@ -169,14 +169,11 @@ def _define_settings_from_features(
             fields.append(ChatField(name=name, required=False))
         elif feature_type == FeatureType.TEXT:
             if attribute_definition == AttributeType.QUESTION:
-                questions.append(TextQuestion(name=name))
+                questions.append(TextQuestion(name=name, required=False))
             elif attribute_definition == AttributeType.FIELD:
                 fields.append(TextField(name=name, required=False))
             elif attribute_definition is None:
-                questions.append(TextQuestion(name=f"{name}_question"))
                 fields.append(TextField(name=name, required=False))
-                mapping[name].append(name)
-                mapping[name].append(f"{name}_question")
             else:
                 raise SettingsError(
                     f"Attribute definition '{attribute_definition}' is not supported for feature '{name}'."
@@ -190,25 +187,10 @@ def _define_settings_from_features(
             if names is None:
                 warnings.warn(f"Feature '{name}' has no labels. Skipping.")
                 continue
-            if attribute_definition == AttributeType.QUESTION:
-                questions.append(
-                    LabelQuestion(
-                        name=name,
-                        labels=names,
-                    )
-                )
+            if attribute_definition == AttributeType.QUESTION or attribute_definition is None:
+                questions.append(LabelQuestion(name=name, labels=names, required=False))
             elif attribute_definition == AttributeType.FIELD:
                 metadata.append(TermsMetadataProperty(name=name))
-            elif attribute_definition is None:
-                questions.append(
-                    LabelQuestion(
-                        name=name,
-                        labels=names,
-                    )
-                )
-                metadata.append(TermsMetadataProperty(name=f"{name}_metadata"))
-                mapping[name].append(name)
-                mapping[name].append(f"{name}_metadata")
             else:
                 raise SettingsError(
                     f"Attribute definition '{attribute_definition}' is not supported for feature '{name}'."

--- a/argilla/src/argilla/settings/_io/_hub.py
+++ b/argilla/src/argilla/settings/_io/_hub.py
@@ -166,7 +166,7 @@ def _render_code_snippet(repo_id: str):
     settings = rg.Settings.from_hub(repo_id="{repo_id}")
     settings.questions.add(rg.TextQuestion(name="new_question", required=True))
     dataset = rg.Dataset.from_hub(repo_id="{repo_id}", settings=settings)
-    
+
     # 2. Map the dataset's columns to question, field, or metadata
     settings = rg.Settings.from_hub(
         repo_id="{repo_id}",

--- a/argilla/src/argilla/settings/_resource.py
+++ b/argilla/src/argilla/settings/_resource.py
@@ -262,11 +262,20 @@ class Settings(DefaultSettingsMixin, Resource):
 
     @classmethod
     def from_hub(
-        cls, repo_id: str, feature_mapping: Optional[Dict[str, Literal["question", "field", "metadata"]]] = None
+        cls,
+        repo_id: str,
+        subset: Optional[str] = None,
+        feature_mapping: Optional[Dict[str, Literal["question", "field", "metadata"]]] = None,
+        **kwargs,
     ) -> "Settings":
-        """Load the settings from the Hub"""
+        """Load the settings from the Hub
 
-        settings = build_settings_from_repo_id(repo_id=repo_id, feature_mapping=feature_mapping)
+        Parameters:
+            repo_id (str): The ID of the repository to load the settings from on the Hub.
+            feature_mapping (Dict[str, Literal["question", "field", "metadata"]]): A dictionary that maps incoming column names to Argilla attributes.
+        """
+
+        settings = build_settings_from_repo_id(repo_id=repo_id, feature_mapping=feature_mapping, subset=subset)
         return settings
 
     def __eq__(self, other: "Settings") -> bool:

--- a/argilla/src/argilla/settings/_resource.py
+++ b/argilla/src/argilla/settings/_resource.py
@@ -14,6 +14,7 @@
 
 import json
 import os
+import re
 from functools import cached_property
 from pathlib import Path
 from typing import List, Optional, TYPE_CHECKING, Dict, Union, Iterator, Sequence, Literal
@@ -391,7 +392,7 @@ class Settings(DefaultSettingsMixin, Resource):
                 dataset_properties_by_name[property.name] = property
 
     @classmethod
-    def _validate_mapping(cls, mapping: Dict[str, Union[str, Sequence[str]]]) -> None:
+    def _validate_mapping(cls, mapping: Dict[str, Union[str, Sequence[str]]]) -> dict:
         validate_mapping = {}
         for key, value in mapping.items():
             if isinstance(value, str):
@@ -400,7 +401,17 @@ class Settings(DefaultSettingsMixin, Resource):
                 validate_mapping[key] = tuple(value)
             else:
                 raise SettingsError(f"Invalid mapping value for key {key!r}: {value}")
+
         return validate_mapping
+
+    @classmethod
+    def _curated_settings_name(cls, name: str) -> str:
+        """Curate the name of the settings"""
+
+        for char in [" ", ":", ".", "&", "?", "!"]:
+            name = name.replace(char, "_")
+
+        return name.lower()
 
     def __process_guidelines(self, guidelines):
         if guidelines is None:
@@ -414,6 +425,11 @@ class Settings(DefaultSettingsMixin, Resource):
                 return file.read()
 
         return guidelines
+
+    @classmethod
+    def _is_valid_name(cls, name: str) -> bool:
+        """Check if the name is valid"""
+        return bool(re.match(r"^(?=.*[a-z0-9])[a-z0-9_-]+$", name))
 
 
 Property = Union[Field, VectorField, MetadataType, QuestionType]

--- a/argilla/src/argilla/settings/_resource.py
+++ b/argilla/src/argilla/settings/_resource.py
@@ -23,8 +23,8 @@ from uuid import UUID
 from argilla._exceptions import SettingsError, ArgillaAPIError, ArgillaSerializeError
 from argilla._models._dataset import DatasetModel
 from argilla._resource import Resource
-from argilla.settings._io import build_settings_from_repo_id
 from argilla.settings._field import Field, _field_from_dict, _field_from_model
+from argilla.settings._io import build_settings_from_repo_id
 from argilla.settings._metadata import MetadataType, MetadataField
 from argilla.settings._question import QuestionType, question_from_model, question_from_dict
 from argilla.settings._task_distribution import TaskDistribution
@@ -405,8 +405,8 @@ class Settings(DefaultSettingsMixin, Resource):
         return validate_mapping
 
     @classmethod
-    def _curated_settings_name(cls, name: str) -> str:
-        """Curate the name of the settings"""
+    def _sanitize_settings_name(cls, name: str) -> str:
+        """Sanitize the name for the settings"""
 
         for char in [" ", ":", ".", "&", "?", "!"]:
             name = name.replace(char, "_")

--- a/argilla/src/argilla/settings/_resource.py
+++ b/argilla/src/argilla/settings/_resource.py
@@ -272,6 +272,7 @@ class Settings(DefaultSettingsMixin, Resource):
 
         Parameters:
             repo_id (str): The ID of the repository to load the settings from on the Hub.
+            subset (Optional[str]): The subset of the repository to load the settings from.
             feature_mapping (Dict[str, Literal["question", "field", "metadata"]]): A dictionary that maps incoming column names to Argilla attributes.
         """
 

--- a/argilla/tests/unit/test_settings/test_settings_from_features.py
+++ b/argilla/tests/unit/test_settings/test_settings_from_features.py
@@ -29,7 +29,6 @@ def test_define_settings_from_features_text():
     assert len(settings.questions) == 1
     assert isinstance(settings.questions[0], rg.LabelQuestion)
     assert settings.questions[0].name == "quality"
-    assert settings.mapping == {}
 
 
 def test_define_settings_from_features_image():
@@ -41,7 +40,6 @@ def test_define_settings_from_features_image():
     assert settings.fields[0].name == "image_column"
     assert len(settings.questions) == 1
     assert settings.questions[0].name == "quality"
-    assert settings.mapping == {}
 
 
 def test_define_settings_from_features_multiple():
@@ -60,7 +58,6 @@ def test_define_settings_from_features_multiple():
     assert len(settings.questions) == 1
     assert isinstance(settings.questions[0], rg.LabelQuestion)
     assert settings.questions[0].name == "label_column"
-    assert settings.mapping == {}
 
 
 def test_mapped_question():
@@ -79,7 +76,6 @@ def test_mapped_question():
     assert settings.questions[0].name == "text_column"
     assert isinstance(settings.questions[1], rg.LabelQuestion)
     assert settings.questions[1].name == "label_column"
-    assert settings.mapping == {}
 
 
 def test_mapped_fields():
@@ -98,7 +94,6 @@ def test_mapped_fields():
     assert len(settings.questions) == 1
     assert isinstance(settings.questions[0], rg.LabelQuestion)
     assert settings.questions[0].name == "label_column"
-    assert settings.mapping == {}
 
 
 def test_define_settings_from_features_unsupported():

--- a/argilla/tests/unit/test_settings/test_settings_from_features.py
+++ b/argilla/tests/unit/test_settings/test_settings_from_features.py
@@ -27,7 +27,7 @@ def test_define_settings_from_features_text():
     assert isinstance(settings.fields[0], rg.TextField)
     assert settings.fields[0].name == "text_column"
     assert len(settings.questions) == 1
-    assert isinstance(settings.questions[0], rg.TextQuestion)
+    assert isinstance(settings.questions[0], rg.LabelQuestion)
     assert settings.questions[0].name == "quality"
     assert settings.mapping == {}
 

--- a/argilla/tests/unit/test_settings/test_settings_from_features.py
+++ b/argilla/tests/unit/test_settings/test_settings_from_features.py
@@ -21,26 +21,26 @@ from argilla.settings._io._hub import _define_settings_from_features
 
 def test_define_settings_from_features_text():
     features = {"text_column": {"_type": "Value", "dtype": "string"}}
-    settings = _define_settings_from_features(features, feature_mapping={})
+    settings = _define_settings_from_features(features, feature_mapping={}, repo_id="repo_id")
 
     assert len(settings.fields) == 1
     assert isinstance(settings.fields[0], rg.TextField)
     assert settings.fields[0].name == "text_column"
     assert len(settings.questions) == 1
     assert isinstance(settings.questions[0], rg.TextQuestion)
-    assert settings.questions[0].name == "comment"
+    assert settings.questions[0].name == "quality"
     assert settings.mapping == {}
 
 
 def test_define_settings_from_features_image():
     features = {"image_column": {"_type": "Image"}}
-    settings = _define_settings_from_features(features, feature_mapping={})
+    settings = _define_settings_from_features(features, feature_mapping={}, repo_id="repo_id")
 
     assert len(settings.fields) == 1
     assert isinstance(settings.fields[0], rg.ImageField)
     assert settings.fields[0].name == "image_column"
     assert len(settings.questions) == 1
-    assert settings.questions[0].name == "comment"
+    assert settings.questions[0].name == "quality"
     assert settings.mapping == {}
 
 
@@ -50,7 +50,7 @@ def test_define_settings_from_features_multiple():
         "image_column": {"_type": "Image"},
         "label_column": {"_type": "ClassLabel", "names": ["A", "B"]},
     }
-    settings = _define_settings_from_features(features, feature_mapping={})
+    settings = _define_settings_from_features(features, feature_mapping={}, repo_id="repo_id")
 
     assert len(settings.fields) == 2
     assert isinstance(settings.fields[0], rg.TextField)
@@ -69,7 +69,7 @@ def test_mapped_question():
         "image_column": {"_type": "Image"},
         "label_column": {"_type": "ClassLabel", "names": ["A", "B"]},
     }
-    settings = _define_settings_from_features(features, feature_mapping={"text_column": "question"})
+    settings = _define_settings_from_features(features, feature_mapping={"text_column": "question"}, repo_id="repo_id")
 
     assert len(settings.fields) == 1
     assert isinstance(settings.fields[0], rg.ImageField)
@@ -88,7 +88,7 @@ def test_mapped_fields():
         "image_column": {"_type": "Image"},
         "label_column": {"_type": "ClassLabel", "names": ["A", "B"]},
     }
-    settings = _define_settings_from_features(features, feature_mapping={"text_column": "field"})
+    settings = _define_settings_from_features(features, feature_mapping={"text_column": "field"}, repo_id="repo_id")
 
     assert len(settings.fields) == 2
     assert isinstance(settings.fields[0], rg.TextField)
@@ -108,7 +108,7 @@ def test_define_settings_from_features_unsupported():
         "label_column": {"_type": "ClassLabel", "names": ["A", "B"]},
     }
     with pytest.warns(UserWarning, match="Feature 'unsupported_column' has an unsupported type"):
-        settings = _define_settings_from_features(features, feature_mapping={})
+        settings = _define_settings_from_features(features, feature_mapping={}, repo_id="repo_id")
 
     assert len(settings.fields) == 1
     assert len(settings.questions) == 1
@@ -118,4 +118,4 @@ def test_define_settings_from_only_label_raises():
     features = {"label_column": {"_type": "ClassLabel", "names": ["A", "B", "C"]}}
 
     with pytest.raises(SettingsError):
-        _define_settings_from_features(features, feature_mapping={})
+        _define_settings_from_features(features, feature_mapping={}, repo_id="repo_id")

--- a/argilla/tests/unit/test_settings/test_settings_from_features.py
+++ b/argilla/tests/unit/test_settings/test_settings_from_features.py
@@ -27,7 +27,7 @@ def test_define_settings_from_features_text():
     assert isinstance(settings.fields[0], rg.TextField)
     assert settings.fields[0].name == "text_column"
     assert len(settings.questions) == 1
-    assert isinstance(settings.questions[0], rg.LabelQuestion)
+    assert isinstance(settings.questions[0], rg.RatingQuestion)
     assert settings.questions[0].name == "quality"
 
 

--- a/argilla/tests/unit/test_settings/test_settings_from_features.py
+++ b/argilla/tests/unit/test_settings/test_settings_from_features.py
@@ -42,6 +42,32 @@ def test_define_settings_from_features_image():
     assert settings.questions[0].name == "quality"
 
 
+@pytest.mark.parametrize(
+    "column,name",
+    [
+        ("Text column", "text_column"),
+        ("text column", "text_column"),
+        ("text:column", "text_column"),
+        ("text.column", "text_column"),
+    ],
+)
+def test_define_settings_from_features_with_non_curated_column_name(column: str, name: str):
+    features = {column: {"_type": "Value", "dtype": "string"}}
+
+    settings = _define_settings_from_features(features, feature_mapping={}, repo_id="repo_id")
+
+    assert len(settings.fields) == 1
+    assert settings.fields[0].name == name
+
+
+@pytest.mark.parametrize("column", ["text<column", "text>column", "text|column", "text]column", "text/column"])
+def test_define_settings_from_features_with_unsupported_column_name(column: str):
+    features = {column: {"_type": "Value", "dtype": "string"}}
+
+    with pytest.raises(SettingsError):
+        _define_settings_from_features(features, feature_mapping={}, repo_id="repo_id")
+
+
 def test_define_settings_from_features_multiple():
     features = {
         "text_column": {"_type": "Value", "dtype": "string"},

--- a/argilla/tests/unit/test_settings/test_settings_from_features.py
+++ b/argilla/tests/unit/test_settings/test_settings_from_features.py
@@ -21,25 +21,25 @@ from argilla.settings._io._hub import _define_settings_from_features
 
 def test_define_settings_from_features_text():
     features = {"text_column": {"_type": "Value", "dtype": "string"}}
-    settings = _define_settings_from_features(features, feature_mapping={}, repo_id="repo_id")
+    settings = _define_settings_from_features(features, feature_mapping={})
 
     assert len(settings.fields) == 1
     assert isinstance(settings.fields[0], rg.TextField)
     assert settings.fields[0].name == "text_column"
-    assert len(settings.questions) == 1
-    assert isinstance(settings.questions[0], rg.RatingQuestion)
-    assert settings.questions[0].name == "quality"
+    assert len(settings.questions) == 0
+    # assert isinstance(settings.questions[0], rg.RatingQuestion)
+    # assert settings.questions[0].name == "quality"
 
 
 def test_define_settings_from_features_image():
     features = {"image_column": {"_type": "Image"}}
-    settings = _define_settings_from_features(features, feature_mapping={}, repo_id="repo_id")
+    settings = _define_settings_from_features(features, feature_mapping={})
 
     assert len(settings.fields) == 1
     assert isinstance(settings.fields[0], rg.ImageField)
     assert settings.fields[0].name == "image_column"
-    assert len(settings.questions) == 1
-    assert settings.questions[0].name == "quality"
+    # assert len(settings.questions) == 0
+    # assert settings.questions[0].name == "quality"
 
 
 @pytest.mark.parametrize(
@@ -54,7 +54,7 @@ def test_define_settings_from_features_image():
 def test_define_settings_from_features_with_non_curated_column_name(column: str, name: str):
     features = {column: {"_type": "Value", "dtype": "string"}}
 
-    settings = _define_settings_from_features(features, feature_mapping={}, repo_id="repo_id")
+    settings = _define_settings_from_features(features, feature_mapping={})
 
     assert len(settings.fields) == 1
     assert settings.fields[0].name == name
@@ -65,7 +65,7 @@ def test_define_settings_from_features_with_unsupported_column_name(column: str)
     features = {column: {"_type": "Value", "dtype": "string"}}
 
     with pytest.raises(SettingsError):
-        _define_settings_from_features(features, feature_mapping={}, repo_id="repo_id")
+        _define_settings_from_features(features, feature_mapping={})
 
 
 def test_define_settings_from_features_multiple():
@@ -74,7 +74,7 @@ def test_define_settings_from_features_multiple():
         "image_column": {"_type": "Image"},
         "label_column": {"_type": "ClassLabel", "names": ["A", "B"]},
     }
-    settings = _define_settings_from_features(features, feature_mapping={}, repo_id="repo_id")
+    settings = _define_settings_from_features(features, feature_mapping={})
 
     assert len(settings.fields) == 2
     assert isinstance(settings.fields[0], rg.TextField)
@@ -92,7 +92,7 @@ def test_mapped_question():
         "image_column": {"_type": "Image"},
         "label_column": {"_type": "ClassLabel", "names": ["A", "B"]},
     }
-    settings = _define_settings_from_features(features, feature_mapping={"text_column": "question"}, repo_id="repo_id")
+    settings = _define_settings_from_features(features, feature_mapping={"text_column": "question"})
 
     assert len(settings.fields) == 1
     assert isinstance(settings.fields[0], rg.ImageField)
@@ -110,7 +110,7 @@ def test_mapped_fields():
         "image_column": {"_type": "Image"},
         "label_column": {"_type": "ClassLabel", "names": ["A", "B"]},
     }
-    settings = _define_settings_from_features(features, feature_mapping={"text_column": "field"}, repo_id="repo_id")
+    settings = _define_settings_from_features(features, feature_mapping={"text_column": "field"})
 
     assert len(settings.fields) == 2
     assert isinstance(settings.fields[0], rg.TextField)
@@ -129,7 +129,7 @@ def test_define_settings_from_features_unsupported():
         "label_column": {"_type": "ClassLabel", "names": ["A", "B"]},
     }
     with pytest.warns(UserWarning, match="Feature 'unsupported_column' has an unsupported type"):
-        settings = _define_settings_from_features(features, feature_mapping={}, repo_id="repo_id")
+        settings = _define_settings_from_features(features, feature_mapping={})
 
     assert len(settings.fields) == 1
     assert len(settings.questions) == 1
@@ -139,4 +139,4 @@ def test_define_settings_from_only_label_raises():
     features = {"label_column": {"_type": "ClassLabel", "names": ["A", "B", "C"]}}
 
     with pytest.raises(SettingsError):
-        _define_settings_from_features(features, feature_mapping={}, repo_id="repo_id")
+        _define_settings_from_features(features, feature_mapping={})

--- a/argilla/tests/unit/test_settings/test_settings_from_features.py
+++ b/argilla/tests/unit/test_settings/test_settings_from_features.py
@@ -28,8 +28,8 @@ def test_define_settings_from_features_text():
     assert settings.fields[0].name == "text_column"
     assert len(settings.questions) == 1
     assert isinstance(settings.questions[0], rg.TextQuestion)
-    assert settings.questions[0].name == "text_column_question"
-    assert settings.mapping == {"text_column": ("text_column", "text_column_question")}
+    assert settings.questions[0].name == "comment"
+    assert settings.mapping == {}
 
 
 def test_define_settings_from_features_image():
@@ -57,15 +57,10 @@ def test_define_settings_from_features_multiple():
     assert settings.fields[0].name == "text_column"
     assert isinstance(settings.fields[1], rg.ImageField)
     assert settings.fields[1].name == "image_column"
-    assert len(settings.questions) == 2
-    assert isinstance(settings.questions[0], rg.TextQuestion)
-    assert settings.questions[0].name == "text_column_question"
-    assert isinstance(settings.questions[1], rg.LabelQuestion)
-    assert settings.questions[1].name == "label_column"
-    assert settings.mapping == {
-        "label_column": ("label_column", "label_column_metadata"),
-        "text_column": ("text_column", "text_column_question"),
-    }
+    assert len(settings.questions) == 1
+    assert isinstance(settings.questions[0], rg.LabelQuestion)
+    assert settings.questions[0].name == "label_column"
+    assert settings.mapping == {}
 
 
 def test_mapped_question():
@@ -84,7 +79,7 @@ def test_mapped_question():
     assert settings.questions[0].name == "text_column"
     assert isinstance(settings.questions[1], rg.LabelQuestion)
     assert settings.questions[1].name == "label_column"
-    assert settings.mapping == {"label_column": ("label_column", "label_column_metadata")}
+    assert settings.mapping == {}
 
 
 def test_mapped_fields():
@@ -103,7 +98,7 @@ def test_mapped_fields():
     assert len(settings.questions) == 1
     assert isinstance(settings.questions[0], rg.LabelQuestion)
     assert settings.questions[0].name == "label_column"
-    assert settings.mapping == {"label_column": ("label_column", "label_column_metadata")}
+    assert settings.mapping == {}
 
 
 def test_define_settings_from_features_unsupported():
@@ -116,7 +111,7 @@ def test_define_settings_from_features_unsupported():
         settings = _define_settings_from_features(features, feature_mapping={})
 
     assert len(settings.fields) == 1
-    assert len(settings.questions) == 2
+    assert len(settings.questions) == 1
 
 
 def test_define_settings_from_only_label_raises():


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds some changes in how settings are built from the dataset features:

- All questions are optional except the first one
- Avoid generating extra questions/metadata duplicated from the same feature
- A default question will be created if there is no question at all

Also, add robustness to the process with the following changes:

- Sanitize settings and dataset name according to the server validation
- Skip features with unsupported names (after sanitizing)
- Allow passing subset dataset configuration for HF datasets.

These changes result in datasets in Argilla with a data structure more similar to the original one.


**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
