### PR TITLE
feat: add a fixed number of rows to take importing dataset from Hub

### DIFF
--- a/argilla-server/src/argilla_server/jobs/hub_jobs.py
+++ b/argilla-server/src/argilla_server/jobs/hub_jobs.py
@@ -29,7 +29,7 @@ from argilla_server.jobs.queues import DEFAULT_QUEUE
 # TODO: Move this to be defined on jobs queues as a shared constant
 JOB_TIMEOUT_DISABLED = -1
 
-HUB_DATASET_TAKE_ROWS = 500_000
+HUB_DATASET_TAKE_ROWS = 10_000
 
 
 # TODO: Once we merge webhooks we should change the queue to use a different one (default queue is deleted there)

--- a/argilla-server/src/argilla_server/jobs/hub_jobs.py
+++ b/argilla-server/src/argilla_server/jobs/hub_jobs.py
@@ -29,6 +29,8 @@ from argilla_server.jobs.queues import DEFAULT_QUEUE
 # TODO: Move this to be defined on jobs queues as a shared constant
 JOB_TIMEOUT_DISABLED = -1
 
+HUB_DATASET_TAKE_ROWS = 500_000
+
 
 # TODO: Once we merge webhooks we should change the queue to use a different one (default queue is deleted there)
 @job(DEFAULT_QUEUE, timeout=JOB_TIMEOUT_DISABLED, retry=Retry(max=3))
@@ -47,4 +49,8 @@ async def import_dataset_from_hub_job(name: str, subset: str, split: str, datase
         async with SearchEngine.get_by_name(settings.search_engine) as search_engine:
             parsed_mapping = HubDatasetMapping.parse_obj(mapping)
 
-            await HubDataset(name, subset, split, parsed_mapping).import_to(db, search_engine, dataset)
+            await (
+                HubDataset(name, subset, split, parsed_mapping)
+                .take(HUB_DATASET_TAKE_ROWS)
+                .import_to(db, search_engine, dataset)
+            )


### PR DESCRIPTION
# Description

I have added a number of row to take importing a dataset from the hub. Specifically 500K rows. This can help us to avoid importing really big datasets with millions of rows into Argilla.

Refs https://github.com/argilla-io/roadmap/issues/21

**Type of change**

- New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [ ] Manually tested importing a dataset with a big number of records (> 500K)

**Checklist**

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
