### PR TITLE
fix: return plain dict from ElasticSearchEngine.info()

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Need more info, check out [our docs](https://argilla-io.github.io/argilla/latest
 
 ## 🥇 Contributors
 
-To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs. 
+To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs.
 
 <a  href="https://github.com/argilla-io/argilla/graphs/contributors">
 

--- a/argilla-server/CHANGELOG.md
+++ b/argilla-server/CHANGELOG.md
@@ -24,6 +24,7 @@ These are the section headers that we use:
 
 - Fixed error when computing user progress with PostgreSQL database. ([#5795](https://github.com/argilla-io/argilla/pull/5795))
 - Fixed error when updating records with PostgreSQL database. ([#5795](https://github.com/argilla-io/argilla/pull/5795))
+- Fixed `GET /api/v1/status` returning 422 on the Elasticsearch backend, which also caused dataset cards to render empty in the UI. ([#5865](https://github.com/argilla-io/argilla/pull/5865)). Contributed by @St4r4x.
 
 ## [2.7.1](https://github.com/argilla-io/argilla/compare/v2.7.0...v2.7.1)
 

--- a/argilla-server/src/argilla_server/search_engine/elasticsearch.py
+++ b/argilla-server/src/argilla_server/search_engine/elasticsearch.py
@@ -69,7 +69,7 @@ class ElasticSearchEngine(BaseElasticAndOpenSearchEngine):
         return await self.client.ping()
 
     async def info(self) -> dict:
-        return await self.client.info()
+        return (await self.client.info()).body
 
     def _mapping_for_vector_settings(self, vector_settings: VectorSettings) -> dict:
         return {

--- a/argilla-server/tests/unit/search_engine/test_elastisearch.py
+++ b/argilla-server/tests/unit/search_engine/test_elastisearch.py
@@ -60,3 +60,8 @@ class TestElasticSearchEngine:
 
         with pytest.raises(RequestError, match="resource_already_exists_exception"):
             await search_engine.create_index(dataset)
+
+    async def test_info_returns_plain_dict(self, search_engine: ElasticSearchEngine):
+        info = await search_engine.info()
+
+        assert isinstance(info, dict)


### PR DESCRIPTION
## Problem
Fixes #5864

`GET /api/v1/status` returns 422 on the Elasticsearch backend, and dataset
cards silently fail to render in the UI as a side effect (both depend on
the same broken data path).

## Root cause
`ElasticSearchEngine.info()` returns `elasticsearch-py`'s raw
`elastic_transport.ObjectApiResponse` directly. It behaves like a dict
(supports `__getitem__`/iteration) but is not an actual `dict` instance,
so pydantic v2's strict `Status.search_engine: dict` validation rejects it.

`OpenSearchEngine.info()` is unaffected — checked `opensearch-py`'s
transport, which already deserializes JSON responses into plain dicts.

## Fix
Unwrap via `.body`, which `elastic_transport` guarantees is a plain dict.
One-line change.

## Verification
- Reproduced against the exact stack in `examples/deployments/docker/docker-compose.yaml` (`elasticsearch:8.17.0`).
- Before: `curl localhost:6900/api/v1/status` → 422 with the `dict_type` pydantic error.
- After (patched running container): same request → 200 with full cluster info; dataset list UI renders correctly again.
- Added `test_info_returns_plain_dict` in `test_elastisearch.py`, following the existing `search_engine` fixture pattern (runs against a live engine, not mocked).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)