### PR TITLE
[REFACTOR] argilla server: moving all record validators

### DIFF
--- a/argilla-server/src/argilla_server/bulk/records_bulk.py
+++ b/argilla-server/src/argilla_server/bulk/records_bulk.py
@@ -145,7 +145,7 @@ class CreateRecordsBulk:
 
 class UpsertRecordsBulk(CreateRecordsBulk):
     async def upsert_records_bulk(self, dataset: Dataset, bulk_upsert: RecordsBulkUpsert) -> RecordsBulkWithUpdateInfo:
-        found_records = await self._fetch_existing_records(dataset, bulk_upsert.items)
+        found_records = await self._fetch_existing_dataset_records(dataset, bulk_upsert.items)
         # found_records is passed to the validator to avoid querying the database again, but ideally, it should be
         # computed inside the validator
         await RecordsBulkUpsertValidator.validate(bulk_upsert, dataset, found_records)
@@ -182,7 +182,7 @@ class UpsertRecordsBulk(CreateRecordsBulk):
             updated_item_ids=[record.id for record in found_records.values()],
         )
 
-    async def _fetch_existing_records(
+    async def _fetch_existing_dataset_records(
         self,
         dataset: Dataset,
         records_upsert: List[RecordUpsert],

--- a/argilla-server/src/argilla_server/contexts/accounts.py
+++ b/argilla-server/src/argilla_server/contexts/accounts.py
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import secrets
-from typing import Dict, Iterable, List, Sequence, Union
+from typing import Iterable, List, Sequence, Union
 from uuid import UUID
 
 from passlib.context import CryptContext
@@ -193,8 +193,3 @@ def generate_user_token(user: User) -> str:
             role=user.role,
         ),
     )
-
-
-async def fetch_users_by_ids_as_dict(db: "AsyncSession", user_ids: List[UUID]) -> Dict[UUID, User]:
-    users = await list_users_by_ids(db, set(user_ids))
-    return {user.id: user for user in users}

--- a/argilla-server/src/argilla_server/models/base.py
+++ b/argilla-server/src/argilla_server/models/base.py
@@ -11,10 +11,10 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
+from typing import Optional
 from uuid import UUID, uuid4
 
-from sqlalchemy.ext.asyncio import AsyncAttrs
+from sqlalchemy.ext.asyncio import AsyncAttrs, async_object_session, AsyncSession
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from argilla_server.models.mixins import CRUDMixin, TimestampMixin
@@ -32,3 +32,7 @@ class DatabaseModel(DeclarativeBase, AsyncAttrs, CRUDMixin, TimestampMixin):
 
     def is_relationship_loaded(self, relationship: str) -> bool:
         return relationship in self.__dict__
+
+    @property
+    def current_async_session(self) -> Optional[AsyncSession]:
+        return async_object_session(self)

--- a/argilla-server/src/argilla_server/models/database.py
+++ b/argilla-server/src/argilla_server/models/database.py
@@ -28,7 +28,6 @@ from sqlalchemy import (
     sql,
 )
 from sqlalchemy.engine.default import DefaultExecutionContext
-from sqlalchemy.ext.asyncio import async_object_session
 from sqlalchemy.ext.mutable import MutableDict, MutableList
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -509,7 +508,7 @@ class User(DatabaseModel):
     async def is_member(self, workspace_id: UUID) -> bool:
         # TODO: Change query to use exists may improve performance
         return (
-            await WorkspaceUser.get_by(async_object_session(self), workspace_id=workspace_id, user_id=self.id)
+            await WorkspaceUser.get_by(self.current_async_session, workspace_id=workspace_id, user_id=self.id)
             is not None
         )
 

--- a/argilla-server/src/argilla_server/validators/records.py
+++ b/argilla-server/src/argilla_server/validators/records.py
@@ -14,20 +14,25 @@
 
 import copy
 import mimetypes
-
-from abc import ABC, abstractmethod
-from typing import Dict, List, Union, Any
-from uuid import UUID
+from abc import ABC
+from typing import Dict, List, Union, Any, Optional
 from urllib.parse import urlparse, ParseResult, ParseResultBytes
+from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from argilla_server.api.schemas.v1.chat import ChatFieldValue
 from argilla_server.api.schemas.v1.records import RecordCreate, RecordUpdate, RecordUpsert
 from argilla_server.api.schemas.v1.records_bulk import RecordsBulkCreate, RecordsBulkUpsert
