### PR TITLE
bug: unwrap the Elasticsearch info response body

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Need more info, check out [our docs](https://argilla-io.github.io/argilla/latest
 
 ## 🥇 Contributors
 
-To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs. 
+To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs.
 
 <a  href="https://github.com/argilla-io/argilla/graphs/contributors">
 

--- a/argilla-server/CHANGELOG.md
+++ b/argilla-server/CHANGELOG.md
@@ -22,6 +22,7 @@ These are the section headers that we use:
 
 ### Fixed
 
+- Fixed the status endpoint response when using the Elasticsearch backend. ([#5864](https://github.com/argilla-io/argilla/issues/5864))
 - Fixed error when computing user progress with PostgreSQL database. ([#5795](https://github.com/argilla-io/argilla/pull/5795))
 - Fixed error when updating records with PostgreSQL database. ([#5795](https://github.com/argilla-io/argilla/pull/5795))
 

--- a/argilla-server/src/argilla_server/search_engine/elasticsearch.py
+++ b/argilla-server/src/argilla_server/search_engine/elasticsearch.py
@@ -69,7 +69,8 @@ class ElasticSearchEngine(BaseElasticAndOpenSearchEngine):
         return await self.client.ping()
 
     async def info(self) -> dict:
-        return await self.client.info()
+        response = await self.client.info()
+        return response.body
 
     def _mapping_for_vector_settings(self, vector_settings: VectorSettings) -> dict:
         return {

--- a/argilla-server/tests/unit/search_engine/test_elastisearch.py
+++ b/argilla-server/tests/unit/search_engine/test_elastisearch.py
@@ -12,6 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
 import pytest
 from argilla_server.search_engine import ElasticSearchEngine
 from argilla_server.search_engine.commons import es_index_name_for_dataset
@@ -20,6 +23,18 @@ from opensearchpy import OpenSearch
 
 from tests.factories import DatasetFactory, VectorSettingsFactory
 from tests.unit.search_engine.test_commons import refresh_dataset
+
+
+@pytest.mark.asyncio
+async def test_info_returns_plain_response_body():
+    engine = object.__new__(ElasticSearchEngine)
+    engine.client = SimpleNamespace(
+        info=AsyncMock(return_value=SimpleNamespace(body={"name": "test-node"})),
+    )
+
+    result = await engine.info()
+
+    assert result == {"name": "test-node"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Return `ObjectApiResponse.body` from the Elasticsearch `info()` adapter so the status schema receives a plain dictionary.
- Leave the OpenSearch adapter unchanged.
- Add a focused async regression and an unreleased server changelog entry.

Closes #5864

## Validation

- Focused Elasticsearch regression — 1 passed; 2 service-dependent tests deselected; 3 existing Pydantic warnings.
- Black left both Python files unchanged.
- `git diff --check`.

## Scope notes

A live Elasticsearch service was not available in this workspace; the unit test exercises the adapter boundary and the reporter documented live ES 8.17.0 verification in #5864.

pre-commit.ci also removed one pre-existing trailing space in the root README. That automated formatting-only edit has no functional effect.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I added relevant documentation.
- [x] I followed the style guidelines of this project.
- [x] I did a self-review of my code.
- [x] I made corresponding changes to the documentation.
- [x] I confirm my changes generate no new warnings.
- [x] I added tests that prove the fix is effective.
- [x] I added a relevant note to `argilla-server/CHANGELOG.md`.