### PR TITLE
feat: add support to `-1` no label values for `ClassLabel` dataset features

### DIFF
--- a/argilla-server/src/argilla_server/api/schemas/v1/datasets.py
+++ b/argilla-server/src/argilla_server/api/schemas/v1/datasets.py
@@ -168,6 +168,15 @@ class HubDatasetMapping(BaseModel):
     suggestions: Optional[List[HubDatasetMappingItem]] = []
     external_id: Optional[str] = None
 
+    @property
+    def sources(self) -> List[str]:
+        fields_sources = [field.source for field in self.fields]
+        metadata_sources = [metadata.source for metadata in self.metadata]
+        suggestions_sources = [suggestion.source for suggestion in self.suggestions]
+        external_id_source = [self.external_id] if self.external_id else []
+
+        return list(set(fields_sources + metadata_sources + suggestions_sources + external_id_source))
+
 
 class HubDataset(BaseModel):
     name: str

--- a/argilla-server/src/argilla_server/contexts/hub.py
+++ b/argilla-server/src/argilla_server/contexts/hub.py
@@ -36,6 +36,9 @@ RESET_ROW_IDX = -1
 FEATURE_TYPE_IMAGE = "Image"
 FEATURE_TYPE_CLASS_LABEL = "ClassLabel"
 
+DATA_URL_DEFAULT_IMAGE_FORMAT = "png"
+DATA_URL_DEFAULT_IMAGE_MIMETYPE = "image/png"
+
 
 class HubDataset:
     def __init__(self, name: str, subset: str, split: str, mapping: HubDatasetMapping):
@@ -178,8 +181,11 @@ class HubDataset:
 def pil_image_to_data_url(image: Image.Image):
     buffer = io.BytesIO()
 
-    image.save(buffer, format=image.format)
+    image_format = image.format or DATA_URL_DEFAULT_IMAGE_FORMAT
+    image_mimetype = image.get_format_mimetype() if image.format else DATA_URL_DEFAULT_IMAGE_MIMETYPE
+
+    image.convert("RGB").save(buffer, format=image_format)
 
     base64_image = base64.b64encode(buffer.getvalue()).decode("utf-8")
 
-    return f"data:{image.get_format_mimetype()};base64,{base64_image}"
+    return f"data:{image_mimetype};base64,{base64_image}"

--- a/argilla-server/src/argilla_server/contexts/hub.py
+++ b/argilla-server/src/argilla_server/contexts/hub.py
@@ -41,6 +41,7 @@ FEATURE_CLASS_LABEL_NO_LABEL = -1
 DATA_URL_DEFAULT_IMAGE_FORMAT = "png"
 DATA_URL_DEFAULT_IMAGE_MIMETYPE = "image/png"
 
+
 class HubDataset:
     def __init__(self, name: str, subset: str, split: str, mapping: HubDatasetMapping):
         self.dataset = load_dataset(path=name, name=subset, split=split, streaming=True)

--- a/argilla-server/src/argilla_server/contexts/hub.py
+++ b/argilla-server/src/argilla_server/contexts/hub.py
@@ -39,6 +39,8 @@ FEATURE_TYPE_CLASS_LABEL = "ClassLabel"
 DATA_URL_DEFAULT_IMAGE_FORMAT = "png"
 DATA_URL_DEFAULT_IMAGE_MIMETYPE = "image/png"
 
+FEATURE_CLASS_LABEL_NO_LABEL = -1
+
 
 class HubDataset:
     def __init__(self, name: str, subset: str, split: str, mapping: HubDatasetMapping):
@@ -99,7 +101,10 @@ class HubDataset:
             feature = self.features[feature_name]
 
             if feature._type == FEATURE_TYPE_CLASS_LABEL:
-                row[feature_name] = feature.int2str(value)
+                if value == FEATURE_CLASS_LABEL_NO_LABEL:
+                    row[feature_name] = None
+                else:
+                    row[feature_name] = feature.int2str(value)
             elif feature._type == FEATURE_TYPE_IMAGE and isinstance(value, Image.Image):
                 row[feature_name] = pil_image_to_data_url(value)
             else:
@@ -129,7 +134,7 @@ class HubDataset:
         for mapping_field in self.mapping.fields:
             value = row[mapping_field.source]
             field = dataset.field_by_name(mapping_field.target)
-            if not field:
+            if value is None or not field:
                 continue
 
             if field.is_text and value is not None:
@@ -144,7 +149,7 @@ class HubDataset:
         for mapping_metadata in self.mapping.metadata:
             value = row[mapping_metadata.source]
             metadata_property = dataset.metadata_property_by_name(mapping_metadata.target)
-            if not metadata_property:
+            if value is None or not metadata_property:
                 continue
 
             metadata[metadata_property.name] = value
@@ -156,7 +161,7 @@ class HubDataset:
         for mapping_suggestion in self.mapping.suggestions:
             value = row[mapping_suggestion.source]
             question = dataset.question_by_name(mapping_suggestion.target)
-            if not question:
+            if value is None or not question:
                 continue
 
             if question.is_text or question.is_label_selection:

--- a/argilla-server/src/argilla_server/contexts/hub.py
+++ b/argilla-server/src/argilla_server/contexts/hub.py
@@ -41,7 +41,7 @@ class HubDataset:
     def __init__(self, name: str, subset: str, split: str, mapping: HubDatasetMapping):
         self.dataset = load_dataset(path=name, name=subset, split=split, streaming=True)
         self.mapping = mapping
-        self.mapping_sources = mapping.sources
+        self.mapping_feature_names = mapping.sources
         self.row_idx = RESET_ROW_IDX
 
     @property
@@ -88,19 +88,19 @@ class HubDataset:
 
     def _batch_index_to_row(self, batch: dict, index: int) -> dict:
         row = {}
-        for key, values in batch.items():
-            if not key in self.mapping_sources:
+        for feature_name, values in batch.items():
+            if not feature_name in self.mapping_feature_names:
                 continue
 
             value = values[index]
-            feature = self.features[key]
+            feature = self.features[feature_name]
 
             if feature._type == FEATURE_TYPE_CLASS_LABEL:
-                row[key] = feature.int2str(value)
+                row[feature_name] = feature.int2str(value)
             elif feature._type == FEATURE_TYPE_IMAGE and isinstance(value, Image.Image):
-                row[key] = pil_image_to_data_url(value)
+                row[feature_name] = pil_image_to_data_url(value)
             else:
-                row[key] = value
+                row[feature_name] = value
 
         return row
 


### PR DESCRIPTION
# Description

This PR adds the following changes:
* Add support to `ClassLabel` features using `-1` (no label) values and casting these values to be `None`.
* Now when importing `fields`, `metadata`, or `suggestions` and the value is `None` they will be ignored.

Refs https://github.com/argilla-io/roadmap/issues/21

**Type of change**

- New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [x] Adding new tests and modifying existing ones.

**Checklist**

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
