### PR TITLE
fix: Prevent compute metrics for draft datasets

### DIFF
--- a/argilla-server/src/argilla_server/search_engine/commons.py
+++ b/argilla-server/src/argilla_server/search_engine/commons.py
@@ -395,6 +395,9 @@ class BaseElasticAndOpenSearchEngine(SearchEngine):
         )
 
     async def get_dataset_progress(self, dataset: Dataset) -> dict:
+        if dataset.is_draft:
+            return {}
+
         index_name = es_index_name_for_dataset(dataset)
 
         metrics = await self._compute_terms_metrics_for(index_name, "status")
@@ -402,6 +405,9 @@ class BaseElasticAndOpenSearchEngine(SearchEngine):
         return {"total": metrics.total, **{metric.term: metric.count for metric in metrics.values}}
 
     async def get_dataset_user_progress(self, dataset: Dataset, user: User) -> dict:
+        if dataset.is_draft:
+            return {}
+
         index_name = es_index_name_for_dataset(dataset)
 
         result = await self._compute_terms_metrics_for(


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Dataset progress and user metrics are not available for draft datasets.

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
