### PR TITLE
Enforce metadata property read policy on search filter and sort scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Need more info, check out [our docs](https://argilla-io.github.io/argilla/latest
 
 ## 🥇 Contributors
 
-To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs. 
+To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs.
 
 <a  href="https://github.com/argilla-io/argilla/graphs/contributors">
 

--- a/argilla-server/src/argilla_server/api/handlers/v1/datasets/records.py
+++ b/argilla-server/src/argilla_server/api/handlers/v1/datasets/records.py
@@ -201,9 +201,9 @@ async def _get_search_responses(
         return await search_engine.search(**search_params)
 
 
-async def _validate_search_records_query(db: "AsyncSession", query: SearchRecordsQuery, dataset: Dataset):
+async def _validate_search_records_query(db: "AsyncSession", query: SearchRecordsQuery, dataset: Dataset, user: User):
     try:
-        await search.validate_search_records_query(db, query, dataset)
+        await search.validate_search_records_query(db, query, dataset, user)
     except (ValueError, NotFoundError) as e:
         raise UnprocessableEntityError(str(e))
 
@@ -296,7 +296,7 @@ async def search_current_user_dataset_records(
 
     await authorize(current_user, DatasetPolicy.search_records(dataset))
 
-    await _validate_search_records_query(db, body, dataset)
+    await _validate_search_records_query(db, body, dataset, current_user)
 
     search_responses = await _get_search_responses(
         db=db,
@@ -357,7 +357,7 @@ async def search_dataset_records(
 
     await authorize(current_user, DatasetPolicy.search_records_with_all_responses(dataset))
 
-    await _validate_search_records_query(db, body, dataset)
+    await _validate_search_records_query(db, body, dataset, current_user)
 
     search_responses = await _get_search_responses(
         db=db,

--- a/argilla-server/src/argilla_server/contexts/search.py
+++ b/argilla-server/src/argilla_server/contexts/search.py
@@ -17,7 +17,9 @@ from uuid import UUID
 from sqlalchemy import func, select
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
+from argilla_server.api.policies.v1 import MetadataPropertyPolicy, authorize
 from argilla_server.api.schemas.v1.records import (
     FilterScope,
     MetadataFilterScope,
@@ -26,22 +28,25 @@ from argilla_server.api.schemas.v1.records import (
 )
 from argilla_server.api.schemas.v1.responses import ResponseFilterScope
 from argilla_server.api.schemas.v1.suggestions import SuggestionFilterScope
-from argilla_server.models import MetadataProperty, Question, Suggestion, Dataset
+from argilla_server.errors.future import NotFoundError
+from argilla_server.models import MetadataProperty, Question, Suggestion, Dataset, User
 
 
 class SearchRecordsQueryValidator:
     @classmethod
-    async def validate(cls, db: AsyncSession, dataset: Dataset, query: SearchRecordsQuery) -> None:
+    async def validate(cls, db: AsyncSession, dataset: Dataset, query: SearchRecordsQuery, user: User) -> None:
         if query.filters:
             for filter in query.filters.and_:
-                await cls._validate_filter_scope(db, dataset, filter.scope)
+                await cls._validate_filter_scope(db, dataset, filter.scope, user)
 
         if query.sort:
             for order in query.sort:
-                await cls._validate_filter_scope(db, dataset, order.scope)
+                await cls._validate_filter_scope(db, dataset, order.scope, user)
 
     @classmethod
-    async def _validate_filter_scope(cls, db: AsyncSession, dataset: Dataset, filter_scope: FilterScope) -> None:
+    async def _validate_filter_scope(
+        cls, db: AsyncSession, dataset: Dataset, filter_scope: FilterScope, user: User
+    ) -> None:
         if isinstance(filter_scope, RecordFilterScope):
             return
         elif isinstance(filter_scope, ResponseFilterScope):
@@ -49,7 +54,7 @@ class SearchRecordsQueryValidator:
         elif isinstance(filter_scope, SuggestionFilterScope):
             await cls._validate_suggestion_filter_scope(db, dataset, filter_scope)
         elif isinstance(filter_scope, MetadataFilterScope):
-            await cls._validate_metadata_filter_scope(db, dataset, filter_scope)
+            await cls._validate_metadata_filter_scope(db, dataset, filter_scope, user)
         else:
             raise ValueError(f"Unknown filter scope entity `{filter_scope.entity}`")
 
@@ -70,17 +75,35 @@ class SearchRecordsQueryValidator:
 
     @staticmethod
     async def _validate_metadata_filter_scope(
-        db: AsyncSession, dataset: Dataset, filter_scope: MetadataFilterScope
+        db: AsyncSession, dataset: Dataset, filter_scope: MetadataFilterScope, user: User
     ) -> None:
-        await MetadataProperty.get_by_or_raise(
-            db,
-            name=filter_scope.metadata_property,
-            dataset_id=dataset.id,
+        # Load the property with its dataset eagerly: the policy action reads
+        # metadata_property.dataset.workspace_id, which would otherwise lazy-load
+        # outside an awaitable context.
+        result = await db.execute(
+            select(MetadataProperty)
+            .filter_by(name=filter_scope.metadata_property, dataset_id=dataset.id)
+            .options(selectinload(MetadataProperty.dataset))
         )
+        metadata_property = result.scalar_one_or_none()
+        if metadata_property is None:
+            raise NotFoundError(
+                f"MetadataProperty not found filtering by name={filter_scope.metadata_property}, "
+                f"dataset_id={dataset.id}"
+            )
+
+        # A metadata property hidden from the requesting user must not be
+        # usable as a filter or sort scope: the property value is stripped
+        # from returned records, but result-set membership would disclose it
+        # record by record. Enforce the same read policy that
+        # _filter_record_metadata_for_user enforces for returned values.
+        await authorize(user, MetadataPropertyPolicy.get(metadata_property))
 
 
-async def validate_search_records_query(db: AsyncSession, query: SearchRecordsQuery, dataset: Dataset) -> None:
-    await SearchRecordsQueryValidator.validate(db, dataset, query)
+async def validate_search_records_query(
+    db: AsyncSession, query: SearchRecordsQuery, dataset: Dataset, user: User
+) -> None:
+    await SearchRecordsQueryValidator.validate(db, dataset, query, user)
 
 
 async def get_dataset_suggestion_agents_by_question(db: AsyncSession, dataset_id: UUID) -> List[Mapping[str, Any]]:

--- a/argilla-server/tests/unit/api/handlers/v1/datasets/test_search_current_user_dataset_records.py
+++ b/argilla-server/tests/unit/api/handlers/v1/datasets/test_search_current_user_dataset_records.py
@@ -267,7 +267,6 @@ class TestSearchCurrentUserDatasetRecords:
             "detail": f"Question not found filtering by name=non-existent, dataset_id={dataset.id}"
         }
 
-
     async def test_search_with_hidden_metadata_filter_scope_for_annotator(self, async_client: AsyncClient):
         dataset = await DatasetFactory.create()
         await TextFieldFactory.create(name="input", dataset=dataset)

--- a/argilla-server/tests/unit/api/handlers/v1/datasets/test_search_current_user_dataset_records.py
+++ b/argilla-server/tests/unit/api/handlers/v1/datasets/test_search_current_user_dataset_records.py
@@ -266,3 +266,111 @@ class TestSearchCurrentUserDatasetRecords:
         assert response.json() == {
             "detail": f"Question not found filtering by name=non-existent, dataset_id={dataset.id}"
         }
+
+
+    async def test_search_with_hidden_metadata_filter_scope_for_annotator(self, async_client: AsyncClient):
+        dataset = await DatasetFactory.create()
+        await TextFieldFactory.create(name="input", dataset=dataset)
+        await TermsMetadataPropertyFactory.create(
+            name="hidden_gold", dataset=dataset, allowed_roles=[UserRole.admin, UserRole.owner]
+        )
+        annotator = await AnnotatorFactory.create(workspaces=[dataset.workspace])
+
+        response = await async_client.post(
+            self.url(dataset.id),
+            headers={API_KEY_HEADER_NAME: annotator.api_key},
+            json={
+                "filters": {
+                    "and": [
+                        {
+                            "type": "terms",
+                            "scope": {"entity": "metadata", "metadata_property": "hidden_gold"},
+                            "values": ["A"],
+                        }
+                    ]
+                }
+            },
+        )
+
+        assert response.status_code == 403
+
+    async def test_search_with_hidden_metadata_sort_scope_for_annotator(self, async_client: AsyncClient):
+        dataset = await DatasetFactory.create()
+        await TextFieldFactory.create(name="input", dataset=dataset)
+        await TermsMetadataPropertyFactory.create(
+            name="hidden_gold", dataset=dataset, allowed_roles=[UserRole.admin, UserRole.owner]
+        )
+        annotator = await AnnotatorFactory.create(workspaces=[dataset.workspace])
+
+        response = await async_client.post(
+            self.url(dataset.id),
+            headers={API_KEY_HEADER_NAME: annotator.api_key},
+            json={"sort": [{"scope": {"entity": "metadata", "metadata_property": "hidden_gold"}, "order": "asc"}]},
+        )
+
+        assert response.status_code == 403
+
+    async def test_search_with_visible_metadata_filter_scope_for_annotator(
+        self, async_client: AsyncClient, mock_search_engine: SearchEngine
+    ):
+        dataset = await DatasetFactory.create()
+        await TextFieldFactory.create(name="input", dataset=dataset)
+        await TermsMetadataPropertyFactory.create(
+            name="annotator_meta", dataset=dataset, allowed_roles=[UserRole.admin, UserRole.annotator]
+        )
+        annotator = await AnnotatorFactory.create(workspaces=[dataset.workspace])
+        record = await RecordFactory.create(metadata_={"annotator_meta": "A"}, dataset=dataset)
+
+        mock_search_engine.search.return_value = SearchResponses(
+            items=[SearchResponseItem(record_id=record.id, score=1.0)],
+            total=1,
+        )
+
+        response = await async_client.post(
+            self.url(dataset.id),
+            headers={API_KEY_HEADER_NAME: annotator.api_key},
+            json={
+                "filters": {
+                    "and": [
+                        {
+                            "type": "terms",
+                            "scope": {"entity": "metadata", "metadata_property": "annotator_meta"},
+                            "values": ["A"],
+                        }
+                    ]
+                }
+            },
+        )
+
+        assert response.status_code == 200
+
+    async def test_search_with_any_metadata_filter_scope_for_owner(
+        self, async_client: AsyncClient, mock_search_engine: SearchEngine, owner_auth_header: dict
+    ):
+        dataset = await DatasetFactory.create()
+        await TextFieldFactory.create(name="input", dataset=dataset)
+        await TermsMetadataPropertyFactory.create(name="owner_meta", dataset=dataset, allowed_roles=[])
+        record = await RecordFactory.create(metadata_={"owner_meta": "A"}, dataset=dataset)
+
+        mock_search_engine.search.return_value = SearchResponses(
+            items=[SearchResponseItem(record_id=record.id, score=1.0)],
+            total=1,
+        )
+
+        response = await async_client.post(
+            self.url(dataset.id),
+            headers=owner_auth_header,
+            json={
+                "filters": {
+                    "and": [
+                        {
+                            "type": "terms",
+                            "scope": {"entity": "metadata", "metadata_property": "owner_meta"},
+                            "values": ["A"],
+                        }
+                    ]
+                }
+            },
+        )
+
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary

A metadata property configured with `visible_for_annotators: false` is withheld from annotators when record metadata values are returned (`_filter_record_metadata_for_user` enforces `MetadataPropertyPolicy.get`), but the search request validator only checked that the property exists. The search endpoints authorized for plain workspace members therefore accepted a terms filter or a sort on a hidden metadata property, translated into an Elasticsearch/OpenSearch query on `metadata.<name>`. The property value stays stripped from the response, but result-set membership discloses it record by record: a filter on `metadata.hidden_gold in ["A"]` returning record R proves R's hidden value is A. This closes that gap.

Fixes #5870.

## Changes

`SearchRecordsQueryValidator` now takes the requesting user and, for every metadata filter and sort scope, authorizes the user against the same `MetadataPropertyPolicy.get` the record projection applies, returning 403 for properties the user cannot read. The property is loaded with its dataset eagerly so the policy action does not lazy-load in the async session. Both search handler call sites pass the current user.

## Verification

New tests in `argilla-server/tests/unit/api/handlers/v1/datasets/test_search_current_user_dataset_records.py`:

- an annotator filtering on an admin/owner-only property gets 403
- an annotator sorting on an admin/owner-only property gets 403
- an annotator filtering on a property their role may read gets 200
- the owner can filter on a property with an empty allowed_roles list

Both 403 tests fail on the pre-fix code (the requests returned 200). Full local run: 10 passed in the file including all pre-existing tests. The only local-only artifact is a session teardown error connecting to OpenSearch, which occurs identically with and without this change.
