### PR TITLE
feat: add new validation to avoid creating records with empty fields

### DIFF
--- a/argilla-server/CHANGELOG.md
+++ b/argilla-server/CHANGELOG.md
@@ -19,6 +19,7 @@ These are the section headers that we use:
 ### Added
 
 - Added new `metadata` attribute for endpoints getting, creating and updating Datasets so now it is possible to store metadata associated to a dataset. ([#5586](https://github.com/argilla-io/argilla/pull/5586))
+- Added new validation to avoid the creation of records with empty `fields` attributes. ([#5639](https://github.com/argilla-io/argilla/pull/5639))
 
 ### Changed
 

--- a/argilla-server/src/argilla_server/api/schemas/v1/records.py
+++ b/argilla-server/src/argilla_server/api/schemas/v1/records.py
@@ -119,7 +119,7 @@ class RecordCreate(BaseModel):
                         f"allowed value of {CHAT_FIELDS_MAX_MESSAGES}"
                     )
 
-            return fields
+        return fields
 
     @validator("responses")
     @classmethod

--- a/argilla-server/src/argilla_server/validators/records.py
+++ b/argilla-server/src/argilla_server/validators/records.py
@@ -52,13 +52,17 @@ CHAT_FIELD_MAX_LENGTH = 500
 class RecordValidatorBase(ABC):
     @classmethod
     def _validate_fields(cls, fields: dict, dataset: Dataset) -> None:
-        fields = fields or {}
-
+        cls._validate_non_empty_fields(fields=fields)
         cls._validate_required_fields(dataset=dataset, fields=fields)
         cls._validate_extra_fields(dataset=dataset, fields=fields)
         cls._validate_image_fields(dataset=dataset, fields=fields)
         cls._validate_chat_fields(dataset=dataset, fields=fields)
         cls._validate_custom_fields(dataset=dataset, fields=fields)
+
+    @classmethod
+    def _validate_non_empty_fields(cls, fields: Dict[str, str]) -> None:
+        if not (isinstance(fields, dict) and len(fields) >= 1):
+            raise UnprocessableEntityError("fields cannot be empty")
 
     @classmethod
     def _validate_required_fields(cls, dataset: Dataset, fields: Dict[str, str]) -> None:

--- a/argilla-server/tests/unit/api/handlers/v1/datasets/records/records_bulk/test_dataset_records_bulk.py
+++ b/argilla-server/tests/unit/api/handlers/v1/datasets/records/records_bulk/test_dataset_records_bulk.py
@@ -175,6 +175,7 @@ class TestDatasetRecordsBulk:
         other_dataset = await self.test_dataset()
 
         record = await RecordFactory.create(dataset=dataset)
+
         response = await async_client.put(
             self.url(other_dataset.id),
             headers=owner_auth_header,
@@ -185,7 +186,9 @@ class TestDatasetRecordsBulk:
             },
         )
 
-        assert response.status_code == 422  # The insert is failing because no fields are provided
+        assert response.status_code == 422
+        assert response.json() == {"detail": "Record at position 0 is not valid because fields cannot be empty"}
+
         assert (await db.execute(select(func.count(Record.id)))).scalar_one() == 1
         assert (await db.execute(select(Record))).scalar_one().metadata_ is None
 

--- a/argilla-server/tests/unit/api/handlers/v1/records/test_upsert_dataset_records_bulk.py
+++ b/argilla-server/tests/unit/api/handlers/v1/records/test_upsert_dataset_records_bulk.py
@@ -16,17 +16,87 @@ import pytest
 
 from uuid import UUID
 from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from argilla_server.models import User
+from argilla_server.models import User, Record
 from argilla_server.enums import DatasetDistributionStrategy, ResponseStatus, DatasetStatus, RecordStatus
 
-from tests.factories import DatasetFactory, RecordFactory, TextQuestionFactory, ResponseFactory, AnnotatorFactory
+from tests.factories import (
+    DatasetFactory,
+    RecordFactory,
+    TextFieldFactory,
+    TextQuestionFactory,
+    ResponseFactory,
+    AnnotatorFactory,
+)
 
 
 @pytest.mark.asyncio
 class TestUpsertDatasetRecordsBulk:
     def url(self, dataset_id: UUID) -> str:
         return f"/api/v1/datasets/{dataset_id}/records/bulk"
+
+    async def test_upsert_dataset_records_with_empty_fields_creating_record(
+        self, db: AsyncSession, async_client: AsyncClient, owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create(status=DatasetStatus.ready)
+
+        await TextFieldFactory.create(name="text-field", dataset=dataset)
+
+        response = await async_client.put(
+            self.url(dataset.id),
+            headers=owner_auth_header,
+            json={
+                "items": [
+                    {
+                        "fields": {
+                            "text-field": "value",
+                        },
+                    },
+                    {
+                        "fields": {},
+                    },
+                ],
+            },
+        )
+
+        assert response.status_code == 422
+        assert response.json() == {"detail": "Record at position 1 is not valid because fields cannot be empty"}
+
+        assert (await db.execute(select(func.count(Record.id)))).scalar_one() == 0
+
+    async def test_upsert_dataset_records_with_empty_fields_updating_record(
+        self, db: AsyncSession, async_client: AsyncClient, owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create(status=DatasetStatus.ready)
+
+        await TextFieldFactory.create(name="text-field", dataset=dataset)
+
+        record = await RecordFactory.create(fields={"text-field": "value"}, dataset=dataset)
+
+        response = await async_client.put(
+            self.url(dataset.id),
+            headers=owner_auth_header,
+            json={
+                "items": [
+                    {
+                        "fields": {
+                            "text-field": "value",
+                        },
+                    },
+                    {
+                        "id": str(record.id),
+                        "fields": {},
+                    },
+                ],
+            },
+        )
+
+        assert response.status_code == 200
+
+        assert record.fields == {"text-field": "value"}
+        assert (await db.execute(select(func.count(Record.id)))).scalar_one() == 2
 
     async def test_upsert_dataset_records_bulk_updates_records_status(
         self, async_client: AsyncClient, owner: User, owner_auth_header: dict


### PR DESCRIPTION
# Description

This PR adds a new validation avoiding the creation of records with `fields` attribute empty. It also includes a fix to a bug to a chat field validation method.

Refs https://github.com/argilla-io/roadmap/issues/21

**Type of change**

- New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [x] Adding new tests.

**Checklist**

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
