### PR TITLE
feat: fix importing datasets features mapped as chat fields

### DIFF
--- a/argilla-server/src/argilla_server/contexts/hub.py
+++ b/argilla-server/src/argilla_server/contexts/hub.py
@@ -19,8 +19,7 @@ from typing import Union
 from typing_extensions import Self
 
 from PIL import Image
-from datasets import load_dataset
-from datasets import features
+from datasets import load_dataset, features
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from argilla_server.models.database import Dataset

--- a/argilla-server/src/argilla_server/contexts/hub.py
+++ b/argilla-server/src/argilla_server/contexts/hub.py
@@ -20,6 +20,7 @@ from typing_extensions import Self
 
 from PIL import Image
 from datasets import load_dataset
+from datasets import features
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from argilla_server.models.database import Dataset
@@ -32,9 +33,6 @@ from argilla_server.api.schemas.v1.suggestions import SuggestionCreate
 
 BATCH_SIZE = 100
 RESET_ROW_IDX = -1
-
-FEATURE_TYPE_IMAGE = "Image"
-FEATURE_TYPE_CLASS_LABEL = "ClassLabel"
 
 FEATURE_CLASS_LABEL_NO_LABEL = -1
 
@@ -100,12 +98,12 @@ class HubDataset:
             value = values[index]
             feature = self.features[feature_name]
 
-            if feature._type == FEATURE_TYPE_CLASS_LABEL:
+            if isinstance(feature, features.ClassLabel):
                 if value == FEATURE_CLASS_LABEL_NO_LABEL:
                     row[feature_name] = None
                 else:
                     row[feature_name] = feature.int2str(value)
-            elif feature._type == FEATURE_TYPE_IMAGE and isinstance(value, Image.Image):
+            elif isinstance(feature, features.Image) and isinstance(value, Image.Image):
                 row[feature_name] = pil_image_to_data_url(value)
             else:
                 row[feature_name] = value


### PR DESCRIPTION
# Description

Using the dataset https://huggingface.co/datasets/mlabonne/ultrachat_200k_sft we have found that the import feature was not mapping correctly the `message` feature.

In order to fix this I'm improving with this PR how the feature values casting is done, checking if the features are instances of certain feature classes instead of using the `_type` method.

I have also added a new test importing the `mlabonne/ultrachat_200k_sft` dataset and using chat fields. 

Refs https://github.com/argilla-io/roadmap/issues/21

**Type of change**

- New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [x] Adding new tests to the suite.

**Checklist**

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
