### PR TITLE
fix: UI - use `last_activity_at` in the dataset list

### DIFF
--- a/argilla-frontend/CHANGELOG.md
+++ b/argilla-frontend/CHANGELOG.md
@@ -16,6 +16,10 @@ These are the section headers that we use:
 
 ## [Unreleased]()
 
+### Fixed
+
+- Fixed dataset update date information in the dataset list ([#5741](https://github.com/argilla-io/argilla/pull/#5741))
+
 ## [2.5.0](https://github.com/argilla-io/argilla/compare/v2.4.1...v2.5.0)
 
 ### Added

--- a/argilla-frontend/components/features/home/dataset-list/DatasetCard.vue
+++ b/argilla-frontend/components/features/home/dataset-list/DatasetCard.vue
@@ -20,7 +20,7 @@
         </div>
         <div class="dataset-card__date">
           <span v-text="$t('home.updatedAt')" />
-          <BaseDate format="date-relative-now" :date="dataset.updatedAt" />
+          <BaseDate format="date-relative-now" :date="dataset.lastActivityAt" />
         </div>
       </div>
       <p class="dataset-card__workspace">{{ dataset.workspaceName }}</p>

--- a/argilla-frontend/components/features/home/dataset-list/DatasetList.vue
+++ b/argilla-frontend/components/features/home/dataset-list/DatasetList.vue
@@ -48,10 +48,10 @@ export default {
     return {
       querySearch: "",
       sortedOrder: "desc",
-      sortedByField: "updatedAt",
+      sortedByField: "lastActivityAt",
       sortOptions: [
         { value: "name", label: this.$t("home.name") },
-        { value: "updatedAt", label: this.$t("home.updatedAt") },
+        { value: "lastActivityAt", label: this.$t("home.updatedAt") },
         { value: "createdAt", label: this.$t("home.createdAt") },
       ],
       selectedWorkspaces: [],


### PR DESCRIPTION
This PR uses `last_activity_At`instead of `updated_at` in the dataset card info and in the sorting filter on the homepage