### PR TITLE
Fix #5858: [DOCS] "Select Small" in Space Settings no longer exists —...

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Need more info, check out [our docs](https://argilla-io.github.io/argilla/latest
 
 ## 🥇 Contributors
 
-To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs. 
+To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs.
 
 <a  href="https://github.com/argilla-io/argilla/graphs/contributors">
 

--- a/argilla/docs/getting_started/how-to-configure-argilla-on-huggingface.md
+++ b/argilla/docs/getting_started/how-to-configure-argilla-on-huggingface.md
@@ -29,13 +29,16 @@ If you just want to quickly test or use Argilla for a few hours with the risk of
 If you want to disable the persistence storage warning, you can set the environment variable `ARGILLA_SHOW_HUGGINGFACE_SPACE_PERSISTENT_STORAGE_WARNING=false`
 
 !!! warning "Read this if you have datasets and want to enable persistent storage"
-    If you want to enable persistent storage `Small PAID` and you have created datasets, users, or workspaces, follow this process:
+    If you want to enable persistent storage and you have created datasets, users, or workspaces, follow this process:
 
     - First, **make a local or remote copy of your datasets**, following the [Import and Export guide](../how_to_guides/import_export.md). This is the most important step, because changing the settings of your Space leads to a restart and thus a data loss.
     - If you have created users (not signed in with Hugging Face login), **consider storing a copy of users** following the [manage users guide](../how_to_guides/user.md).
-    - **Once you have stored all your data safely, go to you Space Settings Tab** and select `Small`.
-    - **Your Space will be restarted and existing data will be lost**. From now on, all the new data you create in Argilla will be kept safely
+    - **Once you have stored all your data safely, go to your Space Settings Tab**, scroll to the **Persistent storage** section, and select a paid storage tier.
+    - **Your Space will be restarted and existing data will be lost**. From now on, all the new data you create in Argilla will be kept safely.
     - **Recover your data**, by following the above mentioned guides.
+
+!!! tip "Disabling persistent storage after annotation work is complete"
+    Once your annotation project is finished and you have exported all your data, you can stop paying for persistent storage by going to your **Space Settings Tab**, scrolling to the **Persistent storage** section, and selecting **Ephemeral FREE**. Make sure to export all datasets before doing this, as the Space will restart and all data stored on disk will be lost.
 
 ## How to configure and disable OAuth access
 


### PR DESCRIPTION
Closes #5858

# Description

Updates the persistent storage documentation in `argilla/docs/getting_started/how-to-configure-argilla-on-huggingface.md` to reflect the current HuggingFace Spaces UI, which no longer offers a "Small" storage tier option. The previous instructions were broken — users following the docs could not complete the documented steps.

Specific changes:
- Removed the outdated reference to `Small PAID` in the warning block header
- Replaced the instruction to "select `Small`" with accurate guidance to scroll to the **Persistent storage** section and select a paid storage tier
- Fixed a missing period in the restart/data-loss warning line
- Added a new tip block documenting how to disable persistent storage after annotation work is complete, including the correct UI path (**Space Settings Tab → Persistent storage section → Ephemeral FREE**) and a clear warning about data loss on Space restart

The new tip block addresses a real workflow gap: teams that complete annotation work and want to stop paying for persistent storage had no documented path to do so.

**Type of change**

- Documentation update

**How Has This Been Tested**

Verified against the current HuggingFace Spaces UI to confirm that the "Persistent storage" section exists with an "Ephemeral FREE" option, and that no "Small" tier appears in the settings tab.

**Checklist**

- [x] I added relevant documentation
- [x] I followed the style guidelines of this project
- [x] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [x] I confirm My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added relevant notes to the CHANGELOG.md file (See https://keepachangelog.com/)

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*