### PR TITLE
Remove duplicate worker deployment labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Need more info, check out [our docs](https://argilla-io.github.io/argilla/latest
 
 ## 🥇 Contributors
 
-To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs. 
+To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs.
 
 <a  href="https://github.com/argilla-io/argilla/graphs/contributors">
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-> [!IMPORTANT]  
+> [!IMPORTANT]
 The original authors have moved on to other projects. While the code might still be functional for its original purpose, please be aware that the original team does not plan to develop new features, bug fixes, or updates. If you'd like to become a maintainer, please open an issue to discuss it.
-> 
+>
 <h1 align="center">
   <a href=""><img src="https://github.com/dvsrepo/imgs/raw/main/rg.svg" alt="Argilla" width="150"></a>
   <br>

--- a/examples/deployments/k8s/argilla-chart/Chart.yaml
+++ b/examples/deployments/k8s/argilla-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/examples/deployments/k8s/argilla-chart/templates/worker-deployment.yaml
+++ b/examples/deployments/k8s/argilla-chart/templates/worker-deployment.yaml
@@ -4,18 +4,15 @@ metadata:
   name: {{ include "argilla.fullname" . }}-worker
   labels:
     {{- include "worker.labels" . | nindent 4 }}
-    app.kubernetes.io/component: worker
 spec:
   replicas: {{ .Values.worker.replicaCount | default 1 }}
   selector:
     matchLabels:
       {{- include "worker.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: worker
   template:
     metadata:
       labels:
         {{- include "worker.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: worker
     spec:
       containers:
         - name: {{ .Chart.Name }}-worker


### PR DESCRIPTION
# Description

Removed duplicate worker deployment labels, which created invalid YAML.
This bug made it impossible to use Kustomize with Helm, since Kustomize validates YAML (Helm apparently skips this validation).

Closes #5788

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

`helm template argilla examples/deployments/k8s/argilla-chart`

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
