### PR TITLE
[REFACTOR] argilla: using split and row idx for default external

### DIFF
--- a/argilla/src/argilla/datasets/_io/_hub.py
+++ b/argilla/src/argilla/datasets/_io/_hub.py
@@ -232,7 +232,7 @@ class HubImportExportMixin(DiskImportExportMixin):
 
         # Extract responses and create Record objects
         records = []
-        hf_dataset = HFDatasetsIO.to_argilla(hf_dataset=hf_dataset)
+        hf_dataset = HFDatasetsIO.to_argilla(hf_dataset=hf_dataset, mapper=mapper)
         for idx, row in enumerate(hf_dataset):
             record = mapper(row)
             for question_name, values in response_questions.items():

--- a/argilla/src/argilla/records/_dataset_records.py
+++ b/argilla/src/argilla/records/_dataset_records.py
@@ -422,11 +422,12 @@ class DatasetRecords(Iterable[Record], LoggingMixin):
         if len(records) == 0:
             raise ValueError("No records provided to ingest.")
 
+        record_mapper = IngestedRecordMapper(mapping=mapping, dataset=self.__dataset, user_id=user_id)
+
         if HFDatasetsIO._is_hf_dataset(dataset=records):
-            records = HFDatasetsIO._record_dicts_from_datasets(hf_dataset=records)
+            records = HFDatasetsIO._record_dicts_from_datasets(hf_dataset=records, mapper=record_mapper)
 
         ingested_records = []
-        record_mapper = IngestedRecordMapper(mapping=mapping, dataset=self.__dataset, user_id=user_id)
         for record in records:
             try:
                 if isinstance(record, dict):

--- a/argilla/tests/integration/test_import_features.py
+++ b/argilla/tests/integration/test_import_features.py
@@ -130,3 +130,16 @@ class TestImportFeaturesFromHub:
 
         assert created_dataset.settings.fields[0].name == "Text"
         assert list(created_dataset.records)[0].fields["Text"] == "Hello World, how are you?"
+
+    def test_import_with_row_id_as_record_id(self, client: rg.Argilla, token: str, dataset_name: str):
+        created_dataset = rg.Dataset.from_hub(
+            "argilla-internal-testing/test_import_from_hub_with_unlabelled_classes",
+            token=token,
+            name=dataset_name,
+            split="train",
+        )
+
+        records = list(created_dataset.records)
+
+        for idx, record in enumerate(records):
+            assert record.id == f"train_{idx}"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Using row idx + split name to generate default record id.


**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->
- Refactor (change restructuring the codebase without changing functionality)
- Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
