### PR TITLE
feat: add support for class labels and casting rows

### DIFF
--- a/argilla-server/src/argilla_server/api/schemas/v1/datasets.py
+++ b/argilla-server/src/argilla_server/api/schemas/v1/datasets.py
@@ -168,6 +168,15 @@ class HubDatasetMapping(BaseModel):
     suggestions: Optional[List[HubDatasetMappingItem]] = []
     external_id: Optional[str] = None
 
+    @property
+    def sources(self) -> List[str]:
+        fields_sources = [field.source for field in self.fields]
+        metadata_sources = [metadata.source for metadata in self.metadata]
+        suggestions_sources = [suggestion.source for suggestion in self.suggestions]
+        external_id_source = [self.external_id] if self.external_id else []
+
+        return list(set(fields_sources + metadata_sources + suggestions_sources + external_id_source))
+
 
 class HubDataset(BaseModel):
     name: str

--- a/argilla-server/src/argilla_server/contexts/hub.py
+++ b/argilla-server/src/argilla_server/contexts/hub.py
@@ -41,7 +41,7 @@ class HubDataset:
     def __init__(self, name: str, subset: str, split: str, mapping: HubDatasetMapping):
         self.dataset = load_dataset(path=name, name=subset, split=split, streaming=True)
         self.mapping = mapping
-        self.mapping_sources = mapping.sources
+        self.mapping_feature_names = mapping.sources
         self.row_idx = RESET_ROW_IDX
 
     @property
@@ -88,19 +88,19 @@ class HubDataset:
 
     def _batch_index_to_row(self, batch: dict, index: int) -> dict:
         row = {}
-        for key, values in batch.items():
-            if not key in self.mapping_sources:
+        for feature_name, values in batch.items():
+            if not feature_name in self.mapping_feature_names:
                 continue
 
             value = values[index]
-            feature = self.features[key]
+            feature = self.features[feature_name]
 
             if feature._type == FEATURE_TYPE_CLASS_LABEL:
-                row[key] = feature.int2str(value)
+                row[feature_name] = feature.int2str(value)
             elif feature._type == FEATURE_TYPE_IMAGE and isinstance(value, Image.Image):
-                row[key] = pil_image_to_data_url(value)
+                row[feature_name] = pil_image_to_data_url(value)
             else:
-                row[key] = value
+                row[feature_name] = value
 
         return row
 


### PR DESCRIPTION
# Description

This PR adds the following features:
* Add support to dataset `ClassLabel` features casting them using `int2str` so we store string values on the Argilla imported dataset.
* Now the casting is done at the row level and discarding keys that are not part of the mapping sources. Once the values arrive to the different record create values these are already casted.
* We are casting `ClassLabel` features to string and `Image` features to data-url strings.

Refs https://github.com/argilla-io/roadmap/issues/21

**Type of change**

- New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [x] Adding additional tests import real datasets from HF.

**Checklist**

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
