### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Need more info, check out [our docs](https://argilla-io.github.io/argilla/latest
 
 ## 🥇 Contributors
 
-To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs. 
+To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs.
 
 <a  href="https://github.com/argilla-io/argilla/graphs/contributors">
 

--- a/argilla-frontend/docs/structure.md
+++ b/argilla-frontend/docs/structure.md
@@ -12,7 +12,7 @@
 ├── components
 │ ├── base -> Base and stateless components
 │ ├── features -> Features used in just one page
-│ ├── annotation -> Componentes used in Annotation page
+│ ├── annotation -> Components used in Annotation page
 │ ├── datasets -> Components to support datasets page
 │ ├── global -> Components used in multiple pages ex: UserAvatarComponent
 │ ├── login -> Components to support login page

--- a/argilla-server/README.md
+++ b/argilla-server/README.md
@@ -73,7 +73,7 @@ These environment variables can be overridden if necessary so feel free to defin
 
 ### Run development server
 
-This single command prepares the development server to run locally. It does so by chaining commands to migrate the databse, create default users and launch the server on the right port.
+This single command prepares the development server to run locally. It does so by chaining commands to migrate the database, create default users and launch the server on the right port.
 
 ```sh
 pdm server-dev

--- a/argilla/docs/getting_started/how-to-configure-argilla-on-huggingface.md
+++ b/argilla/docs/getting_started/how-to-configure-argilla-on-huggingface.md
@@ -19,8 +19,8 @@ In the Space creation UI, persistent storage is set to `Small PAID`, which is a 
 
 **Spaces get restarted due to maintenance, inactivity, and every time you change your Spaces settings**. Persistent storage enables Argilla to save to disk your datasets and configurations across restarts.
 
-!!! warning "Ephimeral FREE persistent storage"
-    Not setting persistent storage to `Small` means that **you will loose your data when the Space restarts**.
+!!! warning "Ephemeral FREE persistent storage"
+    Not setting persistent storage to `Small` means that **you will lose your data when the Space restarts**.
 
     If you plan to **use the Argilla Space beyond testing**, it's highly recommended to **set persistent storage to `Small`**.
 
@@ -83,7 +83,7 @@ Creating an Argilla Space within an organization is useful for several scenarios
 The steps are very similar the [Quickstart guide](quickstart.md) with one important difference:
 
 !!! tip "Enable Persistent Storage `SMALL`"
-    Not setting persistent storage to `Small` means that **you will loose your data when the Space restarts**.
+    Not setting persistent storage to `Small` means that **you will lose your data when the Space restarts**.
 
     For Argilla Spaces with many users, it's strongly recommended to **set persistent storage to `Small`**.
 

--- a/argilla/docs/getting_started/how-to-configure-argilla-on-huggingface.md
+++ b/argilla/docs/getting_started/how-to-configure-argilla-on-huggingface.md
@@ -17,14 +17,14 @@ This section details how to configure and deploy Argilla on Hugging Face Spaces.
 
 In the Space creation UI, persistent storage is set to `Small PAID`, which is a paid service, charged per hour of usage.
 
-**Spaces get restarted due to maintainance, inactivity, and every time you change your Spaces settings**. Persistent storage enables Argilla to save to disk your datasets and configurations across restarts.
+**Spaces get restarted due to maintenance, inactivity, and every time you change your Spaces settings**. Persistent storage enables Argilla to save to disk your datasets and configurations across restarts.
 
 !!! warning "Ephimeral FREE persistent storage"
     Not setting persistent storage to `Small` means that **you will loose your data when the Space restarts**.
 
     If you plan to **use the Argilla Space beyond testing**, it's highly recommended to **set persistent storage to `Small`**.
 
-If you just want to quickly test or use Argilla for a few hours with the risk of loosing your datasets, choose `Ephemeral FREE`. `Ephemeral FREE` means your datasets and configuration will not be saved to disk, when the Space is restarted your datasets, workspaces, and users will be lost.
+If you just want to quickly test or use Argilla for a few hours with the risk of losing your datasets, choose `Ephemeral FREE`. `Ephemeral FREE` means your datasets and configuration will not be saved to disk, when the Space is restarted your datasets, workspaces, and users will be lost.
 
 If you want to disable the persistence storage warning, you can set the environment variable `ARGILLA_SHOW_HUGGINGFACE_SPACE_PERSISTENT_STORAGE_WARNING=false`
 

--- a/argilla/docs/how_to_guides/custom_fields.md
+++ b/argilla/docs/how_to_guides/custom_fields.md
@@ -330,7 +330,7 @@ Besides the new `CustomField` code above, reusing the same approach as in the [U
 
 ## Updating templates
 
-As described in the [dataset guide](./dataset.md), you can update certain setting attributes for a published dataset. This includes the custom fields templates, which is a usefule feature when you want to iterate on the template of a custom field without the need to create a new dataset. The following example shows how to update the template of a custom field.
+As described in the [dataset guide](./dataset.md), you can update certain setting attributes for a published dataset. This includes the custom fields templates, which is a useful feature when you want to iterate on the template of a custom field without the need to create a new dataset. The following example shows how to update the template of a custom field.
 
 ```python
 dataset.settings.fields["custom"].template = "<new-template>"

