### PR TITLE
Fix typo in docker-compose.yaml comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Need more info, check out [our docs](https://argilla-io.github.io/argilla/latest
 
 ## 🥇 Contributors
 
-To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs. 
+To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs.
 
 <a  href="https://github.com/argilla-io/argilla/graphs/contributors">
 

--- a/examples/deployments/docker/docker-compose.yaml
+++ b/examples/deployments/docker/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
     networks:
       - argilla
     volumes:
-      # ARGILLA_HOME_PATH is used to define where Argilla will save it's application data.
+      # ARGILLA_HOME_PATH is used to define where Argilla will save its application data.
       # If you change ARGILLA_HOME_PATH value please copy that same value to argilladata volume too.
       - argilladata:/var/lib/argilla
     depends_on:


### PR DESCRIPTION
# Description
Changed "it's" (contraction of it-is) to possessive "its".

Closes #5848

**Type of change**
- Documentation update

**Checklist**
- [x] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] I confirm My changes generate no new warnings
