### PR TITLE
fix: get default workspace if exits when creating default user

### DIFF
--- a/argilla-server/CHANGELOG.md
+++ b/argilla-server/CHANGELOG.md
@@ -20,6 +20,10 @@ These are the section headers that we use:
 
 - Added helm chart for argilla. ([#5512](https://github.com/argilla-io/argilla/pull/5512))
 
+### Fixed
+
+- Fixed error when creating default user with existing default workspace. ([#5558](https://github.com/argilla-io/argilla/pull/5558))
+
 ## [2.2.0](https://github.com/argilla-io/argilla/compare/v2.1.0...v2.2.0)
 
 ### Added

--- a/argilla-server/src/argilla_server/cli/database/users/create_default.py
+++ b/argilla-server/src/argilla_server/cli/database/users/create_default.py
@@ -20,6 +20,8 @@ from argilla_server.contexts import accounts
 from argilla_server.database import AsyncSessionLocal
 from argilla_server.models import User, UserRole, Workspace
 
+from .utils import get_or_new_workspace
+
 
 async def _create_default(api_key: str, password: str, quiet: bool):
     """Creates a user with default credentials on database suitable to start experimenting with argilla."""
@@ -37,7 +39,7 @@ async def _create_default(api_key: str, password: str, quiet: bool):
             role=UserRole.owner,
             api_key=api_key,
             password_hash=accounts.hash_password(password),
-            workspaces=[Workspace(name=DEFAULT_USERNAME)],
+            workspaces=[await get_or_new_workspace(session, DEFAULT_USERNAME)],
         )
 
         if not quiet:

--- a/argilla-server/tests/unit/cli/database/users/test_create_default.py
+++ b/argilla-server/tests/unit/cli/database/users/test_create_default.py
@@ -15,7 +15,8 @@ from typing import TYPE_CHECKING
 
 from argilla_server.constants import DEFAULT_API_KEY, DEFAULT_PASSWORD, DEFAULT_USERNAME
 from argilla_server.contexts import accounts
-from argilla_server.models import User, UserRole
+from argilla_server.models import User, UserRole, Workspace
+from tests.factories import WorkspaceSyncFactory
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -86,4 +87,14 @@ def test_create_default_with_existent_default_user_and_quiet(sync_db: "Session",
 
     assert result.exit_code == 0
     assert result.output == ""
+    assert sync_db.query(User).count() == 1
+
+
+def test_create_default_with_existent_default_workspace(sync_db: "Session", cli_runner: "CliRunner", cli: "Typer"):
+    WorkspaceSyncFactory.create(name=DEFAULT_USERNAME)
+
+    result = cli_runner.invoke(cli, "database users create_default")
+
+    assert result.exit_code == 0
+    assert result.output != ""
     assert sync_db.query(User).count() == 1


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR fixes the  create_default CLI command errors when creating a default user and the default workspace already exists.

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