--- a/argilla/docs/how_to_guides/index.md
+++ b/argilla/docs/how_to_guides/index.md
@@ -102,7 +102,7 @@ These guides provide step-by-step instructions for common scenarios, including d
 
     ---
 
-    Learn how Argilla webhooks are implented under the hood and the structure of the different events.
+    Learn how Argilla webhooks are implemented under the hood and the structure of the different events.
 
     [:octicons-arrow-right-24: How-to guide](webhooks_internals.md)
 

--- a/argilla/docs/how_to_guides/migrate_from_legacy_datasets.md
+++ b/argilla/docs/how_to_guides/migrate_from_legacy_datasets.md
@@ -15,7 +15,7 @@ To follow this guide, you will need to have the following prerequisites:
 - The `argilla` sdk package installed in your environment.
 
 !!! warning
-    This guide will recreate all `User`'s' and `Workspace`'s' on a new server. Hence, they will be created with new passwords and IDs. If you want to keep the same passwords and IDs, you can can copy the datasets to a temporary v2 instance, then upgrade your current instance to v2.0 and copy the datasets back to your original instance after.
+    This guide will recreate all `User`'s' and `Workspace`'s' on a new server. Hence, they will be created with new passwords and IDs. If you want to keep the same passwords and IDs, you can copy the datasets to a temporary v2 instance, then upgrade your current instance to v2.0 and copy the datasets back to your original instance after.
 
 If your current legacy datasets are on a server with Argilla release after 1.29, you could chose to recreate your legacy datasets as new datasets on the same server. You could then upgrade the server to Argilla 2.0 and carry on working their. Your legacy datasets will not be visible on the new server, but they will remain in storage layers if you need to access them.
 

--- a/argilla/docs/how_to_guides/migrate_from_legacy_datasets.md
+++ b/argilla/docs/how_to_guides/migrate_from_legacy_datasets.md
@@ -15,7 +15,7 @@ To follow this guide, you will need to have the following prerequisites:
 - The `argilla` sdk package installed in your environment.
 
 !!! warning
-    This guide will recreate all `User`'s' and `Workspace`'s' on a new server. Hence, they will be created with new passwords and IDs. If you want to keep the same passwords and IDs, you can copy the datasets to a temporary v2 instance, then upgrade your current instance to v2.0 and copy the datasets back to your original instance after.
+    This guide will recreate all `User`s and `Workspace`s on a new server. Hence, they will be created with new passwords and IDs. If you want to keep the same passwords and IDs, you can copy the datasets to a temporary v2 instance, then upgrade your current instance to v2.0 and copy the datasets back to your original instance after.
 
 If your current legacy datasets are on a server with Argilla release after 1.29, you could chose to recreate your legacy datasets as new datasets on the same server. You could then upgrade the server to Argilla 2.0 and carry on working their. Your legacy datasets will not be visible on the new server, but they will remain in storage layers if you need to access them.
 

