### PR TITLE
fix: resolve HuggingFace Spaces runtime error during deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Need more info, check out [our docs](https://argilla-io.github.io/argilla/latest
 
 ## 🥇 Contributors
 
-To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs. 
+To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs.
 
 <a  href="https://github.com/argilla-io/argilla/graphs/contributors">
 

--- a/argilla-server/docker/argilla-hf-spaces/scripts/start.sh
+++ b/argilla-server/docker/argilla-hf-spaces/scripts/start.sh
@@ -10,7 +10,10 @@ export OAUTH2_HUGGINGFACE_SCOPE=$OAUTH_SCOPES
 
 # Set the space creator name as username if no name is provided, if the user is not found, use the provided space author name
 # See https://huggingface.co/docs/hub/en/spaces-overview#helper-environment-variables for more details
-DEFAULT_USERNAME=$(curl -L -s https://huggingface.co/api/users/${SPACE_CREATOR_USER_ID}/overview | jq -r '.user' || echo "${SPACE_AUTHOR_NAME}")
+# Note: Using 'jq -r .user // empty' ensures we get an empty string instead of "null" when the API
+# returns an error or the user field is missing. This allows the fallback to SPACE_AUTHOR_NAME to work correctly.
+DEFAULT_USERNAME=$(curl -L -s "https://huggingface.co/api/users/${SPACE_CREATOR_USER_ID}/overview" | jq -r '.user // empty')
+DEFAULT_USERNAME="${DEFAULT_USERNAME:-$SPACE_AUTHOR_NAME}"
 export USERNAME="${USERNAME:-$DEFAULT_USERNAME}"
 DEFAULT_PASSWORD=$(pwgen -s 16 1)
 export PASSWORD="${PASSWORD:-$DEFAULT_PASSWORD}"


### PR DESCRIPTION
The issue was in the username retrieval logic in start.sh. When the HuggingFace API returns an error (e.g., user not found), jq would return the literal string "null" instead of triggering the fallback to SPACE_AUTHOR_NAME.

Changes:
- Use jq's '// empty' alternative operator to return empty string instead of "null" when the .user field is missing or null
- Use bash parameter expansion to properly fallback to SPACE_AUTHOR_NAME
- Add proper quoting around the curl URL

This fixes the runtime error reported in issue #5845.

# Description
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Closes #<issue_number>

**Type of change**
<!--  Please delete options that are not relevant. Remember to title the PR according to the type of change  -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (change restructuring the codebase without changing functionality)
- Improvement (change adding some improvement to an existing functionality)
- Documentation update

**How Has This Been Tested**
<!--  Please add some reference about how your feature has been tested.  -->

**Checklist**
<!--  Please go over the list and make sure you've taken everything into account -->

- I added relevant documentation
- I followed the style guidelines of this project
- I did a self-review of my code
- I made corresponding changes to the documentation
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)
