### PR TITLE
feat: added support for `with_vectors` with query filter in sdk

### DIFF
--- a/argilla/CHANGELOG.md
+++ b/argilla/CHANGELOG.md
@@ -19,6 +19,7 @@ These are the section headers that we use:
 ### Changed
 
 - Terms metadata properties accept other values than `str`. ([#5594](https://github.com/argilla-io/argilla/pull/5594))
+- Added support for `with_vectors` while fetching records along with a search query. ([#5638](https://github.com/argilla-io/argilla/pull/5638))
 
 ## [2.3.0](https://github.com/argilla-io/argilla/compare/v2.2.2...v2.3.0)
 

--- a/argilla/src/argilla/_api/_records.py
+++ b/argilla/src/argilla/_api/_records.py
@@ -111,13 +111,15 @@ class RecordsAPI(ResourceAPI[RecordModel]):
         limit: int = 100,
         with_suggestions: bool = True,
         with_responses: bool = True,
-        # TODO: Add support for `with_vectors`
+        with_vectors: Optional[Union[List, bool]] = None,
     ) -> Tuple[List[Tuple[RecordModel, float]], int]:
         include = []
         if with_suggestions:
             include.append("suggestions")
         if with_responses:
             include.append("responses")
+        if with_vectors:
+            include.append(self._represent_vectors_to_include(with_vectors))
         params = {
             "offset": offset,
             "limit": limit,

--- a/argilla/src/argilla/records/_dataset_records.py
+++ b/argilla/src/argilla/records/_dataset_records.py
@@ -132,7 +132,7 @@ class DatasetRecordsIterator:
             offset=self.__offset,
             with_responses=self.__with_responses,
             with_suggestions=self.__with_suggestions,
-            with_vectors=self.__with_vectors
+            with_vectors=self.__with_vectors,
         )
         return [record_model for record_model, _ in search_items]
 

--- a/argilla/src/argilla/records/_dataset_records.py
+++ b/argilla/src/argilla/records/_dataset_records.py
@@ -132,6 +132,7 @@ class DatasetRecordsIterator:
             offset=self.__offset,
             with_responses=self.__with_responses,
             with_suggestions=self.__with_suggestions,
+            with_vectors=self.__with_vectors
         )
         return [record_model for record_model, _ in search_items]
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #5636 

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->
Passed `with_vectors` parameter to the search method while retrieving records and I could see the vectors in the response now. 


- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
