### PR TITLE
correct phrase on docs: "a recod question" -> "a question"

### DIFF
--- a/argilla/docs/reference/argilla/records/responses.md
+++ b/argilla/docs/reference/argilla/records/responses.md
@@ -3,7 +3,7 @@ hide: footer
 ---
 # `rg.Response`
 
-Class for interacting with Argilla Responses of records. Responses are answers to questions by a user. Therefore, a recod question can have multiple responses, one for each user that has answered the question. A `Response` is typically created by a user in the UI or consumed from a data source as a label, unlike a `Suggestion` which is typically created by a model prediction.
+Class for interacting with Argilla Responses of records. Responses are answers to questions by a user. Therefore, a question can have multiple responses, one for each user that has answered the question. A `Response` is typically created by a user in the UI or consumed from a data source as a label, unlike a `Suggestion` which is typically created by a model prediction.
 
 ## Usage Examples
 


### PR DESCRIPTION
# Description
Typo Fix in API Reference (rg.Response).
Phrase with typo: "Therefore, _a recod question_ can have multiple responses, one for each user that has answered the question."
Given correction: " Therefore, _a question_ can have multiple responses, one for each user that has answered the question."
Link to the docs: https://docs.argilla.io/latest/reference/argilla/records/responses/

Closes #5598 

**Type of change**
- Documentation update

**How Has This Been Tested**
No tests needed

**Checklist**

- I made corresponding changes to the documentation