+from argilla_server.api.schemas.v1.responses import UserResponseCreate
+from argilla_server.api.schemas.v1.suggestions import SuggestionCreate
 from argilla_server.contexts import records
 from argilla_server.errors.future.base_errors import UnprocessableEntityError
 from argilla_server.models import Dataset, Record
+from argilla_server.pydantic_v1 import ValidationError
+from argilla_server.validators.responses import ResponseCreateValidator
+from argilla_server.validators.suggestions import SuggestionCreateValidator
+from argilla_server.validators.vectors import VectorValidator
 
 IMAGE_FIELD_WEB_URL_MAX_LENGTH = 2038
 IMAGE_FIELD_DATA_URL_MAX_LENGTH = 5_000_000
@@ -46,37 +51,39 @@ CHAT_FIELD_MAX_LENGTH = 500
 
 class RecordValidatorBase(ABC):
     @classmethod
-    @abstractmethod
-    def validate(cls, record: Union[RecordCreate, RecordUpdate], dataset: Dataset) -> None:
-        pass
+    def _validate_fields(cls, fields: dict, dataset: Dataset) -> None:
+        fields = fields or {}
 
-    @classmethod
-    def _validate_fields(cls, record: Union[RecordCreate, RecordUpdate], dataset: Dataset) -> None:
-        fields = record.fields or {}
-
+        cls._validate_empty_fields(fields=fields)
         cls._validate_required_fields(dataset=dataset, fields=fields)
         cls._validate_extra_fields(dataset=dataset, fields=fields)
         cls._validate_image_fields(dataset=dataset, fields=fields)
         cls._validate_chat_fields(dataset=dataset, fields=fields)
         cls._validate_custom_fields(dataset=dataset, fields=fields)
 
-    @staticmethod
-    def _validate_required_fields(dataset: Dataset, fields: Dict[str, str]) -> None:
+    @classmethod
+    def _validate_empty_fields(cls, fields: Dict[str, str]) -> None:
+        if not fields:
+            raise UnprocessableEntityError("fields are empty")
+
+    @classmethod
+    def _validate_required_fields(cls, dataset: Dataset, fields: Dict[str, str]) -> None:
         for field in dataset.fields:
             if field.required and not (field.name in fields and fields.get(field.name) is not None):
                 raise UnprocessableEntityError(f"missing required value for field: {field.name!r}")
 
-    @staticmethod
-    def _validate_extra_fields(dataset: Dataset, fields: Dict[str, str]) -> None:
+    @classmethod
+    def _validate_extra_fields(cls, dataset: Dataset, fields: Dict[str, str]) -> None:
         fields_copy = copy.copy(fields)
         for field in dataset.fields:
             fields_copy.pop(field.name, None)
         if fields_copy:
             raise UnprocessableEntityError(f"found fields values for non configured fields: {list(fields_copy.keys())}")
 
-    @staticmethod
-    def _validate_metadata(record: Union[RecordCreate, RecordUpdate], dataset: Dataset) -> None:
-        metadata = record.metadata or {}
+    @classmethod
+    def _validate_metadata(cls, metadata: dict, dataset: Dataset) -> None:
+        metadata = metadata or {}
+
         for name, value in metadata.items():
             metadata_property = dataset.metadata_property_by_name(name)
             # TODO(@frascuchon): Create a MetadataPropertyValidator instead of using the parsed_settings
@@ -173,27 +180,93 @@ class RecordValidatorBase(ABC):
         if not isinstance(value, dict):
             raise UnprocessableEntityError(f"custom field {name!r} value must be a dictionary")
 
