### PR TITLE
fix: remove duplicate questions._update() call in Settings.update()

### DIFF
--- a/argilla/src/argilla/settings/_resource.py
+++ b/argilla/src/argilla/settings/_resource.py
@@ -223,7 +223,6 @@ class Settings(DefaultSettingsMixin, Resource):
         self.__questions._update()
         self.__vectors._update()
         self.__metadata._update()
-        self.__questions._update()
 
         self._update_last_api_call()
         return self

--- a/argilla/tests/unit/test_settings/test_settings_update_fix.py
+++ b/argilla/tests/unit/test_settings/test_settings_update_fix.py
@@ -1,0 +1,51 @@
+# Copyright 2024-present, Argilla, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from pytest_mock import MockerFixture
+
+import argilla as rg
+
+
+class TestSettingsUpdateCallsEachGroupOnce:
+    """Settings.update() must call _update() exactly once per property group.
+
+    Bug: the method contained a duplicate ``self.__questions._update()`` call at
+    the end, causing every question to be sent to the API twice and the
+    ``_delete()`` step for removed questions to run twice.
+    """
+
+    def test_update_calls_each_property_group_exactly_once(self, mocker: "MockerFixture"):
+        """Each of fields/questions/vectors/metadata must be updated exactly once."""
+        settings = rg.Settings(
+            fields=[rg.TextField(name="text")],
+            questions=[rg.LabelQuestion(name="label", labels=["pos", "neg"])],
+        )
+
+        mocker.patch.object(settings, "_update_dataset_related_attributes")
+        mocker.patch.object(settings, "_update_last_api_call")
+        mocker.patch.object(settings, "validate")
+
+        # Access the name-mangled private attributes
+        fields_update = mocker.patch.object(settings._Settings__fields, "_update")
+        questions_update = mocker.patch.object(settings._Settings__questions, "_update")
+        vectors_update = mocker.patch.object(settings._Settings__vectors, "_update")
+        metadata_update = mocker.patch.object(settings._Settings__metadata, "_update")
+
+        settings.update()
+
+        fields_update.assert_called_once()
+        questions_update.assert_called_once()
+        vectors_update.assert_called_once()
+        metadata_update.assert_called_once()


### PR DESCRIPTION
# Description

`Settings.update()` in `argilla/src/argilla/settings/_resource.py` called `self.__questions._update()` twice — once at the correct position and again as the last statement before `_update_last_api_call()`. This copy-paste bug caused every question to be sent to the API twice on each `dataset.settings.update()` call and triggered a second `_delete()` pass on already-removed questions, which would raise an error if any question had been removed since the last save.

The `create()` method already calls each property group exactly once; this brings `update()` in line with that behaviour.

**Type of change**

- Bug fix (non-breaking change which fixes an issue)

**How Has This Been Tested**

New unit test `TestSettingsUpdateCallsEachGroupOnce.test_update_calls_each_property_group_exactly_once` in `argilla/tests/unit/test_settings/test_settings_update_fix.py` mocks each `SettingsProperties._update()` call and asserts it is invoked exactly once per `Settings.update()` call. The test fails on the unfixed code and passes after the fix.

```
ARGILLA_API_KEY=test pytest argilla/tests/unit/test_settings/test_settings_update_fix.py -v
# 1 passed
```

**Checklist**

- I followed the style guidelines of this project
- I did a self-review of my code
- I confirm My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works

> This PR was prepared with AI assistance (code analysis and test generation).