### PR TITLE
[REFACTOR]: validate custom fields when creating or updating settings

### DIFF
--- a/argilla/src/argilla/settings/_common.py
+++ b/argilla/src/argilla/settings/_common.py
@@ -63,6 +63,9 @@ class SettingsPropertyBase(Resource):
     def type(self) -> str:
         return self._model.settings.type
 
+    def validate(self):
+        pass
+
     def serialize(self) -> dict[str, Any]:
         serialized_model = super().serialize()
         serialized_model["type"] = self.type

--- a/argilla/src/argilla/settings/_field.py
+++ b/argilla/src/argilla/settings/_field.py
@@ -11,14 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from abc import ABC
 import os
-import requests
+from abc import ABC
 from typing import Optional, Union, TYPE_CHECKING
+
+import requests
 
 from argilla import Argilla
 from argilla._api import FieldsAPI
-from argilla._exceptions import ArgillaError
+from argilla._exceptions import ArgillaError, SettingsError
 from argilla._models import (
     FieldModel,
     TextFieldSettings,
@@ -261,7 +262,12 @@ class CustomField(AbstractField):
     def advanced_mode(self, value: bool) -> None:
         self._model.settings.advanced_mode = value
 
-    def _load_template(self, template: str) -> str:
+    def validate(self):
+        if self.template is None or self.template.strip() == "":
+            raise SettingsError("A valid template is required for CustomField")
+
+    @classmethod
+    def _load_template(cls, template: str) -> str:
         if template.endswith(".html") and os.path.exists(template):
             with open(template, "r") as f:
                 return f.read()

--- a/argilla/src/argilla/settings/_resource.py
+++ b/argilla/src/argilla/settings/_resource.py
@@ -388,8 +388,8 @@ class Settings(DefaultSettingsMixin, Resource):
         self._client.api.datasets.update(dataset_model)
 
     def _validate_empty_settings(self):
-        if not all(self.fields):
-            message = "At least one field must be defined in the settings"
+        if not all([self.fields, self.questions]):
+            message = "Fields and questions are required"
             raise SettingsError(message=message)
 
     def _validate_duplicate_names(self) -> None:

--- a/argilla/src/argilla/settings/_resource.py
+++ b/argilla/src/argilla/settings/_resource.py
@@ -186,6 +186,9 @@ class Settings(DefaultSettingsMixin, Resource):
         self._validate_empty_settings()
         self._validate_duplicate_names()
 
+        for field in self.fields:
+            field.validate()
+
     #####################
     #  Public methods   #
     #####################
@@ -385,8 +388,8 @@ class Settings(DefaultSettingsMixin, Resource):
         self._client.api.datasets.update(dataset_model)
 
     def _validate_empty_settings(self):
-        if not all([self.fields, self.questions]):
-            message = "Fields and questions are required"
+        if not all(self.fields):
+            message = "At least one field must be defined in the settings"
             raise SettingsError(message=message)
 
     def _validate_duplicate_names(self) -> None:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds template validation for custom fields. The validation is a general step when validating settings (settings.validate). The `settings.validate` method is called before creating or updating the settings, which adds more flexibility to the validations we want to include.


**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Refactor (change restructuring the codebase without changing functionality)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
