### PR TITLE
[BUGFIX] argilla server: Prevent convert `ChatFieldValue` objects

### DIFF
--- a/argilla-server/src/argilla_server/api/schemas/v1/records.py
+++ b/argilla-server/src/argilla_server/api/schemas/v1/records.py
@@ -107,7 +107,9 @@ class RecordCreate(BaseModel):
         for key, value in fields.items():
             if isinstance(value, list):
                 try:
-                    fields[key] = [ChatFieldValue(**item) for item in value]
+                    fields[key] = [
+                        item if isinstance(item, ChatFieldValue) else ChatFieldValue(**item) for item in value
+                    ]
                 except ValidationError as e:
                     raise ValueError(f"Error parsing chat field '{key}': {e.errors()}")
 

--- a/argilla-server/tests/unit/api/schemas/v1/records/test_record_create.py
+++ b/argilla-server/tests/unit/api/schemas/v1/records/test_record_create.py
@@ -46,6 +46,30 @@ class TestRecordCreate:
         record_create = RecordCreate(fields={"field": {"key": "value"}})
         assert record_create.fields == {"field": {"key": "value"}}
 
+    def test_record_create_with_chat_field_object(self):
+        record_create = RecordCreate(
+            fields={
+                "field": [
+                    ChatFieldValue(role="user", content="Hello, how are you?"),
+                    ChatFieldValue(role="bot", content="I'm fine, thank you."),
+                ]
+            }
+        )
+
+        assert record_create.fields == {
+            "field": [
+                ChatFieldValue(role="user", content="Hello, how are you?"),
+                ChatFieldValue(role="bot", content="I'm fine, thank you."),
+            ]
+        }
+
+        assert record_create.fields == {
+            "field": [
+                ChatFieldValue(role="user", content="Hello, how are you?"),
+                ChatFieldValue(role="bot", content="I'm fine, thank you."),
+            ]
+        }
+
     def test_record_create_with_chat_field(self):
         record_create = RecordCreate(
             fields={


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Changes introduced in https://github.com/argilla-io/argilla/pull/5600 include a but when the fields in the `RecordCreate` schema already contain `ChatFieldValue` object. This is the cause of [failing integration tests in the develop branch](https://github.com/argilla-io/argilla/actions/runs/11380531039/job/31660006108).

The custom validator must skip these objects even if the `pre` flag is set to True. 

This PR fixes the error.

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