--- a/argilla/docs/how_to_guides/query.md
+++ b/argilla/docs/how_to_guides/query.md
@@ -154,7 +154,7 @@ You can filter records based on the following fields:
 | `status`                | The record status, which can be `pending` or `completed`.                      | `("status", "==", "completed")`                                |
 | `response.status`       | The response status, which can be `draft`, `submitted`, or `discarded`.        | `("response.status", "==", "submitted")`                       |
 | `metadata.<name>`       | Filter by a metadata property                                                  | `("metadata.split", "==", "train")`                            |
-| `<question>.suggestion` | Filter by a question suggestion value                                          | `("label.sugggestion", "==", "positive")`                      |
+| `<question>.suggestion` | Filter by a question suggestion value                                          | `("label.suggestion", "==", "positive")`                       |
 | `<question>.score`      | Filter by a suggestion score                                                   | `("label.score", "<=", "0.9")`                                 |
 | `<question>.agent`      | Filter by a suggestion agent                                                   | `("label.agent", "<=", "ChatGPT4.0")`                          |
 | `<question>.response`   | Filter by a question response                                                  | `("label.response", "==", "negative")`                         |
@@ -207,7 +207,7 @@ filtered_records = dataset.records(similar_filter).to_list(flatten=True)
 
 !!! Note
     The `Similar` search expects a vector field definition as part of the dataset settings. If the dataset does not have a vector field, the search will return an error.
