### PR TITLE
[IMPROVEMENT] feat(helm): add support for default storage class in PVCs

### DIFF
--- a/argilla-server/CHANGELOG.md
+++ b/argilla-server/CHANGELOG.md
@@ -19,6 +19,7 @@ These are the section headers that we use:
 ### Changed
 
 - Changed supported values for terms metadata options to accept other than strings values. ([#5589](https://github.com/argilla-io/argilla/pull/5589))
+- Changed Helm chart to allow the use of a default storage class when none is explicitly specified. This ensures compatibility with environments like k3d that do not have a 'standard' storage class by default.
 
 ### Removed
 

--- a/examples/deployments/k8s/argilla-chart/tests/suite_test.yaml
+++ b/examples/deployments/k8s/argilla-chart/tests/suite_test.yaml
@@ -86,7 +86,6 @@ tests:
       argilla.persistence.enabled: true
       argilla.persistence.accessMode: ReadWriteOnce
       argilla.persistence.size: 5Gi
-      argilla.persistence.storageClass: standard
     templates:
       - templates/pvc.yaml
     asserts:
@@ -98,9 +97,7 @@ tests:
       - equal:
           path: spec.resources.requests.storage
           value: 5Gi
-      - equal:
-          path: spec.storageClassName
-          value: standard
+      - notHasKey: spec.storageClassName
 
   - it: should render service correctly
     templates:

--- a/examples/deployments/k8s/argilla-chart/values.yaml
+++ b/examples/deployments/k8s/argilla-chart/values.yaml
@@ -17,7 +17,6 @@ argilla:
     enabled: true
     accessMode: ReadWriteOnce
     size: 2Gi
-    storageClass: "standard"
     mountPath: "/data"
   ingress:
     enabled: true
@@ -54,7 +53,6 @@ elasticsearch:
     enabled: true
     storage:
       size: 1Gi
-      storageClass: "standard"
       accessModes:
       - ReadWriteOnce
 
@@ -71,7 +69,6 @@ redis:
   master:
     persistence:
       enabled: true
-      storageClass: "standard"
       accessModes:
         - ReadWriteOnce
       size: 1Gi


### PR DESCRIPTION
# Description

I updated the Helm chart to allow the use of a default storage class when none is explicitly specified. This change is important because some Kubernetes environments, like k3d, do not have a 'standard' storage class by default.
Without this change, the setup could fail in such environments, as Kubernetes would attempt to use an undefined or missing storage class. By not explicitly setting a storage class, I allow Kubernetes to default to whatever storage class is configured for the cluster.

This ensures the chart works across various setups, including those that don't predefine a 'standard' storage class.


**Type of change**

- Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

Tested on a MacBook Pro M3 Max with k3d (v5.7.4) and Minikube (v1.34.0).

**Checklist**:

I added relevant documentation
I followed the style guidelines of this project
I did a self-review of my code
I made corresponding changes to the documentation
I confirm My changes generate no new warnings
I have added tests that prove my fix is effective or that my feature works
I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)