### PR TITLE
fix: remove ARM-specific JVM flag from docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Need more info, check out [our docs](https://argilla-io.github.io/argilla/latest
 
 ## 🥇 Contributors
 
-To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs. 
+To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs.
 
 <a  href="https://github.com/argilla-io/argilla/graphs/contributors">
 

--- a/examples/deployments/docker/docker-compose.yaml
+++ b/examples/deployments/docker/docker-compose.yaml
@@ -60,8 +60,8 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
     environment:
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m -XX:UseSVE=0
-      - CLI_JAVA_OPTS=-XX:UseSVE=0
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - CLI_JAVA_OPTS=
       - node.name=elasticsearch
       - cluster.name=es-argilla-local
       - discovery.type=single-node


### PR DESCRIPTION
### Problem
Elasticsearch fails to start on x86_64 Linux due to an ARM-specific JVM flag
(`-XX:UseSVE=0`) in [docker-compose.yaml](cci:7://file:///c:/Users/GAURAV%20PATIL/Desktop/gaurav%27s%20code/Open-Source/argilla/argilla/examples/deployments/docker/docker-compose.yaml:0:0-0:0).

Closes #5846

### Solution
Removed the incompatible JVM flag from the Elasticsearch service configuration.

### Impact
Allows successful local deployment on x86_64 Linux systems.

### Verification
- Tested locally on x86_64 system

### Checklist
- [x] I did a self-review of my code
- [x] I confirm My changes generate no new warnings