### PR TITLE
feat: add record timestamps to export

### DIFF
--- a/argilla-server/src/argilla_server/contexts/hub.py
+++ b/argilla-server/src/argilla_server/contexts/hub.py
@@ -273,6 +273,8 @@ class HubDatasetExporter:
         return {
             "id": record.external_id,
             "status": record.status,
+            "inserted_at": record.inserted_at,
+            "updated_at": record.updated_at,
             "_server_id": str(record.id),
         }
 

--- a/argilla-server/tests/unit/contexts/hub/test_hub_dataset.py
+++ b/argilla-server/tests/unit/contexts/hub/test_hub_dataset.py
@@ -18,7 +18,6 @@ from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from argilla_server.api.schemas.v1.datasets import HubDatasetMapping, HubDatasetMappingItem
-from argilla_server.api.schemas.v1.metadata_properties import IntegerMetadataProperty
 from argilla_server.enums import DatasetStatus, QuestionType
 from argilla_server.models import Record
 from argilla_server.contexts.hub import HubDataset

--- a/argilla-server/tests/unit/contexts/hub/test_hub_dataset_exporter.py
+++ b/argilla-server/tests/unit/contexts/hub/test_hub_dataset_exporter.py
@@ -94,6 +94,8 @@ class TestHubDatasetExporter:
         assert exported_dataset[0] == {
             "id": record.external_id,
             "status": record.status,
+            "inserted_at": record.inserted_at,
+            "updated_at": record.updated_at,
             "_server_id": str(record.id),
             "text": "Hello World",
         }
@@ -279,6 +281,8 @@ class TestHubDatasetExporter:
         assert exported_dataset[0] == {
             "id": record.external_id,
             "status": record.status,
+            "inserted_at": record.inserted_at,
+            "updated_at": record.updated_at,
             "_server_id": str(record.id),
             "text": "Hello World",
             "text-question.responses": ["This is a response", "This is another response"],
@@ -340,6 +344,8 @@ class TestHubDatasetExporter:
         assert exported_dataset[0] == {
             "id": record.external_id,
             "status": record.status,
+            "inserted_at": record.inserted_at,
+            "updated_at": record.updated_at,
             "_server_id": str(record.id),
             "text": "Hello World",
             "text-question.responses": ["This is a response", "This is another response"],
@@ -402,6 +408,8 @@ class TestHubDatasetExporter:
         assert exported_dataset[0] == {
             "id": record.external_id,
             "status": record.status,
+            "inserted_at": record.inserted_at,
+            "updated_at": record.updated_at,
             "_server_id": str(record.id),
             "text": "Hello World",
             "rating-question.responses": [2, 0],
@@ -468,6 +476,8 @@ class TestHubDatasetExporter:
         assert exported_dataset[0] == {
             "id": record.external_id,
             "status": record.status,
+            "inserted_at": record.inserted_at,
+            "updated_at": record.updated_at,
             "_server_id": str(record.id),
             "text": "Hello World",
             "rating-question.responses": [2, 0],
@@ -529,6 +539,8 @@ class TestHubDatasetExporter:
         assert exported_dataset[0] == {
             "id": record.external_id,
             "status": record.status,
+            "inserted_at": record.inserted_at,
+            "updated_at": record.updated_at,
             "_server_id": str(record.id),
             "text": "Hello World",
             "label-question.responses": ["label-b", "label-a"],
@@ -594,6 +606,8 @@ class TestHubDatasetExporter:
         assert exported_dataset[0] == {
             "id": record.external_id,
             "status": record.status,
+            "inserted_at": record.inserted_at,
+            "updated_at": record.updated_at,
             "_server_id": str(record.id),
             "text": "Hello World",
             "label-question.responses": ["label-b", "label-a"],
@@ -655,6 +669,8 @@ class TestHubDatasetExporter:
         assert exported_dataset[0] == {
             "id": record.external_id,
             "status": record.status,
+            "inserted_at": record.inserted_at,
+            "updated_at": record.updated_at,
             "_server_id": str(record.id),
             "text": "Hello World",
             "multi-label-question.responses": [["label-a", "label-b"], ["label-c", "label-a"]],
@@ -720,6 +736,8 @@ class TestHubDatasetExporter:
         assert exported_dataset[0] == {
             "id": record.external_id,
             "status": record.status,
+            "inserted_at": record.inserted_at,
+            "updated_at": record.updated_at,
             "_server_id": str(record.id),
             "text": "Hello World",
             "multi-label-question.responses": [["label-a", "label-b"], ["label-c", "label-a"]],
@@ -790,6 +808,8 @@ class TestHubDatasetExporter:
         assert exported_dataset[0] == {
             "id": record.external_id,
             "status": record.status,
+            "inserted_at": record.inserted_at,
+            "updated_at": record.updated_at,
             "_server_id": str(record.id),
             "text": "Hello World",
             "ranking-question.responses": [
@@ -880,6 +900,8 @@ class TestHubDatasetExporter:
         assert exported_dataset[0] == {
             "id": record.external_id,
             "status": record.status,
+            "inserted_at": record.inserted_at,
+            "updated_at": record.updated_at,
             "_server_id": str(record.id),
             "text": "Hello World",
             "ranking-question.responses": [
@@ -964,6 +986,8 @@ class TestHubDatasetExporter:
         assert exported_dataset[0] == {
             "id": record.external_id,
             "status": record.status,
+            "inserted_at": record.inserted_at,
+            "updated_at": record.updated_at,
             "_server_id": str(record.id),
             "text": "Hello World",
             "span-question.responses": [
@@ -1047,6 +1071,8 @@ class TestHubDatasetExporter:
         assert exported_dataset[0] == {
             "id": record.external_id,
             "status": record.status,
+            "inserted_at": record.inserted_at,
+            "updated_at": record.updated_at,
             "_server_id": str(record.id),
             "text": "Hello World",
             "span-question.responses": [
@@ -1102,6 +1128,8 @@ class TestHubDatasetExporter:
         assert exported_dataset[0] == {
             "id": record.external_id,
             "status": record.status,
+            "inserted_at": record.inserted_at,
+            "updated_at": record.updated_at,
             "_server_id": str(record.id),
             "text": "Hello World",
             "text-question.responses": [None],
@@ -1143,6 +1171,8 @@ class TestHubDatasetExporter:
         assert exported_dataset[0] == {
             "id": record.external_id,
             "status": record.status,
+            "inserted_at": record.inserted_at,
+            "updated_at": record.updated_at,
             "_server_id": str(record.id),
             "text": "Hello World",
             "text-question.responses": [None],


### PR DESCRIPTION
# Description

Only adding record's `inserted_at` and `updated_at` to the list of record attributes used with `HubDatasetExport`.

**Type of change**

- New feature (non-breaking change which adds functionality)

**How Has This Been Tested**

- [x] Changing the test suite for `HubDatasetExporter`.

**Checklist**

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
