### PR TITLE
fix: remove ARM-specific JVM flag from docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Need more info, check out [our docs](https://argilla-io.github.io/argilla/latest
 
 ## 🥇 Contributors
 
-To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs. 
+To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs.
 
 <a  href="https://github.com/argilla-io/argilla/graphs/contributors">
 

--- a/examples/deployments/docker/docker-compose.yaml
+++ b/examples/deployments/docker/docker-compose.yaml
@@ -60,8 +60,7 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
     environment:
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m -XX:UseSVE=0
-      - CLI_JAVA_OPTS=-XX:UseSVE=0
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
       - node.name=elasticsearch
       - cluster.name=es-argilla-local
       - discovery.type=single-node


### PR DESCRIPTION
Remove the -XX:UseSVE=0 JVM flag from ES_JAVA_OPTS and CLI_JAVA_OPTS environment variables in the Elasticsearch service configuration.

This flag is ARM-specific (Scalable Vector Extension) and causes the Elasticsearch container to fail on x86_64 Linux systems with the error "Unrecognized VM option 'UseSVE=0'".

Fixes #5846

# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #<issue_number>

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (change restructuring the codebase without changing functionality)
- Improvement (change adding some improvement to an existing functionality)
- Documentation update

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
