### PR TITLE
Introducing Argilla Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@
 <a href="https://huggingface.co/new-space?template=argilla/argilla-template-space">
 <img src="https://huggingface.co/datasets/huggingface/badges/raw/main/deploy-to-spaces-sm.svg"/>
 </a>
-<a href="https://gurubase.io/g/argilla">
-<img src="https://img.shields.io/badge/Gurubase-Ask%20Argilla%20Guru-006BFF"/>
-</a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
 <a href="https://huggingface.co/new-space?template=argilla/argilla-template-space">
 <img src="https://huggingface.co/datasets/huggingface/badges/raw/main/deploy-to-spaces-sm.svg"/>
 </a>
+<a href="https://gurubase.io/g/argilla">
+<img src="https://img.shields.io/badge/Gurubase-Ask%20Argilla%20Guru-006BFF"/>
+</a>
 </p>
 
 <p align="center">

--- a/argilla/docs/community/index.md
+++ b/argilla/docs/community/index.md
@@ -42,7 +42,7 @@ We are an open-source community-driven project not only focused on building a gr
 
     [:octicons-arrow-right-24: Roadmap ↗](https://github.com/orgs/argilla-io/projects/10/views/1)
 
-    __Gurubase__
+-   __Gurubase__
 
     ---
 

--- a/argilla/docs/community/index.md
+++ b/argilla/docs/community/index.md
@@ -42,4 +42,12 @@ We are an open-source community-driven project not only focused on building a gr
 
     [:octicons-arrow-right-24: Roadmap ↗](https://github.com/orgs/argilla-io/projects/10/views/1)
 
+    __Gurubase__
+
+    ---
+
+    Gurubase is an AI-powered platform designed to answer technical questions using focused knowledge bases. Argilla Guru leverages data from Argilla's GitHub repository and documentation to provide answers to your questions.
+
+    [:octicons-arrow-right-24: Ask Argilla Guru ↗](https://gurubase.io/g/argilla)
+
 </div>


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Argilla Guru](https://gurubase.io/g/argilla) to Gurubase. Argilla Guru uses the data from this repo and data from the [docs](https://docs.argilla.io/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Argilla Guru" badge, which highlights that Argilla now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Argilla Guru in Gurubase, just let me know that's totally fine.