### PR TITLE
fix: problem with question values on README when exporting datasets to the hub

### DIFF
--- a/argilla-server/src/argilla_server/contexts/hub_templates/README.md.jinja2
+++ b/argilla-server/src/argilla_server/contexts/hub_templates/README.md.jinja2
@@ -74,7 +74,7 @@ The **questions** are the questions that will be asked to the annotators. They c
 
 | Question Name | Title | Type | Required | Description | Values/Labels |
 | ------------- | ----- | ---- | -------- | ----------- | ------------- |
-{% for question in argilla_questions %}| {{ question.name }} | {{ question.title }} | {{ question.type }} | {{ question.required }} | {{ question.description | default("N/A", true) }} | {% if question.type in ["rating", "label_selection", "multi_label_selection", "ranking"] %}{% if question.type in ["rating", "ranking"] %}{{ question.values | list }}{% else %}{{ question.labels | list }}{% endif %}{% else %}N/A{% endif %} |
+{% for question in argilla_questions %}| {{ question.name }} | {{ question.title }} | {{ question.type }} | {{ question.required }} | {{ question.description | default("N/A", true) }} | {% if question.type in ["rating", "label_selection", "multi_label_selection", "ranking", "span"] %}{{ question.values | list }}{% else %}N/A{% endif %} |
 {% endfor %}
 
 <!-- check length of metadata properties -->


### PR DESCRIPTION
# Description

Some questions were not rendering values correctly when generating the README dataset card. This PR includes some changes to fix that problem.

**Type of change**

- Improvement (change adding some improvement to an existing functionality)

**How Has This Been Tested**

- [x] Manually uploading a dataset to the hub with all kinds of questions.

**Checklist**

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
