### PR TITLE
fix: skip `helmlint` pre-commit hook on CI because `helm` command is not available

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,12 +75,12 @@ repos:
   # Helm lint hook
   ##############################################################################
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.23
+    rev: v0.1.24
     hooks:
       - id: helmlint
         name: Helm lint
         files: '^examples/deployments/k8s/.*\.yaml$'
-        args: ['helm', 'lint','examples/deployments/k8s/']
+        args: ["helm", "lint", "examples/deployments/k8s/"]
 
 ci:
   autofix_commit_msg: |
@@ -90,5 +90,6 @@ ci:
   autoupdate_branch: ""
   autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
   autoupdate_schedule: weekly
-  skip: []
+  skip:
+    - helmlint # Disabling helmlint on CI by now because helm dependency is not available
   submodules: false


### PR DESCRIPTION
# Description

This should fix errors raised by our pre-commit actions when trying to run `helm lint` and the `helm` command is not available.

I have tried to add `helm` as additional dependency for the `helmlint` hook but is not possible so disabling it by now on CI. It is available when running it locally and you have `helm` installed.

**Type of change**

- Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

- [ ] GitHub Actions with pre-commit should now work as expected without errors.

**Checklist**

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