+    @classmethod
+    def _validate_suggestions(cls, suggestions: List[SuggestionCreate], dataset: Dataset, record: Record):
+        if not suggestions:
+            return
+
+        try:
+            cls._validate_duplicated_suggestions(suggestions)
+
+            for suggestion in suggestions:
+                question = dataset.question_by_id(suggestion.question_id)
+
+                if question is None:
+                    raise UnprocessableEntityError(f"question id={suggestion.question_id} does not exists")
+
+                SuggestionCreateValidator.validate(suggestion, question.parsed_settings, record)
+        except (UnprocessableEntityError, ValueError, ValidationError) as ex:
+            raise UnprocessableEntityError(f"record does not have valid suggestions: {ex}") from ex
+
+    @classmethod
+    def _validate_duplicated_suggestions(cls, suggestions: List[SuggestionCreate]):
+        question_ids = [s.question_id for s in suggestions]
+
+        if len(question_ids) != len(set(question_ids)):
+            raise UnprocessableEntityError("found duplicate suggestions question IDs")
+
+    @classmethod
+    def _validate_vectors(cls, vectors: Optional[dict], dataset: Dataset):
+        if not vectors:
+            return
+
+        try:
+            for name, value in vectors.items():
+                settings = dataset.vector_settings_by_name(name)
+
+                if not settings:
+                    raise UnprocessableEntityError(
+                        f"vector with name={name} does not exist for dataset_id={dataset.id}"
+                    )
+
+                VectorValidator.validate(value, settings)
+        except (UnprocessableEntityError, ValueError) as ex:
+            raise UnprocessableEntityError(f"record does not have valid vectors: {ex}") from ex
+
+    @classmethod
+    async def _validate_responses(cls, responses: List[UserResponseCreate], dataset: Dataset, record: Record):
+        from argilla_server.contexts.accounts import list_users_by_ids
+
+        if not responses:
+            return
+        try:
+            user_ids = [response_create.user_id for response_create in responses]
+            users = await list_users_by_ids(dataset.current_async_session, set(user_ids))
+            users_by_id = {user.id: user for user in users}
+
+            for response_create in responses:
+                if response_create.user_id not in users_by_id:
+                    raise ValueError(f"user with id {response_create.user_id} not found")
+
+                ResponseCreateValidator.validate(response_create, record)
+        except (UnprocessableEntityError, ValueError) as ex:
+            raise UnprocessableEntityError(f"record does not have valid responses: {ex}") from ex
+
 
 class RecordCreateValidator(RecordValidatorBase):
     @classmethod
-    def validate(cls, record: RecordCreate, dataset: Dataset) -> None:
-        cls._validate_fields(record, dataset)
-        cls._validate_metadata(record, dataset)
+    async def validate(cls, record_create: RecordCreate, dataset: Dataset) -> None:
+        record = Record(fields=record_create.fields, dataset=dataset)
+
+        cls._validate_fields(record_create.fields, dataset)
+        cls._validate_metadata(record_create.metadata, dataset)
+        cls._validate_suggestions(record_create.suggestions, dataset, record=record)
+        cls._validate_vectors(record_create.vectors, dataset)
+        await cls._validate_responses(record_create.responses, dataset, record=record)
 
 
-class RecordUpdateValidator(RecordValidatorBase):
+class RecordUpsertValidator(RecordValidatorBase):
     @classmethod
-    def validate(cls, record: RecordUpdate, dataset: Dataset) -> None:
-        cls._validate_metadata(record, dataset)
-        cls._validate_duplicated_suggestions(record)
+    async def validate(cls, record_upsert: RecordUpsert, dataset: Dataset, record: Optional[Record]) -> None:
+        if record is None:
+            cls._validate_fields(record_upsert.fields, dataset)
+            record = Record(fields=record_upsert.fields, dataset=dataset)
 
-    @staticmethod
-    def _validate_duplicated_suggestions(record: RecordUpdate):
-        if not record.suggestions:
-            return
-        question_ids = [s.question_id for s in record.suggestions]
-        if len(question_ids) != len(set(question_ids)):
-            raise UnprocessableEntityError("found duplicate suggestions question IDs")
+        cls._validate_metadata(record_upsert.metadata, dataset)
+        cls._validate_vectors(record_upsert.vectors, dataset)
+
+        cls._validate_suggestions(record_upsert.suggestions, dataset, record=record)
+        await cls._validate_responses(record_upsert.responses, dataset, record=record)
 
 
 class RecordsBulkCreateValidator:
@@ -201,7 +274,7 @@ class RecordsBulkCreateValidator:
     async def validate(cls, db: AsyncSession, records_create: RecordsBulkCreate, dataset: Dataset) -> None:
         cls._validate_dataset_is_ready(dataset)
         await cls._validate_external_ids_are_not_present_in_db(db, records_create, dataset)
-        cls._validate_all_bulk_records(dataset, records_create.items)
+        await cls._validate_all_bulk_records(dataset, records_create.items)
 
     @staticmethod
     def _validate_dataset_is_ready(dataset: Dataset) -> None:
@@ -220,24 +293,26 @@ class RecordsBulkCreateValidator:
             raise UnprocessableEntityError(f"found records with same external ids: {', '.join(found_records)}")
 
     @staticmethod
-    def _validate_all_bulk_records(dataset: Dataset, records_create: List[RecordCreate]):
+    async def _validate_all_bulk_records(dataset: Dataset, records_create: List[RecordCreate]):
         for idx, record_create in enumerate(records_create):
             try:
-                RecordCreateValidator.validate(record_create, dataset)
-            except UnprocessableEntityError as ex:
-                raise UnprocessableEntityError(f"record at position {idx} is not valid because {ex}") from ex
+                await RecordCreateValidator.validate(record_create, dataset)
+            except (UnprocessableEntityError, ValueError) as ex:
+                raise UnprocessableEntityError(f"Record at position {idx} is not valid because {ex}") from ex
 
 
 class RecordsBulkUpsertValidator:
     @classmethod
-    def validate(
+    async def validate(
         cls,
         records_upsert: RecordsBulkUpsert,
         dataset: Dataset,
         existing_records_by_external_id_or_record_id: Union[Dict[Union[str, UUID], Record], None] = None,
     ) -> None:
         cls._validate_dataset_is_ready(dataset)
-        cls._validate_all_bulk_records(dataset, records_upsert.items, existing_records_by_external_id_or_record_id)
+        await cls._validate_all_bulk_records(
+            dataset, records_upsert.items, existing_records_by_external_id_or_record_id
+        )
 
     @staticmethod
     def _validate_dataset_is_ready(dataset: Dataset) -> None:
@@ -245,7 +320,7 @@ class RecordsBulkUpsertValidator:
             raise UnprocessableEntityError("records cannot be created or updated for a non published dataset")
 
     @staticmethod
-    def _validate_all_bulk_records(
+    async def _validate_all_bulk_records(
         dataset: Dataset,
         records_upsert: List[RecordUpsert],
         existing_records_by_external_id_or_record_id: Union[Dict[Union[str, UUID], Record], None] = None,
@@ -257,9 +332,6 @@ class RecordsBulkUpsertValidator:
                     record_upsert.id
                 ) or existing_records_by_external_id_or_record_id.get(record_upsert.external_id)
 
-                if record:
-                    RecordUpdateValidator.validate(RecordUpdate.parse_obj(record_upsert), dataset)
-                else:
-                    RecordCreateValidator.validate(RecordCreate.parse_obj(record_upsert), dataset)
+                await RecordUpsertValidator.validate(record_upsert, dataset, record)
             except (UnprocessableEntityError, ValueError) as ex:
-                raise UnprocessableEntityError(f"record at position {idx} is not valid because {ex}") from ex
+                raise UnprocessableEntityError(f"Record at position {idx} is not valid because {ex}") from ex

--- a/argilla-server/src/argilla_server/validators/records.py
+++ b/argilla-server/src/argilla_server/validators/records.py
@@ -54,17 +54,11 @@ class RecordValidatorBase(ABC):
     def _validate_fields(cls, fields: dict, dataset: Dataset) -> None:
         fields = fields or {}
 
-        cls._validate_empty_fields(fields=fields)
         cls._validate_required_fields(dataset=dataset, fields=fields)
         cls._validate_extra_fields(dataset=dataset, fields=fields)
         cls._validate_image_fields(dataset=dataset, fields=fields)
         cls._validate_chat_fields(dataset=dataset, fields=fields)
         cls._validate_custom_fields(dataset=dataset, fields=fields)
-
-    @classmethod
-    def _validate_empty_fields(cls, fields: Dict[str, str]) -> None:
-        if not fields:
-            raise UnprocessableEntityError("fields are empty")
 
     @classmethod
     def _validate_required_fields(cls, dataset: Dataset, fields: Dict[str, str]) -> None:

--- a/argilla-server/tests/unit/api/handlers/v1/datasets/records/records_bulk/test_create_dataset_records_bulk.py
+++ b/argilla-server/tests/unit/api/handlers/v1/datasets/records/records_bulk/test_create_dataset_records_bulk.py
@@ -323,7 +323,7 @@ class TestCreateDatasetRecordsBulk:
 
         assert response.status_code == 422
         assert response.json() == {
-            "detail": f"record at position 0 is not valid because image field 'image' has an invalid URL value",
+            "detail": f"Record at position 0 is not valid because image field 'image' has an invalid URL value",
         }
 
         assert (await db.execute(select(func.count(Record.id)))).scalar_one() == 0
@@ -352,7 +352,7 @@ class TestCreateDatasetRecordsBulk:
 
         assert response.status_code == 422
         assert response.json() == {
-            "detail": f"record at position 0 is not valid because image field 'image' value is exceeding the maximum length of 2038 characters for Web URLs",
+            "detail": f"Record at position 0 is not valid because image field 'image' value is exceeding the maximum length of 2038 characters for Web URLs",
         }
 
         assert (await db.execute(select(func.count(Record.id)))).scalar_one() == 0
@@ -381,7 +381,7 @@ class TestCreateDatasetRecordsBulk:
 
         assert response.status_code == 422
         assert response.json() == {
-            "detail": f"record at position 0 is not valid because image field 'image' value is using an unsupported MIME type, supported MIME types are: ['image/avif', 'image/gif', 'image/ico', 'image/jpeg', 'image/jpg', 'image/png', 'image/svg', 'image/webp']",
+            "detail": f"Record at position 0 is not valid because image field 'image' value is using an unsupported MIME type, supported MIME types are: ['image/avif', 'image/gif', 'image/ico', 'image/jpeg', 'image/jpg', 'image/png', 'image/svg', 'image/webp']",
         }
 
         assert (await db.execute(select(func.count(Record.id)))).scalar_one() == 0
@@ -410,7 +410,7 @@ class TestCreateDatasetRecordsBulk:
 
         assert response.status_code == 422
         assert response.json() == {
-            "detail": f"record at position 0 is not valid because image field 'image' value is exceeding the maximum length of 5000000 characters for Data URLs",
+            "detail": f"Record at position 0 is not valid because image field 'image' value is exceeding the maximum length of 5000000 characters for Data URLs",
         }
 
         assert (await db.execute(select(func.count(Record.id)))).scalar_one() == 0

--- a/argilla-server/tests/unit/api/handlers/v1/datasets/records/records_bulk/test_dataset_records_bulk.py
+++ b/argilla-server/tests/unit/api/handlers/v1/datasets/records/records_bulk/test_dataset_records_bulk.py
@@ -168,14 +168,13 @@ class TestDatasetRecordsBulk:
         for record in updated_records:
             assert record.metadata_ == new_metadata
 
-    async def test_update_record_for_other_dataset(
+    async def test_upsert_record_for_other_dataset(
         self, async_client: AsyncClient, db: AsyncSession, owner_auth_header: dict
     ):
         dataset = await self.test_dataset()
         other_dataset = await self.test_dataset()
 
         record = await RecordFactory.create(dataset=dataset)
-
         response = await async_client.put(
             self.url(other_dataset.id),
             headers=owner_auth_header,
@@ -186,7 +185,7 @@ class TestDatasetRecordsBulk:
             },
         )
 
-        assert response.status_code == 422, response.json()
+        assert response.status_code == 422  # The insert is failing because no fields are provided
         assert (await db.execute(select(func.count(Record.id)))).scalar_one() == 1
         assert (await db.execute(select(Record))).scalar_one().metadata_ is None
 

--- a/argilla-server/tests/unit/api/handlers/v1/datasets/records/records_bulk/test_dataset_records_bulk.py
+++ b/argilla-server/tests/unit/api/handlers/v1/datasets/records/records_bulk/test_dataset_records_bulk.py
@@ -207,8 +207,9 @@ class TestDatasetRecordsBulk:
 
         await dataset.awaitable_attrs.metadata_properties
 
-    async def _configure_dataset_fields(self, dataset):
-        await TextFieldFactory.create(name="prompt", dataset=dataset)
-        await TextFieldFactory.create(name="response", dataset=dataset)
+    @classmethod
+    async def _configure_dataset_fields(cls, dataset):
+        await TextFieldFactory.create(name="prompt", dataset=dataset, required=True)
+        await TextFieldFactory.create(name="response", dataset=dataset, required=False)
 
         await dataset.awaitable_attrs.fields

--- a/argilla-server/tests/unit/api/handlers/v1/datasets/records/records_bulk/test_dataset_records_bulk_with_responses.py
+++ b/argilla-server/tests/unit/api/handlers/v1/datasets/records/records_bulk/test_dataset_records_bulk_with_responses.py
@@ -317,7 +317,7 @@ class TestDatasetRecordsBulkWithResponses:
 
         assert response.status_code == 422, response.json()
         assert response.json() == {
-            "detail": "Record at position 0 does not have valid responses because "
+            "detail": "Record at position 0 is not valid because record does not have valid responses: "
             "found response value for non configured question with name='other-question'"
         }
 
@@ -348,8 +348,8 @@ class TestDatasetRecordsBulkWithResponses:
 
         assert response.status_code == 422, response.json()
         assert response.json() == {
-            "detail": "Record at position 0 does not have valid responses because 'wrong-label' "
-            "is not a valid label for label selection question.\n"
+            "detail": "Record at position 0 is not valid because record does not have valid responses: "
+            "'wrong-label' is not a valid label for label selection question.\n"
             "Valid labels are: ['label-a', 'label-b']"
         }
 

--- a/argilla-server/tests/unit/api/handlers/v1/datasets/records/records_bulk/test_dataset_records_bulk_with_suggestions.py
+++ b/argilla-server/tests/unit/api/handlers/v1/datasets/records/records_bulk/test_dataset_records_bulk_with_suggestions.py
@@ -298,8 +298,8 @@ class TestDatasetRecordsBulkWithSuggestions:
 
         assert response.status_code == 422, response.json()
         assert response.json() == {
-            "detail": "Record at position 0 does not have valid suggestions because "
-            f"question with question_id={other_question.id} does not exist"
+            "detail": "Record at position 0 is not valid because record does not have valid suggestions: "
+            f"question id={other_question.id} does not exists"
         }
 
     async def test_create_record_with_wrong_suggestion_value_in_bulk(
@@ -328,8 +328,8 @@ class TestDatasetRecordsBulkWithSuggestions:
 
         assert response.status_code == 422, response.json()
         assert response.json() == {
-            "detail": "Record at position 0 does not have valid suggestions because suggestion for question name=label "
-            "is not valid: 'wrong-label' is not a valid label for label selection question.\n"
+            "detail": f"Record at position 0 is not valid because record does not have valid suggestions: "
+            "'wrong-label' is not a valid label for label selection question.\n"
             "Valid labels are: ['label-a', 'label-b']"
         }
 
@@ -339,7 +339,7 @@ class TestDatasetRecordsBulkWithSuggestions:
         dataset = await self.test_dataset()
         question = dataset.question_by_name("label")
         record = await RecordFactory.create(dataset=dataset, fields={"prompt": "Does exercise help reduce stress?"})
-        suggestion = await SuggestionFactory.create(record=record, question=question, value="label-a")
+        await SuggestionFactory.create(record=record, question=question, value="label-a")
         other_question = await TextQuestionFactory.create(name="other-question")
 
         response = await async_client.put(
@@ -359,8 +359,8 @@ class TestDatasetRecordsBulkWithSuggestions:
 
         assert response.status_code == 422, response.json()
         assert response.json() == {
-            "detail": f"Record at position 0 does not have valid suggestions because "
-            f"question with question_id={other_question.id} does not exist"
+            "detail": "Record at position 0 is not valid because record does not have valid suggestions: "
+            f"question id={other_question.id} does not exists"
         }
 
     async def test_update_record_with_wrong_suggestion_value_in_bulk(
@@ -369,7 +369,7 @@ class TestDatasetRecordsBulkWithSuggestions:
         dataset = await self.test_dataset()
         question = dataset.question_by_name("label")
         record = await RecordFactory.create(dataset=dataset, fields={"prompt": "Does exercise help reduce stress?"})
-        suggestion = await SuggestionFactory.create(record=record, question=question, value="label-a")
+        await SuggestionFactory.create(record=record, question=question, value="label-a")
 
         response = await async_client.put(
             self.url(dataset.id),
@@ -388,12 +388,13 @@ class TestDatasetRecordsBulkWithSuggestions:
 
         assert response.status_code == 422, response.json()
         assert response.json() == {
-            "detail": "Record at position 0 does not have valid suggestions because suggestion for question name=label "
-            "is not valid: 'wrong-label' is not a valid label for label selection question.\n"
+            "detail": f"Record at position 0 is not valid because record does not have valid suggestions: "
+            "'wrong-label' is not a valid label for label selection question.\n"
             "Valid labels are: ['label-a', 'label-b']"
         }
 
-    async def _configure_dataset_fields(self, dataset: Dataset):
+    @classmethod
+    async def _configure_dataset_fields(cls, dataset: Dataset):
         await TextFieldFactory.create(name="prompt", dataset=dataset)
         await TextFieldFactory.create(name="response", dataset=dataset)
 

--- a/argilla-server/tests/unit/api/handlers/v1/datasets/records/records_bulk/test_dataset_records_bulk_with_vectors.py
+++ b/argilla-server/tests/unit/api/handlers/v1/datasets/records/records_bulk/test_dataset_records_bulk_with_vectors.py
@@ -232,8 +232,8 @@ class TestDatasetRecordsBulkWithVectors:
 
         assert response.status_code == 422, response.json()
         assert response.json() == {
-            "detail": f"Record at position 0 does not have valid vectors because vector with name=wrong_name "
-            f"does not exist for dataset_id={dataset.id}"
+            "detail": "Record at position 0 is not valid because record does not have valid vectors: "
+            f"vector with name=wrong_name does not exist for dataset_id={dataset.id}"
         }
 
     async def test_create_record_with_wrong_vector_value_in_bulk(
@@ -260,7 +260,7 @@ class TestDatasetRecordsBulkWithVectors:
 
         assert response.status_code == 422, response.json()
         assert response.json() == {
-            "detail": f"Record at position 0 does not have valid vectors because vector value for "
+            "detail": f"Record at position 0 is not valid because record does not have valid vectors: vector value for "
             f"vector name={vector_settings.name} must have 10 elements, got 5 elements"
         }
 
@@ -290,7 +290,7 @@ class TestDatasetRecordsBulkWithVectors:
 
         assert response.status_code == 422, response.json()
         assert response.json() == {
-            "detail": f"Record at position 0 does not have valid vectors because vector with name={other_vector_settings.name} "
+            "detail": f"Record at position 0 is not valid because record does not have valid vectors: vector with name={other_vector_settings.name} "
             f"does not exist for dataset_id={dataset.id}"
         }
 
@@ -319,7 +319,7 @@ class TestDatasetRecordsBulkWithVectors:
 
         assert response.status_code == 422, response.json()
         assert response.json() == {
-            "detail": "Record at position 0 does not have valid vectors because vector value for "
+            "detail": f"Record at position 0 is not valid because record does not have valid vectors: vector value for "
             f"vector name={vector_settings.name} must have 10 elements, got 5 elements"
         }
 

--- a/argilla-server/tests/unit/validators/test_records_bulk.py
+++ b/argilla-server/tests/unit/validators/test_records_bulk.py
@@ -92,7 +92,7 @@ class TestRecordsBulkValidators:
 
         with pytest.raises(
             UnprocessableEntityError,
-            match="record at position 1 is not valid because",
+            match="Record at position 1 is not valid because",
         ):
             await RecordsBulkCreateValidator.validate(db, records_create, dataset)
 
@@ -105,7 +105,7 @@ class TestRecordsBulkValidators:
             ]
         )
 
-        RecordsBulkUpsertValidator.validate(records_upsert, dataset)
+        await RecordsBulkUpsertValidator.validate(records_upsert, dataset)
 
     async def test_records_bulk_upsert_validator_with_draft_dataset(self, db: AsyncSession):
         dataset = await DatasetFactory.create(status="draft")
@@ -119,7 +119,7 @@ class TestRecordsBulkValidators:
                 ]
             )
 
-            RecordsBulkUpsertValidator.validate(records_upsert, dataset)
+            await RecordsBulkUpsertValidator.validate(records_upsert, dataset)
 
     async def test_records_bulk_upsert_validator_with_record_error(self, db: AsyncSession):
         dataset = await self.configure_dataset()
@@ -133,6 +133,6 @@ class TestRecordsBulkValidators:
 
         with pytest.raises(
             UnprocessableEntityError,
-            match="record at position 2 is not valid because",
+            match="Record at position 2 is not valid because",
         ):
-            RecordsBulkUpsertValidator.validate(records_upsert, dataset)
+            await RecordsBulkUpsertValidator.validate(records_upsert, dataset)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR moves all the record relationship validations (suggestions, responses, and vectors) inside the record validator. This helps centralize the validations and prevents objects from flushing into the DB early.

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Refactor (change restructuring the codebase without changing functionality)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
