### PR TITLE
feat: increase webhook requests timeout from 5 to 20 seconds

### DIFF
--- a/argilla-server/src/argilla_server/webhooks/v1/commons.py
+++ b/argilla-server/src/argilla_server/webhooks/v1/commons.py
@@ -25,7 +25,7 @@ from argilla_server.models import Webhook as WebhookModel
 
 MSG_ID_BYTES_LENGTH = 16
 
-NOTIFY_EVENT_DEFAULT_TIMEOUT = httpx.Timeout(timeout=5.0)
+NOTIFY_EVENT_DEFAULT_TIMEOUT = httpx.Timeout(timeout=20.0)
 
 
 # NOTE: We are using standard webhooks implementation.


### PR DESCRIPTION
# Description

This PR increases the timeout for webhook requests from `5` seconds to `20` seconds so the webhook listeners have more time to generate a response.

Refs #1836 

**Type of change**

- Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

- [x] Test suite should be passing.

**Checklist**

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
