### PR TITLE
[CI] fix install deps using python.3.13 

### DIFF
--- a/.github/workflows/argilla.yml
+++ b/.github/workflows/argilla.yml
@@ -33,14 +33,14 @@ jobs:
           USERNAME: argilla
           PASSWORD: 12345678
           API_KEY: argilla.apikey
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: argilla
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup PDM

--- a/.github/workflows/argilla.yml
+++ b/.github/workflows/argilla.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13.0"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup PDM

--- a/argilla/pyproject.toml
+++ b/argilla/pyproject.toml
@@ -1,4 +1,3 @@
-# TODO: Remove me
 [project]
 name = "argilla"
 description = "The Argilla python server SDK"

--- a/argilla/pyproject.toml
+++ b/argilla/pyproject.toml
@@ -1,3 +1,4 @@
+# TODO: Remove me
 [project]
 name = "argilla"
 description = "The Argilla python server SDK"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Some SDK CI pipelines are failing when installing pandas and pillow dependencies 
- https://github.com/argilla-io/argilla/actions/runs/12255950013/job/34197637402
- https://github.com/argilla-io/argilla/actions/runs/12254716138/job/34186264575

This PR fixes the problem by setting the ubuntu version to 22.04. The `ubuntu-latest` (24.0) does not contain a proper compiled distribution for those packages.

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->


**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
