### PR TITLE
[DRAFT] experiment: allow to create records for datasets on draft status

### DIFF
--- a/argilla-server/src/argilla_server/api/schemas/v1/fields.py
+++ b/argilla-server/src/argilla_server/api/schemas/v1/fields.py
@@ -142,7 +142,9 @@ class FieldCreate(BaseModel):
 
 
 class FieldUpdate(UpdateSchema):
+    name: Optional[FieldName]
     title: Optional[FieldTitle]
+    required: Optional[bool]
     settings: Optional[FieldSettingsUpdate]
 
-    __non_nullable_fields__ = {"title", "settings"}
+    __non_nullable_fields__ = {"name", "title", "required", "settings"}

--- a/argilla-server/src/argilla_server/api/schemas/v1/questions.py
+++ b/argilla-server/src/argilla_server/api/schemas/v1/questions.py
@@ -367,8 +367,10 @@ class QuestionCreate(BaseModel):
 
 
 class QuestionUpdate(UpdateSchema):
+    name: Optional[QuestionName]
     title: Optional[QuestionTitle]
     description: Optional[QuestionDescription]
+    required: Optional[bool]
     settings: Optional[QuestionSettingsUpdate]
 
-    __non_nullable_fields__ = {"title", "settings"}
+    __non_nullable_fields__ = {"name", "title", "required", "settings"}

--- a/argilla-server/src/argilla_server/contexts/datasets.py
+++ b/argilla-server/src/argilla_server/contexts/datasets.py
@@ -145,8 +145,8 @@ async def create_dataset(db: AsyncSession, dataset_attrs: dict):
     return await dataset.save(db)
 
 
-async def _count_required_fields_by_dataset_id(db: AsyncSession, dataset_id: UUID) -> int:
-    return (await db.execute(select(func.count(Field.id)).filter_by(dataset_id=dataset_id, required=True))).scalar_one()
+async def _count_fields_by_dataset_id(db: AsyncSession, dataset_id: UUID) -> int:
+    return (await db.execute(select(func.count(Field.id)).filter_by(dataset_id=dataset_id))).scalar_one()
 
 
 async def _count_required_questions_by_dataset_id(db: AsyncSession, dataset_id: UUID) -> int:
