### PR TITLE
fix: Including settings when loading record vectors

### DIFF
--- a/argilla-server/src/argilla_server/contexts/records.py
+++ b/argilla-server/src/argilla_server/contexts/records.py
@@ -97,14 +97,14 @@ def _record_by_dataset_id_query(
         query = query.options(selectinload(Record.suggestions))
 
     if with_vectors is True:
-        query = query.options(selectinload(Record.vectors))
+        query = query.options(selectinload(Record.vectors).selectinload(Vector.vector_settings))
     elif isinstance(with_vectors, list):
         subquery = select(VectorSettings.id).filter(
             and_(VectorSettings.dataset_id == dataset_id, VectorSettings.name.in_(with_vectors))
         )
         query = query.outerjoin(
             Vector, and_(Vector.record_id == Record.id, Vector.vector_settings_id.in_(subquery))
-        ).options(contains_eager(Record.vectors))
+        ).options(contains_eager(Record.vectors).selectinload(Vector.vector_settings))
 
     if offset is not None:
         query = query.offset(offset)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

The error resolved by this PR arises after merging the PR https://github.com/argilla-io/argilla/pull/5170. `VectorSettings` are not loaded properly when loading record vectors.

This error was not found when running tests due to the mocked db session used for tests.

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
