### PR TITLE
[BUGFIX] `argilla`: allow change default distribution values

### DIFF
--- a/argilla/CHANGELOG.md
+++ b/argilla/CHANGELOG.md
@@ -25,6 +25,10 @@ These are the section headers that we use:
 - Added support to webhook listeners. ([#5502](https://github.com/argilla-io/argilla/pull/5502))
 - Added support to Python 3.13. ([#5652](https://github.com/argilla-io/argilla/pull/5652))
 
+### Fixed
+
+- Fixed error when update settings.distribution.min_submitted from defaults ([#5719](https://github.com/argilla-io/argilla/pull/5719))
+
 ## [2.4.0](https://github.com/argilla-io/argilla/compare/v2.3.0...v2.4.0)
 
 ### Added

--- a/argilla/src/argilla/settings/_resource.py
+++ b/argilla/src/argilla/settings/_resource.py
@@ -73,7 +73,7 @@ class Settings(DefaultSettingsMixin, Resource):
         super().__init__(client=_dataset._client if _dataset else None)
 
         self._dataset = _dataset
-        self._distribution = distribution
+        self._distribution = distribution or TaskDistribution.default()
         self._mapping = mapping
         self.__guidelines = self.__process_guidelines(guidelines)
         self.__allow_extra_metadata = allow_extra_metadata
@@ -137,7 +137,7 @@ class Settings(DefaultSettingsMixin, Resource):
 
     @property
     def distribution(self) -> TaskDistribution:
-        return self._distribution or TaskDistribution.default()
+        return self._distribution
 
     @distribution.setter
     def distribution(self, value: TaskDistribution) -> None:

--- a/argilla/tests/unit/test_settings/test_settings.py
+++ b/argilla/tests/unit/test_settings/test_settings.py
@@ -176,6 +176,14 @@ class TestSettings:
         other_settings = rg.Settings(fields=[rg.TextField(name="text", title="title")])
         assert other_settings.distribution == TaskDistribution(min_submitted=1)
 
+    def test_settings_with_modified_task_distribution_value(self):
+        settings = rg.Settings(fields=[rg.TextField(name="text", title="title")])
+
+        assert settings.distribution == TaskDistribution(min_submitted=1)
+        settings.distribution.min_submitted = 10
+
+        assert settings.distribution == TaskDistribution(min_submitted=10)
+
     def test_compare_equal_settings(self):
         settings = rg.Settings(fields=[rg.TextField(name="text", title="title")])
         assert settings == settings


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

When creating a `rg.Settings` instance with default distribution, updates on the `min_submitted` attribute do not take effect.
````python

settings = rg.Settings(fields=...)

settings.distribution.min_submitted= 3 # this not takes effect
````

~Maybe related to https://github.com/argilla-io/argilla/issues/5718~

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