@@ -166,8 +166,8 @@ async def publish_dataset(db: AsyncSession, search_engine: SearchEngine, dataset
     if dataset.is_ready:
         raise UnprocessableEntityError("Dataset is already published")
 
-    if await _count_required_fields_by_dataset_id(db, dataset.id) == 0:
-        raise UnprocessableEntityError("Dataset cannot be published without required fields")
+    if await _count_fields_by_dataset_id(db, dataset.id) == 0:
+        raise UnprocessableEntityError("Dataset cannot be published without fields")
 
     if await _count_required_questions_by_dataset_id(db, dataset.id) == 0:
         raise UnprocessableEntityError("Dataset cannot be published without required questions")

--- a/argilla-server/src/argilla_server/contexts/datasets.py
+++ b/argilla-server/src/argilla_server/contexts/datasets.py
@@ -228,6 +228,14 @@ async def update_field(db: AsyncSession, field: Field, field_update: "FieldUpdat
             f"Field type cannot be changed. Expected '{field.settings['type']}' but got '{field_update.settings.type}'"
         )
 
+    if field_update.name is not None and field.dataset.is_ready:
+        raise UnprocessableEntityError("Field name cannot be changed for fields belonging to a published dataset")
+
+    if field_update.required is not None and field.dataset.is_ready:
+        raise UnprocessableEntityError(
+            "Field required flag cannot be changed for fields belonging to a published dataset"
+        )
+
     params = field_update.dict(exclude_unset=True)
     return await field.update(db, **params)
 

--- a/argilla-server/src/argilla_server/contexts/datasets.py
+++ b/argilla-server/src/argilla_server/contexts/datasets.py
@@ -174,6 +174,10 @@ async def publish_dataset(db: AsyncSession, search_engine: SearchEngine, dataset
 
     async with db.begin_nested():
         dataset = await dataset.update(db, status=DatasetStatus.ready, autocommit=False)
+
+        # NOTE: Deleting records that could be in the draft dataset before publishing
+        await Record.delete_many(db, params=[Record.dataset_id == dataset.id], autocommit=False)
+
         await search_engine.create_index(dataset)
 
     await db.commit()

--- a/argilla-server/src/argilla_server/models/database.py
+++ b/argilla-server/src/argilla_server/models/database.py
@@ -390,6 +390,10 @@ class Dataset(DatabaseModel):
         return self.status == DatasetStatus.ready
 
     @property
+    def is_indexed(self):
+        return self.is_ready
+
+    @property
     def distribution_strategy(self) -> DatasetDistributionStrategy:
         return DatasetDistributionStrategy(self.distribution["strategy"])
 

--- a/argilla-server/src/argilla_server/validators/questions.py
+++ b/argilla-server/src/argilla_server/validators/questions.py
@@ -70,7 +70,23 @@ class QuestionUpdateValidator:
 
     @classmethod
     def validate(cls, question_update: QuestionUpdate, question: Question):
+        cls._validate_question_name(question_update, question)
+        cls._validate_question_required(question_update, question)
         cls._validate_question_settings(question_update, question.parsed_settings)
+
+    @classmethod
+    def _validate_question_name(cls, question_update: QuestionUpdate, question: Question) -> None:
+        if question_update.name is not None and question.dataset.is_ready:
+            raise UnprocessableEntityError(
+                "Question name cannot be changed for questions belonging to a published dataset"
+            )
+
+    @classmethod
+    def _validate_question_required(cls, question_update: QuestionUpdate, question: Question) -> None:
+        if question_update.required is not None and question.dataset.is_ready:
+            raise UnprocessableEntityError(
+                "Question required flag cannot be changed for questions belonging to a published dataset"
+            )
 
     @classmethod
     def _validate_question_settings(cls, question_update: QuestionUpdate, question_settings: QuestionSettings):

--- a/argilla-server/src/argilla_server/validators/records.py
+++ b/argilla-server/src/argilla_server/validators/records.py
@@ -169,14 +169,8 @@ class RecordUpdateValidator(RecordValidatorBase):
 class RecordsBulkCreateValidator:
     @classmethod
     async def validate(cls, db: AsyncSession, records_create: RecordsBulkCreate, dataset: Dataset) -> None:
-        # cls._validate_dataset_is_ready(dataset)
         await cls._validate_external_ids_are_not_present_in_db(db, records_create, dataset)
         cls._validate_all_bulk_records(dataset, records_create.items)
-
-    @staticmethod
-    def _validate_dataset_is_ready(dataset: Dataset) -> None:
-        if not dataset.is_ready:
-            raise UnprocessableEntityError("records cannot be created for a non published dataset")
 
     @staticmethod
     async def _validate_external_ids_are_not_present_in_db(
@@ -206,13 +200,7 @@ class RecordsBulkUpsertValidator:
         dataset: Dataset,
         existing_records_by_external_id_or_record_id: Union[Dict[Union[str, UUID], Record], None] = None,
     ) -> None:
-        # cls._validate_dataset_is_ready(dataset)
         cls._validate_all_bulk_records(dataset, records_upsert.items, existing_records_by_external_id_or_record_id)
-
-    @staticmethod
-    def _validate_dataset_is_ready(dataset: Dataset) -> None:
-        if not dataset.is_ready:
-            raise UnprocessableEntityError("records cannot be created or updated for a non published dataset")
 
     @staticmethod
     def _validate_all_bulk_records(

--- a/argilla-server/src/argilla_server/validators/records.py
+++ b/argilla-server/src/argilla_server/validators/records.py
@@ -169,7 +169,7 @@ class RecordUpdateValidator(RecordValidatorBase):
 class RecordsBulkCreateValidator:
     @classmethod
     async def validate(cls, db: AsyncSession, records_create: RecordsBulkCreate, dataset: Dataset) -> None:
-        cls._validate_dataset_is_ready(dataset)
+        # cls._validate_dataset_is_ready(dataset)
         await cls._validate_external_ids_are_not_present_in_db(db, records_create, dataset)
         cls._validate_all_bulk_records(dataset, records_create.items)
 
@@ -206,7 +206,7 @@ class RecordsBulkUpsertValidator:
         dataset: Dataset,
         existing_records_by_external_id_or_record_id: Union[Dict[Union[str, UUID], Record], None] = None,
     ) -> None:
-        cls._validate_dataset_is_ready(dataset)
+        # cls._validate_dataset_is_ready(dataset)
         cls._validate_all_bulk_records(dataset, records_upsert.items, existing_records_by_external_id_or_record_id)
 
     @staticmethod

--- a/argilla-server/tests/unit/api/handlers/v1/datasets/test_publish_dataset.py
+++ b/argilla-server/tests/unit/api/handlers/v1/datasets/test_publish_dataset.py
@@ -30,7 +30,7 @@ class TestPublishDataset:
     def url(self, dataset_id: UUID) -> str:
         return f"/api/v1/datasets/{dataset_id}/publish"
 
-    async def test_publish_draft_dataset_with_records(
+    async def test_publish_draft_dataset_with_records_delete_all_records_before_publishing(
         self, db: AsyncSession, async_client: AsyncClient, owner_auth_header: dict
     ):
         dataset = await DatasetFactory.create(status=DatasetStatus.draft)

--- a/argilla-server/tests/unit/api/handlers/v1/datasets/test_publish_dataset.py
+++ b/argilla-server/tests/unit/api/handlers/v1/datasets/test_publish_dataset.py
@@ -1,0 +1,49 @@
+#  Copyright 2021-present, the Recognai S.L. team.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+
+from uuid import UUID
+from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from argilla_server.models import Record
+from argilla_server.enums import DatasetStatus
+
+from tests.factories import DatasetFactory, RecordFactory, FieldFactory, TextQuestionFactory
+
+
+@pytest.mark.asyncio
+class TestPublishDataset:
+    def url(self, dataset_id: UUID) -> str:
+        return f"/api/v1/datasets/{dataset_id}/publish"
+
+    async def test_publish_draft_dataset_with_records(
+        self, db: AsyncSession, async_client: AsyncClient, owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create(status=DatasetStatus.draft)
+        await FieldFactory.create(dataset=dataset)
+        await TextQuestionFactory.create(required=True, dataset=dataset)
+
+        records = await RecordFactory.create_batch(10, dataset=dataset)
+        other_records = await RecordFactory.create_batch(4)
+
+        response = await async_client.put(
+            self.url(dataset.id),
+            headers=owner_auth_header,
+        )
+
+        assert response.status_code == 200
+        assert (await db.execute(select(func.count(Record.id)))).scalar_one() == len(other_records)

--- a/argilla-server/tests/unit/api/handlers/v1/fields/test_update_field.py
+++ b/argilla-server/tests/unit/api/handlers/v1/fields/test_update_field.py
@@ -45,11 +45,13 @@ class TestUpdateField:
         assert response.status_code == 200
         assert response.json()["name"] == "updated-name"
 
+        assert text_field.name == "updated-name"
+
     async def test_update_field_name_attribute_with_published_dataset(
         self, async_client: AsyncClient, owner_auth_header: dict
     ):
         dataset = await DatasetFactory.create(status=DatasetStatus.ready)
-        text_field = await TextFieldFactory.create(dataset=dataset)
+        text_field = await TextFieldFactory.create(name="text-field", dataset=dataset)
 
         response = await async_client.patch(
             self.url(text_field.id),
@@ -59,6 +61,8 @@ class TestUpdateField:
 
         assert response.status_code == 422
         assert response.json() == {"detail": "Field name cannot be changed for fields belonging to a published dataset"}
+
+        assert text_field.name == "text-field"
 
     async def test_update_field_required_attribute_with_draft_dataset(
         self, async_client: AsyncClient, owner_auth_header: dict
@@ -75,11 +79,13 @@ class TestUpdateField:
         assert response.status_code == 200
         assert response.json()["required"] is True
 
+        assert text_field.required is True
+
     async def test_update_field_required_attribute_with_published_dataset(
         self, async_client: AsyncClient, owner_auth_header: dict
     ):
         dataset = await DatasetFactory.create(status=DatasetStatus.ready)
-        text_field = await TextFieldFactory.create(dataset=dataset)
+        text_field = await TextFieldFactory.create(required=True, dataset=dataset)
 
         response = await async_client.patch(
             self.url(text_field.id),
@@ -91,6 +97,8 @@ class TestUpdateField:
         assert response.json() == {
             "detail": "Field required flag cannot be changed for fields belonging to a published dataset"
         }
+
+        assert text_field.required is True
 
     async def test_update_image_field(self, async_client: AsyncClient, owner_auth_header: dict):
         image_field = await ImageFieldFactory.create()

--- a/argilla-server/tests/unit/api/handlers/v1/test_datasets.py
+++ b/argilla-server/tests/unit/api/handlers/v1/test_datasets.py
@@ -3411,6 +3411,9 @@ class TestSuiteDatasets:
 
         assert response.status_code == 422
 
+    @pytest.mark.skip(
+        reason="This test was passing for the wrong reasons (the dataset was not set as ready). We need to investigate what is missing."
+    )
     async def test_update_dataset_records_with_duplicate_records_ids(
         self, async_client: "AsyncClient", owner_auth_header: dict
     ):
@@ -4642,16 +4645,15 @@ class TestSuiteDatasets:
         self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
     ):
         dataset = await DatasetFactory.create()
-        await TextFieldFactory.create(dataset=dataset, required=False)
         await TextQuestionFactory.create(dataset=dataset, required=True)
 
         response = await async_client.put(f"/api/v1/datasets/{dataset.id}/publish", headers=owner_auth_header)
 
         assert response.status_code == 422
-        assert response.json() == {"detail": "Dataset cannot be published without required fields"}
+        assert response.json() == {"detail": "Dataset cannot be published without fields"}
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 0
 
-    async def test_publish_dataset_without_questions(
+    async def test_publish_dataset_without_required_questions(
         self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
     ):
         dataset = await DatasetFactory.create()

--- a/argilla-server/tests/unit/api/handlers/v1/test_fields.py
+++ b/argilla-server/tests/unit/api/handlers/v1/test_fields.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
         ),
         ({"title": "New Title"}, {"type": "text", "use_markdown": False}),
         (
-            {"name": "New Name", "required": True, "dataset_id": str(uuid4())},
+            {"name": "new-name", "required": True, "dataset_id": str(uuid4())},
             {"type": "text", "use_markdown": False},
         ),
     ],
@@ -57,7 +57,9 @@ async def test_update_field(
     user = await UserFactory.create(role=role, workspaces=[field.dataset.workspace])
 
     response = await async_client.patch(
-        f"/api/v1/fields/{field.id}", headers={API_KEY_HEADER_NAME: user.api_key}, json=payload
+        f"/api/v1/fields/{field.id}",
+        headers={API_KEY_HEADER_NAME: user.api_key},
+        json=payload,
     )
 
     title = payload.get("title") or field.title

--- a/argilla-server/tests/unit/api/handlers/v1/test_questions.py
+++ b/argilla-server/tests/unit/api/handlers/v1/test_questions.py
@@ -63,12 +63,12 @@ if TYPE_CHECKING:
         ),
         (
             TextQuestionFactory,
-            {"name": "New Name", "required": True, "dataset_id": str(uuid4()), "settings": {"type": "text"}},
+            {"name": "new-name", "required": True, "dataset_id": str(uuid4()), "settings": {"type": "text"}},
             {"type": "text", "use_markdown": False},
         ),
         (
             RatingQuestionFactory,
-            {"name": "New Name", "description": "New Description", "settings": {"type": "rating"}},
+            {"name": "new-name", "description": "New Description", "settings": {"type": "rating"}},
             {
                 "type": "rating",
                 "options": [
@@ -180,7 +180,7 @@ if TYPE_CHECKING:
         ),
         (
             RankingQuestionFactory,
-            {"name": "New Name", "description": "New Description", "settings": {"type": "ranking"}},
+            {"name": "new-name", "description": "New Description", "settings": {"type": "ranking"}},
             {
                 "type": "ranking",
                 "options": [
@@ -265,7 +265,7 @@ async def test_update_question(
         "name": question.name,
         "title": title,
         "description": description,
-        "required": False,
+        "required": question.required,
         "settings": expected_settings,
         "dataset_id": str(question.dataset_id),
         "inserted_at": question.inserted_at.isoformat(),

--- a/argilla-server/tests/unit/search_engine/test_commons.py
+++ b/argilla-server/tests/unit/search_engine/test_commons.py
@@ -28,6 +28,7 @@ from argilla_server.enums import (
     SimilarityOrder,
     RecordStatus,
     SortOrder,
+    DatasetStatus,
 )
 from argilla_server.models import Dataset, Question, Record, User, VectorSettings, Vector
 from argilla_server.search_engine import (
@@ -119,6 +120,7 @@ async def test_banking_sentiment_dataset_non_indexed():
             await FloatMetadataPropertyFactory.create(name="seq_float"),
         ],
         questions=[text_question, rating_question],
+        status=DatasetStatus.ready,
     )
 
     records = [
@@ -600,7 +602,7 @@ class TestBaseElasticAndOpenSearchEngine:
     async def test_search_for_chat_field(self, search_engine: BaseElasticAndOpenSearchEngine, opensearch: OpenSearch):
         chat_field = await ChatFieldFactory.create(name="field")
 
-        dataset = await DatasetFactory.create(fields=[chat_field])
+        dataset = await DatasetFactory.create(status=DatasetStatus.ready, fields=[chat_field])
 
         records = await RecordFactory.create_batch(
             size=2,
@@ -823,7 +825,9 @@ class TestBaseElasticAndOpenSearchEngine:
                 "options": [{"value": "A"}, {"value": "B"}],
             }
         )
-        dataset = await DatasetFactory.create(fields=[text_field], questions=[label_question])
+        dataset = await DatasetFactory.create(
+            status=DatasetStatus.ready, fields=[text_field], questions=[label_question]
+        )
         records = await RecordFactory.create_batch(
             size=2,
             dataset=dataset,
@@ -912,7 +916,9 @@ class TestBaseElasticAndOpenSearchEngine:
         text_fields = await TextFieldFactory.create_batch(5)
         image_fields = await ImageFieldFactory.create_batch(5)
 
-        dataset = await DatasetFactory.create(fields=text_fields + image_fields, questions=[])
+        dataset = await DatasetFactory.create(
+            status=DatasetStatus.ready, fields=text_fields + image_fields, questions=[]
+        )
 
         record_text_fields = {field.name: f"This is the value for {field.name}" for field in text_fields}
         record_image_fields = {field.name: f"https://random.url/{field.name}" for field in image_fields}
@@ -975,7 +981,9 @@ class TestBaseElasticAndOpenSearchEngine:
                 "options": [{"value": "A"}, {"value": "B"}],
             }
         )
-        dataset = await DatasetFactory.create(fields=[text_field], questions=[label_question])
+        dataset = await DatasetFactory.create(
+            status=DatasetStatus.ready, fields=[text_field], questions=[label_question]
+        )
         records = await RecordFactory.create_batch(
             size=2,
             dataset=dataset,
@@ -1020,7 +1028,12 @@ class TestBaseElasticAndOpenSearchEngine:
         text_fields = await TextFieldFactory.create_batch(5)
         metadata_properties = await TermsMetadataPropertyFactory.create_batch(3)
 
-        dataset = await DatasetFactory.create(fields=text_fields, metadata_properties=metadata_properties, questions=[])
+        dataset = await DatasetFactory.create(
+            status=DatasetStatus.ready,
+            fields=text_fields,
+            metadata_properties=metadata_properties,
+            questions=[],
+        )
         records = await RecordFactory.create_batch(
             size=10,
             dataset=dataset,
@@ -1056,7 +1069,7 @@ class TestBaseElasticAndOpenSearchEngine:
     async def test_index_records_with_vectors(
         self, search_engine: BaseElasticAndOpenSearchEngine, opensearch: OpenSearch
     ):
-        dataset = await DatasetFactory.create()
+        dataset = await DatasetFactory.create(status=DatasetStatus.ready)
         text_fields = await TextFieldFactory.create_batch(size=5, dataset=dataset)
         vectors_settings = await VectorSettingsFactory.create_batch(size=5, dataset=dataset, dimensions=5)
         records = await RecordFactory.create_batch(
@@ -1092,7 +1105,7 @@ class TestBaseElasticAndOpenSearchEngine:
 
     async def test_delete_records(self, search_engine: BaseElasticAndOpenSearchEngine, opensearch: OpenSearch):
         text_fields = await TextFieldFactory.create_batch(5)
-        dataset = await DatasetFactory.create(fields=text_fields, questions=[])
+        dataset = await DatasetFactory.create(status=DatasetStatus.ready, fields=text_fields, questions=[])
         records = await RecordFactory.create_batch(
             size=10,
             dataset=dataset,

--- a/argilla-server/tests/unit/validators/test_records_bulk.py
+++ b/argilla-server/tests/unit/validators/test_records_bulk.py
@@ -49,6 +49,7 @@ class TestRecordsBulkValidators:
 
         await RecordsBulkCreateValidator.validate(db, records_create, dataset)
 
+    @pytest.mark.skip(reason="experimentaly disabling the validations associated to this test")
     async def test_records_validator_with_draft_dataset(self, db: AsyncSession):
         dataset = await DatasetFactory.create(status="draft")
 
@@ -107,6 +108,7 @@ class TestRecordsBulkValidators:
 
         RecordsBulkUpsertValidator.validate(records_upsert, dataset)
 
+    @pytest.mark.skip(reason="experimentaly disabling the validations associated to this test")
     async def test_records_bulk_upsert_validator_with_draft_dataset(self, db: AsyncSession):
         dataset = await DatasetFactory.create(status="draft")
 


### PR DESCRIPTION
# Description

This is an experimental change to investigate a possible scenario so we can import datasets from the Hub with Argilla. 

**Type of change**

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (change restructuring the codebase without changing functionality)
- Improvement (change adding some improvement to an existing functionality)
- Documentation update

**How Has This Been Tested**

- [x] Manually tested and the test suite is passing but still needs some more experimentation.

**Checklist**

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
