### PR TITLE
feat: Add support to other than str values for terms metadata properties

### DIFF
--- a/argilla/CHANGELOG.md
+++ b/argilla/CHANGELOG.md
@@ -16,6 +16,10 @@ These are the section headers that we use:
 
 ## [Unreleased]()
 
+### Changed
+
+- Terms metadata properties accept other values than `str`. ([#5594](https://github.com/argilla-io/argilla/pull/5594))
+
 ## [2.3.0](https://github.com/argilla-io/argilla/compare/v2.2.2...v2.3.0)
 
 ### Added

--- a/argilla/src/argilla/_models/_settings/_metadata.py
+++ b/argilla/src/argilla/_models/_settings/_metadata.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from enum import Enum
-from typing import List, Literal, Optional, Union, Annotated
+from typing import List, Literal, Optional, Union, Annotated, Any
 from uuid import UUID
 
 from pydantic import BaseModel, Field, field_serializer, field_validator, model_validator
@@ -35,7 +35,7 @@ class BaseMetadataPropertySettings(BaseModel):
 
 class TermsMetadataPropertySettings(BaseMetadataPropertySettings):
     type: Literal[MetadataPropertyType.terms]
-    values: Optional[List[str]] = None
+    values: Optional[List[Any]] = None
 
     @field_validator("values")
     @classmethod
@@ -44,8 +44,6 @@ class TermsMetadataPropertySettings(BaseMetadataPropertySettings):
             return None
         if not isinstance(values, list):
             raise ValueError(f"values must be a list, got {type(values)}")
-        elif not all(isinstance(value, str) for value in values):
-            raise ValueError("All values must be strings for terms metadata.")
         return values
 
 

--- a/argilla/src/argilla/settings/_metadata.py
+++ b/argilla/src/argilla/settings/_metadata.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Union, List, TYPE_CHECKING
+from typing import Optional, Union, List, TYPE_CHECKING, Any
 
 from argilla._api._metadata import MetadataAPI
 from argilla._exceptions import MetadataError
@@ -103,7 +103,7 @@ class TermsMetadataProperty(MetadataPropertyBase):
     def __init__(
         self,
         name: str,
-        options: Optional[List[str]] = None,
+        options: Optional[List[Any]] = None,
         title: Optional[str] = None,
         visible_for_annotators: Optional[bool] = True,
         client: Optional[Argilla] = None,
@@ -112,7 +112,7 @@ class TermsMetadataProperty(MetadataPropertyBase):
 
         Parameters:
             name (str): The name of the metadata field
-            options (Optional[List[str]]): The list of options
+            options (Optional[List[Any]]): The list of options
             title (Optional[str]): The title of the metadata to be shown in the UI
             visible_for_annotators (Optional[bool]): Whether the metadata field is visible for annotators.
 

--- a/argilla/tests/integration/test_add_records.py
+++ b/argilla/tests/integration/test_add_records.py
@@ -743,3 +743,29 @@ def test_add_records_objects_with_responses(client: Argilla, username: str):
     assert dataset_records[3].id == records[3].id
     assert dataset_records[3].responses["comment"][0].value == "The comment"
     assert dataset_records[3].responses["comment"][0].status == "draft"
+
+
+def test_add_records_with_boolean_metadata(client: Argilla, dataset_name: str):
+    settings = rg.Settings(
+        fields=[rg.TextField(name="text")],
+        metadata=[rg.TermsMetadataProperty(name="boolean", options=[True, False])],
+        questions=[rg.TextQuestion(name="comment", use_markdown=False)],
+    )
+    dataset = rg.Dataset(
+        name=dataset_name,
+        settings=settings,
+        client=client,
+    ).create()
+
+    dataset.records.log(
+        [
+            {"id": 0, "text": "Hello World, how are you?", "boolean": True},
+            {"id": 1, "text": "Hello World, how are you?", "boolean": False},
+            {"id": 2, "text": "Hello World, how are you?"},
+        ]
+    )
+
+    dataset_records = list(dataset.records())
+    assert dataset_records[0].metadata["boolean"] is True
+    assert dataset_records[1].metadata["boolean"] is False
+    assert "boolean" not in dataset_records[2].metadata

--- a/argilla/tests/unit/test_settings/test_metadata.py
+++ b/argilla/tests/unit/test_settings/test_metadata.py
@@ -14,27 +14,28 @@
 
 import uuid
 
+import pytest
+
 import argilla as rg
 from argilla._models import MetadataFieldModel, TermsMetadataPropertySettings
 
 
 class TestMetadata:
-    def test_create_metadata_terms(self):
-        property = rg.TermsMetadataProperty(
-            title="A metadata property", name="metadata", options=["option1", "option2"]
-        )
+    @pytest.mark.parametrize("options", [["option1", "option2"], [1, 2, 3, 4], [True, False]])
+    def test_create_metadata_terms(self, options: list):
+        property = rg.TermsMetadataProperty(title="A metadata property", name="metadata", options=options)
 
         assert property._model.type == "terms"
         assert property.title == "A metadata property"
         assert property.name == "metadata"
         assert property.visible_for_annotators is True
-        assert property.options == ["option1", "option2"]
+        assert property.options == options
 
         assert property.api_model().model_dump() == {
             "id": None,
             "dataset_id": None,
             "name": "metadata",
-            "settings": {"type": "terms", "values": ["option1", "option2"], "visible_for_annotators": True},
+            "settings": {"type": "terms", "values": options, "visible_for_annotators": True},
             "title": "A metadata property",
             "type": "terms",
             "visible_for_annotators": True,
@@ -89,3 +90,7 @@ class TestMetadata:
     def test_create_float_metadata_with_visible_for_annotators(self):
         metadata = rg.FloatMetadataProperty(name="integer", min=3.5, max=10.5, visible_for_annotators=False)
         assert metadata.visible_for_annotators is False
+
+    def test_create_terms_metadata_with_boolean_options(self):
+        metadata = rg.TermsMetadataProperty(name="metadata", options=[True, False])
+        assert metadata.options == [True, False]


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adapts the SDK to support changes included in https://github.com/argilla-io/argilla/pull/5589.  This allows to define terms metadata properties with other values than str (boolean, a set of integers,...)

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Improvement (change adding some improvement to an existing functionality)
- Documentation update

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
