### PR TITLE
feat: change dataset publish validation from at least one required field to at least one field (required or not)

### DIFF
--- a/argilla-server/src/argilla_server/validators/datasets.py
+++ b/argilla-server/src/argilla_server/validators/datasets.py
@@ -45,7 +45,7 @@ class DatasetPublishValidator:
     @classmethod
     async def validate(cls, db: AsyncSession, dataset: Dataset) -> None:
         await cls._validate_has_not_been_published_yet(db, dataset)
-        await cls._validate_has_at_least_one_required_field(db, dataset)
+        await cls._validate_has_at_least_one_field(db, dataset)
         await cls._validate_has_at_least_one_required_question(db, dataset)
 
     @classmethod
@@ -54,9 +54,9 @@ class DatasetPublishValidator:
             raise UnprocessableEntityError("Dataset has already been published")
 
     @classmethod
-    async def _validate_has_at_least_one_required_field(cls, db: AsyncSession, dataset: Dataset) -> None:
-        if await Field.count_by(db, dataset_id=dataset.id, required=True) == 0:
-            raise UnprocessableEntityError("Dataset cannot be published without required fields")
+    async def _validate_has_at_least_one_field(cls, db: AsyncSession, dataset: Dataset) -> None:
+        if await Field.count_by(db, dataset_id=dataset.id) == 0:
+            raise UnprocessableEntityError("Dataset cannot be published without fields")
 
     @classmethod
     async def _validate_has_at_least_one_required_question(cls, db: AsyncSession, dataset: Dataset) -> None:

--- a/argilla-server/tests/unit/api/handlers/v1/test_datasets.py
+++ b/argilla-server/tests/unit/api/handlers/v1/test_datasets.py
@@ -4675,17 +4675,16 @@ class TestSuiteDatasets:
         assert response.json() == {"detail": "Dataset has already been published"}
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 0
 
-    async def test_publish_dataset_without_required_fields(
+    async def test_publish_dataset_without_fields(
         self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
     ):
         dataset = await DatasetFactory.create()
-        await TextFieldFactory.create(dataset=dataset, required=False)
         await TextQuestionFactory.create(dataset=dataset, required=True)
 
         response = await async_client.put(f"/api/v1/datasets/{dataset.id}/publish", headers=owner_auth_header)
 
         assert response.status_code == 422
-        assert response.json() == {"detail": "Dataset cannot be published without required fields"}
+        assert response.json() == {"detail": "Dataset cannot be published without fields"}
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 0
 
     async def test_publish_dataset_without_required_questions(


### PR DESCRIPTION
# Description

In this PR we are changing how dataset publish validation works moving from:
* At least one required field to be a valid publishable dataset.

To:

* At least one field (required or not) to be a valid publishable dataset.

Refs https://github.com/argilla-io/roadmap/issues/21

**Type of change**

- New feature (non-breaking change which adds functionality)


**How Has This Been Tested**

- [x] Modifying test suite. 

**Checklist**

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