-    Vist the [Vectors](./dataset.md#vectors) section for more details on how to define a vector field.
+    Visit the [Vectors](./dataset.md#vectors) section for more details on how to define a vector field.
 
 ## Query and filter a dataset
 

--- a/argilla/docs/how_to_guides/record.md
+++ b/argilla/docs/how_to_guides/record.md
@@ -169,7 +169,7 @@ Fields are the main pieces of information of the record. These are shown at firs
 === "Image"
     Image fields expect a remote URL or local path to an image file in the form of a `string`, or a PIL object.
 
-    > Check the [Dataset.records - Python Reference](../reference/argilla/datasets/dataset_records.md) to see how to add records with with images in detail.
+    > Check the [Dataset.records - Python Reference](../reference/argilla/datasets/dataset_records.md) to see how to add records with images in detail.
 
     ```python
     records = [

--- a/argilla/docs/reference/argilla-server/configuration.md
+++ b/argilla/docs/reference/argilla-server/configuration.md
@@ -67,7 +67,7 @@ If `USERNAME` and `PASSWORD` are provided, the owner user will be created with t
 
 The following environment variables are useful only when SQLite is used:
 
-- `ARGILLA_DATABASE_SQLITE_TIMEOUT`: How many seconds the connection should wait before raising an `OperationalError` when a table is locked. If another connection opens a transaction to modify a table, that table will be locked until the transaction is committed. (Defaut: `15` seconds).
+- `ARGILLA_DATABASE_SQLITE_TIMEOUT`: How many seconds the connection should wait before raising an `OperationalError` when a table is locked. If another connection opens a transaction to modify a table, that table will be locked until the transaction is committed. (Default: `15` seconds).
 
 ##### PostgreSQL
 
@@ -124,7 +124,7 @@ Redis is used by Argilla to store information about jobs to be processed on back
 
 - `PASSWORD`: If provided, the owner password. If `USERNAME` and `PASSWORD` are provided, the owner user will be created with these credentials on the server startup (Default: `""`).
 
-- `WORKSPACE`: If provided, the workspace name. If `USERNAME`, `PASSWORD` and `WORSPACE` are provided, a default workspace will be created with this name (Default: `""`).
+- `WORKSPACE`: If provided, the workspace name. If `USERNAME`, `PASSWORD` and `WORKSPACE` are provided, a default workspace will be created with this name (Default: `""`).
 
 - `API_KEY`: The default user api key to user. If API_KEY is not provided, a new random api key will be generated (Default: `""`).
 

--- a/argilla/docs/reference/argilla-server/configuration.md
+++ b/argilla/docs/reference/argilla-server/configuration.md
@@ -126,7 +126,7 @@ Redis is used by Argilla to store information about jobs to be processed on back
 
 - `WORKSPACE`: If provided, the workspace name. If `USERNAME`, `PASSWORD` and `WORKSPACE` are provided, a default workspace will be created with this name (Default: `""`).
 
-- `API_KEY`: The default user api key to user. If API_KEY is not provided, a new random api key will be generated (Default: `""`).
+- `API_KEY`: The default user api key to use. If API_KEY is not provided, a new random api key will be generated (Default: `""`).
 
 - `UVICORN_APP`: [Advanced] The name of the FastAPI app to run. This is useful when you want to extend the FastAPI app with additional routes or middleware. The default value is `argilla_server:app`.
 

--- a/argilla/docs/reference/argilla/records/metadata.md
+++ b/argilla/docs/reference/argilla/records/metadata.md
@@ -3,7 +3,7 @@ hide: footer
 ---
 # `metadata`
 
-Metadata in argilla is a dictionary that can be attached to a record. It is used to store additional information about the record that is not part of the record's fields or responses. For example, the source of the record, the date it was created, or any other information that is relevant to the record. Metadata can be added to a record directly or as valules within a dictionary.
+Metadata in argilla is a dictionary that can be attached to a record. It is used to store additional information about the record that is not part of the record's fields or responses. For example, the source of the record, the date it was created, or any other information that is relevant to the record. Metadata can be added to a record directly or as values within a dictionary.
 
 ## Usage Examples
 

--- a/argilla/docs/reference/argilla/records/records.md
+++ b/argilla/docs/reference/argilla/records/records.md
@@ -64,7 +64,7 @@ for record in dataset.records(with_metadata=True):
     record.metadata = {"department": "toys"}
 ```
 
-For changes to take effect, the user must call the `update` method on the `Dataset` object, or pass the updated records to `Dataset.records.log`. All core record atttributes can be updated in this way. Check their respective documentation for more information: [Suggestions](suggestions.md), [Responses](responses.md), [Metadata](metadata.md), [Vectors](vectors.md).
+For changes to take effect, the user must call the `update` method on the `Dataset` object, or pass the updated records to `Dataset.records.log`. All core record attributes can be updated in this way. Check their respective documentation for more information: [Suggestions](suggestions.md), [Responses](responses.md), [Metadata](metadata.md), [Vectors](vectors.md).
 
 
 ---


### PR DESCRIPTION
Small documentation-only pass over the v2 docs, the `argilla-server` README, and the frontend structure notes. No code or behaviour changes.

Two are worth calling out:

- **`argilla/docs/how_to_guides/query.md`** — the filter reference table documents `<question>.suggestion`, but the example in the same row reads `("label.sugggestion", "==", "positive")`. Copying the example as-is would not match the documented key.
- **`argilla/docs/reference/argilla-server/configuration.md`** — the entry documents the `WORKSPACE` environment variable and then refers to it as `WORSPACE` in the following sentence.

The rest are plain spelling fixes and doubled words:

| File | Fix |
| --- | --- |
| `argilla-server/README.md` | `databse` → `database` |
| `argilla-frontend/docs/structure.md` | `Componentes` → `Components` |
| `argilla/docs/getting_started/how-to-configure-argilla-on-huggingface.md` | `maintainance` → `maintenance`, `loosing` → `losing` |
| `argilla/docs/how_to_guides/custom_fields.md` | `usefule` → `useful` |
| `argilla/docs/how_to_guides/index.md` | `implented` → `implemented` |
| `argilla/docs/how_to_guides/query.md` | `Vist` → `Visit` |
| `argilla/docs/how_to_guides/migrate_from_legacy_datasets.md` | `you can can copy` → `you can copy` |
| `argilla/docs/how_to_guides/record.md` | `records with with images` → `records with images` |
| `argilla/docs/reference/argilla-server/configuration.md` | `Defaut` → `Default` |
| `argilla/docs/reference/argilla/records/metadata.md` | `valules` → `values` |
| `argilla/docs/reference/argilla/records/records.md` | `atttributes` → `attributes` |

I left the frozen v1 docs under `docs/_source/` untouched, since they are no longer part of the published site. Happy to include them if you would prefer.