### PR TITLE
feat: change dataset publish validation to have at least one question (required or not)

### DIFF
--- a/argilla-server/CHANGELOG.md
+++ b/argilla-server/CHANGELOG.md
@@ -19,7 +19,7 @@ These are the section headers that we use:
 ### Changed
 
 - Now it is possible to publish a dataset without required fields. Allowing being published with at least one field (required or not). ([#5569](https://github.com/argilla-io/argilla/pull/5569))
-- Now it is possible to publish a dataset without required questions. Allowing being published with at least one question (required or not). ([]())
+- Now it is possible to publish a dataset without required questions. Allowing being published with at least one question (required or not). ([#5588](https://github.com/argilla-io/argilla/pull/5588))
 
 ### Removed
 

--- a/argilla-server/CHANGELOG.md
+++ b/argilla-server/CHANGELOG.md
@@ -19,6 +19,7 @@ These are the section headers that we use:
 ### Changed
 
 - Now it is possible to publish a dataset without required fields. Allowing being published with at least one field (required or not). ([#5569](https://github.com/argilla-io/argilla/pull/5569))
+- Now it is possible to publish a dataset without required questions. Allowing being published with at least one question (required or not). ([]())
 
 ### Removed
 

--- a/argilla-server/src/argilla_server/validators/datasets.py
+++ b/argilla-server/src/argilla_server/validators/datasets.py
@@ -46,7 +46,7 @@ class DatasetPublishValidator:
     async def validate(cls, db: AsyncSession, dataset: Dataset) -> None:
         await cls._validate_has_not_been_published_yet(db, dataset)
         await cls._validate_has_at_least_one_field(db, dataset)
-        await cls._validate_has_at_least_one_required_question(db, dataset)
+        await cls._validate_has_at_least_one_question(db, dataset)
 
     @classmethod
     async def _validate_has_not_been_published_yet(cls, db: AsyncSession, dataset: Dataset) -> None:
@@ -59,9 +59,9 @@ class DatasetPublishValidator:
             raise UnprocessableEntityError("Dataset cannot be published without fields")
 
     @classmethod
-    async def _validate_has_at_least_one_required_question(cls, db: AsyncSession, dataset: Dataset) -> None:
-        if await Question.count_by(db, dataset_id=dataset.id, required=True) == 0:
-            raise UnprocessableEntityError("Dataset cannot be published without required questions")
+    async def _validate_has_at_least_one_question(cls, db: AsyncSession, dataset: Dataset) -> None:
+        if await Question.count_by(db, dataset_id=dataset.id) == 0:
+            raise UnprocessableEntityError("Dataset cannot be published without questions")
 
 
 class DatasetUpdateValidator:

--- a/argilla-server/tests/unit/api/handlers/v1/test_datasets.py
+++ b/argilla-server/tests/unit/api/handlers/v1/test_datasets.py
@@ -4422,17 +4422,16 @@ class TestSuiteDatasets:
         assert response.json() == {"detail": "Dataset cannot be published without fields"}
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 0
 
-    async def test_publish_dataset_without_required_questions(
+    async def test_publish_dataset_without_questions(
         self, async_client: "AsyncClient", db: "AsyncSession", owner_auth_header: dict
     ):
         dataset = await DatasetFactory.create()
         await TextFieldFactory.create(dataset=dataset, required=True)
-        await TextQuestionFactory.create(dataset=dataset, required=False)
 
         response = await async_client.put(f"/api/v1/datasets/{dataset.id}/publish", headers=owner_auth_header)
 
         assert response.status_code == 422
-        assert response.json() == {"detail": "Dataset cannot be published without required questions"}
+        assert response.json() == {"detail": "Dataset cannot be published without questions"}
         assert (await db.execute(select(func.count(Record.id)))).scalar() == 0
 
     async def test_publish_dataset_with_nonexistent_dataset_id(


### PR DESCRIPTION
# Description

This PR includes changes aligning validations for publishing datasets so a dataset can be published with at least one question (being required or not). The same that we were doing before with fields.

Refs https://github.com/argilla-io/roadmap/issues/21

**Type of change**

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

**How Has This Been Tested**

- [x] Modifying tests but we should do additional manual testing.

**Checklist**

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
