### PR TITLE
docs: add Easypanel deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Need more info, check out [our docs](https://argilla-io.github.io/argilla/latest
 
 ## 🥇 Contributors
 
-To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs. 
+To help our community with the creation of contributions, we have created our [community](https://argilla-io.github.io/argilla/latest/community/) docs.
 
 <a  href="https://github.com/argilla-io/argilla/graphs/contributors">
 

--- a/argilla/docs/getting_started/how-to-deploy-argilla-with-easypanel.md
+++ b/argilla/docs/getting_started/how-to-deploy-argilla-with-easypanel.md
@@ -1,0 +1,14 @@
+---
+description: Deploy Argilla with Easypanel
+---
+
+This guide describes how to deploy Argilla using [Easypanel](https://easypanel.io/), a server control panel that can deploy Argilla with one click using its official template, without needing to manually run Docker commands.
+
+1. Open your Easypanel dashboard and create (or open) a project
+2. Click **+ Add Service** and choose **Templates**
+3. Search for **Argilla** and select it
+4. Click **Create** to deploy the service
+
+Easypanel provisions the required PostgreSQL, Redis, and Elasticsearch services automatically and runs the Argilla web and worker containers for you.
+
+See the [official Argilla template on Easypanel](https://easypanel.io/templates/argilla) for more details.

--- a/argilla/mkdocs.yml
+++ b/argilla/mkdocs.yml
@@ -159,6 +159,7 @@ nav:
   - Getting started:
       - Quickstart: getting_started/quickstart.md
       - Deploy with Docker: getting_started/how-to-deploy-argilla-with-docker.md
+      - Deploy with Easypanel: getting_started/how-to-deploy-argilla-with-easypanel.md
       - Hugging Face Spaces settings: getting_started/how-to-configure-argilla-on-huggingface.md
       - FAQ: getting_started/faq.md
   - How-to guides:


### PR DESCRIPTION
Adds an Easypanel guide alongside the existing Docker deployment guide. Argilla has an official one-click template on Easypanel (https://easypanel.io/templates/argilla) that provisions PostgreSQL, Redis, and Elasticsearch automatically.