### PR TITLE
feat: add dataset split to be used along with row idx when `external_id` is not provided on mapping

### DIFF
--- a/argilla-server/src/argilla_server/contexts/hub.py
+++ b/argilla-server/src/argilla_server/contexts/hub.py
@@ -42,6 +42,7 @@ DATA_URL_DEFAULT_IMAGE_MIMETYPE = "image/png"
 class HubDataset:
     def __init__(self, name: str, subset: str, split: str, mapping: HubDatasetMapping):
         self.dataset = load_dataset(path=name, name=subset, split=split, streaming=True)
+        self.split = split
         self.mapping = mapping
         self.mapping_feature_names = mapping.sources
         self.row_idx = RESET_ROW_IDX
@@ -124,7 +125,7 @@ class HubDataset:
 
     def _row_external_id(self, row: dict) -> str:
         if not self.mapping.external_id:
-            return str(self._next_row_idx())
+            return f"{self.split}_{self._next_row_idx()}"
 
         return row[self.mapping.external_id]
 


### PR DESCRIPTION
# Description

This PR add the dataset imported split to be used as `external_id` when there is no value for `external_id` specified on the import mapping.

If importing the split `train` for a dataset and no `external_id` is provided the `external_id` will be calculated like the following:
- `train_0`: first row of `train` split.
- `train_1`: second row of `train` split.
- ...

With this we are avoiding row duplications when another split is imported to the same dataset. So if later we import the `test` split for the same dataset we will have for `external_id`:
- `train_0`: first row of `train` split.
- `train_1`: second row of `train` split.
- ...
- `test_0`: first row of `test` split.
- `test_1`: second row of `test` split.
- ...

Refs https://github.com/argilla-io/roadmap/issues/21

**Type of change**

- New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [x] Adding additional tests.

**Checklist**

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
