### PR TITLE
refactor: add `DatasetPublishValidator` class

### DIFF
--- a/argilla-server/src/argilla_server/models/mixins.py
+++ b/argilla-server/src/argilla_server/models/mixins.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Set, TypeVar, Union
 from uuid import UUID
 
-from sqlalchemy import select, sql
+from sqlalchemy import select, func, sql
 from sqlalchemy.dialects.mysql import insert as mysql_insert
 from sqlalchemy.dialects.postgresql import insert as postgres_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
@@ -99,6 +99,10 @@ class CRUDMixin:
         conditions_str = ", ".join([f"{key}={value}" for key, value in conditions.items()])
 
         raise NotFoundError(f"{cls.__name__} not found filtering by {conditions_str}")
+
+    @classmethod
+    async def count_by(cls, db: AsyncSession, **conditions) -> int:
+        return (await db.execute(select(func.count(cls.id)).filter_by(**conditions))).scalar_one()
 
     async def update(
         self,

--- a/argilla-server/tests/unit/api/handlers/v1/test_datasets.py
+++ b/argilla-server/tests/unit/api/handlers/v1/test_datasets.py
@@ -4672,10 +4672,10 @@ class TestSuiteDatasets:
         response = await async_client.put(f"/api/v1/datasets/{dataset.id}/publish", headers=owner_auth_header)
 
         assert response.status_code == 422
-        assert response.json() == {"detail": "Dataset is already published"}
+        assert response.json() == {"detail": "Dataset has already been published"}
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 0
 
-    async def test_publish_dataset_without_fields(
+    async def test_publish_dataset_without_required_fields(
         self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
     ):
         dataset = await DatasetFactory.create()
@@ -4688,7 +4688,7 @@ class TestSuiteDatasets:
         assert response.json() == {"detail": "Dataset cannot be published without required fields"}
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 0
 
-    async def test_publish_dataset_without_questions(
+    async def test_publish_dataset_without_required_questions(
         self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
     ):
         dataset = await DatasetFactory.create()


### PR DESCRIPTION
# Description

A small refactor moving validation logic for `publish_dataset` context function to `DatasetPublishValidator` class. Once we merge this PR then I can do changes to the validations so we can increase flexibility to import datasets from the Hub.

I was bored of creating "helper functions" for counting queries for database so I have added `count_by` function into our database models mixin class. I hope it can be useful.

**Type of change**

- Refactor (change restructuring the codebase without changing functionality)

**How Has This Been Tested**

- [x] Running test suite.

**Checklist**

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
